### PR TITLE
e2e-nightly: Added correct command prefix to main cmd

### DIFF
--- a/cmd/cometbft/main.go
+++ b/cmd/cometbft/main.go
@@ -48,7 +48,7 @@ func main() {
 	// Create & start node
 	rootCmd.AddCommand(cmd.NewRunNodeCmd(nodeFunc))
 
-	cmd := cli.PrepareBaseCmd(rootCmd, "TM", os.ExpandEnv(filepath.Join("$HOME", cfg.DefaultTendermintDir)))
+	cmd := cli.PrepareBaseCmd(rootCmd, "CMT", os.ExpandEnv(filepath.Join("$HOME", cfg.DefaultTendermintDir)))
 	if err := cmd.Execute(); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
The e2e nightly tests failed when we renamed TMHOME to CMTHOME. 

This PR is an attempt to fix it. 