### PR TITLE
ci: De-duplicate release workflows for v0.34.x

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - v0.34.x
-      - main
-      - release/**
 
 jobs:
   split-test-files:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,8 +6,6 @@ on:
   push:
     branches:
       - v0.34.x
-      - main
-      - release/**
 
 jobs:
   e2e-test:

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -8,8 +8,6 @@ on:
   pull_request:
   push:
     branches:
-      - main
-      - release/**
       - v0.34.x
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,8 +12,8 @@ on:
   pull_request:
   push:
     branches:
-      - main
       - v0.34.x
+
 jobs:
   golangci:
     name: golangci-lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,8 +6,6 @@ on:
   pull_request:
   push:
     branches:
-      - main
-      - release/**
       - v0.34.x
 
 jobs:


### PR DESCRIPTION
De-duplicates workflows on `release/*` branches in a similar way to https://github.com/informalsystems/tendermint/pull/13, but tailored to the current state of the branch.

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

