### PR TITLE
RFC100: Upgrade path section

### DIFF
--- a/docs/rfc/rfc-100-abci-vote-extension-propag.md
+++ b/docs/rfc/rfc-100-abci-vote-extension-propag.md
@@ -643,8 +643,9 @@ of the application and is therefore not valuable to these applications.
 Additional discussion and implementation of this upgrade strategy can be found
 in GitHub [issue 8453][toggle-vote-extensions].
 
-We now explain the changes needed to key solutions/implementation proposed in previous sections.
-For simplicity, in any conditions comparing a height to *h<sub>e</sub>*, 
+We now explain the changes we need to introduce in key solutions/implementation proposed in previous sections
+so that the still work in the presence of an upgrade to ABCI 2.0.
+For simplicity, in any conditions comparing a height to *h<sub>e</sub>*,
 if *h<sub>e</sub>* is 0 (not set yet) then the condition assumes *h<sub>e</sub> = ∞*.
 
 #### Changes Required in Solution 3

--- a/docs/rfc/rfc-100-abci-vote-extension-propag.md
+++ b/docs/rfc/rfc-100-abci-vote-extension-propag.md
@@ -5,6 +5,7 @@
 - 11-Apr-2022: Initial draft (@sergio-mena).
 - 15-Apr-2022: Addressed initial comments. First complete version (@sergio-mena).
 - 09-May-2022: Addressed all outstanding comments (@sergio-mena).
+- 09-May-2022: Add section on upgrade path (@wbanfield)
 - 02-Mar-2023: Migrated to CometBFT RFCs. New number: RFC 100 (@sergio-mena).
 
 ## Abstract
@@ -420,6 +421,13 @@ These are the solutions proposed in discussions leading up to this RFC.
     being fed a block without extensions to make it believe it is late, in a similar way as explained
     for Solution 2.
 
+    This solution can be implemented in normal operation of Tendermint, but notably cannot be
+    used when upgrading from a previous version of Tendermint that did not implement vote
+    extensions. The previous version of Tendermint did not have any vote extension data,
+    so nodes transitioning to use vote extensions must agree on the initial height
+    during which vote extension data will be required. Additional discussion of this
+    is included in the [upgrade path](#upgrade-path) section.
+
 ### Feasibility of the Proposed Solutions
 
 Solution 0, besides the drawbacks described in the previous section, provides guarantees that are
@@ -554,6 +562,53 @@ Then, we need to handle two new situations, roughly equivalent to cases (h.1) an
   progress (they all have pruned the corresponding extended commit).
   However we can manually have the node crash and recover as a workaround. This effectively converts
   this case into (h.1).
+
+### Upgrade Path
+
+v0.36 of Tendermint will be the first version to implement the vote extension system.
+The v0.36 release aims to be backwards compatible with the previous release, v0.35,
+via a coordinated upgrade. Chains that were previously running v0.35 must be able
+to upgrade to v0.36 without creating a new chain. v0.35 had no implementation
+of vote extensions and no mechanisms in place to facilitate their later addition.
+
+Vote extensions pose an issue for Tendermint upgrades. Chains that upgrade from
+v0.35 to v0.36 will attempt to produce the first height running v0.36 without vote
+extension data from the previous height. We intend to allow chains to _require_
+vote extensions data. Chains that require vote extension data will not make progress
+without it. The corresponding application will expect vote extension
+data to be present for each [PrepareProposal](https://github.com/tendermint/tendermint/blob/cec0a9798/proto/tendermint/abci/types.proto#L129) call it receives.
+
+To facilitate the upgrade and provide applications a mechanism to require
+vote extensions, we will provide application developers with a [ConsensusParam](https://github.com/tendermint/tendermint/blob/cec0a9798/proto/tendermint/types/params.proto#L13)
+to transition the chain from maintaining no history of vote extensions to requiring vote extensions.
+This parameter will be an `int64` representing the first height where vote extensions
+will be required for votes to be considered valid.
+
+Concretely, this value must be set to some height, `H`, that is higher than the
+current height of the chain. During all heights >= `H`, the consensus algorithm will
+reject any votes that do not have vote extension data as invalid. Height `H+1`
+will be the first height for which `PrepareProposal` is guaranteed to have vote
+extension data.
+
+The mechanism for transitioning a chain to requiring vote extensions
+_must_ save the height at which the parameter changed. Tendermint must be able
+to distinguish between the first height that vote extensions are required during
+consensus voting and the first height during which `PrepareProposal` must
+receive the extensions. A simple on/off boolean cannot encode this information.
+
+Once the configured height occurs, the parameter will be disallowed from changing.
+Vote extensions cannot flip from being required to being optional. This will be
+enforced by the `ConsensusParam` validation logic. Forcing vote extensions to
+be required beyond the configured height simplifies the logic for transitioning
+from optional to required since all checks will only need to understand if the
+chain _ever_ enabled vote extensions in the past. Additionally, the major known
+uses cases of vote extensions such as threshold decryption and oracle data will
+be _central_ components of the applications that use vote extensions. Flipping
+vote extensions to be no longer required will fundamentally change the behavior
+of the application and is therefore not valuable to these applications.
+
+Additional discussion and implementation of this upgrade strategy can be found
+in github [issue 8453](https://github.com/tendermint/tendermint/issues/8453).
 
 ### Formalization Work
 

--- a/docs/rfc/rfc-100-abci-vote-extension-propag.md
+++ b/docs/rfc/rfc-100-abci-vote-extension-propag.md
@@ -641,7 +641,7 @@ vote extensions to be no longer required will fundamentally change the behavior
 of the application and is therefore not valuable to these applications.
 
 Additional discussion and implementation of this upgrade strategy can be found
-in GitHub [issue 8453](https://github.com/tendermint/tendermint/issues/8453).
+in GitHub [issue 8453][toggle-vote-extensions].
 
 We now explain the changes needed to key solutions/implementation proposed in previous sections.
 For simplicity, in any conditions comparing a height to *h<sub>e</sub>*, 
@@ -731,9 +731,11 @@ required to make progress will always be held somewhere in the network.
 - [ABCI 1.0 specification][abci-1-0]
 - [ABCI 2.0 specification][abci-2-0]
 - [Light client verification][light-client-spec]
-- [Vote extensions issue](https://github.com/tendermint/tendermint/issues/8174)
+- [Empty vote extensions issue](https://github.com/tendermint/tendermint/issues/8174)
+- [Toggle vote extensions issue](https://github.com/tendermint/tendermint/issues/8453)
 
 [abci-0-17-0]: https://github.com/cometbft/cometbft/blob/v0.34.x/spec/abci/README.md
 [abci-1-0]: https://github.com/cometbft/cometbft/blob/v0.37.x/spec/abci/README.md
 [abci-2-0]: https://github.com/cometbft/cometbft/blob/main/spec/abci/README.md
 [light-client-spec]: https://github.com/cometbft/cometbft/blob/main/spec/light-client/README.md
+[toggle-vote-extensions]: https://github.com/tendermint/tendermint/issues/8453

--- a/docs/rfc/rfc-100-abci-vote-extension-propag.md
+++ b/docs/rfc/rfc-100-abci-vote-extension-propag.md
@@ -36,10 +36,10 @@ worded abstracting away from implementation details, whilst subsections
 [Current Limitations and Possible Implementations](#current-limitations-and-possible-implementations)
 analyze the viability of one of the proposed solutions in the context of CometBFT's architecture
 based on reactors.
-Subsection [Upgrade Path](#upgrade-path) discusses how CometBFT node can upgrade
+Subsection [Upgrade Path](#upgrade-path) discusses how a CometBFT node can upgrade
 from a version predating vote extensions, to one featuring it.
 Finally, [Formalization Work](#formalization-work) briefly discusses the work
-still needed demonstrate the correctness of the chosen solution.
+still needed to demonstrate the correctness of the chosen solution.
 
 The high level subsections are aimed at readers who are familiar with consensus algorithms, in
 particular with the Tendermint algorithm described [here](https://arxiv.org/abs/1807.04938),
@@ -221,7 +221,7 @@ discussions and need to be addressed. They are (roughly) ordered from easiest to
     | *valset<sub>h</sub>* &cap; *L<sub>h<sub>p</sub></sub>*  | *< n<sub>h</sub>/3*
 
     So, full nodes that are validators at some height h between *h<sub>s</sub>* and *h<sub>p</sub>-1*
-    can be in *L<sub>h<sub>p</sub></sub>*, but not more than 1/3 of those acting as validator in
+    can be in *L<sub>h<sub>p</sub></sub>*, but not more than 1/3 of those acting as validators in
     the same height.
     If this property does not hold for a particular height *h*, where
     *h<sub>s</sub> ≤ h < h<sub>p</sub>*, CometBFT could not have progressed beyond *h* and
@@ -518,7 +518,7 @@ A chain might be started at a height *h<sub>i</sub> > 0*, all other heights
 block *h<sub>i</sub>* is applied, so the first condition above allows the node to switch to consensus even
 if blocksync has not processed any block (which is always the case if all nodes are starting from scratch).
 
-The third condition is need to ensure liveness in the case where all validators crash at the same height.
+The third condition is needed to ensure liveness in the case where all validators crash at the same height.
 Without the third condition, they all would wait to blocksync at least one block upon recovery.
 However, as all validators crashed no further block can be produced and thus blocksync would block forever.
 
@@ -697,7 +697,7 @@ Changes to the consensus reactor:
   which is more than 2 heights behind,
     - if *h<sub>p</sub> ≥ h<sub>e</sub>*, *f* uses the extended commit to
       reconstruct the precommit votes with their corresponding extensions
-    - if *h<sub>p</sub> < h<sub>e</sub>*, *f* uses the canonical to commit reconstruct the precommit votes,
+    - if *h<sub>p</sub> < h<sub>e</sub>*, *f* uses the canonical commit to reconstruct the precommit votes,
       as done for ABCI 1.0 and earlier
 
 Changes to the blocksync reactor:

--- a/docs/rfc/rfc-100-abci-vote-extension-propag.md
+++ b/docs/rfc/rfc-100-abci-vote-extension-propag.md
@@ -7,6 +7,7 @@
 - 09-May-2022: Addressed all outstanding comments (@sergio-mena).
 - 09-May-2022: Add section on upgrade path (@wbanfield)
 - 02-Mar-2023: Migrated to CometBFT RFCs. New number: RFC 100 (@sergio-mena).
+- 03-Mar-2023: Added "changes needed" to solutions in upgrade path section (@sergio-mena)
 
 ## Abstract
 

--- a/docs/rfc/rfc-100-abci-vote-extension-propag.md
+++ b/docs/rfc/rfc-100-abci-vote-extension-propag.md
@@ -644,7 +644,7 @@ Additional discussion and implementation of this upgrade strategy can be found
 in GitHub [issue 8453][toggle-vote-extensions].
 
 We now explain the changes we need to introduce in key solutions/implementation proposed in previous sections
-so that the still work in the presence of an upgrade to ABCI 2.0.
+so that they still work in the presence of an upgrade to ABCI 2.0.
 For simplicity, in any conditions comparing a height to *h<sub>e</sub>*,
 if *h<sub>e</sub>* is 0 (not set yet) then the condition assumes *h<sub>e</sub> = ∞*.
 

--- a/docs/rfc/rfc-100-abci-vote-extension-propag.md
+++ b/docs/rfc/rfc-100-abci-vote-extension-propag.md
@@ -732,7 +732,7 @@ required to make progress will always be held somewhere in the network.
 - [ABCI 2.0 specification][abci-2-0]
 - [Light client verification][light-client-spec]
 - [Empty vote extensions issue](https://github.com/tendermint/tendermint/issues/8174)
-- [Toggle vote extensions issue](https://github.com/tendermint/tendermint/issues/8453)
+- [Toggle vote extensions issue][toggle-vote-extensions]
 
 [abci-0-17-0]: https://github.com/cometbft/cometbft/blob/v0.34.x/spec/abci/README.md
 [abci-1-0]: https://github.com/cometbft/cometbft/blob/v0.37.x/spec/abci/README.md

--- a/docs/rfc/tendermint-core/rfc-017-abci++-vote-extension-propag.md
+++ b/docs/rfc/tendermint-core/rfc-017-abci++-vote-extension-propag.md
@@ -5,6 +5,7 @@
 - 11-Apr-2022: Initial draft (@sergio-mena).
 - 15-Apr-2022: Addressed initial comments. First complete version (@sergio-mena).
 - 09-May-2022: Addressed all outstanding comments.
+- 09-May-2022: Add section on upgrade path (@wbanfield)
 
 ## Abstract
 
@@ -418,6 +419,13 @@ These are the solutions proposed in discussions leading up to this RFC.
     being fed a block without extensions to make it believe it is late, in a similar way as explained
     for Solution 2.
 
+    This solution can be implemented in normal operation of Tendermint, but notably cannot be
+    used when upgrading from a previous version of Tendermint that did not implement vote
+    extensions. The previous version of Tendermint did not have any vote extension data,
+    so nodes transitioning to use vote extensions must agree on the initial height
+    during which vote extension data will be required. Additional discussion of this
+    is included in the [upgrade path](#upgrade-path) section.
+
 ### Feasibility of the Proposed Solutions
 
 Solution 0, besides the drawbacks described in the previous section, provides guarantees that are
@@ -552,6 +560,53 @@ Then, we need to handle two new situations, roughly equivalent to cases (h.1) an
   progress (they all have pruned the corresponding extended commit).
   However we can manually have the node crash and recover as a workaround. This effectively converts
   this case into (h.1).
+
+### Upgrade Path
+
+v0.36 of Tendermint will be the first version to implement the vote extension system.
+The v0.36 release aims to be backwards compatible with the previous release, v0.35,
+via a coordinated upgrade. Chains that were previously running v0.35 must be able
+to upgrade to v0.36 without creating a new chain. v0.35 had no implementation 
+of vote extensions and no mechanisms in place to facilitate their later addition.
+
+Vote extensions pose an issue for Tendermint upgrades. Chains that upgrade from
+v0.35 to v0.36 will attempt to produce the first height running v0.36 without vote
+extension data from the previous height. We intend to allow chains to _require_
+vote extensions data. Chains that require vote extension data will not make progress
+without it. The corresponding application will expect vote extension
+data to be present for each [PrepareProposal](https://github.com/tendermint/tendermint/blob/cec0a9798/proto/tendermint/abci/types.proto#L129) call it receives.
+
+To facilitate the upgrade and provide applications a mechanism to require
+vote extensions, we will provide application developers with a [ConsensusParam](https://github.com/tendermint/tendermint/blob/cec0a9798/proto/tendermint/types/params.proto#L13)
+to transition the chain from maintaining no history of vote extensions to requiring vote extensions.
+This parameter will be an `int64` representing the first height where vote extensions
+will be required for votes to be considered valid.
+
+Concretely, this value must be set to some height, `H`, that is higher than the
+current height of the chain. During all heights >= `H`, the consensus algorithm will
+reject any votes that do not have vote extension data as invalid. Height `H+1`
+will be the first height for which `PrepareProposal` is guaranteed to have vote
+extension data.
+
+The mechanism for transitioning a chain to requiring vote extensions
+_must_ save the height at which the parameter changed. Tendermint must be able
+to distinguish between the first height that vote extensions are required during
+consensus voting and the first height during which `PrepareProposal` must
+receive the extensions. A simple on/off boolean cannot encode this information.
+
+Once the configured height occurs, the parameter will be disallowed from changing.
+Vote extensions cannot flip from being required to being optional. This will be
+enforced by the `ConsensusParam` validation logic. Forcing vote extensions to
+be required beyond the configured height simplifies the logic for transitioning
+from optional to required since all checks will only need to understand if the
+chain _ever_ enabled vote extensions in the past. Additionally, the major known
+uses cases of vote extensions such as threshold decryption and oracle data will
+be _central_ components of the applications that use vote extensions. Flipping
+vote extensions to be no longer required will fundamentally change the behavior
+of the application and is therefore not valuable to these applications. 
+
+Additional discussion and implementation of this upgrade strategy can be found
+in github [issue 8453](https://github.com/tendermint/tendermint/issues/8453).
 
 ### Formalization Work
 


### PR DESCRIPTION
Closes #444 

[Rendered](https://github.com/cometbft/cometbft/blob/sergio/444-rfc100-upgrade-path/docs/rfc/rfc-100-abci-vote-extension-propag.md)

In this PR:
* I retrieved the text from tendermint/tendermint#8484 and adapted it (new version names, new repo, etc.)
* I extended the "Upgrade Path" section to explain the changes needed in the main solutions/implementations described earlier in the document so that they work in blockchains that upgrade from ABCI 1.0 to ABCI 2.0.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments

