### PR TITLE
e2e: fix Makefile to produce commit_hash for builtin

### DIFF
--- a/.changelog/unreleased/bug-fixes/430-e2e-builting-commit-hash.md
+++ b/.changelog/unreleased/bug-fixes/430-e2e-builting-commit-hash.md
@@ -1,0 +1,2 @@
+- `[e2e]` Fixed the Makefile logic so that builtin e2e nodes have a commit hash.
+  ([\#430](https://github.com/informalsystems/tendermint/pull/430))

--- a/.changelog/unreleased/bug-fixes/430-e2e-builting-commit-hash.md
+++ b/.changelog/unreleased/bug-fixes/430-e2e-builting-commit-hash.md
@@ -1,2 +1,0 @@
-- `[e2e]` Fixed the Makefile logic so that builtin e2e nodes have a commit hash.
-  ([\#430](https://github.com/informalsystems/tendermint/pull/430))

--- a/Makefile
+++ b/Makefile
@@ -1,51 +1,11 @@
+include common.mk
+
 PACKAGES=$(shell go list ./...)
 BUILDDIR?=$(CURDIR)/build
 OUTPUT?=$(BUILDDIR)/cometbft
 
-BUILD_TAGS?=cometbft
-
-COMMIT_HASH := $(shell git rev-parse --short HEAD)
-LD_FLAGS = -X github.com/cometbft/cometbft/version.TMGitCommitHash=$(COMMIT_HASH)
-BUILD_FLAGS = -mod=readonly -ldflags "$(LD_FLAGS)"
 HTTPS_GIT := https://github.com/cometbft/cometbft.git
 CGO_ENABLED ?= 0
-
-# handle nostrip
-ifeq (,$(findstring nostrip,$(COMETBFT_BUILD_OPTIONS)))
-  BUILD_FLAGS += -trimpath
-  LD_FLAGS += -s -w
-endif
-
-# handle race
-ifeq (race,$(findstring race,$(COMETBFT_BUILD_OPTIONS)))
-  CGO_ENABLED=1
-  BUILD_FLAGS += -race
-endif
-
-# handle cleveldb
-ifeq (cleveldb,$(findstring cleveldb,$(COMETBFT_BUILD_OPTIONS)))
-  CGO_ENABLED=1
-  BUILD_TAGS += cleveldb
-endif
-
-# handle badgerdb
-ifeq (badgerdb,$(findstring badgerdb,$(COMETBFT_BUILD_OPTIONS)))
-  BUILD_TAGS += badgerdb
-endif
-
-# handle rocksdb
-ifeq (rocksdb,$(findstring rocksdb,$(COMETBFT_BUILD_OPTIONS)))
-  CGO_ENABLED=1
-  BUILD_TAGS += rocksdb
-endif
-
-# handle boltdb
-ifeq (boltdb,$(findstring boltdb,$(COMETBFT_BUILD_OPTIONS)))
-  BUILD_TAGS += boltdb
-endif
-
-# allow users to pass additional flags via the conventional LDFLAGS variable
-LD_FLAGS += $(LDFLAGS)
 
 # Process Docker environment varible TARGETPLATFORM
 # in order to build binary with correspondent ARCH

--- a/common.mk
+++ b/common.mk
@@ -1,0 +1,43 @@
+# This contains Makefile logic that is common to several makefiles
+
+BUILD_TAGS ?= cometbft
+
+COMMIT_HASH := $(shell git rev-parse --short HEAD)
+LD_FLAGS = -X github.com/cometbft/cometbft/version.TMGitCommitHash=$(COMMIT_HASH)
+BUILD_FLAGS = -mod=readonly -ldflags "$(LD_FLAGS)"
+# allow users to pass additional flags via the conventional LDFLAGS variable
+LD_FLAGS += $(LDFLAGS)
+
+# handle nostrip
+ifeq (,$(findstring nostrip,$(COMETBFT_BUILD_OPTIONS)))
+  BUILD_FLAGS += -trimpath
+  LD_FLAGS += -s -w
+endif
+
+# handle race
+ifeq (race,$(findstring race,$(COMETBFT_BUILD_OPTIONS)))
+  CGO_ENABLED=1
+  BUILD_FLAGS += -race
+endif
+
+# handle cleveldb
+ifeq (cleveldb,$(findstring cleveldb,$(COMETBFT_BUILD_OPTIONS)))
+  CGO_ENABLED=1
+  BUILD_TAGS += cleveldb
+endif
+
+# handle badgerdb
+ifeq (badgerdb,$(findstring badgerdb,$(COMETBFT_BUILD_OPTIONS)))
+  BUILD_TAGS += badgerdb
+endif
+
+# handle rocksdb
+ifeq (rocksdb,$(findstring rocksdb,$(COMETBFT_BUILD_OPTIONS)))
+  CGO_ENABLED=1
+  BUILD_TAGS += rocksdb
+endif
+
+# handle boltdb
+ifeq (boltdb,$(findstring boltdb,$(COMETBFT_BUILD_OPTIONS)))
+  BUILD_TAGS += boltdb
+endif

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -1,3 +1,7 @@
+COMETBFT_BUILD_OPTIONS += badgerdb,boltdb,cleveldb,rocksdb
+
+include ../../common.mk
+
 all: docker generator runner
 
 docker:
@@ -11,7 +15,7 @@ docker:
 # order to build a binary with a CometBFT node in it (for built-in
 # ABCI testing).
 node:
-	go build -o build/node -tags badgerdb,boltdb,cleveldb,rocksdb ./node
+	go build $(BUILD_FLAGS) -tags '$(BUILD_TAGS)' -o build/node ./node
 
 generator:
 	go build -o build/generator ./generator


### PR DESCRIPTION
Closes #430

Extracted some Makefile logic into a common file (rather than copy-pasting) so that the e2e node is built with the flags allowing it to have a commit hash.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

