### PR TITLE
Release v0.34.27-alpha.1

### DIFF
--- a/.changelog/unreleased/improvements/314-prio-mempool-badtxlog.md
+++ b/.changelog/unreleased/improvements/314-prio-mempool-badtxlog.md
@@ -1,0 +1,3 @@
+- `[mempool/v1]` Suppress "rejected bad transaction" in priority mempool logs by
+  reducing log level from info to debug
+  ([\#314](https://github.com/cometbft/cometbft/pull/314): @JayT106)

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -20,24 +20,16 @@ jobs:
         with:
           go-version: '1.18'
 
-      - name: Build
-        uses: goreleaser/goreleaser-action@v4
-        if: ${{ github.event_name == 'pull_request' }}
-        with:
-          version: latest
-          args: build --skip-validate   # skip validate skips initial sanity checks in order to be able to fully run
-
-      # Link to CHANGELOG.md as release notes (ensure that changelog is built
-      # with unreleased entries prior to cutting a pre-release)
       - run: |
-          echo ":book: [CHANGELOG](https://github.com/cometbft/cometbft/blob/${GITHUB_REF#refs/tags/}/CHANGELOG.md)" > ../release_notes.md
+          VERSION="${GITHUB_REF#refs/tags/}"
+          CHANGELOG_URL="https://github.com/cometbft/cometbft/blob/${VERSION}/CHANGELOG.md"
+          echo "See the [CHANGELOG](${CHANGELOG_URL}) for changes available in this pre-release, but not yet officially released." > ../release_notes.md
 
       - name: Release
         uses: goreleaser/goreleaser-action@v4
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           version: latest
-          args: release --rm-dist --release-notes=../release_notes.md
+          args: release --clean --release-notes ../release_notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -20,7 +20,8 @@ jobs:
         with:
           go-version: '1.18'
 
-      - run: |
+      - name: Generate release notes
+        run: |
           VERSION="${GITHUB_REF#refs/tags/}"
           CHANGELOG_URL="https://github.com/cometbft/cometbft/blob/${VERSION}/CHANGELOG.md"
           echo "See the [CHANGELOG](${CHANGELOG_URL}) for changes available in this pre-release, but not yet officially released." > ../release_notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,21 +18,18 @@ jobs:
         with:
           go-version: '1.18'
 
-      - name: Build
-        uses: goreleaser/goreleaser-action@v4
-        if: ${{ github.event_name == 'pull_request' }}
-        with:
-          version: latest
-          args: build --skip-validate   # skip validate skips initial sanity checks in order to be able to fully run
-
-      - run: echo https://github.com/cometbft/cometbft/blob/${GITHUB_REF#refs/tags/}/CHANGELOG.md#${GITHUB_REF#refs/tags/} > ../release_notes.md
+      - run: |
+          VERSION="${GITHUB_REF#refs/tags/}"
+          CHANGELOG_BASE_URL="https://github.com/cometbft/cometbft/blob/${VERSION}/CHANGELOG.md"
+          VERSION_REF="${VERSION//[\.]/}"
+          CHANGELOG_URL="${CHANGELOG_BASE_URL}#${VERSION_REF}"
+          echo "See the [CHANGELOG](${CHANGELOG_URL}) for this release." > ../release_notes.md
 
       - name: Release
         uses: goreleaser/goreleaser-action@v4
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           version: latest
-          args: release --rm-dist --release-notes=../release_notes.md
+          args: release --clean --release-notes ../release_notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,8 @@ jobs:
         with:
           go-version: '1.18'
 
-      - run: |
+      - name: Generate release notes
+        run: |
           VERSION="${GITHUB_REF#refs/tags/}"
           VERSION_REF="${VERSION//[\.]/}"
           CHANGELOG_URL="https://github.com/cometbft/cometbft/blob/${VERSION}/CHANGELOG.md#${VERSION_REF}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,8 @@ jobs:
 
       - run: |
           VERSION="${GITHUB_REF#refs/tags/}"
-          CHANGELOG_BASE_URL="https://github.com/cometbft/cometbft/blob/${VERSION}/CHANGELOG.md"
           VERSION_REF="${VERSION//[\.]/}"
-          CHANGELOG_URL="${CHANGELOG_BASE_URL}#${VERSION_REF}"
+          CHANGELOG_URL="https://github.com/cometbft/cometbft/blob/${VERSION}/CHANGELOG.md#${VERSION_REF}"
           echo "See the [CHANGELOG](${CHANGELOG_URL}) for this release." > ../release_notes.md
 
       - name: Release

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,7 +26,7 @@ checksum:
 
 release:
   prerelease: auto
-  name_template: "{{.Version}}"
+  name_template: "v{{.Version}}"
 
 archives:
   - files:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@
   ([\#136](https://github.com/cometbft/cometbft/issues/136))
 - Append the commit hash to the version of CometBFT being built
   ([\#204](https://github.com/cometbft/cometbft/pull/204))
+- `[mempool/v1]` Suppress "rejected bad transaction" in priority mempool logs by
+  reducing log level from info to debug
+  ([\#314](https://github.com/cometbft/cometbft/pull/314): @JayT106)
 - `[consensus]` Add `consensus_block_gossip_parts_received` and
   `consensus_step_duration_seconds` metrics in order to aid in investigating the
   impact of database compaction on consensus performance

--- a/version/version.go
+++ b/version/version.go
@@ -3,7 +3,7 @@ package version
 const (
 	// TMCoreSemVer is the used as the fallback version of CometBFT Core
 	// when not using git describe. It is formatted with semantic versioning.
-	TMCoreSemVer = "0.34.27"
+	TMCoreSemVer = "0.34.27-alpha.1"
 	// ABCISemVer is the semantic version of the ABCI library
 	ABCISemVer = "0.17.0"
 
@@ -20,8 +20,6 @@ var (
 	BlockProtocol uint64 = 11
 )
 
-var (
-	// TMGitCommitHash uses git rev-parse HEAD to find commit hash which is helpful
-	// for the engineering team when working with the cometbft binary. See Makefile
-	TMGitCommitHash = ""
-)
+// TMGitCommitHash uses git rev-parse HEAD to find commit hash which is helpful
+// for the engineering team when working with the cometbft binary. See Makefile
+var TMGitCommitHash = ""


### PR DESCRIPTION
We're cutting an alpha of v0.34.27 in order to help facilitate integration with this release series.

Once we have confirmed that our QA is done, we will cut v0.34.27.

Also includes some of the changes from #317 in order to slightly improve the pre-release/release processes.

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

