### PR TITLE
ci: Enforce release version check when pushing tags

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -20,6 +20,23 @@ jobs:
         with:
           go-version: '1.20'
 
+      # Similar check to ./release-version.yml, but enforces this when pushing
+      # tags. The ./release-version.yml check can be bypassed and is mainly
+      # present for informational purposes.
+      - name: Check release version
+        run: |
+          # We strip the refs/tags/v prefix of the tag name.
+          TAG_VERSION=${GITHUB_REF#refs/tags/v}
+          # Get the version of the code, which has no "v" prefix.
+          CODE_VERSION=`go run ./cmd/cometbft/ version`
+          if [ "$TAG_VERSION" != "$CODE_VERSION" ]; then
+            echo ""
+            echo "Tag version ${TAG_VERSION} does not match code version ${CODE_VERSION}"
+            echo ""
+            echo "Please either fix the release tag or the version of the software in version/version.go."
+            exit 1
+          fi
+
       - name: Generate release notes
         run: |
           VERSION="${GITHUB_REF#refs/tags/}"

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -24,6 +24,7 @@ jobs:
           # Get the version of the code, which has no "v" prefix.
           CODE_VERSION=`go run ./cmd/cometbft/ version`
           if [ "$BRANCH_VERSION" != "$CODE_VERSION" ]; then
+            echo ""
             echo "Branch version ${BRANCH_VERSION} does not match code version ${CODE_VERSION}"
             echo ""
             echo "Please either fix the release branch naming (which must have a 'release/v' prefix)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,23 @@ jobs:
         with:
           go-version: '1.20'
 
+      # Similar check to ./release-version.yml, but enforces this when pushing
+      # tags. The ./release-version.yml check can be bypassed and is mainly
+      # present for informational purposes.
+      - name: Check release version
+        run: |
+          # We strip the refs/tags/v prefix of the tag name.
+          TAG_VERSION=${GITHUB_REF#refs/tags/v}
+          # Get the version of the code, which has no "v" prefix.
+          CODE_VERSION=`go run ./cmd/cometbft/ version`
+          if [ "$TAG_VERSION" != "$CODE_VERSION" ]; then
+            echo ""
+            echo "Tag version ${TAG_VERSION} does not match code version ${CODE_VERSION}"
+            echo ""
+            echo "Please either fix the release tag or the version of the software in version/version.go."
+            exit 1
+          fi
+
       - name: Generate release notes
         run: |
           VERSION="${GITHUB_REF#refs/tags/}"


### PR DESCRIPTION
Follow-up to #427. The workflow in #427 is merely informational, which is helpful, but can be bypassed. It's probably best to enforce this check when we push tags.

If the check fails, it will prevent the cutting of a release, meaning we'll have to delete the tag, fix the version number, and tag again.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

