### PR TITLE
Allow inclusion of repository in the tag name, so ghcr and dockerub ...

### DIFF
--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -31,6 +31,7 @@ var (
 	nodeVersions = weightedChoice{
 		"": 2,
 	}
+
 	// The following specify randomly chosen values for testnet nodes.
 	nodeDatabases = uniformChoice{"goleveldb", "cleveldb", "rocksdb", "boltdb", "badgerdb"}
 	ipv6          = uniformChoice{false, true}
@@ -69,15 +70,20 @@ type generateConfig struct {
 
 // Generate generates random testnets using the given RNG.
 func Generate(cfg *generateConfig) ([]e2e.Manifest, error) {
+	upgradeVersion := ""
+
 	if cfg.multiVersion != "" {
 		var err error
-		nodeVersions, err = parseWeightedVersions(cfg.multiVersion)
+		nodeVersions, upgradeVersion, err = parseWeightedVersions(cfg.multiVersion)
 		if err != nil {
 			return nil, err
 		}
 		if _, ok := nodeVersions["local"]; ok {
 			nodeVersions[""] = nodeVersions["local"]
 			delete(nodeVersions, "local")
+			if upgradeVersion == "local" {
+				upgradeVersion = ""
+			}
 		}
 		if _, ok := nodeVersions["latest"]; ok {
 			latestVersion, err := gitRepoLatestReleaseVersion(cfg.outputDir)
@@ -86,6 +92,9 @@ func Generate(cfg *generateConfig) ([]e2e.Manifest, error) {
 			}
 			nodeVersions[latestVersion] = nodeVersions["latest"]
 			delete(nodeVersions, "latest")
+			if upgradeVersion == "latest" {
+				upgradeVersion = latestVersion
+			}
 		}
 	}
 	fmt.Println("Generating testnet with weighted versions:")
@@ -98,7 +107,7 @@ func Generate(cfg *generateConfig) ([]e2e.Manifest, error) {
 	}
 	manifests := []e2e.Manifest{}
 	for _, opt := range combinations(testnetCombinations) {
-		manifest, err := generateTestnet(cfg.randSource, opt)
+		manifest, err := generateTestnet(cfg.randSource, opt, upgradeVersion)
 		if err != nil {
 			return nil, err
 		}
@@ -108,7 +117,7 @@ func Generate(cfg *generateConfig) ([]e2e.Manifest, error) {
 }
 
 // generateTestnet generates a single testnet with the given options.
-func generateTestnet(r *rand.Rand, opt map[string]interface{}) (e2e.Manifest, error) {
+func generateTestnet(r *rand.Rand, opt map[string]interface{}, upgradeVersion string) (e2e.Manifest, error) {
 	manifest := e2e.Manifest{
 		IPv6:             ipv6.Choose(r).(bool),
 		ABCIProtocol:     nodeABCIProtocols.Choose(r).(string),
@@ -118,6 +127,7 @@ func generateTestnet(r *rand.Rand, opt map[string]interface{}) (e2e.Manifest, er
 		ValidatorUpdates: map[string]map[string]int64{},
 		Evidence:         evidence.Choose(r).(int),
 		Nodes:            map[string]*e2e.ManifestNode{},
+		UpgradeVersion:   upgradeVersion,
 	}
 
 	switch abciDelays.Choose(r).(string) {
@@ -324,25 +334,37 @@ func ptrUint64(i uint64) *uint64 {
 
 // Parses strings like "v0.34.21:1,v0.34.22:2" to represent two versions
 // ("v0.34.21" and "v0.34.22") with weights of 1 and 2 respectively.
-func parseWeightedVersions(s string) (weightedChoice, error) {
+// Versions may be specified as cometbft/e2e-node:v0.34.27-alpha.1:1 or
+// ghcr.io/informalsystems/tendermint:v0.34.26:1.
+// If only the tag and weight are specified, cometbft/e2e-node is assumed.
+// Also returns the last version in the list, which will be used for updates.
+func parseWeightedVersions(s string) (weightedChoice, string, error) {
 	wc := make(weightedChoice)
+	lv := ""
 	wvs := strings.Split(strings.TrimSpace(s), ",")
 	for _, wv := range wvs {
 		parts := strings.Split(strings.TrimSpace(wv), ":")
-		if len(parts) != 2 {
-			return nil, fmt.Errorf("unexpected weight:version combination: %s", wv)
+		var ver string
+		if len(parts) == 2 {
+			ver = strings.TrimSpace(strings.Join([]string{"cometbft/e2e-node", parts[0]}, ":"))
+		} else if len(parts) == 3 {
+			ver = strings.TrimSpace(strings.Join([]string{parts[0], parts[1]}, ":"))
+		} else {
+			return nil, "", fmt.Errorf("unexpected weight:version combination: %s", wv)
 		}
-		ver := strings.TrimSpace(parts[0])
-		wt, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+
+		wt, err := strconv.Atoi(strings.TrimSpace(parts[len(parts)-1]))
 		if err != nil {
-			return nil, fmt.Errorf("unexpected weight \"%s\": %w", parts[1], err)
+			return nil, "", fmt.Errorf("unexpected weight \"%s\": %w", parts[1], err)
 		}
+
 		if wt < 1 {
-			return nil, errors.New("version weights must be >= 1")
+			return nil, "", errors.New("version weights must be >= 1")
 		}
 		wc[ver] = uint(wt)
+		lv = ver
 	}
-	return wc, nil
+	return wc, lv, nil
 }
 
 // Extracts the latest release version from the given Git repository. Uses the

--- a/test/e2e/generator/main.go
+++ b/test/e2e/generator/main.go
@@ -31,7 +31,7 @@ type CLI struct {
 func NewCLI() *CLI {
 	cli := &CLI{}
 	cli.root = &cobra.Command{
-		Use:           "generator",
+		Use:           "generator -d dir [-g int] [-m version_weight_csv]",
 		Short:         "End-to-end testnet generator",
 		SilenceUsage:  true,
 		SilenceErrors: true, // we'll output them ourselves in Run()

--- a/test/e2e/pkg/infra/docker/docker.go
+++ b/test/e2e/pkg/infra/docker/docker.go
@@ -57,7 +57,7 @@ services:
     labels:
       e2e: true
     container_name: {{ .Name }}
-    image: cometbft/e2e-node:{{ .Version }}
+    image: {{ .Version }}
 {{- if or (eq .ABCIProtocol "builtin") (eq .ABCIProtocol "builtin_unsync") }}
     entrypoint: /usr/bin/entrypoint-builtin
 {{- end }}
@@ -72,13 +72,13 @@ services:
     networks:
       {{ $.Name }}:
         ipv{{ if $.IPv6 }}6{{ else }}4{{ end}}_address: {{ .IP }}
-{{- if ne .Version  $.UpgradeVersion}}
+{{- if ne .Version $.UpgradeVersion}}
 
   {{ .Name }}_u:
     labels:
       e2e: true
     container_name: {{ .Name }}_u
-    image: cometbft/e2e-node:{{ $.UpgradeVersion }}
+    image: {{ $.UpgradeVersion }}
 {{- if or (eq .ABCIProtocol "builtin") (eq .ABCIProtocol "builtin_unsync") }}
     entrypoint: /usr/bin/entrypoint-builtin
 {{- end }}

--- a/test/e2e/pkg/manifest.go
+++ b/test/e2e/pkg/manifest.go
@@ -75,7 +75,7 @@ type Manifest struct {
 	CheckTxDelay         time.Duration `toml:"check_tx_delay"`
 	// TODO: add vote extension and finalize block delay (@cmwaters)
 
-	// UpgradeVersion specifies to which version nodes need to upgrade to.
+	// UpgradeVersion specifies to which version nodes need to upgrade.
 	// Currently only uncoordinated upgrade is supported
 	UpgradeVersion string `toml:"upgrade_version"`
 

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -26,7 +26,7 @@ const (
 	defaultConnections = 1
 	defaultTxSizeBytes = 1024
 
-	localVersion = "local-version"
+	localVersion = "cometbft/e2e-node:local-version"
 )
 
 type (
@@ -182,6 +182,7 @@ func LoadTestnet(manifest Manifest, fname string, ifd InfrastructureData) (*Test
 		if v == "" {
 			v = localVersion
 		}
+
 		node := &Node{
 			Name:             name,
 			Version:          v,


### PR DESCRIPTION
can be used, inclusively in the same experiment.

This is a forward port of (#345)

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments

