### PR TITLE
Update description of profobuf definitions in the doc

### DIFF
--- a/spec/abci/abci++_methods.md
+++ b/spec/abci/abci++_methods.md
@@ -874,25 +874,4 @@ enum VerifyStatus {
         * If `Status` is `ACCEPT`, the consensus algorithm will accept the vote as valid.
         * If `Status` is `REJECT`, the consensus algorithm will reject the vote as invalid.
 
-
-### CanonicalVoteExtension
-
->**TODO**: This protobuf message definition is not part of the ABCI++ interface, but rather belongs to the
-> Precommit message which is broadcast via P2P. So it is to be moved to the relevant section of the spec.
-
-* **Fields**:
-
-    | Name      | Type   | Description                                                                                | Field Number |
-    |-----------|--------|--------------------------------------------------------------------------------------------|--------------|
-    | extension | bytes  | Vote extension provided by the Application.                                                | 1            |
-    | height    | int64  | Height in which the extension was provided.                                                | 2            |
-    | round     | int32  | Round in which the extension was provided.                                                 | 3            |
-    | chain_id  | string | ID of the blockchain running consensus.                                                    | 4            |
-    | address   | bytes  | [Address](../core/data_structures.md#address) of the validator that provided the extension | 5            |
-
-* **Usage**:
-    * CometBFT is to sign the whole data structure and attach it to a Precommit message
-    * Upon reception, CometBFT validates the sender's signature and sanity-checks the values of `height`, `round`, and `chain_id`.
-      Then it sends `extension` to the Application via `RequestVerifyVoteExtension` for verification.
-
 [protobuf-timestamp]: https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp

--- a/spec/abci/abci++_methods.md
+++ b/spec/abci/abci++_methods.md
@@ -517,17 +517,19 @@ then _p_ locks _v_  and sends a Precommit message in the following way
 1. _p_ sets _lockedValue_ and _validValue_ to _v_, and sets _lockedRound_ and _validRound_ to _r_
 2. _p_'s CometBFT calls `RequestExtendVote` with _id(v)_ (`RequestExtendVote.hash`). The call is synchronous.
 3. The Application returns an array of bytes, `ResponseExtendVote.extension`, which is not interpreted by the consensus algorithm.
-4. _p_ includes `ResponseExtendVote.extension` in a field of type [CanonicalVoteExtension](#canonicalvoteextension),
-   it then populates the other fields in [CanonicalVoteExtension](#canonicalvoteextension), and signs the populated
-   data structure.
+4. _p_ includes `ResponseExtendVote.extension` in a field of type
+   [CanonicalVoteExtension](../core/data_structures.md#canonicalvoteextension),
+   it then populates the other fields in [CanonicalVoteExtension](../core/data_structures.md#canonicalvoteextension),
+   and signs the populated data structure.
 5. _p_ constructs and signs the [CanonicalVote](../core/data_structures.md#canonicalvote) structure.
 6. _p_ constructs the Precommit message (i.e. [Vote](../core/data_structures.md#vote) structure)
-   using [CanonicalVoteExtension](#canonicalvoteextension) and [CanonicalVote](../core/data_structures.md#canonicalvote).
+   using [CanonicalVoteExtension](../core/data_structures.md#canonicalvoteextension)
+   and [CanonicalVote](../core/data_structures.md#canonicalvote).
 7. _p_ broadcasts the Precommit message.
 
 In the cases when _p_ is to broadcast `precommit nil` messages (either _2f+1_ `prevote nil` messages received,
 or _timeoutPrevote_ triggered), _p_'s CometBFT does **not** call `RequestExtendVote` and will not include
-a [CanonicalVoteExtension](#canonicalvoteextension) field in the `precommit nil` message.
+a [CanonicalVoteExtension](../core/data_structures.md#canonicalvoteextension) field in the `precommit nil` message.
 
 ### VerifyVoteExtension
 

--- a/spec/abci/abci++_methods.md
+++ b/spec/abci/abci++_methods.md
@@ -517,9 +517,9 @@ then _p_ locks _v_  and sends a Precommit message in the following way
 1. _p_ sets _lockedValue_ and _validValue_ to _v_, and sets _lockedRound_ and _validRound_ to _r_
 2. _p_'s CometBFT calls `RequestExtendVote` with _id(v)_ (`RequestExtendVote.hash`). The call is synchronous.
 3. The Application returns an array of bytes, `ResponseExtendVote.extension`, which is not interpreted by the consensus algorithm.
-4. _p_ includes `ResponseExtendVote.extension` in a field of type
+4. _p_ sets `ResponseExtendVote.extension` as the value of the `extension` field of type
    [CanonicalVoteExtension](../core/data_structures.md#canonicalvoteextension),
-   it then populates the other fields in [CanonicalVoteExtension](../core/data_structures.md#canonicalvoteextension),
+   populates the other fields in [CanonicalVoteExtension](../core/data_structures.md#canonicalvoteextension),
    and signs the populated data structure.
 5. _p_ constructs and signs the [CanonicalVote](../core/data_structures.md#canonicalvote) structure.
 6. _p_ constructs the Precommit message (i.e. [Vote](../core/data_structures.md#vote) structure)

--- a/spec/core/data_structures.md
+++ b/spec/core/data_structures.md
@@ -195,10 +195,22 @@ Commit is a simple wrapper for a list of signatures, with one for each validator
 
 | Name       | Type                             | Description                                                          | Validation                                                                                               |
 |------------|----------------------------------|----------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
-| Height     | uint64                            | Height at which this commit was created.                             | Must be > 0                                                                                              |
+| Height     | int64                            | Height at which this commit was created.                             | Must be > 0                                                                                              |
 | Round      | int32                            | Round that the commit corresponds to.                                | Must be > 0                                                                                              |
 | BlockID    | [BlockID](#blockid)              | The blockID of the corresponding block.                              | Must adhere to the validation rules of [BlockID](#blockid).                                              |
 | Signatures | Array of [CommitSig](#commitsig) | Array of commit signatures that correspond to current validator set. | Length of signatures must be > 0 and adhere to the validation of each individual [Commitsig](#commitsig) |
+
+## ExtendedCommit
+
+`ExtendedCommit`, similarly to Commit, wraps a list of votes with signatures together with other data needed to verify them.
+In addition, it contains the verified vote extensions, one for each non-`nil` vote, along with the extension signatures.
+
+| Name               | Type                                     | Description                                                                         | Validation                                                                                                               |
+|--------------------|------------------------------------------|-------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
+| Height             | int64                                    | Height at which this commit was created.                                            | Must be > 0                                                                                                              |
+| Round              | int32                                    | Round that the commit corresponds to.                                               | Must be > 0                                                                                                              |
+| BlockID            | [BlockID](#blockid)                      | The blockID of the corresponding block.                                             | Must adhere to the validation rules of [BlockID](#blockid).                                                              |
+| ExtendedSignatures | Array of [ExtendedCommitSig](#commitsig) | The current validator set's commit signatures, extension, and extension signatures. | Length of signatures must be > 0 and adhere to the validation of each individual [ExtendedCommitSig](#extendedcommitsig) |
 
 ## CommitSig
 
@@ -206,15 +218,32 @@ Commit is a simple wrapper for a list of signatures, with one for each validator
 a particular `BlockID` or was absent. It's a part of the `Commit` and can be used
 to reconstruct the vote set given the validator set.
 
-| Name             | Type                        | Description                                                                                                                                                      | Validation                                                        |
-|------------------|-----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|
+| Name             | Type                        | Description                                                                                                                                       | Validation                                                        |
+|------------------|-----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|
 | BlockIDFlag      | [BlockIDFlag](#blockidflag) | Represents the validators participation in consensus: its vote was not received, voted for the block that received the majority, or voted for nil | Must be one of the fields in the [BlockIDFlag](#blockidflag) enum |
-| ValidatorAddress | [Address](#address)         | Address of the validator                                                                                                                                         | Must be of length 20                                              |
-| Timestamp        | [Time](#time)               | This field will vary from `CommitSig` to `CommitSig`. It represents the timestamp of the validator.                                                              | [Time](#time)                                                     |
-| Signature        | [Signature](#signature)     | Signature corresponding to the validators participation in consensus.                                                                                            | The length of the signature must be > 0 and < than  64            |
+| ValidatorAddress | [Address](#address)         | Address of the validator                                                                                                                          | Must be of length 20                                              |
+| Timestamp        | [Time](#time)               | This field will vary from `CommitSig` to `CommitSig`. It represents the timestamp of the validator.                                               | [Time](#time)                                                     |
+| Signature        | [Signature](#signature)     | Signature corresponding to the validators participation in consensus.                                                                             | The length of the signature must be > 0 and < than  64            |
 
 NOTE: `ValidatorAddress` and `Timestamp` fields may be removed in the future
 (see [ADR-25](https://github.com/cometbft/cometbft/blob/main/docs/architecture/adr-025-commit.md)).
+
+## ExtendedCommitSig
+
+`ExtendedCommitSig` represents a signature of a validator that has voted either for `nil`,
+a particular `BlockID` or was absent. It is part of the `ExtendedCommit` and can be used
+to reconstruct the vote set given the validator set.
+Additionally it contains the vote extensions that were attached to each non-`nil` precommit vote.
+All these extensions have been verified by the application operating at the signing validator's node.
+
+| Name               | Type                        | Description                                                                                                                                       | Validation                                                          |
+|--------------------|-----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------|
+| BlockIDFlag        | [BlockIDFlag](#blockidflag) | Represents the validators participation in consensus: its vote was not received, voted for the block that received the majority, or voted for nil | Must be one of the fields in the [BlockIDFlag](#blockidflag) enum   |
+| ValidatorAddress   | [Address](#address)         | Address of the validator                                                                                                                          | Must be of length 20                                                |
+| Timestamp          | [Time](#time)               | This field will vary from `CommitSig` to `CommitSig`. It represents the timestamp of the validator.                                               |                                                                     |
+| Signature          | [Signature](#signature)     | Signature corresponding to the validators participation in consensus.                                                                             | Length must be > 0 and < 64                                         |
+| Extension          | bytes                       | Vote extension provided by the Application running on the sender of the precommit vote, and verified by the local application.                    | Length must be zero if BlockIDFlag is not `Commit`                  |
+| ExtensionSignature | [Signature](#signature)     | Signature of the vote extension.                                                                                                                  | Length must be > 0 and < than 64 if BlockIDFlag is `Commit`, else 0 |
 
 ## BlockIDFlag
 
@@ -234,32 +263,33 @@ enum BlockIDFlag {
 A vote is a signed message from a validator for a particular block.
 The vote includes information about the validator signing it. When stored in the blockchain or propagated over the network, votes are encoded in Protobuf.
 
-| Name             | Type                            | Description                                                                                 | Validation                                                                                           |
-|------------------|---------------------------------|---------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------|
-| Type             | [SignedMsgType](#signedmsgtype) | Either prevote or precommit. [SignedMsgType](#signedmsgtype)                                | A Vote is valid if its corresponding fields are included in the enum [signedMsgType](#signedmsgtype) |
-| Height           | uint64                           | Height for which this vote was created for                                                  | Must be > 0                                                                                          |
-| Round            | int32                           | Round that the commit corresponds to.                                                       | Must be > 0                                                                                          |
-| BlockID          | [BlockID](#blockid)             | The blockID of the corresponding block.                                                     | [BlockID](#blockid)                                                                                  |
-| Timestamp        | [Time](#time)                   | Timestamp represents the time at which a validator signed.                                  | [Time](#time)                                                                                        |
-| ValidatorAddress | slice of bytes (`[]byte`)       | Address of the validator                                                                    | Length must be equal to 20                                                                           |
-| ValidatorIndex   | int32                           | Index at a specific block height that corresponds to the Index of the validator in the set. | must be > 0                                                                                          |
-| Signature        | slice of bytes (`[]byte`)       | Signature by the validator if they participated in consensus for the associated bock.       | Length of signature must be > 0 and < 64                                                             |
+| Name               | Type                            | Description                                                                              | Validation                               |
+|--------------------|---------------------------------|------------------------------------------------------------------------------------------|------------------------------------------|
+| Type               | [SignedMsgType](#signedmsgtype) | The type of message the vote refers to                                                   | Must be `PrevoteType` or `PrecommitType` |
+| Height             | int64                           | Height for which this vote was created for                                               | Must be > 0                              |
+| Round              | int32                           | Round that the commit corresponds to.                                                    | Must be > 0                              |
+| BlockID            | [BlockID](#blockid)             | The blockID of the corresponding block.                                                  |                                          |
+| Timestamp          | [Time](#time)                   | Timestamp represents the time at which a validator signed.                               |                                          |
+| ValidatorAddress   | bytes                           | Address of the validator                                                                 | Length must be equal to 20               |
+| ValidatorIndex     | int32                           | Index at a specific block height corresponding to the Index of the validator in the set. | Must be > 0                              |
+| Signature          | bytes                           | Signature by the validator if they participated in consensus for the associated block.   | Length must be > 0 and < 64              |
+| Extension          | bytes                           | Vote extension provided by the Application running at the validator's node.              | Length can be 0                          |
+| ExtensionSignature | bytes                           | Signature for the extension                                                              | Length must be > 0 and < 64              |
 
 ## CanonicalVote
 
-CanonicalVote is for validator signing. This type will not be present in a block. Votes are represented via `CanonicalVote` and also encoded using protobuf via `type.SignBytes` which includes the `ChainID`, and uses a different ordering of
-the fields.
+CanonicalVote is for validator signing. This type will not be present in a block.
+Votes are represented via `CanonicalVote` and also encoded using protobuf via `type.SignBytes` which includes the `ChainID`,
+and uses a different ordering of the fields.
 
-```proto
-message CanonicalVote {
-  SignedMsgType             type      = 1;
-  fixed64                  height    = 2;
-  sfixed64                  round     = 3;
-  CanonicalBlockID          block_id  = 4;
-  google.protobuf.Timestamp timestamp = 5;
-  string                    chain_id  = 6;
-}
-```
+| Name      | Type                            | Description                             | Validation                               |
+|-----------|---------------------------------|-----------------------------------------|------------------------------------------|
+| Type      | [SignedMsgType](#signedmsgtype) | The type of message the vote refers to  | Must be `PrevoteType` or `PrecommitType` |
+| Height    | int64                           | Height in which the vote was provided.  | Must be > 0                              |
+| Round     | int64                           | Round in which the vote was provided.   | Must be > 0                              |
+| BlockID   | string                          | ID of the block the vote refers to.     |                                          |
+| Timestamp | string                          | Time of the vote.                       |                                          |
+| ChainID   | string                          | ID of the blockchain running consensus. |                                          |
 
 For signing, votes are represented via [`CanonicalVote`](#canonicalvote) and also encoded using protobuf via
 `type.SignBytes` which includes the `ChainID`, and uses a different ordering of
@@ -280,6 +310,18 @@ func (vote *Vote) Verify(chainID string, pubKey crypto.PubKey) error {
  return nil
 }
 ```
+
+### CanonicalVoteExtension
+
+Vote extensions are signed using a representation similar to votes.
+This is the structure to marshall in order to obtain the bytes to sign or verify the signature.
+
+| Name      | Type   | Description                                 | Validation           |
+|-----------|--------|---------------------------------------------|----------------------|
+| Extension | bytes  | Vote extension provided by the Application. | Can have zero length |
+| Height    | int64  | Height in which the extension was provided. | Must be > 0          |
+| Round     | int64  | Round in which the extension was provided.  | Must be > 0          |
+| ChainID   | string | ID of the blockchain running consensus.     |                      |
 
 ## Proposal
 

--- a/spec/p2p/messages/block-sync.md
+++ b/spec/p2p/messages/block-sync.md
@@ -10,7 +10,7 @@ Block sync has one channel.
 
 | Name              | Number |
 |-------------------|--------|
-| BlocksyncChannel | 64     |
+| BlocksyncChannel  | 64     |
 
 ## Message Types
 
@@ -35,10 +35,12 @@ NoBlockResponse notifies the peer requesting a block that the node does not cont
 ### BlockResponse
 
 BlockResponse contains the block requested.
+It also contains an extended commit _iff_ vote extensions are enabled at the block's height.
 
-| Name  | Type                                         | Description     | Field Number |
-|-------|----------------------------------------------|-----------------|--------------|
-| Block | [Block](../../core/data_structures.md#block) | Requested Block | 1            |
+| Name      | Type                                                           | Description                     | Field Number |
+|-----------|----------------------------------------------------------------|---------------------------------|--------------|
+| Block     | [Block](../../core/data_structures.md#block)                   | Requested Block                 | 1            |
+| ExtCommit | [ExtendedCommit](../../core/data_structures.md#extendedcommit) | Sender's LastCommit information | 2            |
 
 ### StatusRequest
 
@@ -48,21 +50,21 @@ StatusRequest is an empty message that notifies the peer to respond with the hig
 
 ### StatusResponse
 
-StatusResponse responds to a peer with the highest and lowest block stored.
+StatusResponse responds to a peer with the highest and lowest heights of any block it has in its blockstore.
 
 | Name   | Type  | Description                                                       | Field Number |
 |--------|-------|-------------------------------------------------------------------|--------------|
 | Height | int64 | Current Height of a node                                          | 1            |
-| base   | int64 | First known block, if pruning is enabled it will be higher than 1 | 1            |
+| Base   | int64 | First known block, if pruning is enabled it will be higher than 1 | 2            |
 
 ### Message
 
 Message is a [`oneof` protobuf type](https://developers.google.com/protocol-buffers/docs/proto#oneof). The `oneof` consists of five messages.
 
-| Name              | Type                             | Description                                                  | Field Number |
-|-------------------|----------------------------------|--------------------------------------------------------------|--------------|
-| block_request     | [BlockRequest](#blockrequest)    | Request a block from a peer                                  | 1            |
+| Name              | Type                                | Description                                                  | Field Number |
+|-------------------|-------------------------------------|--------------------------------------------------------------|--------------|
+| block_request     | [BlockRequest](#blockrequest)       | Request a block from a peer                                  | 1            |
 | no_block_response | [NoBlockResponse](#noblockresponse) | Response saying it doe snot have the requested block         | 2            |
-| block_response    | [BlockResponse](#blockresponse)   | Response with requested block                                | 3            |
-| status_request    | [StatusRequest](#statusrequest)   | Request the highest and lowest block numbers from a peer     | 4            |
-| status_response   | [StatusResponse](#statusresponse)  | Response with the highest and lowest block numbers the store | 5            |
+| block_response    | [BlockResponse](#blockresponse)     | Response with requested block + (optionally) vote extensions | 3            |
+| status_request    | [StatusRequest](#statusrequest)     | Request the highest and lowest block numbers from a peer     | 4            |
+| status_response   | [StatusResponse](#statusresponse)   | Response with the highest and lowest block numbers the store | 5            |


### PR DESCRIPTION
Closes #544

With the changes to various protobufs in this branch, parts of the documentation had fallen out of sync.
This PR updates those spots to match the current protobufs.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments

