### PR TITLE
Release v0.34.27-alpha.2

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -3,7 +3,7 @@ package version
 const (
 	// TMCoreSemVer is the used as the fallback version of CometBFT Core
 	// when not using git describe. It is formatted with semantic versioning.
-	TMCoreSemVer = "0.34.27-alpha.1"
+	TMCoreSemVer = "0.34.27-alpha.2"
 	// ABCISemVer is the semantic version of the ABCI library
 	ABCISemVer = "0.17.0"
 


### PR DESCRIPTION
Cutting an additional alpha release to facilitate integration with the SDK.
The go package name changes have been rolled back (#351).

N.B.: Manually ran e2e-nightly on this branch [here](https://github.com/cometbft/cometbft/actions/runs/4228794979/jobs/7354951621).

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments

