### PR TITLE
ci: Fix manual E2E test on v0.34.x

### DIFF
--- a/.github/workflows/e2e-manual.yml
+++ b/.github/workflows/e2e-manual.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Generate testnets
         working-directory: test/e2e
         # When changing -g, also change the matrix groups above
-        run: ./generator-multiversion.sh -g 4 -d networks/nightly/
+        run: ./build/generator -g 4 -d networks/nightly
 
       - name: Run ${{ matrix.p2p }} p2p testnets
         working-directory: test/e2e


### PR DESCRIPTION
Trying to run the manual E2E tests on `v0.34.x` results in this: https://github.com/cometbft/cometbft/actions/runs/4285915271

This PR fixes that (as evidenced in https://github.com/cometbft/cometbft/actions/runs/4286035807). This also shows that our nightly E2Es work for the current `v0.34.x` branch, from which I'll be cutting v0.34.27 shortly.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

