### PR TITLE
ci: Update release and pre-release workflows and process

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -20,7 +20,8 @@ jobs:
         with:
           go-version: '1.18'
 
-      - run: |
+      - name: Generate release notes
+        run: |
           VERSION="${GITHUB_REF#refs/tags/}"
           CHANGELOG_URL="https://github.com/cometbft/cometbft/blob/${VERSION}/CHANGELOG.md"
           echo "See the [CHANGELOG](${CHANGELOG_URL}) for changes available in this pre-release, but not yet officially released." > ../release_notes.md

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -27,8 +27,10 @@ jobs:
           version: latest
           args: build --skip-validate   # skip validate skips initial sanity checks in order to be able to fully run
 
-      # Link to CHANGELOG_PENDING.md as release notes.
-      - run: echo https://github.com/cometbft/cometbft/blob/${GITHUB_REF#refs/tags/}/CHANGELOG_PENDING.md > ../release_notes.md
+      # Link to CHANGELOG.md as release notes (ensure that changelog is built
+      # with unreleased entries prior to cutting a pre-release)
+      - run: |
+          echo ":book: [CHANGELOG](https://github.com/cometbft/cometbft/blob/${GITHUB_REF#refs/tags/}/CHANGELOG.md)" > ../release_notes.md
 
       - name: Release
         uses: goreleaser/goreleaser-action@v4

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -20,24 +20,16 @@ jobs:
         with:
           go-version: '1.18'
 
-      - name: Build
-        uses: goreleaser/goreleaser-action@v4
-        if: ${{ github.event_name == 'pull_request' }}
-        with:
-          version: latest
-          args: build --skip-validate   # skip validate skips initial sanity checks in order to be able to fully run
-
-      # Link to CHANGELOG.md as release notes (ensure that changelog is built
-      # with unreleased entries prior to cutting a pre-release)
       - run: |
-          echo ":book: [CHANGELOG](https://github.com/cometbft/cometbft/blob/${GITHUB_REF#refs/tags/}/CHANGELOG.md)" > ../release_notes.md
+          VERSION="${GITHUB_REF#refs/tags/}"
+          CHANGELOG_URL="https://github.com/cometbft/cometbft/blob/${VERSION}/CHANGELOG.md"
+          echo "See the [CHANGELOG](${CHANGELOG_URL}) for unreleased changes in this pre-release." > ../release_notes.md
 
       - name: Release
         uses: goreleaser/goreleaser-action@v4
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           version: latest
-          args: release --rm-dist --release-notes=../release_notes.md
+          args: release --clean --release-notes ../release_notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -23,7 +23,7 @@ jobs:
       - run: |
           VERSION="${GITHUB_REF#refs/tags/}"
           CHANGELOG_URL="https://github.com/cometbft/cometbft/blob/${VERSION}/CHANGELOG.md"
-          echo "See the [CHANGELOG](${CHANGELOG_URL}) for unreleased changes in this pre-release." > ../release_notes.md
+          echo "See the [CHANGELOG](${CHANGELOG_URL}) for changes available in this pre-release, but not yet officially released." > ../release_notes.md
 
       - name: Release
         uses: goreleaser/goreleaser-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,21 +18,18 @@ jobs:
         with:
           go-version: '1.18'
 
-      - name: Build
-        uses: goreleaser/goreleaser-action@v4
-        if: ${{ github.event_name == 'pull_request' }}
-        with:
-          version: latest
-          args: build --skip-validate   # skip validate skips initial sanity checks in order to be able to fully run
-
-      - run: echo https://github.com/cometbft/cometbft/blob/${GITHUB_REF#refs/tags/}/CHANGELOG.md#${GITHUB_REF#refs/tags/} > ../release_notes.md
+      - run: |
+          VERSION="${GITHUB_REF#refs/tags/}"
+          CHANGELOG_BASE_URL="https://github.com/cometbft/cometbft/blob/${VERSION}/CHANGELOG.md"
+          VERSION_REF="${VERSION//[\.]/}"
+          CHANGELOG_URL="${CHANGELOG_BASE_URL}#${VERSION_REF}"
+          echo "See the [CHANGELOG](${CHANGELOG_URL}) for this release." > ../release_notes.md
 
       - name: Release
         uses: goreleaser/goreleaser-action@v4
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           version: latest
-          args: release --rm-dist --release-notes=../release_notes.md
+          args: release --clean --release-notes ../release_notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,8 @@ jobs:
         with:
           go-version: '1.18'
 
-      - run: |
+      - name: Generate release notes
+        run: |
           VERSION="${GITHUB_REF#refs/tags/}"
           VERSION_REF="${VERSION//[\.]/}"
           CHANGELOG_URL="https://github.com/cometbft/cometbft/blob/${VERSION}/CHANGELOG.md#${VERSION_REF}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,8 @@ jobs:
 
       - run: |
           VERSION="${GITHUB_REF#refs/tags/}"
-          CHANGELOG_BASE_URL="https://github.com/cometbft/cometbft/blob/${VERSION}/CHANGELOG.md"
           VERSION_REF="${VERSION//[\.]/}"
-          CHANGELOG_URL="${CHANGELOG_BASE_URL}#${VERSION_REF}"
+          CHANGELOG_URL="https://github.com/cometbft/cometbft/blob/${VERSION}/CHANGELOG.md#${VERSION_REF}"
           echo "See the [CHANGELOG](${CHANGELOG_URL}) for this release." > ../release_notes.md
 
       - name: Release

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,7 +26,7 @@ checksum:
 
 release:
   prerelease: auto
-  name_template: "{{.Version}}"
+  name_template: "v{{.Version}}"
 
 archives:
   - files:

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -150,11 +150,13 @@ backport branch (see above). Otherwise:
    (which can be triggered from the GitHub UI;
    e.g., <https://github.com/cometbft/cometbft/actions/workflows/e2e-nightly-37x.yml>).
 3. Prepare the pre-release documentation:
-   * Ensure that all relevant changes are in the `CHANGELOG_PENDING.md` file.
-     This file's contents must only be included in the `CHANGELOG.md` when we
-     cut final releases.
-   * Ensure that `UPGRADING.md` is up-to-date and includes notes on any breaking changes
-      or other upgrading flows.
+   * Build the changelog with [unclog] _without_ doing an unclog release, and
+     commit the built changelog. This ensures that all changelog entries appear
+     under an "Unreleased" heading in the pre-release's changelog. The changes
+     are only considered officially "released" once we cut a regular (final)
+     release.
+   * Ensure that `UPGRADING.md` is up-to-date and includes notes on any breaking
+     changes or other upgrading flows.
 4. Prepare the versioning:
    * Bump TMVersionDefault version in  `version.go`
    * Bump P2P and block protocol versions in  `version.go`, if necessary.
@@ -181,13 +183,10 @@ Before performing these steps, be sure the
 1. Start on the backport branch (e.g. `v0.38.x`)
 2. Run integration tests (`make test_integrations`) and the e2e nightlies.
 3. Prepare the release:
-   * "Squash" changes from the changelog entries for the pre-releases into a
-     single entry, and add all changes included in `CHANGELOG_PENDING.md`.
-     (Squashing includes both combining all entries, as well as removing or
-     simplifying any intra-pre-release changes. It may also help to alphabetize
-     the entries by package name.)
-   * Run `python ./scripts/linkify_changelog.py CHANGELOG.md` to add links for
-     all PRs
+   * Do a [release][unclog-release] with [unclog] for the desired version,
+     ensuring that you write up a good summary of the major highlights of the
+     release that users would be interested in.
+   * Build the changelog using unclog, and commit the built changelog.
    * Ensure that `UPGRADING.md` is up-to-date and includes notes on any breaking changes
       or other upgrading flows.
    * Bump TMVersionDefault version in  `version.go`
@@ -214,14 +213,10 @@ To create a patch release:
 1. Checkout the long-lived backport branch: `git checkout v0.38.x`
 2. Run integration tests (`make test_integrations`) and the nightlies.
 3. Check out a new branch and prepare the release:
-   * Copy `CHANGELOG_PENDING.md` to top of `CHANGELOG.md`
-   * Run `python ./scripts/linkify_changelog.py CHANGELOG.md` to add links for
-     all issues
-   * Run `bash ./scripts/authors.sh` to get a list of authors since the latest
-     release, and add the GitHub aliases of external contributors to the top of
-     the CHANGELOG. To lookup an alias from an email, try `bash
-     ./scripts/authors.sh <email>`
-   * Reset the `CHANGELOG_PENDING.md`
+   * Do a [release][unclog-release] with [unclog] for the desired version,
+     ensuring that you write up a good summary of the major highlights of the
+     release that users would be interested in.
+   * Build the changelog using unclog, and commit the built changelog.
    * Bump the TMDefaultVersion in `version.go`
    * Bump the ABCI version number, if necessary. (Note that ABCI follows semver,
      and that ABCI versions are the only versions which can change during patch
@@ -362,3 +357,6 @@ of 150 validators is configured to only possess a cumulative stake of 67% of
 the total stake. The remaining 33% of the stake is configured to belong to
 a validator that is never actually run in the test network. The network is run
 for multiple days, ensuring that it is able to produce blocks without issue.
+
+[unclog]: https://github.com/informalsystems/unclog
+[unclog-release]: https://github.com/informalsystems/unclog#releasing-a-new-versions-change-set


### PR DESCRIPTION
This updates the release and pre-release workflows to simplify, fix and clarify them. It also updates the `RELEASES.md` file to refer to unclog when building the changelog.

Needs to be backported to v0.37.x, since I'm updating this for the v0.34.x branch in #316.

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

