### PR TITLE
Strengthen CometBFT's internal checks on vote extension enablement

### DIFF
--- a/blocksync/reactor.go
+++ b/blocksync/reactor.go
@@ -453,11 +453,10 @@ FOR_LOOP:
 				// validate the block before we persist it
 				err = bcR.blockExec.ValidateBlock(state, first)
 			}
-			if err == nil && state.ConsensusParams.ABCI.VoteExtensionsEnabled(first.Height) {
+			if err == nil {
 				// if vote extensions were required at this height, ensure they exist.
-				err = extCommit.EnsureExtensions()
+				err = extCommit.EnsureExtensions(state.ConsensusParams.ABCI.VoteExtensionsEnabled(first.Height))
 			}
-
 			if err != nil {
 				bcR.Logger.Error("Error in validation", "err", err)
 				peerID := bcR.pool.RedoRequest(first.Height)

--- a/blocksync/reactor.go
+++ b/blocksync/reactor.go
@@ -462,10 +462,6 @@ FOR_LOOP:
 						err = fmt.Errorf("received non-nil extCommit for height %d (extensions disabled)", first.Height)
 					}
 				}
-				//TODO Remove
-				if err != nil {
-					panic(fmt.Errorf("this shouldn't happen: %w", err))
-				}
 			}
 			if err != nil {
 				bcR.Logger.Error("Error in validation", "err", err)

--- a/blocksync/reactor.go
+++ b/blocksync/reactor.go
@@ -455,7 +455,17 @@ FOR_LOOP:
 			}
 			if err == nil {
 				// if vote extensions were required at this height, ensure they exist.
-				err = extCommit.EnsureExtensions(state.ConsensusParams.ABCI.VoteExtensionsEnabled(first.Height))
+				if state.ConsensusParams.ABCI.VoteExtensionsEnabled(first.Height) {
+					err = extCommit.EnsureExtensions(true)
+				} else {
+					if extCommit != nil {
+						err = fmt.Errorf("received non-nil extCommit for height %d (extensions disabled)", first.Height)
+					}
+				}
+				//TODO Remove
+				if err != nil {
+					panic(fmt.Errorf("this shouldn't happen: %w", err))
+				}
 			}
 			if err != nil {
 				bcR.Logger.Error("Error in validation", "err", err)

--- a/blocksync/reactor.go
+++ b/blocksync/reactor.go
@@ -462,6 +462,10 @@ FOR_LOOP:
 						err = fmt.Errorf("received non-nil extCommit for height %d (extensions disabled)", first.Height)
 					}
 				}
+				//TODO DIAGNOSE Remove
+				if err != nil {
+					panic(fmt.Errorf("this shouldn't happen with correct nodes: %w", err))
+				}
 			}
 			if err != nil {
 				bcR.Logger.Error("Error in validation", "err", err)

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -192,7 +192,8 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 			extCommit = &types.ExtendedCommit{}
 		case lazyProposer.LastCommit.HasTwoThirdsMajority():
 			// Make the commit from LastCommit
-			extCommit = lazyProposer.LastCommit.MakeExtendedCommit()
+			veHeightParam := types.ABCIParams{VoteExtensionsEnableHeight: height}
+			extCommit = lazyProposer.LastCommit.MakeExtendedCommit(veHeightParam)
 		default: // This shouldn't happen.
 			lazyProposer.Logger.Error("enterPropose: Cannot propose anything: No commit for the previous block")
 			return

--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -76,7 +76,7 @@ func (cs *State) readReplayMessage(msg *TimedWALMessage, newStepSub types.Subscr
 		case *VoteMessage:
 			v := msg.Vote
 			cs.Logger.Info("Replay: Vote", "height", v.Height, "round", v.Round, "type", v.Type,
-				"blockID", v.BlockID, "peer", peerID)
+				"blockID", v.BlockID, "peer", peerID, "extensionLen", len(v.Extension), "extSigLen", len(v.ExtensionSignature))
 		}
 
 		cs.handleMsg(m)

--- a/consensus/replay_test.go
+++ b/consensus/replay_test.go
@@ -356,7 +356,7 @@ func setupChainWithChangingValidators(t *testing.T, name string, nBlocks int) (*
 	ensureNewRound(newRoundCh, height, 0)
 	ensureNewProposal(proposalCh, height, round)
 	rs := css[0].GetRoundState()
-	signAddVotes(css[0], cmtproto.PrecommitType, rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header(), vss[1:nVals]...)
+	signAddVotes(css[0], cmtproto.PrecommitType, rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header(), true, vss[1:nVals]...)
 	ensureNewRound(newRoundCh, height+1, 0)
 
 	// HEIGHT 2
@@ -388,7 +388,7 @@ func setupChainWithChangingValidators(t *testing.T, name string, nBlocks int) (*
 	}
 	ensureNewProposal(proposalCh, height, round)
 	rs = css[0].GetRoundState()
-	signAddVotes(css[0], cmtproto.PrecommitType, rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header(), vss[1:nVals]...)
+	signAddVotes(css[0], cmtproto.PrecommitType, rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header(), true, vss[1:nVals]...)
 	ensureNewRound(newRoundCh, height+1, 0)
 
 	// HEIGHT 3
@@ -420,7 +420,7 @@ func setupChainWithChangingValidators(t *testing.T, name string, nBlocks int) (*
 	}
 	ensureNewProposal(proposalCh, height, round)
 	rs = css[0].GetRoundState()
-	signAddVotes(css[0], cmtproto.PrecommitType, rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header(), vss[1:nVals]...)
+	signAddVotes(css[0], cmtproto.PrecommitType, rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header(), true, vss[1:nVals]...)
 	ensureNewRound(newRoundCh, height+1, 0)
 
 	// HEIGHT 4
@@ -488,7 +488,7 @@ func setupChainWithChangingValidators(t *testing.T, name string, nBlocks int) (*
 		if i == selfIndex {
 			continue
 		}
-		signAddVotes(css[0], cmtproto.PrecommitType, rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header(), newVss[i])
+		signAddVotes(css[0], cmtproto.PrecommitType, rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header(), true, newVss[i])
 	}
 
 	ensureNewRound(newRoundCh, height+1, 0)
@@ -507,7 +507,7 @@ func setupChainWithChangingValidators(t *testing.T, name string, nBlocks int) (*
 		if i == selfIndex {
 			continue
 		}
-		signAddVotes(css[0], cmtproto.PrecommitType, rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header(), newVss[i])
+		signAddVotes(css[0], cmtproto.PrecommitType, rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header(), true, newVss[i])
 	}
 	ensureNewRound(newRoundCh, height+1, 0)
 
@@ -544,7 +544,7 @@ func setupChainWithChangingValidators(t *testing.T, name string, nBlocks int) (*
 		if i == selfIndex {
 			continue
 		}
-		signAddVotes(css[0], cmtproto.PrecommitType, rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header(), newVss[i])
+		signAddVotes(css[0], cmtproto.PrecommitType, rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header(), true, newVss[i])
 	}
 	ensureNewRound(newRoundCh, height+1, 0)
 

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -2161,7 +2161,9 @@ func (cs *State) addVote(vote *types.Vote, peerID p2p.ID) (added bool, err error
 		// is disabled on the network.
 		// https://github.com/tendermint/tendermint/issues/8565
 		if len(vote.Extension) > 0 || len(vote.ExtensionSignature) > 0 {
-			return false, fmt.Errorf("received vote with vote extension for height %v (extensions disabled) from peer ID %s", vote.Height, peerID)
+			//TODO DIAGNOSE Remove
+			panic(fmt.Errorf("received vote with vote extension for height %v (extensions disabled) from peer ID %s", vote.Height, peerID))
+			//return false, fmt.Errorf("received vote with vote extension for height %v (extensions disabled) from peer ID %s", vote.Height, peerID)
 		}
 	}
 

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1258,7 +1258,7 @@ func (cs *State) createProposalBlock(ctx context.Context) (*types.Block, error) 
 
 	case cs.LastCommit.HasTwoThirdsMajority():
 		// Make the commit from LastCommit
-		lastExtCommit = cs.LastCommit.MakeExtendedCommit()
+		lastExtCommit = cs.LastCommit.MakeExtendedCommit(cs.state.ConsensusParams.ABCI)
 
 	default: // This shouldn't happen.
 		return nil, errors.New("propose step; cannot propose anything without commit for the previous block")
@@ -1695,7 +1695,7 @@ func (cs *State) finalizeCommit(height int64) {
 	if cs.blockStore.Height() < block.Height {
 		// NOTE: the seenCommit is local justification to commit this block,
 		// but may differ from the LastCommit included in the next block
-		seenExtendedCommit := cs.Votes.Precommits(cs.CommitRound).MakeExtendedCommit()
+		seenExtendedCommit := cs.Votes.Precommits(cs.CommitRound).MakeExtendedCommit(cs.state.ConsensusParams.ABCI)
 		if cs.state.ConsensusParams.ABCI.VoteExtensionsEnabled(block.Height) {
 			cs.blockStore.SaveBlockWithExtendedCommit(block, blockParts, seenExtendedCommit)
 		} else {

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -589,6 +589,10 @@ func (cs *State) votesFromExtendedCommit(state sm.State) (*types.VoteSet, error)
 	if ec == nil {
 		return nil, fmt.Errorf("extended commit for height %v not found", state.LastBlockHeight)
 	}
+	//XXXXX Remove this?
+	if ec.Height != state.LastBlockHeight {
+		return nil, fmt.Errorf("heights don't match in ec %v!=%v", ec.Height, state.LastBlockHeight)
+	}
 	vs := ec.ToExtendedVoteSet(state.ChainID, state.LastValidators)
 	if !vs.HasTwoThirdsMajority() {
 		return nil, errors.New("extended commit does not have +2/3 majority")
@@ -604,7 +608,10 @@ func (cs *State) votesFromSeenCommit(state sm.State) (*types.VoteSet, error) {
 	if commit == nil {
 		return nil, fmt.Errorf("commit for height %v not found", state.LastBlockHeight)
 	}
-
+	//XXXXX Remove this?
+	if commit.Height != state.LastBlockHeight {
+		return nil, fmt.Errorf("heights don't match in seen commit %v!=%v", commit.Height, state.LastBlockHeight)
+	}
 	vs := commit.ToVoteSet(state.ChainID, state.LastValidators)
 	if !vs.HasTwoThirdsMajority() {
 		return nil, errors.New("commit does not have +2/3 majority")
@@ -2114,7 +2121,7 @@ func (cs *State) addVote(vote *types.Vote, peerID p2p.ID) (added bool, err error
 	}
 
 	// Check to see if the chain is configured to extend votes.
-	if cs.state.ConsensusParams.ABCI.VoteExtensionsEnabled(cs.Height) {
+	if cs.state.ConsensusParams.ABCI.VoteExtensionsEnabled(vote.Height) {
 		// The chain is configured to extend votes, check that the vote is
 		// not for a nil block and verify the extensions signature against the
 		// corresponding public key.
@@ -2145,18 +2152,20 @@ func (cs *State) addVote(vote *types.Vote, peerID p2p.ID) (added bool, err error
 		}
 	} else {
 		// Vote extensions are not enabled on the network.
-		// strip the extension data from the vote in case any is present.
+		// Reject the vote, as it is malformed
 		//
 		// TODO punish a peer if it sent a vote with an extension when the feature
 		// is disabled on the network.
 		// https://github.com/tendermint/tendermint/issues/8565
 		if stripped := vote.StripExtension(); stripped {
-			cs.Logger.Error("vote included extension data but vote extensions are not enabled", "peer", peerID)
+			//TODO XXXX remove the panic (for testing) and restore the return
+			panic(fmt.Errorf("received vote with vote extension for height %v (extensions disabled) from peer ID %s", vote.Height, peerID))
+			//return false, fmt.Errorf("received vote with vote extension for height %v (extensions disabled) from peer ID %s", vote.Height, peerID)
 		}
 	}
 
 	height := cs.Height
-	added, err = cs.Votes.AddVote(vote, peerID)
+	added, err = cs.Votes.AddVote(vote, peerID, cs.state.ConsensusParams.ABCI.VoteExtensionsEnabled(vote.Height))
 	if !added {
 		// Either duplicate, or error upon cs.Votes.AddByIndex()
 		return
@@ -2363,35 +2372,39 @@ func (cs *State) signAddVote(
 	msgType cmtproto.SignedMsgType,
 	hash []byte,
 	header types.PartSetHeader,
-) *types.Vote {
+) {
 	if cs.privValidator == nil { // the node does not have a key
-		return nil
+		return
 	}
 
 	if cs.privValidatorPubKey == nil {
 		// Vote won't be signed, but it's not critical.
 		cs.Logger.Error(fmt.Sprintf("signAddVote: %v", errPubKeyIsNotSet))
-		return nil
+		return
 	}
 
 	// If the node not in the validator set, do nothing.
 	if !cs.Validators.HasAddress(cs.privValidatorPubKey.Address()) {
-		return nil
+		return
 	}
 
 	// TODO: pass pubKey to signVote
 	vote, err := cs.signVote(msgType, hash, header)
 	if err != nil {
 		cs.Logger.Error("failed signing vote", "height", cs.Height, "round", cs.Round, "vote", vote, "err", err)
-		return nil
+		return
 	}
-	if !cs.state.ConsensusParams.ABCI.VoteExtensionsEnabled(vote.Height) {
+	hasExt := len(vote.ExtensionSignature) > 0
+	extEnabled := cs.state.ConsensusParams.ABCI.VoteExtensionsEnabled(vote.Height)
+	if vote.Type == cmtproto.PrecommitType && !vote.BlockID.IsZero() && hasExt != extEnabled {
 		// The signer will sign the extension, make sure to remove the data on the way out
-		vote.StripExtension()
+		//vote.StripExtension()
+		panic(fmt.Errorf("Vote extension does not match extensions enabled %t!=%t, height %d, type %v",
+			hasExt, extEnabled, vote.Height, vote.Type))
 	}
 	cs.sendInternalMessage(msgInfo{&VoteMessage{vote}, ""})
 	cs.Logger.Debug("signed and pushed vote", "height", cs.Height, "round", cs.Round, "vote", vote)
-	return vote
+	return
 }
 
 // updatePrivValidatorPubKey get's the private validator public key and

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -2076,6 +2076,8 @@ func (cs *State) addVote(vote *types.Vote, peerID p2p.ID) (added bool, err error
 		"vote_type", vote.Type,
 		"val_index", vote.ValidatorIndex,
 		"cs_height", cs.Height,
+		"extLen", len(vote.Extension),
+		"extSigLen", len(vote.ExtensionSignature),
 	)
 
 	if vote.Height < cs.Height || (vote.Height == cs.Height && vote.Round < cs.Round) {

--- a/consensus/types/height_vote_set.go
+++ b/consensus/types/height_vote_set.go
@@ -133,10 +133,8 @@ func (hvs *HeightVoteSet) addRound(round int32) {
 func (hvs *HeightVoteSet) AddVote(vote *types.Vote, peerID p2p.ID, extEnabled bool) (added bool, err error) {
 	hvs.mtx.Lock()
 	defer hvs.mtx.Unlock()
-
-	//TODO: Remove?
 	if hvs.extensionsEnabled != extEnabled {
-		panic(fmt.Errorf("Extensions enabled param does not match in HeightVoteSet %t!=%t", hvs.extensionsEnabled, extEnabled))
+		panic(fmt.Errorf("extensions enabled general param does not match the one in HeightVoteSet %t!=%t", hvs.extensionsEnabled, extEnabled))
 	}
 	if !types.IsVoteTypeValid(vote.Type) {
 		return

--- a/consensus/types/height_vote_set.go
+++ b/consensus/types/height_vote_set.go
@@ -130,9 +130,14 @@ func (hvs *HeightVoteSet) addRound(round int32) {
 
 // Duplicate votes return added=false, err=nil.
 // By convention, peerID is "" if origin is self.
-func (hvs *HeightVoteSet) AddVote(vote *types.Vote, peerID p2p.ID) (added bool, err error) {
+func (hvs *HeightVoteSet) AddVote(vote *types.Vote, peerID p2p.ID, extEnabled bool) (added bool, err error) {
 	hvs.mtx.Lock()
 	defer hvs.mtx.Unlock()
+
+	//TODO: Remove?
+	if hvs.extensionsEnabled != extEnabled {
+		panic(fmt.Errorf("Extensions enabled param does not match in HeightVoteSet %t!=%t", hvs.extensionsEnabled, extEnabled))
+	}
 	if !types.IsVoteTypeValid(vote.Type) {
 		return
 	}

--- a/consensus/types/height_vote_set_test.go
+++ b/consensus/types/height_vote_set_test.go
@@ -28,19 +28,19 @@ func TestPeerCatchupRounds(t *testing.T) {
 	hvs := NewExtendedHeightVoteSet(test.DefaultTestChainID, 1, valSet)
 
 	vote999_0 := makeVoteHR(t, 1, 0, 999, privVals)
-	added, err := hvs.AddVote(vote999_0, "peer1")
+	added, err := hvs.AddVote(vote999_0, "peer1", true)
 	if !added || err != nil {
 		t.Error("Expected to successfully add vote from peer", added, err)
 	}
 
 	vote1000_0 := makeVoteHR(t, 1, 0, 1000, privVals)
-	added, err = hvs.AddVote(vote1000_0, "peer1")
+	added, err = hvs.AddVote(vote1000_0, "peer1", true)
 	if !added || err != nil {
 		t.Error("Expected to successfully add vote from peer", added, err)
 	}
 
 	vote1001_0 := makeVoteHR(t, 1, 0, 1001, privVals)
-	added, err = hvs.AddVote(vote1001_0, "peer1")
+	added, err = hvs.AddVote(vote1001_0, "peer1", true)
 	if err != ErrGotVoteFromUnwantedRound {
 		t.Errorf("expected GotVoteFromUnwantedRoundError, but got %v", err)
 	}
@@ -48,7 +48,7 @@ func TestPeerCatchupRounds(t *testing.T) {
 		t.Error("Expected to *not* add vote from peer, too many catchup rounds.")
 	}
 
-	added, err = hvs.AddVote(vote1001_0, "peer2")
+	added, err = hvs.AddVote(vote1001_0, "peer2", true)
 	if !added || err != nil {
 		t.Error("Expected to successfully add vote from another peer")
 	}

--- a/evidence/verify_test.go
+++ b/evidence/verify_test.go
@@ -208,9 +208,8 @@ func TestVerifyLightClientAttack_Equivocation(t *testing.T) {
 	// except the last validator vote twice
 	blockID := makeBlockID(conflictingHeader.Hash(), 1000, []byte("partshash"))
 	voteSet := types.NewExtendedVoteSet(evidenceChainID, 10, 1, cmtproto.SignedMsgType(2), conflictingVals)
-	extCommit, err := test.MakeExtendedCommitFromVoteSet(blockID, voteSet, conflictingPrivVals[:4], defaultEvidenceTime)
+	commit, err := test.MakeCommitFromVoteSet(blockID, voteSet, conflictingPrivVals[:4], defaultEvidenceTime)
 	require.NoError(t, err)
-	commit := extCommit.ToCommit()
 	ev := &types.LightClientAttackEvidence{
 		ConflictingBlock: &types.LightBlock{
 			SignedHeader: &types.SignedHeader{
@@ -227,9 +226,8 @@ func TestVerifyLightClientAttack_Equivocation(t *testing.T) {
 
 	trustedBlockID := makeBlockID(trustedHeader.Hash(), 1000, []byte("partshash"))
 	trustedVoteSet := types.NewExtendedVoteSet(evidenceChainID, 10, 1, cmtproto.SignedMsgType(2), conflictingVals)
-	trustedExtCommit, err := test.MakeExtendedCommitFromVoteSet(trustedBlockID, trustedVoteSet, conflictingPrivVals, defaultEvidenceTime)
+	trustedCommit, err := test.MakeCommitFromVoteSet(trustedBlockID, trustedVoteSet, conflictingPrivVals, defaultEvidenceTime)
 	require.NoError(t, err)
-	trustedCommit := trustedExtCommit.ToCommit()
 	trustedSignedHeader := &types.SignedHeader{
 		Header: trustedHeader,
 		Commit: trustedCommit,
@@ -294,9 +292,8 @@ func TestVerifyLightClientAttack_Amnesia(t *testing.T) {
 	// except the last validator vote twice. However this time the commits are of different rounds.
 	blockID := makeBlockID(conflictingHeader.Hash(), 1000, []byte("partshash"))
 	voteSet := types.NewExtendedVoteSet(evidenceChainID, 10, 0, cmtproto.SignedMsgType(2), conflictingVals)
-	extCommit, err := test.MakeExtendedCommitFromVoteSet(blockID, voteSet, conflictingPrivVals, defaultEvidenceTime)
+	commit, err := test.MakeCommitFromVoteSet(blockID, voteSet, conflictingPrivVals, defaultEvidenceTime)
 	require.NoError(t, err)
-	commit := extCommit.ToCommit()
 	ev := &types.LightClientAttackEvidence{
 		ConflictingBlock: &types.LightBlock{
 			SignedHeader: &types.SignedHeader{
@@ -313,9 +310,8 @@ func TestVerifyLightClientAttack_Amnesia(t *testing.T) {
 
 	trustedBlockID := makeBlockID(trustedHeader.Hash(), 1000, []byte("partshash"))
 	trustedVoteSet := types.NewExtendedVoteSet(evidenceChainID, 10, 1, cmtproto.SignedMsgType(2), conflictingVals)
-	trustedExtCommit, err := test.MakeExtendedCommitFromVoteSet(trustedBlockID, trustedVoteSet, conflictingPrivVals, defaultEvidenceTime)
+	trustedCommit, err := test.MakeCommitFromVoteSet(trustedBlockID, trustedVoteSet, conflictingPrivVals, defaultEvidenceTime)
 	require.NoError(t, err)
-	trustedCommit := trustedExtCommit.ToCommit()
 	trustedSignedHeader := &types.SignedHeader{
 		Header: trustedHeader,
 		Commit: trustedCommit,
@@ -489,9 +485,8 @@ func makeLunaticEvidence(
 
 	blockID := makeBlockID(conflictingHeader.Hash(), 1000, []byte("partshash"))
 	voteSet := types.NewExtendedVoteSet(evidenceChainID, height, 1, cmtproto.SignedMsgType(2), conflictingVals)
-	extCommit, err := test.MakeExtendedCommitFromVoteSet(blockID, voteSet, conflictingPrivVals, defaultEvidenceTime)
+	commit, err := test.MakeCommitFromVoteSet(blockID, voteSet, conflictingPrivVals, defaultEvidenceTime)
 	require.NoError(t, err)
-	commit := extCommit.ToCommit()
 	ev = &types.LightClientAttackEvidence{
 		ConflictingBlock: &types.LightBlock{
 			SignedHeader: &types.SignedHeader{
@@ -517,9 +512,8 @@ func makeLunaticEvidence(
 	trustedBlockID := makeBlockID(trustedHeader.Hash(), 1000, []byte("partshash"))
 	trustedVals, privVals := types.RandValidatorSet(totalVals, defaultVotingPower)
 	trustedVoteSet := types.NewExtendedVoteSet(evidenceChainID, height, 1, cmtproto.SignedMsgType(2), trustedVals)
-	trustedExtCommit, err := test.MakeExtendedCommitFromVoteSet(trustedBlockID, trustedVoteSet, privVals, defaultEvidenceTime)
+	trustedCommit, err := test.MakeCommitFromVoteSet(trustedBlockID, trustedVoteSet, privVals, defaultEvidenceTime)
 	require.NoError(t, err)
-	trustedCommit := trustedExtCommit.ToCommit()
 	trusted = &types.LightBlock{
 		SignedHeader: &types.SignedHeader{
 			Header: trustedHeader,

--- a/evidence/verify_test.go
+++ b/evidence/verify_test.go
@@ -207,7 +207,7 @@ func TestVerifyLightClientAttack_Equivocation(t *testing.T) {
 	// we are simulating a duplicate vote attack where all the validators in the conflictingVals set
 	// except the last validator vote twice
 	blockID := makeBlockID(conflictingHeader.Hash(), 1000, []byte("partshash"))
-	voteSet := types.NewExtendedVoteSet(evidenceChainID, 10, 1, cmtproto.SignedMsgType(2), conflictingVals)
+	voteSet := types.NewVoteSet(evidenceChainID, 10, 1, cmtproto.SignedMsgType(2), conflictingVals)
 	commit, err := test.MakeCommitFromVoteSet(blockID, voteSet, conflictingPrivVals[:4], defaultEvidenceTime)
 	require.NoError(t, err)
 	ev := &types.LightClientAttackEvidence{
@@ -225,7 +225,7 @@ func TestVerifyLightClientAttack_Equivocation(t *testing.T) {
 	}
 
 	trustedBlockID := makeBlockID(trustedHeader.Hash(), 1000, []byte("partshash"))
-	trustedVoteSet := types.NewExtendedVoteSet(evidenceChainID, 10, 1, cmtproto.SignedMsgType(2), conflictingVals)
+	trustedVoteSet := types.NewVoteSet(evidenceChainID, 10, 1, cmtproto.SignedMsgType(2), conflictingVals)
 	trustedCommit, err := test.MakeCommitFromVoteSet(trustedBlockID, trustedVoteSet, conflictingPrivVals, defaultEvidenceTime)
 	require.NoError(t, err)
 	trustedSignedHeader := &types.SignedHeader{
@@ -291,7 +291,7 @@ func TestVerifyLightClientAttack_Amnesia(t *testing.T) {
 	// we are simulating an amnesia attack where all the validators in the conflictingVals set
 	// except the last validator vote twice. However this time the commits are of different rounds.
 	blockID := makeBlockID(conflictingHeader.Hash(), 1000, []byte("partshash"))
-	voteSet := types.NewExtendedVoteSet(evidenceChainID, 10, 0, cmtproto.SignedMsgType(2), conflictingVals)
+	voteSet := types.NewVoteSet(evidenceChainID, 10, 0, cmtproto.SignedMsgType(2), conflictingVals)
 	commit, err := test.MakeCommitFromVoteSet(blockID, voteSet, conflictingPrivVals, defaultEvidenceTime)
 	require.NoError(t, err)
 	ev := &types.LightClientAttackEvidence{
@@ -309,7 +309,7 @@ func TestVerifyLightClientAttack_Amnesia(t *testing.T) {
 	}
 
 	trustedBlockID := makeBlockID(trustedHeader.Hash(), 1000, []byte("partshash"))
-	trustedVoteSet := types.NewExtendedVoteSet(evidenceChainID, 10, 1, cmtproto.SignedMsgType(2), conflictingVals)
+	trustedVoteSet := types.NewVoteSet(evidenceChainID, 10, 1, cmtproto.SignedMsgType(2), conflictingVals)
 	trustedCommit, err := test.MakeCommitFromVoteSet(trustedBlockID, trustedVoteSet, conflictingPrivVals, defaultEvidenceTime)
 	require.NoError(t, err)
 	trustedSignedHeader := &types.SignedHeader{
@@ -484,7 +484,7 @@ func makeLunaticEvidence(
 	conflictingHeader.ValidatorsHash = conflictingVals.Hash()
 
 	blockID := makeBlockID(conflictingHeader.Hash(), 1000, []byte("partshash"))
-	voteSet := types.NewExtendedVoteSet(evidenceChainID, height, 1, cmtproto.SignedMsgType(2), conflictingVals)
+	voteSet := types.NewVoteSet(evidenceChainID, height, 1, cmtproto.SignedMsgType(2), conflictingVals)
 	commit, err := test.MakeCommitFromVoteSet(blockID, voteSet, conflictingPrivVals, defaultEvidenceTime)
 	require.NoError(t, err)
 	ev = &types.LightClientAttackEvidence{
@@ -511,7 +511,7 @@ func makeLunaticEvidence(
 	}
 	trustedBlockID := makeBlockID(trustedHeader.Hash(), 1000, []byte("partshash"))
 	trustedVals, privVals := types.RandValidatorSet(totalVals, defaultVotingPower)
-	trustedVoteSet := types.NewExtendedVoteSet(evidenceChainID, height, 1, cmtproto.SignedMsgType(2), trustedVals)
+	trustedVoteSet := types.NewVoteSet(evidenceChainID, height, 1, cmtproto.SignedMsgType(2), trustedVals)
 	trustedCommit, err := test.MakeCommitFromVoteSet(trustedBlockID, trustedVoteSet, privVals, defaultEvidenceTime)
 	require.NoError(t, err)
 	trusted = &types.LightBlock{

--- a/internal/test/commit.go
+++ b/internal/test/commit.go
@@ -8,7 +8,8 @@ import (
 	"github.com/cometbft/cometbft/types"
 )
 
-func MakeExtendedCommitFromVoteSet(blockID types.BlockID, voteSet *types.VoteSet, validators []types.PrivValidator, now time.Time) (*types.ExtendedCommit, error) {
+func MakeCommitFromVoteSet(blockID types.BlockID, voteSet *types.VoteSet, validators []types.PrivValidator, now time.Time) (*types.Commit, error) {
+	// TODO: check that the voteSet has extensions disabled
 	// all sign
 	for i := 0; i < len(validators); i++ {
 		pubKey, err := validators[i].GetPubKey()
@@ -31,13 +32,16 @@ func MakeExtendedCommitFromVoteSet(blockID types.BlockID, voteSet *types.VoteSet
 			return nil, err
 		}
 		vote.Signature = v.Signature
-		vote.ExtensionSignature = v.ExtensionSignature
+		//vote.ExtensionSignature = v.ExtensionSignature
 		if _, err := voteSet.AddVote(vote); err != nil {
 			return nil, err
 		}
 	}
 
-	return voteSet.MakeExtendedCommit(), nil
+	ap := types.ABCIParams{
+		VoteExtensionsEnableHeight: 1000000,
+	}
+	return voteSet.MakeExtendedCommit(ap).ToCommit(), nil
 }
 
 func MakeCommit(blockID types.BlockID, height int64, round int32, valSet *types.ValidatorSet, privVals []types.PrivValidator, chainID string, now time.Time) (*types.Commit, error) {

--- a/internal/test/commit.go
+++ b/internal/test/commit.go
@@ -9,7 +9,6 @@ import (
 )
 
 func MakeCommitFromVoteSet(blockID types.BlockID, voteSet *types.VoteSet, validators []types.PrivValidator, now time.Time) (*types.Commit, error) {
-	// TODO: check that the voteSet has extensions disabled
 	// all sign
 	for i := 0; i < len(validators); i++ {
 		pubKey, err := validators[i].GetPubKey()
@@ -32,16 +31,12 @@ func MakeCommitFromVoteSet(blockID types.BlockID, voteSet *types.VoteSet, valida
 			return nil, err
 		}
 		vote.Signature = v.Signature
-		//vote.ExtensionSignature = v.ExtensionSignature
 		if _, err := voteSet.AddVote(vote); err != nil {
 			return nil, err
 		}
 	}
 
-	ap := types.ABCIParams{
-		VoteExtensionsEnableHeight: 1000000,
-	}
-	return voteSet.MakeExtendedCommit(ap).ToCommit(), nil
+	return voteSet.MakeExtendedCommit(types.ABCIParams{VoteExtensionsEnableHeight: 0}).ToCommit(), nil
 }
 
 func MakeCommit(blockID types.BlockID, height int64, round int32, valSet *types.ValidatorSet, privVals []types.PrivValidator, chainID string, now time.Time) (*types.Commit, error) {

--- a/state/execution.go
+++ b/state/execution.go
@@ -485,7 +485,7 @@ func buildExtendedCommitInfo(ec *types.ExtendedCommit, store Store, initialHeigh
 		// the proposer. If they were not enabled during this previous height, we
 		// will not deliver extension data.
 		if err := ecs.EnsureExtension(ap.VoteExtensionsEnabled(ec.Height)); err != nil {
-			panic(fmt.Errorf("commit at height %d received with missing vote extension data; err %w", ec.Height, err))
+			panic(fmt.Errorf("commit at height %d has problems with vote extension data; err %w", ec.Height, err))
 		}
 
 		votes[i] = abci.ExtendedVoteInfo{

--- a/state/execution.go
+++ b/state/execution.go
@@ -485,13 +485,11 @@ func buildExtendedCommitInfo(ec *types.ExtendedCommit, store Store, initialHeigh
 		// during that height, we ensure they are present and deliver the data to
 		// the proposer. If they were not enabled during this previous height, we
 		// will not deliver extension data.
-		if ap.VoteExtensionsEnabled(ec.Height) && ecs.BlockIDFlag == types.BlockIDFlagCommit {
-			if ecs.EnsureExtension() != nil {
-				panic(fmt.Errorf("commit at height %d received with missing vote extensions data", ec.Height))
-			}
-			ext = ecs.Extension
-			extSig = ecs.ExtensionSignature
+		if err := ecs.EnsureExtension(ap.VoteExtensionsEnabled(ec.Height)); err != nil {
+			panic(fmt.Errorf("commit at height %d received with missing vote extension data; err %w", ec.Height, err))
 		}
+		ext = ecs.Extension
+		extSig = ecs.ExtensionSignature
 
 		votes[i] = abci.ExtendedVoteInfo{
 			Validator:          types.TM2PB.Validator(val),

--- a/state/execution.go
+++ b/state/execution.go
@@ -479,7 +479,6 @@ func buildExtendedCommitInfo(ec *types.ExtendedCommit, store Store, initialHeigh
 			))
 		}
 
-		var ext, extSig []byte
 		// Check if vote extensions were enabled during the commit's height: ec.Height.
 		// ec is the commit from the previous height, so if extensions were enabled
 		// during that height, we ensure they are present and deliver the data to
@@ -488,14 +487,12 @@ func buildExtendedCommitInfo(ec *types.ExtendedCommit, store Store, initialHeigh
 		if err := ecs.EnsureExtension(ap.VoteExtensionsEnabled(ec.Height)); err != nil {
 			panic(fmt.Errorf("commit at height %d received with missing vote extension data; err %w", ec.Height, err))
 		}
-		ext = ecs.Extension
-		extSig = ecs.ExtensionSignature
 
 		votes[i] = abci.ExtendedVoteInfo{
 			Validator:          types.TM2PB.Validator(val),
 			BlockIdFlag:        cmtproto.BlockIDFlag(ecs.BlockIDFlag),
-			VoteExtension:      ext,
-			ExtensionSignature: extSig,
+			VoteExtension:      ecs.Extension,
+			ExtensionSignature: ecs.ExtensionSignature,
 		}
 	}
 

--- a/store/store.go
+++ b/store/store.go
@@ -410,7 +410,7 @@ func (bs *BlockStore) SaveBlockWithExtendedCommit(block *types.Block, blockParts
 	if block == nil {
 		panic("BlockStore can only save a non-nil block")
 	}
-	if err := seenExtendedCommit.EnsureExtensions(); err != nil {
+	if err := seenExtendedCommit.EnsureExtensions(true); err != nil {
 		panic(fmt.Errorf("saving block with extensions: %w", err))
 	}
 	if err := bs.saveBlockToBatch(block, blockParts, seenExtendedCommit.ToCommit()); err != nil {

--- a/store/store.go
+++ b/store/store.go
@@ -411,7 +411,7 @@ func (bs *BlockStore) SaveBlockWithExtendedCommit(block *types.Block, blockParts
 		panic("BlockStore can only save a non-nil block")
 	}
 	if err := seenExtendedCommit.EnsureExtensions(true); err != nil {
-		panic(fmt.Errorf("saving block with extensions: %w", err))
+		panic(fmt.Errorf("problems saving block with extensions: %w", err))
 	}
 	if err := bs.saveBlockToBatch(block, blockParts, seenExtendedCommit.ToCommit()); err != nil {
 		panic(err)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -352,6 +352,21 @@ func TestBlockStoreSaveLoadBlock(t *testing.T) {
 	}
 }
 
+// StripExtensions removes all VoteExtension data from an ExtendedCommit. This
+// is useful when dealing with an ExendedCommit but vote extension data is
+// expected to be absent.
+func stripExtensions(ec *types.ExtendedCommit) bool {
+	stripped := false
+	for idx := range ec.ExtendedSignatures {
+		if len(ec.ExtendedSignatures[idx].Extension) > 0 || len(ec.ExtendedSignatures[idx].ExtensionSignature) > 0 {
+			stripped = true
+		}
+		ec.ExtendedSignatures[idx].Extension = nil
+		ec.ExtendedSignatures[idx].ExtensionSignature = nil
+	}
+	return stripped
+}
+
 // TestSaveBlockWithExtendedCommitPanicOnAbsentExtension tests that saving a
 // block with an extended commit panics when the extension data is absent.
 func TestSaveBlockWithExtendedCommitPanicOnAbsentExtension(t *testing.T) {
@@ -368,7 +383,7 @@ func TestSaveBlockWithExtendedCommitPanicOnAbsentExtension(t *testing.T) {
 		{
 			name: "save commit with no extensions",
 			malleateCommit: func(c *types.ExtendedCommit) {
-				c.StripExtensions()
+				stripExtensions(c)
 			},
 			shouldPanic: true,
 		},

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -352,7 +352,7 @@ func TestBlockStoreSaveLoadBlock(t *testing.T) {
 	}
 }
 
-// StripExtensions removes all VoteExtension data from an ExtendedCommit. This
+// stripExtensions removes all VoteExtension data from an ExtendedCommit. This
 // is useful when dealing with an ExendedCommit but vote extension data is
 // expected to be absent.
 func stripExtensions(ec *types.ExtendedCommit) bool {

--- a/test/e2e/runner/evidence.go
+++ b/test/e2e/runner/evidence.go
@@ -172,8 +172,8 @@ func generateLightClientAttackEvidence(
 
 	// create a commit for the forged header
 	blockID := makeBlockID(header.Hash(), 1000, []byte("partshash"))
-	voteSet := types.NewExtendedVoteSet(chainID, forgedHeight, 0, cmtproto.SignedMsgType(2), conflictingVals)
-	ec, err := test.MakeExtendedCommitFromVoteSet(blockID, voteSet, pv, forgedTime)
+	voteSet := types.NewVoteSet(chainID, forgedHeight, 0, cmtproto.SignedMsgType(2), conflictingVals)
+	commit, err := test.MakeCommitFromVoteSet(blockID, voteSet, pv, forgedTime)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func generateLightClientAttackEvidence(
 		ConflictingBlock: &types.LightBlock{
 			SignedHeader: &types.SignedHeader{
 				Header: header,
-				Commit: ec.ToCommit(),
+				Commit: commit,
 			},
 			ValidatorSet: conflictingVals,
 		},

--- a/test/e2e/runner/evidence.go
+++ b/test/e2e/runner/evidence.go
@@ -99,8 +99,10 @@ func InjectEvidence(ctx context.Context, r *rand.Rand, testnet *e2e.Testnet, amo
 				ctx, privVals, evidenceHeight, valSet, testnet.Name, blockRes.Block.Time,
 			)
 			if dve.VoteA.Height < testnet.VoteExtensionsEnableHeight {
-				dve.VoteA.StripExtension()
-				dve.VoteB.StripExtension()
+				dve.VoteA.Extension = nil
+				dve.VoteA.ExtensionSignature = nil
+				dve.VoteB.Extension = nil
+				dve.VoteB.ExtensionSignature = nil
 			}
 			ev = dve
 		}

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -214,7 +214,6 @@ func MakeConfig(node *e2e.Node) (*config.Config, error) {
 
 	cfg.BlockSyncMode = true
 	cfg.BlockSync.Version = "v0"
-	//cfg.BaseConfig.LogLevel = "consensus:debug,*:info"
 
 	if node.StateSync {
 		cfg.StateSync.Enable = true

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -212,11 +212,9 @@ func MakeConfig(node *e2e.Node) (*config.Config, error) {
 		return nil, fmt.Errorf("unexpected mode %q", node.Mode)
 	}
 
-	if node.BlockSync == "" {
-		cfg.BlockSyncMode = false
-	} else {
-		cfg.BlockSync.Version = node.BlockSync
-	}
+	cfg.BlockSyncMode = true
+	cfg.BlockSync.Version = "v0"
+	//cfg.BaseConfig.LogLevel = "consensus:debug,*:info"
 
 	if node.StateSync {
 		cfg.StateSync.Enable = true

--- a/types/block.go
+++ b/types/block.go
@@ -1107,14 +1107,6 @@ func (commit *Commit) ToVoteSet(chainID string, vals *ValidatorSet) *VoteSet {
 // EnsureExtensions validates that a vote extensions signature is present for
 // every ExtendedCommitSig in the ExtendedCommit.
 func (ec *ExtendedCommit) EnsureExtensions(extEnabled bool) error {
-	/*
-		if ec.ExtendedSignatures == nil {
-			if extEnabled {
-				return fmt.Errorf("extension signature array is missing; but extensions are enabled; height %d", ec.Height)
-			}
-			return nil
-		}
-	*/
 	for _, ecs := range ec.ExtendedSignatures {
 		if err := ecs.EnsureExtension(extEnabled); err != nil {
 			return err

--- a/types/block.go
+++ b/types/block.go
@@ -765,14 +765,20 @@ func (ecs ExtendedCommitSig) ValidateBasic() error {
 // this ExtendedCommitSig.
 func (ecs ExtendedCommitSig) EnsureExtension(extEnabled bool) error {
 	if extEnabled {
-		if ecs.BlockIDFlag == BlockIDFlagCommit && len(ecs.Extension) == 0 {
-			return fmt.Errorf("vote extension is missing; validator addr %s, timestamp %v",
+		if ecs.BlockIDFlag == BlockIDFlagCommit && len(ecs.ExtensionSignature) == 0 {
+			return fmt.Errorf("vote extension signature is missing; validator addr %s, timestamp %v",
 				ecs.ValidatorAddress.String(),
 				ecs.Timestamp,
 			)
 		}
-		if ecs.BlockIDFlag == BlockIDFlagCommit && len(ecs.ExtensionSignature) == 0 {
-			return fmt.Errorf("vote extension signature is missing; validator add %s, timestamp %v",
+		if ecs.BlockIDFlag != BlockIDFlagCommit && len(ecs.Extension) != 0 {
+			return fmt.Errorf("non-commit vote extension present; validator addr %s, timestamp %v",
+				ecs.ValidatorAddress.String(),
+				ecs.Timestamp,
+			)
+		}
+		if ecs.BlockIDFlag != BlockIDFlagCommit && len(ecs.ExtensionSignature) != 0 {
+			return fmt.Errorf("non-commit vote extension signature present; validator addr %s, timestamp %v",
 				ecs.ValidatorAddress.String(),
 				ecs.Timestamp,
 			)
@@ -785,7 +791,7 @@ func (ecs ExtendedCommitSig) EnsureExtension(extEnabled bool) error {
 			)
 		}
 		if len(ecs.ExtensionSignature) != 0 {
-			return fmt.Errorf("vote extension signature present but extensions disabled; validator add %s, timestamp %v",
+			return fmt.Errorf("vote extension signature present but extensions disabled; validator addr %s, timestamp %v",
 				ecs.ValidatorAddress.String(),
 				ecs.Timestamp,
 			)
@@ -1060,15 +1066,6 @@ func (ec *ExtendedCommit) ToExtendedVoteSet(chainID string, vals *ValidatorSet) 
 	return voteSet
 }
 
-// ToVoteSet constructs a VoteSet from the Commit and validator set.
-// Panics if signatures from the ExtendedCommit can't be added to the voteset.
-// Inverse of VoteSet.MakeExtendedCommit().
-func (ec *ExtendedCommit) ToVoteSet(chainID string, vals *ValidatorSet) *VoteSet {
-	voteSet := NewVoteSet(chainID, ec.Height, ec.Round, cmtproto.PrecommitType, vals)
-	ec.addSigsToVoteSet(voteSet)
-	return voteSet
-}
-
 // addSigsToVoteSet adds all of the signature to voteSet.
 func (ec *ExtendedCommit) addSigsToVoteSet(voteSet *VoteSet) {
 	for idx, ecs := range ec.ExtendedSignatures {
@@ -1110,27 +1107,20 @@ func (commit *Commit) ToVoteSet(chainID string, vals *ValidatorSet) *VoteSet {
 // EnsureExtensions validates that a vote extensions signature is present for
 // every ExtendedCommitSig in the ExtendedCommit.
 func (ec *ExtendedCommit) EnsureExtensions(extEnabled bool) error {
+	/*
+		if ec.ExtendedSignatures == nil {
+			if extEnabled {
+				return fmt.Errorf("extension signature array is missing; but extensions are enabled; height %d", ec.Height)
+			}
+			return nil
+		}
+	*/
 	for _, ecs := range ec.ExtendedSignatures {
 		if err := ecs.EnsureExtension(extEnabled); err != nil {
 			return err
 		}
 	}
 	return nil
-}
-
-// StripExtensions removes all VoteExtension data from an ExtendedCommit. This
-// is useful when dealing with an ExendedCommit but vote extension data is
-// expected to be absent.
-func (ec *ExtendedCommit) StripExtensions() bool {
-	stripped := false
-	for idx := range ec.ExtendedSignatures {
-		if len(ec.ExtendedSignatures[idx].Extension) > 0 || len(ec.ExtendedSignatures[idx].ExtensionSignature) > 0 {
-			stripped = true
-		}
-		ec.ExtendedSignatures[idx].Extension = nil
-		ec.ExtendedSignatures[idx].ExtensionSignature = nil
-	}
-	return stripped
 }
 
 // ToCommit converts an ExtendedCommit to a Commit by removing all vote

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -584,6 +584,15 @@ func TestVoteSetToExtendedCommit(t *testing.T) {
 	}
 }
 
+// ToVoteSet constructs a VoteSet from the Commit and validator set.
+// Panics if signatures from the ExtendedCommit can't be added to the voteset.
+// Inverse of VoteSet.MakeExtendedCommit().
+func toVoteSet(ec *ExtendedCommit, chainID string, vals *ValidatorSet) *VoteSet {
+	voteSet := NewVoteSet(chainID, ec.Height, ec.Round, cmtproto.PrecommitType, vals)
+	ec.addSigsToVoteSet(voteSet)
+	return voteSet
+}
+
 // TestExtendedCommitToVoteSet tests that the vote set produced from an extended commit
 // contains the same vote information as the extended commit. The test ensures
 // that the ToVoteSet method behaves as expected, whether vote extensions
@@ -625,7 +634,7 @@ func TestExtendedCommitToVoteSet(t *testing.T) {
 			if testCase.includeExtension {
 				voteSet2 = extCommit.ToExtendedVoteSet(chainID, valSet)
 			} else {
-				voteSet2 = extCommit.ToVoteSet(chainID, valSet)
+				voteSet2 = toVoteSet(extCommit, chainID, valSet)
 			}
 
 			for i := int32(0); int(i) < len(vals); i++ {

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -38,8 +38,8 @@ func TestBlockAddEvidence(t *testing.T) {
 	lastID := makeBlockIDRandom()
 	h := int64(3)
 
-	voteSet, _, vals := randVoteSet(h-1, 1, cmtproto.PrecommitType, 10, 1)
-	extCommit, err := MakeExtCommit(lastID, h-1, 1, voteSet, vals, time.Now())
+	voteSet, _, vals := randVoteSet(h-1, 1, cmtproto.PrecommitType, 10, 1, false)
+	extCommit, err := MakeExtCommit(lastID, h-1, 1, voteSet, vals, time.Now(), false)
 	require.NoError(t, err)
 
 	ev, err := NewMockDuplicateVoteEvidenceWithValidator(h, time.Now(), vals[0], "block-test-chain")
@@ -59,8 +59,8 @@ func TestBlockValidateBasic(t *testing.T) {
 	lastID := makeBlockIDRandom()
 	h := int64(3)
 
-	voteSet, valSet, vals := randVoteSet(h-1, 1, cmtproto.PrecommitType, 10, 1)
-	extCommit, err := MakeExtCommit(lastID, h-1, 1, voteSet, vals, time.Now())
+	voteSet, valSet, vals := randVoteSet(h-1, 1, cmtproto.PrecommitType, 10, 1, false)
+	extCommit, err := MakeExtCommit(lastID, h-1, 1, voteSet, vals, time.Now(), false)
 	require.NoError(t, err)
 	commit := extCommit.ToCommit()
 
@@ -132,8 +132,8 @@ func TestBlockMakePartSetWithEvidence(t *testing.T) {
 	lastID := makeBlockIDRandom()
 	h := int64(3)
 
-	voteSet, _, vals := randVoteSet(h-1, 1, cmtproto.PrecommitType, 10, 1)
-	extCommit, err := MakeExtCommit(lastID, h-1, 1, voteSet, vals, time.Now())
+	voteSet, _, vals := randVoteSet(h-1, 1, cmtproto.PrecommitType, 10, 1, false)
+	extCommit, err := MakeExtCommit(lastID, h-1, 1, voteSet, vals, time.Now(), false)
 	require.NoError(t, err)
 
 	ev, err := NewMockDuplicateVoteEvidenceWithValidator(h, time.Now(), vals[0], "block-test-chain")
@@ -152,8 +152,8 @@ func TestBlockHashesTo(t *testing.T) {
 
 	lastID := makeBlockIDRandom()
 	h := int64(3)
-	voteSet, valSet, vals := randVoteSet(h-1, 1, cmtproto.PrecommitType, 10, 1)
-	extCommit, err := MakeExtCommit(lastID, h-1, 1, voteSet, vals, time.Now())
+	voteSet, valSet, vals := randVoteSet(h-1, 1, cmtproto.PrecommitType, 10, 1, false)
+	extCommit, err := MakeExtCommit(lastID, h-1, 1, voteSet, vals, time.Now(), false)
 	require.NoError(t, err)
 
 	ev, err := NewMockDuplicateVoteEvidenceWithValidator(h, time.Now(), vals[0], "block-test-chain")
@@ -231,8 +231,8 @@ func TestNilDataHashDoesntCrash(t *testing.T) {
 func TestCommit(t *testing.T) {
 	lastID := makeBlockIDRandom()
 	h := int64(3)
-	voteSet, _, vals := randVoteSet(h-1, 1, cmtproto.PrecommitType, 10, 1)
-	extCommit, err := MakeExtCommit(lastID, h-1, 1, voteSet, vals, time.Now())
+	voteSet, _, vals := randVoteSet(h-1, 1, cmtproto.PrecommitType, 10, 1, true)
+	extCommit, err := MakeExtCommit(lastID, h-1, 1, voteSet, vals, time.Now(), true)
 	require.NoError(t, err)
 
 	assert.Equal(t, h-1, extCommit.Height)
@@ -439,8 +439,8 @@ func TestMaxHeaderBytes(t *testing.T) {
 func randCommit(now time.Time) *Commit {
 	lastID := makeBlockIDRandom()
 	h := int64(3)
-	voteSet, _, vals := randVoteSet(h-1, 1, cmtproto.PrecommitType, 10, 1)
-	extCommit, err := MakeExtCommit(lastID, h-1, 1, voteSet, vals, now)
+	voteSet, _, vals := randVoteSet(h-1, 1, cmtproto.PrecommitType, 10, 1, false)
+	extCommit, err := MakeExtCommit(lastID, h-1, 1, voteSet, vals, now, false)
 	if err != nil {
 		panic(err)
 	}
@@ -584,7 +584,7 @@ func TestVoteSetToExtendedCommit(t *testing.T) {
 	}
 }
 
-// ToVoteSet constructs a VoteSet from the Commit and validator set.
+// toVoteSet constructs a VoteSet from the Commit and validator set.
 // Panics if signatures from the ExtendedCommit can't be added to the voteset.
 // Inverse of VoteSet.MakeExtendedCommit().
 func toVoteSet(ec *ExtendedCommit, chainID string, vals *ValidatorSet) *VoteSet {
@@ -615,8 +615,8 @@ func TestExtendedCommitToVoteSet(t *testing.T) {
 			lastID := makeBlockIDRandom()
 			h := int64(3)
 
-			voteSet, valSet, vals := randVoteSet(h-1, 1, cmtproto.PrecommitType, 10, 1)
-			extCommit, err := MakeExtCommit(lastID, h-1, 1, voteSet, vals, time.Now())
+			voteSet, valSet, vals := randVoteSet(h-1, 1, cmtproto.PrecommitType, 10, 1, true)
+			extCommit, err := MakeExtCommit(lastID, h-1, 1, voteSet, vals, time.Now(), true)
 			assert.NoError(t, err)
 
 			if !testCase.includeExtension {

--- a/types/evidence_test.go
+++ b/types/evidence_test.go
@@ -95,11 +95,11 @@ func TestLightClientAttackEvidenceBasic(t *testing.T) {
 	height := int64(5)
 	commonHeight := height - 1
 	nValidators := 10
-	voteSet, valSet, privVals := randVoteSet(height, 1, cmtproto.PrecommitType, nValidators, 1)
+	voteSet, valSet, privVals := randVoteSet(height, 1, cmtproto.PrecommitType, nValidators, 1, false)
 	header := makeHeaderRandom()
 	header.Height = height
 	blockID := makeBlockID(tmhash.Sum([]byte("blockhash")), math.MaxInt32, tmhash.Sum([]byte("partshash")))
-	extCommit, err := MakeExtCommit(blockID, height, 1, voteSet, privVals, defaultVoteTime)
+	extCommit, err := MakeExtCommit(blockID, height, 1, voteSet, privVals, defaultVoteTime, false)
 	require.NoError(t, err)
 	commit := extCommit.ToCommit()
 
@@ -156,12 +156,12 @@ func TestLightClientAttackEvidenceValidation(t *testing.T) {
 	height := int64(5)
 	commonHeight := height - 1
 	nValidators := 10
-	voteSet, valSet, privVals := randVoteSet(height, 1, cmtproto.PrecommitType, nValidators, 1)
+	voteSet, valSet, privVals := randVoteSet(height, 1, cmtproto.PrecommitType, nValidators, 1, false)
 	header := makeHeaderRandom()
 	header.Height = height
 	header.ValidatorsHash = valSet.Hash()
 	blockID := makeBlockID(header.Hash(), math.MaxInt32, tmhash.Sum([]byte("partshash")))
-	extCommit, err := MakeExtCommit(blockID, height, 1, voteSet, privVals, time.Now())
+	extCommit, err := MakeExtCommit(blockID, height, 1, voteSet, privVals, time.Now(), false)
 	require.NoError(t, err)
 	commit := extCommit.ToCommit()
 

--- a/types/params.go
+++ b/types/params.go
@@ -319,8 +319,10 @@ func ConsensusParamsFromProto(pbParams cmtproto.ConsensusParams) ConsensusParams
 			App: pbParams.Version.App,
 		},
 	}
+	fmt.Printf("XXXXXX pbParams.Abci %v getenableheight %v\n", pbParams.Abci, pbParams.Abci.GetVoteExtensionsEnableHeight())
 	if pbParams.Abci != nil {
 		c.ABCI.VoteExtensionsEnableHeight = pbParams.Abci.GetVoteExtensionsEnableHeight()
 	}
+	fmt.Printf("XXXXXX read value %v\n", c.ABCI.VoteExtensionsEnableHeight)
 	return c
 }

--- a/types/params.go
+++ b/types/params.go
@@ -319,10 +319,8 @@ func ConsensusParamsFromProto(pbParams cmtproto.ConsensusParams) ConsensusParams
 			App: pbParams.Version.App,
 		},
 	}
-	fmt.Printf("XXXXXX pbParams.Abci %v getenableheight %v\n", pbParams.Abci, pbParams.Abci.GetVoteExtensionsEnableHeight())
 	if pbParams.Abci != nil {
 		c.ABCI.VoteExtensionsEnableHeight = pbParams.Abci.GetVoteExtensionsEnableHeight()
 	}
-	fmt.Printf("XXXXXX read value %v\n", c.ABCI.VoteExtensionsEnableHeight)
 	return c
 }

--- a/types/test_util.go
+++ b/types/test_util.go
@@ -12,7 +12,7 @@ import (
 )
 
 func MakeExtCommit(blockID BlockID, height int64, round int32,
-	voteSet *VoteSet, validators []PrivValidator, now time.Time) (*ExtendedCommit, error) {
+	voteSet *VoteSet, validators []PrivValidator, now time.Time, extEnabled bool) (*ExtendedCommit, error) {
 
 	// all sign
 	for i := 0; i < len(validators); i++ {
@@ -36,8 +36,12 @@ func MakeExtCommit(blockID BlockID, height int64, round int32,
 		}
 	}
 
-	return nil, nil
-	//return voteSet.MakeExtendedCommit(true), nil
+	var enableHeight int64
+	if extEnabled {
+		enableHeight = height
+	}
+
+	return voteSet.MakeExtendedCommit(ABCIParams{VoteExtensionsEnableHeight: enableHeight}), nil
 }
 
 func signAddVote(privVal PrivValidator, vote *Vote, voteSet *VoteSet) (bool, error) {

--- a/types/test_util.go
+++ b/types/test_util.go
@@ -36,7 +36,8 @@ func MakeExtCommit(blockID BlockID, height int64, round int32,
 		}
 	}
 
-	return voteSet.MakeExtendedCommit(), nil
+	return nil, nil
+	//return voteSet.MakeExtendedCommit(true), nil
 }
 
 func signAddVote(privVal PrivValidator, vote *Vote, voteSet *VoteSet) (bool, error) {

--- a/types/validation_test.go
+++ b/types/validation_test.go
@@ -142,8 +142,8 @@ func TestValidatorSet_VerifyCommit_CheckAllSignatures(t *testing.T) {
 		blockID = makeBlockIDRandom()
 	)
 
-	voteSet, valSet, vals := randVoteSet(h, 0, cmtproto.PrecommitType, 4, 10)
-	extCommit, err := MakeExtCommit(blockID, h, 0, voteSet, vals, time.Now())
+	voteSet, valSet, vals := randVoteSet(h, 0, cmtproto.PrecommitType, 4, 10, false)
+	extCommit, err := MakeExtCommit(blockID, h, 0, voteSet, vals, time.Now(), false)
 	require.NoError(t, err)
 	commit := extCommit.ToCommit()
 	require.NoError(t, valSet.VerifyCommit(chainID, blockID, h, commit))
@@ -170,8 +170,8 @@ func TestValidatorSet_VerifyCommitLight_ReturnsAsSoonAsMajorityOfVotingPowerSign
 		blockID = makeBlockIDRandom()
 	)
 
-	voteSet, valSet, vals := randVoteSet(h, 0, cmtproto.PrecommitType, 4, 10)
-	extCommit, err := MakeExtCommit(blockID, h, 0, voteSet, vals, time.Now())
+	voteSet, valSet, vals := randVoteSet(h, 0, cmtproto.PrecommitType, 4, 10, false)
+	extCommit, err := MakeExtCommit(blockID, h, 0, voteSet, vals, time.Now(), false)
 	require.NoError(t, err)
 	commit := extCommit.ToCommit()
 	require.NoError(t, valSet.VerifyCommit(chainID, blockID, h, commit))
@@ -196,8 +196,8 @@ func TestValidatorSet_VerifyCommitLightTrusting_ReturnsAsSoonAsTrustLevelOfVotin
 		blockID = makeBlockIDRandom()
 	)
 
-	voteSet, valSet, vals := randVoteSet(h, 0, cmtproto.PrecommitType, 4, 10)
-	extCommit, err := MakeExtCommit(blockID, h, 0, voteSet, vals, time.Now())
+	voteSet, valSet, vals := randVoteSet(h, 0, cmtproto.PrecommitType, 4, 10, false)
+	extCommit, err := MakeExtCommit(blockID, h, 0, voteSet, vals, time.Now(), false)
 	require.NoError(t, err)
 	commit := extCommit.ToCommit()
 	require.NoError(t, valSet.VerifyCommit(chainID, blockID, h, commit))
@@ -218,8 +218,8 @@ func TestValidatorSet_VerifyCommitLightTrusting_ReturnsAsSoonAsTrustLevelOfVotin
 func TestValidatorSet_VerifyCommitLightTrusting(t *testing.T) {
 	var (
 		blockID                       = makeBlockIDRandom()
-		voteSet, originalValset, vals = randVoteSet(1, 1, cmtproto.PrecommitType, 6, 1)
-		extCommit, err                = MakeExtCommit(blockID, 1, 1, voteSet, vals, time.Now())
+		voteSet, originalValset, vals = randVoteSet(1, 1, cmtproto.PrecommitType, 6, 1, false)
+		extCommit, err                = MakeExtCommit(blockID, 1, 1, voteSet, vals, time.Now(), false)
 		newValSet, _                  = RandValidatorSet(2, 1)
 	)
 	require.NoError(t, err)
@@ -260,8 +260,8 @@ func TestValidatorSet_VerifyCommitLightTrusting(t *testing.T) {
 func TestValidatorSet_VerifyCommitLightTrustingErrorsOnOverflow(t *testing.T) {
 	var (
 		blockID               = makeBlockIDRandom()
-		voteSet, valSet, vals = randVoteSet(1, 1, cmtproto.PrecommitType, 1, MaxTotalVotingPower)
-		extCommit, err        = MakeExtCommit(blockID, 1, 1, voteSet, vals, time.Now())
+		voteSet, valSet, vals = randVoteSet(1, 1, cmtproto.PrecommitType, 1, MaxTotalVotingPower, false)
+		extCommit, err        = MakeExtCommit(blockID, 1, 1, voteSet, vals, time.Now(), false)
 	)
 	require.NoError(t, err)
 

--- a/types/validation_test.go
+++ b/types/validation_test.go
@@ -59,7 +59,7 @@ func TestValidatorSet_VerifyCommit_All(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.description, func(t *testing.T) {
-			_, valSet, vals := randVoteSet(tc.height, round, cmtproto.PrecommitType, tc.valSize, 10)
+			_, valSet, vals := randVoteSet(tc.height, round, cmtproto.PrecommitType, tc.valSize, 10, false)
 			totalVotes := tc.blockVotes + tc.absentVotes + tc.nilVotes
 			sigs := make([]CommitSig, totalVotes)
 			vi := 0

--- a/types/vote.go
+++ b/types/vote.go
@@ -117,7 +117,7 @@ func (vote *Vote) CommitSig() CommitSig {
 // chain has not enabled vote extensions.
 // Returns true if extension data was present before stripping and false otherwise.
 func (vote *Vote) StripExtension() bool {
-	stripped := len(vote.Extension) > 0 || len(vote.ExtensionSignature) > 0
+	stripped := len(vote.ExtensionSignature) > 0
 	vote.Extension = nil
 	vote.ExtensionSignature = nil
 	return stripped

--- a/types/vote.go
+++ b/types/vote.go
@@ -113,16 +113,6 @@ func (vote *Vote) CommitSig() CommitSig {
 	}
 }
 
-// StripExtension removes any extension data from the vote. Useful if the
-// chain has not enabled vote extensions.
-// Returns true if extension data was present before stripping and false otherwise.
-func (vote *Vote) StripExtension() bool {
-	stripped := len(vote.ExtensionSignature) > 0
-	vote.Extension = nil
-	vote.ExtensionSignature = nil
-	return stripped
-}
-
 // ExtendedCommitSig attempts to construct an ExtendedCommitSig from this vote.
 // Panics if either the vote extension signature is missing or if the block ID
 // is not either empty or complete.

--- a/types/vote_set.go
+++ b/types/vote_set.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -224,7 +223,14 @@ func (voteSet *VoteSet) addVote(vote *Vote) (added bool, err error) {
 			return false, fmt.Errorf("failed to verify vote with ChainID %s and PubKey %s: %w", voteSet.chainID, val.PubKey, err)
 		}
 		if len(vote.ExtensionSignature) > 0 || len(vote.Extension) > 0 {
-			return false, errors.New("unexpected vote extension data present in vote")
+			panic(fmt.Errorf("unexpected vote extension data present in vote; ext_len %d, sig_len %d",
+				len(vote.Extension),
+				len(vote.ExtensionSignature),
+			))
+			//return false, fmt.Errorf("unexpected vote extension data present in vote; ext_len %d, sig_len %d",
+			//	len(vote.Extension),
+			//	len(vote.ExtensionSignature),
+			//)
 		}
 	}
 
@@ -632,11 +638,12 @@ func (voteSet *VoteSet) sumTotalFrac() (int64, int64, float64) {
 // Panics if the vote type is not PrecommitType or if there's no +2/3 votes for
 // a single block.
 func (voteSet *VoteSet) MakeExtendedCommit(ap ABCIParams) *ExtendedCommit {
+	voteSet.mtx.Lock()
+	defer voteSet.mtx.Unlock()
+
 	if voteSet.signedMsgType != cmtproto.PrecommitType {
 		panic("Cannot MakeExtendCommit() unless VoteSet.Type is PrecommitType")
 	}
-	voteSet.mtx.Lock()
-	defer voteSet.mtx.Unlock()
 
 	// Make sure we have a 2/3 majority
 	if voteSet.maj23 == nil {
@@ -662,7 +669,8 @@ func (voteSet *VoteSet) MakeExtendedCommit(ap ABCIParams) *ExtendedCommit {
 		ExtendedSignatures: sigs,
 	}
 	if err := ec.EnsureExtensions(ap.VoteExtensionsEnabled(ec.Height)); err != nil {
-		panic(fmt.Errorf("problem with vote extension data in extended commit at height %d; %w", ec.Height, err))
+		panic(fmt.Errorf("problem with vote extension data when making extended commit of height %d; %w",
+			ec.Height, err))
 	}
 	return ec
 }

--- a/types/vote_set.go
+++ b/types/vote_set.go
@@ -223,14 +223,10 @@ func (voteSet *VoteSet) addVote(vote *Vote) (added bool, err error) {
 			return false, fmt.Errorf("failed to verify vote with ChainID %s and PubKey %s: %w", voteSet.chainID, val.PubKey, err)
 		}
 		if len(vote.ExtensionSignature) > 0 || len(vote.Extension) > 0 {
-			panic(fmt.Errorf("unexpected vote extension data present in vote; ext_len %d, sig_len %d",
+			return false, fmt.Errorf("unexpected vote extension data present in vote; ext_len %d, sig_len %d",
 				len(vote.Extension),
 				len(vote.ExtensionSignature),
-			))
-			//return false, fmt.Errorf("unexpected vote extension data present in vote; ext_len %d, sig_len %d",
-			//	len(vote.Extension),
-			//	len(vote.ExtensionSignature),
-			//)
+			)
 		}
 	}
 

--- a/types/vote_set.go
+++ b/types/vote_set.go
@@ -223,10 +223,15 @@ func (voteSet *VoteSet) addVote(vote *Vote) (added bool, err error) {
 			return false, fmt.Errorf("failed to verify vote with ChainID %s and PubKey %s: %w", voteSet.chainID, val.PubKey, err)
 		}
 		if len(vote.ExtensionSignature) > 0 || len(vote.Extension) > 0 {
-			return false, fmt.Errorf("unexpected vote extension data present in vote; ext_len %d, sig_len %d",
+			//TODO DIAGNOSE Remove
+			panic(fmt.Errorf("unexpected vote extension data present in vote; ext_len %d, sig_len %d",
 				len(vote.Extension),
 				len(vote.ExtensionSignature),
-			)
+			))
+			//return false, fmt.Errorf("unexpected vote extension data present in vote; ext_len %d, sig_len %d",
+			//	len(vote.Extension),
+			//	len(vote.ExtensionSignature),
+			//)
 		}
 	}
 

--- a/types/vote_set_test.go
+++ b/types/vote_set_test.go
@@ -565,9 +565,13 @@ func randVoteSet(
 	signedMsgType cmtproto.SignedMsgType,
 	numValidators int,
 	votingPower int64,
+	extEnabled bool,
 ) (*VoteSet, *ValidatorSet, []PrivValidator) {
 	valSet, privValidators := RandValidatorSet(numValidators, votingPower)
-	if signedMsgType == cmtproto.PrecommitType {
+	if extEnabled {
+		if signedMsgType != cmtproto.PrecommitType {
+			return nil, nil, nil
+		}
 		return NewExtendedVoteSet("test_chain_id", height, round, signedMsgType, valSet), valSet, privValidators
 	}
 	return NewVoteSet("test_chain_id", height, round, signedMsgType, valSet), valSet, privValidators

--- a/types/vote_set_test.go
+++ b/types/vote_set_test.go
@@ -476,7 +476,7 @@ func TestVoteSet_MakeCommit(t *testing.T) {
 }
 
 // TestVoteSet_VoteExtensionsEnabled tests that the vote set correctly validates
-// vote extensions data when either required or not required.
+// vote extension data when either required or not required.
 func TestVoteSet_VoteExtensionsEnabled(t *testing.T) {
 	for _, tc := range []struct {
 		name              string


### PR DESCRIPTION
Contributes to #10

While troubleshooting #539, I had to navigate the production code dealing with vote extensions quite a bit. I realized we are not doing enough validation at key points: our checks tend to focus on making sure the vote extensions are there when they are needed, but less so on making sure we don't get vote extensions while they are disabled.

I started progressively adding the missing checks while investigating #539 to exclude various hypothesis. The end result is this PR.

How I tested it:

* Notice the commit named "Added TODO DIAGNOSE panics for e2e testing", where I converted all checks for vote extensions performed on input from the network (so we should NOT panic in production, as then we'd be easily DOS-able) into panics.
* Then, I ran our nightly tests locally (i.e., `./build/generator -g 5 -d networks/nightly/ && ./run-multiple.sh networks/nightly/*-group*-*.toml`) on that version of the code. The idea being that the introduced panics should not be triggered as we have no byzantine nodes in our e2e tests ATM.
* All nightly tests _passed_ with that version of the code.
* Finally, I reverted that commit to get the code in this PR production-ready

---

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

