### PR TITLE
Mark priority mempool config fields as deprecated

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -159,6 +159,12 @@ func (cfg *Config) CheckDeprecated() []string {
 	if cfg.Mempool.Version == MempoolV1 {
 		warnings = append(warnings, "prioritized mempool detected. This version of the mempool will be removed in the next major release.")
 	}
+	if cfg.Mempool.TTLNumBlocks != 0 {
+		warnings = append(warnings, "prioritized mempool key detected. This key, together with this version of the mempool, will be removed in the next major release.")
+	}
+	if cfg.Mempool.TTLDuration != 0 {
+		warnings = append(warnings, "prioritized mempool key detected. This key, together with this version of the mempool, will be removed in the next major release.")
+	}
 	if cfg.DeprecatedFastSyncConfig != nil {
 		warnings = append(warnings, "[fastsync] table detected. This section has been renamed to [blocksync]. The values in this deprecated section will be disregarded.")
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -757,7 +757,8 @@ type MempoolConfig struct {
 	// has existed in the mempool at least TTLNumBlocks number of blocks or if it's
 	// insertion time into the mempool is beyond TTLDuration.
 	//
-	// Deprecated: Only used by priority mempool, which will be removed in the next major release.
+	// Deprecated: Only used by priority mempool, which will be removed in the
+	// next major release.
 	TTLDuration time.Duration `mapstructure:"ttl-duration"`
 
 	// TTLNumBlocks, if non-zero, defines the maximum number of blocks a transaction
@@ -767,7 +768,8 @@ type MempoolConfig struct {
 	// has existed in the mempool at least TTLNumBlocks number of blocks or if
 	// it's insertion time into the mempool is beyond TTLDuration.
 	//
-	// Deprecated: Only used by priority mempool, which will be removed in the next major release.
+	// Deprecated: Only used by priority mempool, which will be removed in the
+	// next major release.
 	TTLNumBlocks int64 `mapstructure:"ttl-num-blocks"`
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -756,6 +756,8 @@ type MempoolConfig struct {
 	// Note, if TTLNumBlocks is also defined, a transaction will be removed if it
 	// has existed in the mempool at least TTLNumBlocks number of blocks or if it's
 	// insertion time into the mempool is beyond TTLDuration.
+	//
+	// Deprecated: Only used by priority mempool, which will be removed in the next major release.
 	TTLDuration time.Duration `mapstructure:"ttl-duration"`
 
 	// TTLNumBlocks, if non-zero, defines the maximum number of blocks a transaction
@@ -764,6 +766,8 @@ type MempoolConfig struct {
 	// Note, if TTLDuration is also defined, a transaction will be removed if it
 	// has existed in the mempool at least TTLNumBlocks number of blocks or if
 	// it's insertion time into the mempool is beyond TTLDuration.
+	//
+	// Deprecated: Only used by priority mempool, which will be removed in the next major release.
 	TTLNumBlocks int64 `mapstructure:"ttl-num-blocks"`
 }
 

--- a/mempool/v1/mempool.go
+++ b/mempool/v1/mempool.go
@@ -728,7 +728,7 @@ func (txmp *TxMempool) canAddTx(wtx *WrappedTx) error {
 //
 // The caller must hold txmp.mtx exclusively.
 func (txmp *TxMempool) purgeExpiredTxs(blockHeight int64) {
-	if txmp.config.TTLNumBlocks == 0 && txmp.config.TTLDuration == 0 {
+	if txmp.config.TTLNumBlocks == 0 && txmp.config.TTLDuration == 0 { //nolint:staticcheck // SA1019 Priority mempool deprecated but still supported in this release.
 		return // nothing to do
 	}
 
@@ -740,11 +740,11 @@ func (txmp *TxMempool) purgeExpiredTxs(blockHeight int64) {
 		next := cur.Next()
 
 		w := cur.Value.(*WrappedTx)
-		if txmp.config.TTLNumBlocks > 0 && (blockHeight-w.height) > txmp.config.TTLNumBlocks {
+		if txmp.config.TTLNumBlocks > 0 && (blockHeight-w.height) > txmp.config.TTLNumBlocks { //nolint:staticcheck // SA1019 Priority mempool deprecated but still supported in this release.
 			txmp.removeTxByElement(cur)
 			txmp.cache.Remove(w.tx)
 			txmp.metrics.EvictedTxs.Add(1)
-		} else if txmp.config.TTLDuration > 0 && now.Sub(w.timestamp) > txmp.config.TTLDuration {
+		} else if txmp.config.TTLDuration > 0 && now.Sub(w.timestamp) > txmp.config.TTLDuration { //nolint:staticcheck // SA1019 Priority mempool deprecated but still supported in this release.
 			txmp.removeTxByElement(cur)
 			txmp.cache.Remove(w.tx)
 			txmp.metrics.EvictedTxs.Add(1)

--- a/mempool/v1/mempool_test.go
+++ b/mempool/v1/mempool_test.go
@@ -521,7 +521,7 @@ func TestTxMempool_ConcurrentTxs(t *testing.T) {
 
 func TestTxMempool_ExpiredTxs_Timestamp(t *testing.T) {
 	txmp := setup(t, 5000)
-	txmp.config.TTLDuration = 5 * time.Millisecond
+	txmp.config.TTLDuration = 5 * time.Millisecond //nolint:staticcheck // SA1019 Priority mempool deprecated but still supported in this release.
 
 	added1 := checkTxs(t, txmp, 10, 0)
 	require.Equal(t, len(added1), txmp.Size())
@@ -570,7 +570,7 @@ func TestTxMempool_ExpiredTxs_Timestamp(t *testing.T) {
 func TestTxMempool_ExpiredTxs_NumBlocks(t *testing.T) {
 	txmp := setup(t, 500)
 	txmp.height = 100
-	txmp.config.TTLNumBlocks = 10
+	txmp.config.TTLNumBlocks = 10 //nolint:staticcheck // SA1019 Priority mempool deprecated but still supported in this release.
 
 	tTxs := checkTxs(t, txmp, 100, 0)
 	require.Equal(t, len(tTxs), txmp.Size())


### PR DESCRIPTION
The priority mempool was marked as deprecated for v0.37.x in #259. The mempool config fields `TTLDuration` and `TTLNumBlocks` are only used by the priority mempool and will be deleted in v0.38.x, but we forgot to marked them as deprecated. This PR fixes it.