### PR TITLE
Move `apphash`from `Commit`to `FinalizeBlock` (leftovers)

### DIFF
--- a/.changelog/unreleased/breaking-changes/8664-move-app-hash-to-commit.md
+++ b/.changelog/unreleased/breaking-changes/8664-move-app-hash-to-commit.md
@@ -1,0 +1,2 @@
+- `[abci]` Move `app_hash` parameter from `Commit` to `FinalizeBlock` (@sergio-mena)
+  ([\#8664](https://github.com/tendermint/tendermint/pull/8664))

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -19,30 +19,19 @@ This guide provides instructions for upgrading to specific versions of CometBFT.
 
 ### ABCI Changes
 
-* The `ABCIVersion` is now `1.0.0`.
-
-* Added new ABCI methods `PrepareProposal` and `ProcessProposal`. For details,
-  please see the [spec](spec/abci/README.md). Applications upgrading to
-  v0.37.0 must implement these methods, at the very minimum, as described
+* The `ABCIVersion` is now `2.0.0`.
+* Added new ABCI methods `ExtendVote`, and `VerifyVoteExtension`.
+  Applications upgrading to v0.38.0 must implement these methods as described
   [here](./spec/abci/abci++_app_requirements.md)
-* Deduplicated `ConsensusParams` and `BlockParams`.
-  In the v0.34 branch they are defined both in `abci/types.proto` and `types/params.proto`.
-  The definitions in `abci/types.proto` have been removed.
-  In-process applications should make sure they are not using the deleted
-  version of those structures.
-* In v0.34, messages on the wire used to be length-delimited with `int64` varint
-  values, which was inconsistent with the `uint64` varint length delimiters used
-  in the P2P layer. Both now consistently use `uint64` varint length delimiters.
-* Added `AbciVersion` to `RequestInfo`.
-  Applications should check that CometBFT's ABCI version matches the one they expect
-  in order to ensure compatibility.
-* The `SetOption` method has been removed from the ABCI `Client` interface.
-  The corresponding Protobuf types have been deprecated.
-* The `key` and `value` fields in the `EventAttribute` type have been changed
-  from type `bytes` to `string`. As per the [Protocol Buffers updating
-  guidelines](https://developers.google.com/protocol-buffers/docs/proto3#updating),
-  this should have no effect on the wire-level encoding for UTF8-encoded
-  strings.
+* Removed methods `BeginBlock`, `DeliverTx`, `EndBlock`, and replaced them by
+  method `FinalizeBlock`. Applications upgrading to v0.38.0 must refactor
+  the logic handling the methods removed to handle `FinalizeBlock`.
+* The Application's hash (or any data representing the Application's current state)
+  is known by the time `FinalizeBlock` finishes its execution.
+  Accordingly, the `app_hash` parameter has been moved from `ResponseCommit`
+  to `ResponseFinalizeBlock`, and renamed `agreed_app_data`.
+* For details, please see the updated [specification](spec/abci/README.md)
+
 
 ### Mempool Changes
 

--- a/abci/tests/test_cli/ex1.abci
+++ b/abci/tests/test_cli/ex1.abci
@@ -1,6 +1,7 @@
 echo hello
 info
 prepare_proposal "abc=123"
+process_proposal "abc==456"
 process_proposal "abc=123"
 finalize_block "abc=123"
 commit

--- a/abci/tests/test_cli/ex1.abci.out
+++ b/abci/tests/test_cli/ex1.abci.out
@@ -12,6 +12,10 @@
 -> code: OK
 -> log: Succeeded. Tx: abc=123
 
+> process_proposal "abc==456"
+-> code: OK
+-> status: REJECT
+
 > process_proposal "abc=123"
 -> code: OK
 -> status: ACCEPT

--- a/abci/tests/test_cli/test.sh
+++ b/abci/tests/test_cli/test.sh
@@ -31,7 +31,7 @@ function testExample() {
 		echo "Expected:"
 		cat "${INPUT}.out"
 		echo "Diff:"
-		diff "${INPUT}.out" "${INPUT}.out.new"
+		diff -u "${INPUT}.out" "${INPUT}.out.new"
 		exit 1
 	fi
 

--- a/consensus/mempool_test.go
+++ b/consensus/mempool_test.go
@@ -133,6 +133,7 @@ func TestMempoolTxConcurrentWithCommit(t *testing.T) {
 		case msg := <-newBlockEventsCh:
 			event := msg.Data().(types.EventDataNewBlockEvents)
 			n += event.NumTxs
+			t.Log("new transactions", "nTxs", event.NumTxs, "total", n)
 		case <-time.After(30 * time.Second):
 			t.Fatal("Timed out waiting 30s to commit blocks with transactions")
 		}

--- a/docs/app-dev/abci-cli.md
+++ b/docs/app-dev/abci-cli.md
@@ -173,85 +173,66 @@ Try running these commands:
 -> data: hello
 -> data.hex: 0x68656C6C6F
 
-> info 
+> info
 -> code: OK
 -> data: {"size":0}
 -> data.hex: 0x7B2273697A65223A307D
 
-> prepare_proposal "abc"
+> prepare_proposal "abc=123"
 -> code: OK
--> log: Succeeded. Tx: abc
+-> log: Succeeded. Tx: abc=123
 
-> process_proposal "abc"
+> process_proposal "abc==456"
+-> code: OK
+-> status: REJECT
+
+> process_proposal "abc=123"
 -> code: OK
 -> status: ACCEPT
 
-> commit 
+> finalize_block "abc=123"
 -> code: OK
--> data.hex: 0x0000000000000000
+-> code: OK
+-> data.hex: 0x0200000000000000
 
-> deliver_tx "abc"
+> commit
 -> code: OK
 
-> info 
+> info
 -> code: OK
 -> data: {"size":1}
 -> data.hex: 0x7B2273697A65223A317D
 
-> commit 
--> code: OK
--> data.hex: 0x0200000000000000
-
 > query "abc"
 -> code: OK
 -> log: exists
--> height: 2
+-> height: 0
 -> key: abc
 -> key.hex: 616263
--> value: abc
--> value.hex: 616263
+-> value: 123
+-> value.hex: 313233
 
-> deliver_tx "def=xyz"
+> finalize_block "def=xyz" "ghi=123"
 -> code: OK
+-> code: OK
+-> code: OK
+-> data.hex: 0x0600000000000000
 
-> commit 
+> commit
 -> code: OK
--> data.hex: 0x0400000000000000
 
 > query "def"
 -> code: OK
 -> log: exists
--> height: 3
+-> height: 0
 -> key: def
 -> key.hex: 646566
 -> value: xyz
 -> value.hex: 78797A
-
-> prepare_proposal "preparedef"
--> code: OK
--> log: Succeeded. Tx: replacedef
-
-> process_proposal "replacedef"
--> code: OK
--> status: ACCEPT
-
-> process_proposal "preparedef"
--> code: OK
--> status: REJECT
-
-> prepare_proposal 
-
-> process_proposal 
--> code: OK
--> status: ACCEPT
-
-> commit 
--> code: OK
--> data.hex: 0x0400000000000000
 ```
 
-Note that if we do `deliver_tx "abc"` it will store `(abc, abc)`, but if
-we do `deliver_tx "abc=efg"` it will store `(abc, efg)`.
+Note that if we do `finalize_block "abc" ...` it will store `(abc, abc)`, but if
+we do `finalize_block "abc=efg" ...` it will store `(abc, efg)`.
 
 You could put the commands in a file and run
 `abci-cli --verbose batch < myfile`.

--- a/spec/abci/abci++_methods.md
+++ b/spec/abci/abci++_methods.md
@@ -210,9 +210,9 @@ title: Methods
 
 * **Response**:
 
-    | Name  | Type  | Description                                                                                                                                           | Field Number |
-    |-------|-------|-------------------------------------------------------------------------------------------------------------------------------------------------------|--------------|
-    | chunk | bytes | The binary chunk contents, in an arbitray format. Chunk messages cannot be larger than 16 MB _including metadata_, so 10 MB is a good starting point. | 1            |
+    | Name  | Type  | Description                                                                                                                                            | Field Number |
+    |-------|-------|--------------------------------------------------------------------------------------------------------------------------------------------------------|--------------|
+    | chunk | bytes | The binary chunk contents, in an arbitrary format. Chunk messages cannot be larger than 16 MB _including metadata_, so 10 MB is a good starting point. | 1            |
 
 * **Usage**:
     * Used during state sync to retrieve snapshot chunks from peers.


### PR DESCRIPTION
Contributes to #10

Partial cherry-pick of tendermint/tendermint#8664

The changes in this PR are the leftovers from backporting this functionality manually late last year.


---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

