### PR TITLE
ci: Add release version check

### DIFF
--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -1,9 +1,11 @@
 # Checks that, if we're working on a release branch and are about to cut a
 # release, we have set the version correctly.
+name: Check release version
+
 on:
   pull_request:
     branches:
-      - 'release/**'
+      - 'release/*'
 
 jobs:
   check-version:

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -1,0 +1,30 @@
+# Checks that, if we're working on a release branch and are about to cut a
+# release, we have set the version correctly.
+on:
+  pull_request:
+    branches:
+      - 'release/**'
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.20'
+
+      - name: Check version
+        run: |
+          # We strip the refs/heads/release/v prefix of the branch name.
+          BRANCH_VERSION=${GITHUB_REF#refs/heads/release/v}
+          # Get the version of the code, which has no "v" prefix.
+          CODE_VERSION=`go run ./cmd/cometbft/ version`
+          if [ "$BRANCH_VERSION" != "$CODE_VERSION" ]; then
+            echo "Branch version ${BRANCH_VERSION} does not match code version ${CODE_VERSION}"
+            echo ""
+            echo "Please either fix the release branch naming (which must have a 'release/v' prefix)"
+            echo "or the version of the software in version/version.go."
+            exit 1
+          fi


### PR DESCRIPTION
Since I forgot to update the version in `version/version.go` yesterday, I thought I'd cut another RC, this time introducing a workflow to check that the version has indeed been updated.

This workflow strips the `release/v` prefix from a release branch name to obtain the version number, and compares it to the version output by `go run ./cmd/cometbft/ version` (which should just output the version from `version/version.go`).

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

