### PR TITLE
ci: Update Docker build workflows

### DIFF
--- a/.github/workflows/tendermint-docker.yml
+++ b/.github/workflows/tendermint-docker.yml
@@ -1,6 +1,6 @@
 name: Docker
 # Build & Push rebuilds the Tendermint docker image on every push to main and creation of tags
-# and pushes the image to https://hub.docker.com/r/tendermint/tendermint
+# and pushes the image to https://hub.docker.com/r/cometbft/tendermint
 on:
   push:
     branches:
@@ -19,7 +19,7 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          DOCKER_IMAGE=tendermint/tendermint
+          DOCKER_IMAGE=cometbft/tendermint
           VERSION=noop
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}

--- a/.github/workflows/testapp-docker.yml
+++ b/.github/workflows/testapp-docker.yml
@@ -1,6 +1,6 @@
 name: Docker E2E Node
 # Build & Push rebuilds the e2e Testapp docker image on every push to main and creation of tags
-# and pushes the image to https://hub.docker.com/r/tendermint/e2e-node
+# and pushes the image to https://hub.docker.com/r/cometbft/e2e-node
 on:
   push:
     branches:
@@ -19,7 +19,7 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          DOCKER_IMAGE=tendermint/e2e-node
+          DOCKER_IMAGE=cometbft/e2e-node
           VERSION=noop
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}


### PR DESCRIPTION
Updates the workflows for building the Tendermint and E2E node Docker images.

I've configured these at <https://hub.docker.com/repository/docker/cometbft/tendermint> and <https://hub.docker.com/repository/docker/cometbft/e2e-node> respectively for now.

I've also configured the repository secrets and the bot user, so this should work.

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

