### PR TITLE
docs: Update issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us squash bugs!
-
+labels: bug, needs-triage
 ---
 <!--
 
@@ -15,8 +15,13 @@ ask you to provide additional logs and data (CometBFT & App).
 
 -->
 
+## Bug Report
+
+### Setup
+
 **CometBFT version** (use `cometbft version` or `git rev-parse --verify HEAD` if installed from source):
 
+**Have you tried the latest version**: yes/no
 
 **ABCI app** (name for built-in, URL for self-written if it's publicly available):
 
@@ -25,23 +30,54 @@ ask you to provide additional logs and data (CometBFT & App).
 - **Install tools**:
 - **Others**:
 
-
-**What happened**:
-
-
-**What you expected to happen**:
-
-
-**Have you tried the latest version**: yes/no
-
-**How to reproduce it** (as minimally and precisely as possible):
-
-**Logs (paste a small part showing an error (< 10 lines) or link a pastebin, gist, etc. containing more of the log file)**:
-
-**Config (you can paste only the changes you've made)**:
-
 **node command runtime flags**:
 
-**Please provide the output from the `http://<ip>:<port>/dump_consensus_state` RPC endpoint for consensus bugs**
+### Config
 
-**Anything else we need to know**:
+<!--
+
+You can paste only the changes you've made.
+
+-->
+
+### What happened?
+
+### What did you expect to happen?
+
+### How to reproduce it
+
+<!--
+
+Provide a description here as minimally and precisely as possible as to how to
+reproduce the issue. Ideally only using our kvstore application, as debugging
+app chains is not within our team's scope.
+
+-->
+
+### Logs
+
+<!--
+
+Paste a small part showing an error (< 10 lines) or link a pastebin, gist, etc.
+containing more of the log file).
+
+-->
+
+### `dump_consensus_state` output
+
+<!--
+
+Please provide the output from the `http://<ip>:<port>/dump_consensus_state` RPC
+endpoint for consensus bugs.
+
+-->
+
+### Anything else we need to know
+
+<!--
+
+Is there any additional information not covered by the other sections that would
+help us to triage/debug/fix this issue?
+
+-->
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,6 @@ contact_links:
   - name: Ask a question
     url: https://github.com/cometbft/cometbft/discussions
     about: Please ask and answer questions here
+  - name: Security Bug Bounty
+    url: https://hackerone.com/cosmos
+    about: Please report security vulnerabilities here

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Create a proposal to request a feature
-
+labels: enhancement, needs-triage
 ---
 
 <!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
@@ -11,17 +11,19 @@ v    Word of caution: poorly thought-out proposals may be rejected
 v                     without deliberation 
 ☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->
 
-## Summary
+## Feature Request
+
+### Summary
 
 <!-- Short, concise description of the proposed feature -->
 
-## Problem Definition
+### Problem Definition
 
-<!-- Why do we need this feature? 
+<!-- Why do we need this feature?
 What problems may be addressed by introducing this feature?
 What benefits does CometBFT stand to gain by including this feature?
 Are there any disadvantages of including this feature? -->
 
-## Proposal
+### Proposal
 
 <!-- Detailed description of requirements of implementation -->

--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -1,7 +1,7 @@
 ---
 name: Protocol change proposal
 about: Create a proposal to request a change to the protocol
-
+labels: protocol-change, needs-triage
 ---
 
 <!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
@@ -10,19 +10,19 @@ v    Before smashing the submit button please review the template.
 v    Word of caution: Under-specified proposals may be rejected summarily 
 ☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->
 
-# Protocol Change Proposal
+## Protocol Change Proposal
 
-## Summary
+### Summary
 
 <!-- Short, concise description of the proposed change -->
 
-## Problem Definition
+### Problem Definition
 
-<!-- Why do we need this change? 
+<!-- Why do we need this change?
 What problems may be addressed by introducing this change?
 What benefits does CometBFT stand to gain by including this change?
 Are there any disadvantages of including this change? -->
 
-## Proposal
+### Proposal
 
 <!-- Detailed description of requirements of implementation -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,8 +25,8 @@ https://github.com/orgs/cometbft/projects/1
 
 #### PR checklist
 
-- [ ] Tests written/updated, or no tests needed
-- [ ] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
-- [ ] Updated relevant documentation (`docs/`) and code comments, or no
-      documentation updates needed
+- [ ] Tests written/updated
+- [ ] Changelog entry added in `.changelog` (we use
+  [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
+- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
 


### PR DESCRIPTION
This does a few things:

1. Automatically applies relevant labels on new issues/PRs as users submit them.
2. Cleans up and syncs the structure of all of the issue templates.
3. Clearly adds a link, when submitting an issue, to our HackerOne bug bounty program, so folks know where to submit security vulnerabilities.
4. Updates the PR template to remind folks to use `unclog` format when submitting changelog entries.

---

#### PR checklist

- [x] Tests written/updated, or no tests needed
- [x] `CHANGELOG_PENDING.md` updated, or no changelog entry needed
- [x] Updated relevant documentation (`docs/`) and code comments, or no
      documentation updates needed

