### PR TITLE
ABCI calls should crash/exit in all cases when the call itself reports and error

### DIFF
--- a/.changelog/unreleased/bug-fixes/496-error-on-applyblock-should-panic.md
+++ b/.changelog/unreleased/bug-fixes/496-error-on-applyblock-should-panic.md
@@ -1,0 +1,2 @@
+- `[consensus]` Unexpected error conditions in `ApplyBlock` are non-recoverable, so ignoring the error and carrying on is a bug. We replaced a `return` that disregarded the error by a `panic`.
+  ([\#496](https://github.com/cometbft/cometbft/pull/496))

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.20"
+          go-version: "1.20.2"
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6
         with:

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1706,8 +1706,7 @@ func (cs *State) finalizeCommit(height int64) {
 		block,
 	)
 	if err != nil {
-		logger.Error("failed to apply block", "err", err)
-		return
+		panic(fmt.Sprintf("failed to apply block; error %v", err))
 	}
 
 	fail.Fail() // XXX

--- a/state/execution.go
+++ b/state/execution.go
@@ -164,7 +164,7 @@ func (blockExec *BlockExecutor) ProcessProposal(
 		NextValidatorsHash: block.NextValidatorsHash,
 	})
 	if err != nil {
-		return false, ErrInvalidBlock(err)
+		return false, err
 	}
 	if resp.IsStatusUnknown() {
 		panic(fmt.Sprintf("ProcessProposal responded with status %s", resp.Status.String()))


### PR DESCRIPTION
Closes #490

Followed the call hierarchy of ABCI methods to make sure that reporting an error ultimately results in a crash/exit (also followed new methods in branch `feature/abci++vef`).

Found one blind spot that should be considered a bug, and should probably be backported. Hence, I'm opening this against `main` and not `feature/abci++vef`

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

