### PR TITLE
Fixed two bugs related to metrics

### DIFF
--- a/consensus/metrics.gen.go
+++ b/consensus/metrics.gen.go
@@ -155,7 +155,7 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Subsystem: MetricsSubsystem,
 			Name:      "vote_extension_receive_count",
 			Help:      "VoteExtensionReceiveCount is the number of vote extensions received by this node. The metric is annotated by the status of the vote extension from the application, either 'accepted' or 'rejected'.",
-		}, labels).With(labelsAndValues...),
+		}, append(labels, "status")).With(labelsAndValues...),
 		ProposalReceiveCount: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,

--- a/consensus/metrics.go
+++ b/consensus/metrics.go
@@ -94,7 +94,7 @@ type Metrics struct {
 	// VoteExtensionReceiveCount is the number of vote extensions received by this
 	// node. The metric is annotated by the status of the vote extension from the
 	// application, either 'accepted' or 'rejected'.
-	VoteExtensionReceiveCount metrics.Counter
+	VoteExtensionReceiveCount metrics.Counter `metrics_labels:"status"`
 
 	// ProposalReceiveCount is the total number of proposals received by this node
 	// since process start.

--- a/proxy/app_conn.go
+++ b/proxy/app_conn.go
@@ -74,38 +74,38 @@ func (app *appConnConsensus) Error() error {
 }
 
 func (app *appConnConsensus) InitChain(ctx context.Context, req *types.RequestInitChain) (*types.ResponseInitChain, error) {
-	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "init_chain"))()
+	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "init_chain", "type", "sync"))()
 	return app.appConn.InitChain(ctx, req)
 }
 
 func (app *appConnConsensus) PrepareProposal(ctx context.Context,
 	req *types.RequestPrepareProposal) (*types.ResponsePrepareProposal, error) {
-	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "prepare_proposal"))()
+	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "prepare_proposal", "type", "sync"))()
 	return app.appConn.PrepareProposal(ctx, req)
 }
 
 func (app *appConnConsensus) ProcessProposal(ctx context.Context, req *types.RequestProcessProposal) (*types.ResponseProcessProposal, error) {
-	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "process_proposal"))()
+	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "process_proposal", "type", "sync"))()
 	return app.appConn.ProcessProposal(ctx, req)
 }
 
 func (app *appConnConsensus) ExtendVote(ctx context.Context, req *types.RequestExtendVote) (*types.ResponseExtendVote, error) {
-	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "extend_vote"))()
+	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "extend_vote", "type", "sync"))()
 	return app.appConn.ExtendVote(ctx, req)
 }
 
 func (app *appConnConsensus) VerifyVoteExtension(ctx context.Context, req *types.RequestVerifyVoteExtension) (*types.ResponseVerifyVoteExtension, error) {
-	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "verify_vote_extension"))()
+	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "verify_vote_extension", "type", "sync"))()
 	return app.appConn.VerifyVoteExtension(ctx, req)
 }
 
 func (app *appConnConsensus) FinalizeBlock(ctx context.Context, req *types.RequestFinalizeBlock) (*types.ResponseFinalizeBlock, error) {
-	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "finalize_block"))()
+	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "finalize_block", "type", "sync"))()
 	return app.appConn.FinalizeBlock(ctx, req)
 }
 
 func (app *appConnConsensus) Commit(ctx context.Context) (*types.ResponseCommit, error) {
-	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "commit"))()
+	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "commit", "type", "sync"))()
 	return app.appConn.Commit(ctx, &types.RequestCommit{})
 }
 
@@ -133,7 +133,7 @@ func (app *appConnMempool) Error() error {
 }
 
 func (app *appConnMempool) Flush(ctx context.Context) error {
-	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "flush"))()
+	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "flush", "type", "sync"))()
 	return app.appConn.Flush(ctx)
 }
 
@@ -167,17 +167,17 @@ func (app *appConnQuery) Error() error {
 }
 
 func (app *appConnQuery) Echo(ctx context.Context, msg string) (*types.ResponseEcho, error) {
-	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "echo"))()
+	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "echo", "type", "sync"))()
 	return app.appConn.Echo(ctx, msg)
 }
 
 func (app *appConnQuery) Info(ctx context.Context, req *types.RequestInfo) (*types.ResponseInfo, error) {
-	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "info"))()
+	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "info", "type", "sync"))()
 	return app.appConn.Info(ctx, req)
 }
 
 func (app *appConnQuery) Query(ctx context.Context, req *types.RequestQuery) (*types.ResponseQuery, error) {
-	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "query"))()
+	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "query", "type", "sync"))()
 	return app.appConn.Query(ctx, req)
 }
 
@@ -201,22 +201,22 @@ func (app *appConnSnapshot) Error() error {
 }
 
 func (app *appConnSnapshot) ListSnapshots(ctx context.Context, req *types.RequestListSnapshots) (*types.ResponseListSnapshots, error) {
-	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "list_snapshots"))()
+	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "list_snapshots", "type", "sync"))()
 	return app.appConn.ListSnapshots(ctx, req)
 }
 
 func (app *appConnSnapshot) OfferSnapshot(ctx context.Context, req *types.RequestOfferSnapshot) (*types.ResponseOfferSnapshot, error) {
-	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "offer_snapshot"))()
+	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "offer_snapshot", "type", "sync"))()
 	return app.appConn.OfferSnapshot(ctx, req)
 }
 
 func (app *appConnSnapshot) LoadSnapshotChunk(ctx context.Context, req *types.RequestLoadSnapshotChunk) (*types.ResponseLoadSnapshotChunk, error) {
-	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "load_snapshot_chunk"))()
+	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "load_snapshot_chunk", "type", "sync"))()
 	return app.appConn.LoadSnapshotChunk(ctx, req)
 }
 
 func (app *appConnSnapshot) ApplySnapshotChunk(ctx context.Context, req *types.RequestApplySnapshotChunk) (*types.ResponseApplySnapshotChunk, error) {
-	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "apply_snapshot_chunk"))()
+	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "apply_snapshot_chunk", "type", "sync"))()
 	return app.appConn.ApplySnapshotChunk(ctx, req)
 }
 

--- a/scripts/qa/reporting/latency_plotter.py
+++ b/scripts/qa/reporting/latency_plotter.py
@@ -9,7 +9,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-release = 'v0.37.x-alpha3'
+release = 'abci++vef_Smoke'
 
 #FIXME: figure out in which timezone prometheus was running to adjust to UTC.
 tz = pytz.timezone('America/Sao_Paulo')

--- a/scripts/qa/reporting/prometheus_plotter.py
+++ b/scripts/qa/reporting/prometheus_plotter.py
@@ -32,7 +32,8 @@ ext_window_size = dict(seconds=180)
 #left_end = '2023-02-07T18:07:00Z' #homogeneous
 #left_end = '2022-10-13T19:41:23Z' #baseline
 #left_end = '2023-02-22T18:56:29Z' #CMT 0.37.x-alpha3
-left_end = '2022-10-13T15:57:50Z' #TM v0.37 (200 nodes) baseline
+#left_end = '2022-10-13T15:57:50Z' #TM v0.37 (200 nodes) baseline
+left_end = '2023-03-20T19:45:35Z' #feature/abci++vef merged with main (7d8c9d426)
 
 right_end = pd.to_datetime(left_end) + pd.Timedelta(**window_size)
 time_window = (left_end, right_end.strftime('%Y-%m-%dT%H:%M:%SZ'))
@@ -42,8 +43,8 @@ ext_time_window = (left_end, ext_right_end.strftime('%Y-%m-%dT%H:%M:%SZ'))
 
 
 
-#fork='cometbft'
-fork='tendermint'
+fork='cometbft'
+#fork='tendermint'
 
 # Do prometheus queries
 queries = [ 

--- a/test/e2e/networks/ci.toml
+++ b/test/e2e/networks/ci.toml
@@ -11,6 +11,7 @@ process_proposal_delay = "100ms"
 check_tx_delay = "0ms"
 # The most common case (e.g. Cosmos SDK-based chains).
 abci_protocol = "builtin"
+prometheus = true
 
 [validators]
 validator01 = 100


### PR DESCRIPTION
Contributes to #10

When testing in prometheus-enabled testnets, we caught two places where the metrics gathering were causing a panic.
This PR also includes adjustments to e2e `ci.toml` config that is able to trigger these bugs.
Finally (not important, but for the record), I have included the time window I used to extract metrics from the 200-node test.

---

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

