### PR TITLE
Release v0.37.0-alpha.3

### DIFF
--- a/.changelog/unreleased/breaking-changes/230-p2p-peer-msg-type-and-metric.md
+++ b/.changelog/unreleased/breaking-changes/230-p2p-peer-msg-type-and-metric.md
@@ -1,4 +1,4 @@
-- `[p2p]` Reactor `Send`, `TrySend` and `Receive` renamed to `EnvelopeSend` to
-  allow a metric to be appended to the message and measure bytes sent/received
-  by message type.
+- - `[p2p]` Reactor `Send`, `TrySend` and `Receive` renamed to `SendEnvelope`,
+  `TrySendEnvelope` and `ReceiveEnvelope` to allow metrics to be appended to
+  messages and measure bytes sent/received.
   ([\#230](https://github.com/cometbft/cometbft/pull/230))

--- a/.changelog/unreleased/bug-fixes/9500-p2p-prevent-adding-errored-peers.md
+++ b/.changelog/unreleased/bug-fixes/9500-p2p-prevent-adding-errored-peers.md
@@ -1,2 +1,2 @@
-- `[p2p]` prevent peers who have errored being added to the peer_set
+- `[p2p]` prevent peers who have errored from being added to `peer_set`
   ([\#9500](https://github.com/tendermint/tendermint/pull/9500))

--- a/.changelog/unreleased/improvements/230-p2p-peer-msg-type-and-metric.md
+++ b/.changelog/unreleased/improvements/230-p2p-peer-msg-type-and-metric.md
@@ -1,4 +1,4 @@
-- `[p2p]` Reactor `Send`, `TrySend` and `Receive` renamed to `EnvelopeSend` to
-  allow a metric to be appended to the message and measure bytes sent/received
-  by message type.
+- `[p2p]` Reactor `Send`, `TrySend` and `Receive` renamed to `SendEnvelope`,
+  `TrySendEnvelope` and `ReceiveEnvelope` to allow metrics to be appended to
+  messages and measure bytes sent/received.
   ([\#230](https://github.com/cometbft/cometbft/pull/230))

--- a/.changelog/unreleased/improvements/9171-cli-add-hard-flag.md
+++ b/.changelog/unreleased/improvements/9171-cli-add-hard-flag.md
@@ -1,4 +1,4 @@
 - `[cli]` add `--hard` flag to rollback command (and a boolean to the `RollbackState` method). This will rollback
    state and remove the last block. This command can be triggered multiple times. The application must also rollback
-   state to the same height. 
+   state to the same height.
   ([\#9171](https://github.com/tendermint/tendermint/pull/9171))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### BREAKING CHANGES
 
+- The `TMHOME` environment variable was renamed to `CMTHOME`, and all environment variables starting with `TM_` are instead prefixed with `CMT_`
+  ([\#211](https://github.com/cometbft/cometbft/issues/211))
+- `[p2p]` Reactor `Send`, `TrySend` and `Receive` renamed to `EnvelopeSend` to
+  allow a metric to be appended to the message and measure bytes sent/received
+  by message type.
+  ([\#230](https://github.com/cometbft/cometbft/pull/230))
 - `[abci]` Make length delimiter encoding consistent
   (`uint64`) between ABCI and P2P wire-level protocols
   ([\#5783](https://github.com/tendermint/tendermint/pull/5783))
@@ -46,6 +52,9 @@
 
 ### BUG FIXES
 
+- `[consensus]` Fixed a busy loop that happened when sending of a block part failed by sleeping in case of error.
+  ([\#4](https://github.com/informalsystems/tendermint/pull/4))
+- `[state/kvindexer]` \#77 Fixed the default behaviour of the kvindexer to index and query attributes by events in which they occur. In 0.34.25 this was mitigated by a separated RPC flag.  (@jmalicevic)
 - `[docker]` enable cross platform build using docker buildx
   ([\#9073](https://github.com/tendermint/tendermint/pull/9073))
 - `[consensus]` fix round number of `enterPropose`
@@ -53,6 +62,8 @@
   ([\#9229](https://github.com/tendermint/tendermint/pull/9229))
 - `[docker]` ensure Docker image uses consistent version of Go
   ([\#9462](https://github.com/tendermint/tendermint/pull/9462))
+- `[p2p]` prevent peers who have errored being added to the peer_set
+  ([\#9500](https://github.com/tendermint/tendermint/pull/9500))
 - `[blocksync]` handle the case when the sending
   queue is full: retry block request after a timeout
   ([\#9518](https://github.com/tendermint/tendermint/pull/9518))
@@ -65,15 +76,31 @@
 
 ### IMPROVEMENTS
 
+- `[e2e]` Add functionality for uncoordinated (minor) upgrades
+  ([\#56](https://github.com/tendermint/tendermint/pull/56))
+- `[tools/tm-signer-harness]` Remove the folder as it is unused
+  ([\#136](https://github.com/cometbft/cometbft/issues/136))
+- `[p2p]` Reactor `Send`, `TrySend` and `Receive` renamed to `EnvelopeSend` to
+  allow a metric to be appended to the message and measure bytes sent/received
+  by message type.
+  ([\#230](https://github.com/cometbft/cometbft/pull/230))
 - `[abci]` Added `AbciVersion` to `RequestInfo` allowing
   applications to check ABCI version when connecting to CometBFT.
   ([\#5706](https://github.com/tendermint/tendermint/pull/5706))
+- `[cli]` add `--hard` flag to rollback command (and a boolean to the `RollbackState` method). This will rollback
+   state and remove the last block. This command can be triggered multiple times. The application must also rollback
+   state to the same height.
+  ([\#9171](https://github.com/tendermint/tendermint/pull/9171))
 - `[crypto]` Update to use btcec v2 and the latest btcutil.
   ([\#9250](https://github.com/tendermint/tendermint/pull/9250))
 - `[rpc]` Added `header` and `header_by_hash` queries to the RPC client
   ([\#9276](https://github.com/tendermint/tendermint/pull/9276))
 - `[proto]` Migrate from `gogo/protobuf` to `cosmos/gogoproto`
   ([\#9356](https://github.com/tendermint/tendermint/pull/9356))
+- `[rpc]` Enable caching of RPC responses
+  ([\#9650](https://github.com/tendermint/tendermint/pull/9650))
+- `[consensus]` Save peer LastCommit correctly to achieve 50% reduction in gossiped precommits.
+  ([\#9760](https://github.com/tendermint/tendermint/pull/9760))
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@
 
 - The `TMHOME` environment variable was renamed to `CMTHOME`, and all environment variables starting with `TM_` are instead prefixed with `CMT_`
   ([\#211](https://github.com/cometbft/cometbft/issues/211))
-- `[p2p]` Reactor `Send`, `TrySend` and `Receive` renamed to `EnvelopeSend` to
-  allow a metric to be appended to the message and measure bytes sent/received
-  by message type.
+- - `[p2p]` Reactor `Send`, `TrySend` and `Receive` renamed to `SendEnvelope`,
+  `TrySendEnvelope` and `ReceiveEnvelope` to allow metrics to be appended to
+  messages and measure bytes sent/received.
   ([\#230](https://github.com/cometbft/cometbft/pull/230))
 - `[abci]` Make length delimiter encoding consistent
   (`uint64`) between ABCI and P2P wire-level protocols
@@ -62,7 +62,7 @@
   ([\#9229](https://github.com/tendermint/tendermint/pull/9229))
 - `[docker]` ensure Docker image uses consistent version of Go
   ([\#9462](https://github.com/tendermint/tendermint/pull/9462))
-- `[p2p]` prevent peers who have errored being added to the peer_set
+- `[p2p]` prevent peers who have errored from being added to `peer_set`
   ([\#9500](https://github.com/tendermint/tendermint/pull/9500))
 - `[blocksync]` handle the case when the sending
   queue is full: retry block request after a timeout
@@ -80,9 +80,9 @@
   ([\#56](https://github.com/tendermint/tendermint/pull/56))
 - `[tools/tm-signer-harness]` Remove the folder as it is unused
   ([\#136](https://github.com/cometbft/cometbft/issues/136))
-- `[p2p]` Reactor `Send`, `TrySend` and `Receive` renamed to `EnvelopeSend` to
-  allow a metric to be appended to the message and measure bytes sent/received
-  by message type.
+- `[p2p]` Reactor `Send`, `TrySend` and `Receive` renamed to `SendEnvelope`,
+  `TrySendEnvelope` and `ReceiveEnvelope` to allow metrics to be appended to
+  messages and measure bytes sent/received.
   ([\#230](https://github.com/cometbft/cometbft/pull/230))
 - `[abci]` Added `AbciVersion` to `RequestInfo` allowing
   applications to check ABCI version when connecting to CometBFT.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -196,7 +196,7 @@ Before performing these steps, be sure the
    * Ensure that `UPGRADING.md` is up-to-date and includes notes on any breaking changes
       or other upgrading flows.
    * Bump TMCoreSemVer version in `version.go`
-   * Bump P2P and block protocol versions in  `version.go`, if necessary
+   * Bump P2P and block protocol versions in `version.go`, if necessary
    * Bump ABCI protocol version in `version.go`, if necessary
 4. Open a PR with these changes against the backport branch.
 5. Once these changes are on the backport branch, push a tag with prepared release details.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -164,7 +164,7 @@ backport branch (see above). Otherwise:
    * Ensure that `UPGRADING.md` is up-to-date and includes notes on any breaking
      changes or other upgrading flows.
 4. Prepare the versioning:
-   * Bump TMVersionDefault version in  `version.go`
+   * Bump TMCoreSemVer version in `version.go`
    * Bump P2P and block protocol versions in  `version.go`, if necessary.
      Check the changelog for breaking changes in these components.
    * Bump ABCI protocol version in `version.go`, if necessary
@@ -195,7 +195,7 @@ Before performing these steps, be sure the
    * Build the changelog using unclog, and commit the built changelog.
    * Ensure that `UPGRADING.md` is up-to-date and includes notes on any breaking changes
       or other upgrading flows.
-   * Bump TMVersionDefault version in  `version.go`
+   * Bump TMCoreSemVer version in `version.go`
    * Bump P2P and block protocol versions in  `version.go`, if necessary
    * Bump ABCI protocol version in `version.go`, if necessary
 4. Open a PR with these changes against the backport branch.

--- a/version/version.go
+++ b/version/version.go
@@ -5,7 +5,7 @@ const (
 	// The default version of TMCoreSemVer is the value used as the
 	// fallback version of CometBFT when not using git describe.
 	// It is formatted with semantic versioning.
-	TMCoreSemVer = "0.37.0-alpha.1"
+	TMCoreSemVer = "0.37.0-alpha.3"
 	// ABCISemVer is the semantic version of the ABCI protocol
 	ABCISemVer  = "1.0.0"
 	ABCIVersion = ABCISemVer


### PR DESCRIPTION
This PR is in preparation to cut pre-release `Release v0.37.0-alpha.3`.
* This is the version that will be used for the second iteration of QA on the `v0.37.0` branch. This QA iteration will be complementary to the one run in October 2022 (which was performed on Tendermint Core)
* As this is the first pre-release in the CometBFT `v0.37.x` branch, it can be used by other teams to integrate with it.

N.B.: Manually ran `e2e-nightly` on this branch [here](https://github.com/cometbft/cometbft/actions/runs/4228759518/jobs/7355172792).

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments

