### PR TITLE
Update Dependabot and Mergify config to use new labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,8 @@ updates:
     target-branch: "main"
     open-pull-requests-limit: 10
     labels:
-      - T:dependencies
-      - S:automerge
+      - dependencies
+      - automerge
 
   - package-ecosystem: github-actions
     directory: "/"
@@ -17,8 +17,8 @@ updates:
     target-branch: "v0.37.x"
     open-pull-requests-limit: 10
     labels:
-      - T:dependencies
-      - S:automerge
+      - dependencies
+      - automerge
 
   - package-ecosystem: github-actions
     directory: "/"
@@ -27,8 +27,8 @@ updates:
     target-branch: "v0.34.x"
     open-pull-requests-limit: 10
     labels:
-      - T:dependencies
-      - S:automerge
+      - dependencies
+      - automerge
 
   ###################################
   ##
@@ -41,8 +41,8 @@ updates:
     target-branch: "main"
     open-pull-requests-limit: 10
     labels:
-      - T:dependencies
-      - S:automerge
+      - dependencies
+      - automerge
 
   - package-ecosystem: gomod
     directory: "/"
@@ -53,8 +53,8 @@ updates:
     # branches.
     open-pull-requests-limit: 0
     labels:
-      - T:dependencies
-      - S:automerge
+      - dependencies
+      - automerge
 
   - package-ecosystem: gomod
     directory: "/"
@@ -65,5 +65,5 @@ updates:
     # branches.
     open-pull-requests-limit: 0
     labels:
-      - T:dependencies
-      - S:automerge
+      - dependencies
+      - automerge

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -2,13 +2,13 @@ queue_rules:
   - name: default
     conditions:
       - base=main
-      - label=S:automerge
+      - label=automerge
 
 pull_request_rules:
   - name: Automerge to main
     conditions:
       - base=main
-      - label=S:automerge
+      - label=automerge
     actions:
       queue:
         method: squash
@@ -20,7 +20,7 @@ pull_request_rules:
   - name: backport patches to v0.37.x branch
     conditions:
       - base=main
-      - label=S:backport-to-v0.37.x
+      - label=backport-to-v0.37.x
     actions:
       backport:
         branches:
@@ -28,7 +28,7 @@ pull_request_rules:
   - name: backport patches to v0.34.x branch
     conditions:
       - base=main
-      - label=S:backport-to-v0.34.x
+      - label=backport-to-v0.34.x
     actions:
       backport:
         branches:


### PR DESCRIPTION
I'm not using the precise same labelling scheme as in the old repo. We can discuss changing this in our team meeting in future if anyone has any strong preferences to keep the old labelling scheme.

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

