### PR TITLE
txindexer v0.34.x: Enable the indexer to parse slashes in query 

### DIFF
--- a/.changelog/unreleased/bug-fixes/383-txindexer-fix-slash-parsing.md
+++ b/.changelog/unreleased/bug-fixes/383-txindexer-fix-slash-parsing.md
@@ -1,1 +1,1 @@
-- `[state/kvindexer]` \#382 Resolved crashes when event values containted slashes, introduced after adding event sequences.  (@jmalicevic)
+- `[state/kvindexer]` \#382 Resolved crashes when event values contained slashes, introduced after adding event sequences.  (@jmalicevic)

--- a/.changelog/unreleased/bug-fixes/383-txindexer-fix-slash-parsing.md
+++ b/.changelog/unreleased/bug-fixes/383-txindexer-fix-slash-parsing.md
@@ -1,0 +1,1 @@
+- `[state/kvindexer]` \#382 Resolved crashes when event values containted slashes, introduced after adding event sequences.  (@jmalicevic)

--- a/state/txindex/kv/kv.go
+++ b/state/txindex/kv/kv.go
@@ -619,9 +619,10 @@ LOOP:
 // Keys
 
 func isTagKey(key []byte) bool {
-	// This should be always 4 if data is indexed together with event sequences
-	// The check for 3 was added to allow data indexed before (w/o the event number)
-	// to be retrieved.
+	// Normally, if the event was indexed with an event sequence, the number of
+	// tags should 4. Alternatively it should be 3 if the event was not indexed
+	// with the corresponding event sequence. However, some attribute values in
+	// production can contain the tag separator. Therefore, the condition is >= 3.
 	numTags := strings.Count(string(key), tagKeySeparator)
 	return numTags >= 3
 }

--- a/state/txindex/kv/kv.go
+++ b/state/txindex/kv/kv.go
@@ -19,7 +19,8 @@ import (
 )
 
 const (
-	tagKeySeparator = "/"
+	tagKeySeparator   = "/"
+	eventSeqSeparator = "$es$"
 )
 
 var _ txindex.TxIndexer = (*TxIndex)(nil)
@@ -622,45 +623,57 @@ func isTagKey(key []byte) bool {
 	// The check for 3 was added to allow data indexed before (w/o the event number)
 	// to be retrieved.
 	numTags := strings.Count(string(key), tagKeySeparator)
-	return numTags == 4 || numTags == 3
+	return numTags >= 3
 }
 
 func extractHeightFromKey(key []byte) (int64, error) {
 	parts := strings.SplitN(string(key), tagKeySeparator, -1)
-	return strconv.ParseInt(parts[2], 10, 64)
+	return strconv.ParseInt(parts[len(parts)-2], 10, 64)
 }
 func extractValueFromKey(key []byte) string {
-	parts := strings.SplitN(string(key), tagKeySeparator, -1)
-	return parts[1]
+	keyString := string(key)
+	parts := strings.SplitN(keyString, tagKeySeparator, -1)
+	partsLen := len(parts)
+	value := strings.TrimPrefix(keyString, parts[0]+tagKeySeparator)
+
+	suffix := ""
+	suffixLen := 2
+
+	for i := 1; i <= suffixLen; i++ {
+		suffix = tagKeySeparator + parts[partsLen-i] + suffix
+	}
+	return strings.TrimSuffix(value, suffix)
 }
 
 func extractEventSeqFromKey(key []byte) string {
 	parts := strings.SplitN(string(key), tagKeySeparator, -1)
 
-	if len(parts) == 5 {
-		return parts[4]
+	lastEl := parts[len(parts)-1]
+
+	if strings.Contains(lastEl, eventSeqSeparator) {
+		return strings.SplitN(lastEl, eventSeqSeparator, 2)[1]
 	}
 	return "0"
 }
 func keyForEvent(key string, value []byte, result *abci.TxResult, eventSeq int64) []byte {
-	return []byte(fmt.Sprintf("%s/%s/%d/%d/%d",
+	return []byte(fmt.Sprintf("%s/%s/%d/%d%s",
 		key,
 		value,
 		result.Height,
 		result.Index,
-		eventSeq,
+		eventSeqSeparator+strconv.FormatInt(eventSeq, 10),
 	))
 }
 
 func keyForHeight(result *abci.TxResult) []byte {
-	return []byte(fmt.Sprintf("%s/%d/%d/%d/%d",
+	return []byte(fmt.Sprintf("%s/%d/%d/%d%s",
 		types.TxHeightKey,
 		result.Height,
 		result.Height,
 		result.Index,
 		// Added to facilitate having the eventSeq in event keys
 		// Otherwise queries break expecting 5 entries
-		0,
+		eventSeqSeparator+"0",
 	))
 }
 

--- a/state/txindex/kv/kv_test.go
+++ b/state/txindex/kv/kv_test.go
@@ -71,6 +71,7 @@ func TestTxSearch(t *testing.T) {
 	txResult := txResultWithEvents([]abci.Event{
 		{Type: "account", Attributes: []abci.EventAttribute{{Key: []byte("number"), Value: []byte("1"), Index: true}}},
 		{Type: "account", Attributes: []abci.EventAttribute{{Key: []byte("owner"), Value: []byte("Ivan"), Index: true}}},
+		{Type: "account", Attributes: []abci.EventAttribute{{Key: []byte("owner"), Value: []byte("/Ivan/"), Index: true}, {Key: []byte("number"), Value: []byte("10"), Index: true}}},
 		{Type: "", Attributes: []abci.EventAttribute{{Key: []byte("not_allowed"), Value: []byte("Vlad"), Index: true}}},
 	})
 	hash := types.Tx(txResult.Tx).Hash()
@@ -82,7 +83,7 @@ func TestTxSearch(t *testing.T) {
 		q             string
 		resultsLength int
 	}{
-		// search by hash
+		//	search by hash
 		{fmt.Sprintf("tx.hash = '%X'", hash), 1},
 		// search by hash (lower)
 		{fmt.Sprintf("tx.hash = '%x'", hash), 1},
@@ -101,6 +102,16 @@ func TestTxSearch(t *testing.T) {
 		{"account.number < 10000 AND account.owner = 'Ivan'", 1},
 		// search using a prefix of the stored value
 		{"account.owner = 'Iv'", 0},
+		// search for owner with dash in name
+		{"account.owner = '/Ivan/'", 1},
+		// search for owner with dash in name and match events
+		{"match.events = 1 AND account.owner = '/Ivan/' AND account.number = 10", 1},
+		// search for owner with dash in name and match events with no match
+		{"match.events = 1 AND account.owner = '/Ivan/' AND account.number = 1", 0},
+		// search for owner with dash in name with CONTAINS
+		{"account.owner CONTAINS 'an'", 1},
+		// search for owner with dash in name with CONTAINS and match events
+		{"match.events = 1 AND account.owner CONTAINS 'an'", 1},
 		// search by range
 		{"account.number >= 1 AND account.number <= 5", 1},
 		// search by range and another key

--- a/state/txindex/kv/kv_test.go
+++ b/state/txindex/kv/kv_test.go
@@ -102,15 +102,15 @@ func TestTxSearch(t *testing.T) {
 		{"account.number < 10000 AND account.owner = 'Ivan'", 1},
 		// search using a prefix of the stored value
 		{"account.owner = 'Iv'", 0},
-		// search for owner with dash in name
+		// search for owner with slash in name
 		{"account.owner = '/Ivan/'", 1},
-		// search for owner with dash in name and match events
+		// search for owner with slash in name and match events
 		{"match.events = 1 AND account.owner = '/Ivan/' AND account.number = 10", 1},
-		// search for owner with dash in name and match events with no match
+		// search for owner with slash in name and match events with no match
 		{"match.events = 1 AND account.owner = '/Ivan/' AND account.number = 1", 0},
-		// search for owner with dash in name with CONTAINS
+		// search for owner with slash in name with CONTAINS
 		{"account.owner CONTAINS 'an'", 1},
-		// search for owner with dash in name with CONTAINS and match events
+		// search for owner with slash in name with CONTAINS and match events
 		{"match.events = 1 AND account.owner CONTAINS 'an'", 1},
 		// search by range
 		{"account.number >= 1 AND account.number <= 5", 1},


### PR DESCRIPTION
The transaction indexer indexes transaction events by creating a custom key containing the following: 
- event attribute key
- event attribute value
- txresult
- height
- event sequence

These elements are separated with a '/'. This however causes problems when the value (over which we have no control), contains a '/' . This PR fixes this by making sure to isolate the element containing the value.

The code was tested for backwards compatibility, making sure we can parse events indexed with older versions of Tendermint (without this fix). 

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

