### PR TITLE
light client: Address panic in response to empty signed header

### DIFF
--- a/light/provider/http/http.go
+++ b/light/provider/http/http.go
@@ -180,6 +180,15 @@ func (p *http) signedHeader(ctx context.Context, height *int64) (*types.SignedHe
 		commit, err := p.client.Commit(ctx, height)
 		switch {
 		case err == nil:
+			// See https://github.com/cometbft/cometbft/issues/575
+			// If the node is starting at a non-zero height, but does not yet
+			// have any blocks, it can return an empty signed header without
+			// returning an error.
+			if commit.SignedHeader.IsEmpty() {
+				// Technically this means that the provider still needs to
+				// catch up.
+				return nil, provider.ErrHeightTooHigh
+			}
 			return &commit.SignedHeader, nil
 
 		case regexpTooHigh.MatchString(err.Error()):

--- a/types/light.go
+++ b/types/light.go
@@ -120,6 +120,11 @@ type SignedHeader struct {
 	Commit *Commit `json:"commit"`
 }
 
+// IsEmpty returns true if both the header and commit are nil.
+func (sh SignedHeader) IsEmpty() bool {
+	return sh.Header == nil && sh.Commit == nil
+}
+
 // ValidateBasic does basic consistency checks and makes sure the header
 // and commit are consistent.
 //


### PR DESCRIPTION
Closes #575.

This at least addresses the panic in the light client, instead turning it into a temporary error (i.e. that the node does not yet have the signed header for the requisite height, which is true here).

I've tested this patch on the `v0.34.x` branch and it prevents the panic, but instead causes the E2E tests to hang indefinitely. As such, I've logged #576.

The code change is identical across `main`, `v0.37.x` and `v0.34.x`, so backports should be clean. I'll add changelog entries on the backport branches prior to merging them.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

