### PR TITLE
docs: Emphasize docs on DoS exposure for RPC in production

### DIFF
--- a/docs/core/running-in-production.md
+++ b/docs/core/running-in-production.md
@@ -93,15 +93,33 @@ mechanisms.
 
 ### RPC
 
+#### DoS Exposure and Mitigation
+
+**It is generally not recommended to expose one's RPC publicly**, as the
+CometBFT RPC does not currently cater for advanced security features. Exposing
+one's RPC publicly without appropriate protection can make the associated node
+vulnerable to a variety of DoS attacks.
+
+It is entirely up to operators to ensure that, if they do have to expose their
+RPC endpoint, that they have taken appropriate measures to mitigate such
+attacks. Some measures include, but are not limited to, rate-limiting and
+authentication (as provided by reverse proxies like [nginx](https://nginx.org/)
+and/or DDoS protection services like [Cloudflare](https://www.cloudflare.com)),
+and only exposing the specific endpoints necessary for their use cases.
+
+If you are unsure as to how to properly secure your node against attacks, or do
+not have access to expertise to assist you in doing so, rather do not expose
+your RPC endpoint at all.
+
+**Under no condition should any of the [unsafe RPC endpoints](../rpc/#/Unsafe)
+ever be exposed publicly.**
+
+#### Endpoints Returning Multiple Entries
+
 Endpoints returning multiple entries are limited by default to return 30
 elements (100 max). See the [RPC Documentation](https://docs.cometbft.com/main/rpc/)
 for more information.
 
-Rate-limiting and authentication are another key aspects to help protect
-against DOS attacks. Validators are supposed to use external tools like
-[NGINX](https://www.nginx.com/blog/rate-limiting-nginx/) or
-[traefik](https://doc.traefik.io/traefik/middlewares/http/ratelimit/)
-to achieve the same things.
 
 ## Debugging CometBFT
 

--- a/docs/core/running-in-production.md
+++ b/docs/core/running-in-production.md
@@ -95,17 +95,24 @@ mechanisms.
 
 #### DoS Exposure and Mitigation
 
-**It is generally not recommended to expose one's RPC publicly**, as the
-CometBFT RPC does not currently cater for advanced security features. Exposing
-one's RPC publicly without appropriate protection can make the associated node
-vulnerable to a variety of DoS attacks.
+**It is generally not recommended to expose one's RPC publicly, and especially
+so if the node in question is a validator**, as the CometBFT RPC does not
+currently cater for advanced security features. Exposing one's RPC publicly
+without appropriate protection can make the associated node vulnerable to a
+variety of DoS attacks.
 
 It is entirely up to operators to ensure that, if they do have to expose their
 RPC endpoint, that they have taken appropriate measures to mitigate such
-attacks. Some measures include, but are not limited to, rate-limiting and
-authentication (as provided by reverse proxies like [nginx](https://nginx.org/)
-and/or DDoS protection services like [Cloudflare](https://www.cloudflare.com)),
-and only exposing the specific endpoints necessary for their use cases.
+attacks. Some measures include, but are not limited to:
+
+- Never publicly exposing the RPC endpoints of your validator(s) (i.e. if you
+  absolutely have to expose your RPC endpoint, ensure you do so only on full
+  nodes and with appropriate protection)
+- Rate-limiting and authentication (as provided by reverse proxies like
+  [nginx](https://nginx.org/) and/or DDoS protection services like
+  [Cloudflare](https://www.cloudflare.com))
+- Only exposing the specific endpoints necessary for their use cases
+  (configurable via nginx/Cloudflare/etc.)
 
 If you are unsure as to how to properly secure your node against attacks, or do
 not have access to expertise to assist you in doing so, rather do not expose


### PR DESCRIPTION
For some reason this topic keeps coming up and I'd like us to emphasize this part of the documentation to put this topic to rest. Operators are, and have always been, ultimately responsible for securing their RPC endpoints if they choose to make them available publicly.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments

