### PR TITLE
Add sleep times (`VoteExtension` and `Finalizeblock`) to e2e app

### DIFF
--- a/test/e2e/app/app.go
+++ b/test/e2e/app/app.go
@@ -86,7 +86,7 @@ type Config struct {
 	ProcessProposalDelay time.Duration `toml:"process_proposal_delay"`
 	CheckTxDelay         time.Duration `toml:"check_tx_delay"`
 	FinalizeBlockDelay   time.Duration `toml:"finalize_block_delay"`
-	// TODO: add vote extension delays once completed (@cmwaters)
+	VoteExtensionDelay   time.Duration `toml:"vote_extension_delay"`
 }
 
 func DefaultConfig(dir string) *Config {
@@ -416,6 +416,11 @@ func (app *Application) ExtendVote(_ context.Context, req *abci.RequestExtendVot
 	//nolint:gosec // G404: Use of weak random number generator
 	num := rand.Int63n(voteExtensionMaxVal)
 	extLen := binary.PutVarint(ext, num)
+
+	if app.cfg.VoteExtensionDelay != 0 {
+		time.Sleep(app.cfg.VoteExtensionDelay)
+	}
+
 	app.logger.Info("generated vote extension", "num", num, "ext", fmt.Sprintf("%x", ext[:extLen]), "state.Height", app.state.Height)
 	return &abci.ResponseExtendVote{
 		VoteExtension: ext[:extLen],
@@ -446,6 +451,11 @@ func (app *Application) VerifyVoteExtension(_ context.Context, req *abci.Request
 			Status: abci.ResponseVerifyVoteExtension_REJECT,
 		}, nil
 	}
+
+	if app.cfg.VoteExtensionDelay != 0 {
+		time.Sleep(app.cfg.VoteExtensionDelay)
+	}
+
 	app.logger.Info("verified vote extension value", "req", req, "num", num)
 	return &abci.ResponseVerifyVoteExtension{
 		Status: abci.ResponseVerifyVoteExtension_ACCEPT,

--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -136,10 +136,14 @@ func generateTestnet(r *rand.Rand, opt map[string]interface{}, upgradeVersion st
 	case "small":
 		manifest.PrepareProposalDelay = 100 * time.Millisecond
 		manifest.ProcessProposalDelay = 100 * time.Millisecond
+		manifest.VoteExtensionDelay = 20 * time.Millisecond
+		manifest.FinalizeBlockDelay = 200 * time.Millisecond
 	case "large":
 		manifest.PrepareProposalDelay = 200 * time.Millisecond
 		manifest.ProcessProposalDelay = 200 * time.Millisecond
 		manifest.CheckTxDelay = 20 * time.Millisecond
+		manifest.VoteExtensionDelay = 100 * time.Millisecond
+		manifest.FinalizeBlockDelay = 500 * time.Millisecond
 	}
 
 	if voteExtensionEnabled.Choose(r).(bool) {

--- a/test/e2e/pkg/manifest.go
+++ b/test/e2e/pkg/manifest.go
@@ -78,7 +78,8 @@ type Manifest struct {
 	PrepareProposalDelay time.Duration `toml:"prepare_proposal_delay"`
 	ProcessProposalDelay time.Duration `toml:"process_proposal_delay"`
 	CheckTxDelay         time.Duration `toml:"check_tx_delay"`
-	// TODO: add vote extension and finalize block delay (@cmwaters)
+	VoteExtensionDelay   time.Duration `toml:"vote_extension_delay"`
+	FinalizeBlockDelay   time.Duration `toml:"finalize_block_delay"`
 
 	// UpgradeVersion specifies to which version nodes need to upgrade.
 	// Currently only uncoordinated upgrade is supported

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -79,6 +79,8 @@ type Testnet struct {
 	PrepareProposalDelay       time.Duration
 	ProcessProposalDelay       time.Duration
 	CheckTxDelay               time.Duration
+	VoteExtensionDelay         time.Duration
+	FinalizeBlockDelay         time.Duration
 	UpgradeVersion             string
 	Prometheus                 bool
 	VoteExtensionsEnableHeight int64
@@ -154,6 +156,8 @@ func NewTestnetFromManifest(manifest Manifest, file string, ifd InfrastructureDa
 		PrepareProposalDelay: manifest.PrepareProposalDelay,
 		ProcessProposalDelay: manifest.ProcessProposalDelay,
 		CheckTxDelay:         manifest.CheckTxDelay,
+		VoteExtensionDelay:   manifest.VoteExtensionDelay,
+		FinalizeBlockDelay:   manifest.FinalizeBlockDelay,
 		UpgradeVersion:       manifest.UpgradeVersion,
 		Prometheus:           manifest.Prometheus,
 	}

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -270,6 +270,8 @@ func MakeAppConfig(node *e2e.Node) ([]byte, error) {
 		"prepare_proposal_delay": node.Testnet.PrepareProposalDelay,
 		"process_proposal_delay": node.Testnet.ProcessProposalDelay,
 		"check_tx_delay":         node.Testnet.CheckTxDelay,
+		"vote_extension_delay":   node.Testnet.VoteExtensionDelay,
+		"finalize_block_delay":   node.Testnet.FinalizeBlockDelay,
 	}
 	switch node.ABCIProtocol {
 	case e2e.ProtocolUNIX:


### PR DESCRIPTION
This is a partial cherry-pick of the original implementation, done on `v0.36.x` via #8638

---

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

