### PR TITLE
docs: Bump Go version for v0.37.x in readme on main

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ looking for, see [our security policy](SECURITY.md).
 | CometBFT version | Requirement | Notes             |
 |------------------|-------------|-------------------|
 | v0.34.x          | Go version  | Go 1.19 or higher |
-| v0.37.x          | Go version  | Go 1.19 or higher |
+| v0.37.x          | Go version  | Go 1.20 or higher |
 | main             | Go version  | Go 1.20 or higher |
 
 ### Install


### PR DESCRIPTION
As of #419, we now use Go 1.20 on the `v0.37.x` branch.

This is already up-to-date on the `v0.37.x` branch itself: https://github.com/cometbft/cometbft/tree/v0.37.x#minimum-requirements

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

