### PR TITLE
(preliminarily) add long-running weekly e2e workflow

### DIFF
--- a/.github/workflows/e2e-long-main.yml
+++ b/.github/workflows/e2e-long-main.yml
@@ -1,0 +1,57 @@
+# Weekly run of the E2E testnet using the long-running manifest on main
+
+# !! Relevant changes to this file should be propagated to the e2e-nightly-<V>x
+# files for the supported backport branches, when appropriate, modulo version
+# markers.
+
+name: e2e-long-main
+on:
+  schedule:
+    - cron: '0 3 * * 4'
+
+jobs:
+  e2e-long-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.20'
+
+      - uses: actions/checkout@v3
+
+      - name: Build
+        working-directory: test/e2e
+        # Run make jobs in parallel, since we can't run steps in parallel.
+        run: make -j2 docker runner
+
+      - name: Run testnet
+        working-directory: test/e2e
+        run: ./run-multiple.sh networks/long.toml
+
+  e2e-long-fail:
+    needs: e2e-long-test
+    if: ${{ failure() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack on failure
+        uses: slackapi/slack-github-action@v1.23.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          BRANCH: ${{ github.ref_name }}
+          RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          COMMITS_URL: "${{ github.server_url }}/${{ github.repository }}/commits/${{ github.ref_name }}"
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":skull: Weekly long-run E2E tests for `${{ env.BRANCH }}` failed. See the <${{ env.RUN_URL }}|run details> and the <${{ env.COMMITS_URL }}|latest commits> possibly related to the failure."
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/e2e-long-main.yml
+++ b/.github/workflows/e2e-long-main.yml
@@ -6,6 +6,7 @@
 
 name: e2e-long-main
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 3 * * 4'
 


### PR DESCRIPTION
Contributes to #283

PR #375 introduces a new long-running manifest, used as part of the renaming-related QA for `v0.37.x`.
This adds a (preliminary) workflow to run this on `main` on a weekly basis (on Wed to Thu).

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

