### PR TITLE
Backport vote extension metrics

### DIFF
--- a/consensus/metrics.gen.go
+++ b/consensus/metrics.gen.go
@@ -150,6 +150,12 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Name:      "full_prevote_delay",
 			Help:      "Interval in seconds between the proposal timestamp and the timestamp of the latest prevote in a round where all validators voted.",
 		}, append(labels, "proposer_address")).With(labelsAndValues...),
+		VoteExtensionReceiveCount: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "vote_extension_receive_count",
+			Help:      "VoteExtensionReceiveCount is the number of vote extensions received by this node. The metric is annotated by the status of the vote extension from the application, either 'accepted' or 'rejected'.",
+		}, labels).With(labelsAndValues...),
 		ProposalReceiveCount: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
@@ -160,7 +166,7 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "proposal_create_count",
-			Help:      "ProposalCreationCount is the total number of proposals created by this node since process start.",
+			Help:      "ProposalCreationCount is the total number of proposals created by this node since process start. The metric is annotated by the status of the proposal from the application, either 'accepted' or 'rejected'.",
 		}, labels).With(labelsAndValues...),
 		RoundVotingPowerPercent: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
@@ -201,6 +207,7 @@ func NopMetrics() *Metrics {
 		BlockGossipPartsReceived:  discard.NewCounter(),
 		QuorumPrevoteDelay:        discard.NewGauge(),
 		FullPrevoteDelay:          discard.NewGauge(),
+		VoteExtensionReceiveCount: discard.NewCounter(),
 		ProposalReceiveCount:      discard.NewCounter(),
 		ProposalCreateCount:       discard.NewCounter(),
 		RoundVotingPowerPercent:   discard.NewGauge(),

--- a/consensus/metrics.go
+++ b/consensus/metrics.go
@@ -91,6 +91,11 @@ type Metrics struct {
 	//metrics:Interval in seconds between the proposal timestamp and the timestamp of the latest prevote in a round where all validators voted.
 	FullPrevoteDelay metrics.Gauge `metrics_labels:"proposer_address"`
 
+	// VoteExtensionReceiveCount is the number of vote extensions received by this
+	// node. The metric is annotated by the status of the vote extension from the
+	// application, either 'accepted' or 'rejected'.
+	VoteExtensionReceiveCount metrics.Counter
+
 	// ProposalReceiveCount is the total number of proposals received by this node
 	// since process start.
 	// The metric is annotated by the status of the proposal from the application,
@@ -99,6 +104,8 @@ type Metrics struct {
 
 	// ProposalCreationCount is the total number of proposals created by this node
 	// since process start.
+	// The metric is annotated by the status of the proposal from the application,
+	// either 'accepted' or 'rejected'.
 	ProposalCreateCount metrics.Counter
 
 	// RoundVotingPowerPercent is the percentage of the total voting power received
@@ -128,6 +135,14 @@ func (m *Metrics) MarkProposalProcessed(accepted bool) {
 	m.ProposalReceiveCount.With("status", status).Add(1)
 }
 
+func (m *Metrics) MarkVoteExtensionReceived(accepted bool) {
+	status := "accepted"
+	if !accepted {
+		status = "rejected"
+	}
+	m.VoteExtensionReceiveCount.With("status", status).Add(1)
+}
+
 func (m *Metrics) MarkVoteReceived(vt cmtproto.SignedMsgType, power, totalPower int64) {
 	p := float64(power) / float64(totalPower)
 	n := strings.ToLower(strings.TrimPrefix(vt.String(), "SIGNED_MSG_TYPE_"))
@@ -138,6 +153,14 @@ func (m *Metrics) MarkRound(r int32, st time.Time) {
 	m.Rounds.Set(float64(r))
 	roundTime := time.Since(st).Seconds()
 	m.RoundDurationSeconds.Observe(roundTime)
+
+	pvt := cmtproto.PrevoteType
+	pvn := strings.ToLower(strings.TrimPrefix(pvt.String(), "SIGNED_MSG_TYPE_"))
+	m.RoundVotingPowerPercent.With("vote_type", pvn).Set(0)
+
+	pct := cmtproto.PrecommitType
+	pcn := strings.ToLower(strings.TrimPrefix(pct.String(), "SIGNED_MSG_TYPE_"))
+	m.RoundVotingPowerPercent.With("vote_type", pcn).Set(0)
 }
 
 func (m *Metrics) MarkLateVote(vt cmtproto.SignedMsgType) {

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -2137,7 +2137,9 @@ func (cs *State) addVote(vote *types.Vote, peerID p2p.ID) (added bool, err error
 				return false, err
 			}
 
-			if err = cs.blockExec.VerifyVoteExtension(context.TODO(), vote); err != nil {
+			err := cs.blockExec.VerifyVoteExtension(context.TODO(), vote)
+			cs.metrics.MarkVoteExtensionReceived(err == nil)
+			if err != nil {
 				return false, err
 			}
 		}

--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -44,6 +44,7 @@ The following metrics are available:
 | consensus\_block\_gossip\_parts\_received  | Counter   | matches\_current | Number of block parts received by the node                                                                                                 |
 | consensus\_quorum\_prevote\_delay          | Gauge     |                  | Interval in seconds between the proposal timestamp and the timestamp of the earliest prevote that achieved a quorum                        |
 | consensus\_full\_prevote\_delay            | Gauge     |                  | Interval in seconds between the proposal timestamp and the timestamp of the latest prevote in a round where all validators voted           |
+| consensus\_vote\_extension\_receive\_count | Counter   | status           | Number of vote extensions received                                                                                                         |
 | consensus\_proposal\_receive\_count        | Counter   | status           | Total number of proposals received by the node since process start                                                                         |
 | consensus\_proposal\_create\_count         | Counter   |                  | Total number of proposals created by the node since process start                                                                          |
 | consensus\_round\_voting\_power\_percent   | Gauge     | vote\_type       | A value between 0 and 1.0 representing the percentage of the total voting power per vote type received within a round                      |

--- a/state/metrics.gen.go
+++ b/state/metrics.gen.go
@@ -18,7 +18,7 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "block_processing_time",
-			Help:      "Time spent processig finalize block.",
+			Help:      "Time spent processing FinalizeBlock",
 
 			Buckets: stdprometheus.LinearBuckets(1, 10, 10),
 		}, labels).With(labelsAndValues...),
@@ -26,13 +26,13 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "consensus_param_updates",
-			Help:      "ConsensusParamUpdates is the total number of times the application has udated the consensus params since process start.",
+			Help:      "Number of consensus parameter updates returned by the application since process start.",
 		}, labels).With(labelsAndValues...),
 		ValidatorSetUpdates: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "validator_set_updates",
-			Help:      "ValidatorSetUpdates is the total number of times the application has udated the validator set since process start.",
+			Help:      "Number of validator set updates returned by the application since process start.",
 		}, labels).With(labelsAndValues...),
 	}
 }

--- a/state/metrics.go
+++ b/state/metrics.go
@@ -18,10 +18,12 @@ type Metrics struct {
 	BlockProcessingTime metrics.Histogram `metrics_buckettype:"lin" metrics_bucketsizes:"1, 10, 10"`
 
 	// ConsensusParamUpdates is the total number of times the application has
-	// udated the consensus params since process start.
+	// updated the consensus params since process start.
+	//metrics:Number of consensus parameter updates returned by the application since process start.
 	ConsensusParamUpdates metrics.Counter
 
 	// ValidatorSetUpdates is the total number of times the application has
-	// udated the validator set since process start.
+	// updated the validator set since process start.
+	//metrics:Number of validator set updates returned by the application since process start.
 	ValidatorSetUpdates metrics.Counter
 }


### PR DESCRIPTION
Contributes to #10

Partial cherry-pick of #8480

The rest of #8480 was backported for `v0.37.x`.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

