### PR TITLE
Update CI and root docs on `main` for v0.38 release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,16 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    target-branch: "v0.38.x"
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - automerge
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
     target-branch: "v0.37.x"
     open-pull-requests-limit: 10
     labels:
@@ -40,6 +50,18 @@ updates:
       interval: weekly
     target-branch: "main"
     open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - automerge
+
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: daily
+    target-branch: "v0.38.x"
+    # Only allow automated security-related dependency updates on release
+    # branches.
+    open-pull-requests-limit: 0
     labels:
       - dependencies
       - automerge

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -17,6 +17,14 @@ pull_request_rules:
           {{ title }} (#{{ number }})
 
           {{ body }}
+  - name: backport patches to v0.38.x branch
+    conditions:
+      - base=main
+      - label=backport-to-v0.38.x
+    actions:
+      backport:
+        branches:
+          - v0.38.x
   - name: backport patches to v0.37.x branch
     conditions:
       - base=main

--- a/.github/workflows/e2e-nightly-38x.yml
+++ b/.github/workflows/e2e-nightly-38x.yml
@@ -1,0 +1,77 @@
+# Runs randomly generated E2E testnets nightly on the v0.38.x branch.
+
+# !! This file should be kept in sync with the e2e-nightly-main.yml file,
+# modulo changes to the version labels.
+
+name: e2e-nightly-38x
+on:
+  schedule:
+    - cron: '0 2 * * *'
+
+jobs:
+  e2e-nightly-test:
+    # Run parallel jobs for the listed testnet groups (must match the
+    # ./build/generator -g flag)
+    strategy:
+      fail-fast: false
+      matrix:
+        group: ['00', '01', '02', '03', "04"]
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+
+      - uses: actions/checkout@v3
+        with:
+          ref: 'v0.38.x'
+
+      - name: Capture git repo info
+        id: git-info
+        run: |
+          echo "branch=`git branch --show-current`" >> $GITHUB_OUTPUT
+
+      - name: Build
+        working-directory: test/e2e
+        # Run make jobs in parallel, since we can't run steps in parallel.
+        run: make -j2 docker generator runner tests
+
+      - name: Generate testnets
+        working-directory: test/e2e
+        # When changing -g, also change the matrix groups above
+        run: ./build/generator -g 5 -d networks/nightly/ -p
+
+      - name: Run ${{ matrix.p2p }} p2p testnets
+        working-directory: test/e2e
+        run: ./run-multiple.sh networks/nightly/*-group${{ matrix.group }}-*.toml
+
+    outputs:
+      git-branch: ${{ steps.git-info.outputs.branch }}
+
+  e2e-nightly-fail:
+    needs: e2e-nightly-test
+    if: ${{ failure() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack on failure
+        uses: slackapi/slack-github-action@v1.23.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          BRANCH: ${{ needs.e2e-nightly-test.outputs.git-branch }}
+          RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          COMMITS_URL: "${{ github.server_url }}/${{ github.repository }}/commits/${{ needs.e2e-nightly-test.outputs.git-branch }}"
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":skull: Nightly E2E tests for `${{ env.BRANCH }}` failed. See the <${{ env.RUN_URL }}|run details> and the <${{ env.COMMITS_URL }}|latest commits> possibly related to the failure."
+                  }
+                }
+              ]
+            }

--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@
 [![License][license-badge]][license-url]
 [![Sourcegraph][sg-badge]][sg-url]
 
-| Branch  | Tests                                    | Linting                               |
-|---------|------------------------------------------|---------------------------------------|
-| main    | [![Tests][tests-badge]][tests-url]       | [![Lint][lint-badge]][lint-url]       |
-| v0.37.x | [![Tests][tests-badge-v037x]][tests-url] | [![Lint][lint-badge-v037x]][lint-url] |
-| v0.34.x | [![Tests][tests-badge-v034x]][tests-url] | [![Lint][lint-badge-v034x]][lint-url] |
+| Branch  | Tests                                          | Linting                                     |
+|---------|------------------------------------------------|---------------------------------------------|
+| main    | [![Tests][tests-badge]][tests-url]             | [![Lint][lint-badge]][lint-url]             |
+| v0.38.x | [![Tests][tests-badge-v038x]][tests-url-v038x] | [![Lint][lint-badge-v038x]][lint-url-v038x] |
+| v0.37.x | [![Tests][tests-badge-v037x]][tests-url-v037x] | [![Lint][lint-badge-v037x]][lint-url-v037x] |
+| v0.34.x | [![Tests][tests-badge-v034x]][tests-url-v034x] | [![Lint][lint-badge-v034x]][lint-url-v034x] |
 
 CometBFT is a Byzantine Fault Tolerant (BFT) middleware that takes a
 state transition machine - written in any programming language - and securely
@@ -61,6 +62,7 @@ looking for, see [our security policy](SECURITY.md).
 | CometBFT version | Requirement | Notes             |
 |------------------|-------------|-------------------|
 | main             | Go version  | Go 1.20 or higher |
+| v0.38.x          | Go version  | Go 1.20 or higher |
 | v0.37.x          | Go version  | Go 1.20 or higher |
 | v0.34.x          | Go version  | Go 1.19 or higher |
 
@@ -120,6 +122,8 @@ CometBFT up-to-date. Upgrading instructions can be found in
 
 Currently supported versions include:
 
+- v0.38.x: CometBFT v0.38 introduces ABCI 2.0, which implements the entirety of
+  ABCI++
 - v0.37.x: CometBFT v0.37 introduces ABCI 1.0, which is the first major step
   towards the full ABCI++ implementation in ABCI 2.0
 - v0.34.x: The CometBFT v0.34 series is compatible with the Tendermint Core
@@ -177,11 +181,19 @@ maintains [cometbft.com](https://cometbft.com).
 [sg-badge]: https://sourcegraph.com/github.com/cometbft/cometbft/-/badge.svg
 [sg-url]: https://sourcegraph.com/github.com/cometbft/cometbft?badge
 [tests-url]: https://github.com/cometbft/cometbft/actions/workflows/tests.yml
+[tests-url-v038x]: https://github.com/cometbft/cometbft/actions/workflows/tests.yml?query=branch%3Av0.38.x
+[tests-url-v037x]: https://github.com/cometbft/cometbft/actions/workflows/tests.yml?query=branch%3Av0.37.x
+[tests-url-v034x]: https://github.com/cometbft/cometbft/actions/workflows/tests.yml?query=branch%3Av0.34.x
 [tests-badge]: https://github.com/cometbft/cometbft/actions/workflows/tests.yml/badge.svg?branch=main
+[tests-badge-v038x]: https://github.com/cometbft/cometbft/actions/workflows/tests.yml/badge.svg?branch=v0.38.x
 [tests-badge-v037x]: https://github.com/cometbft/cometbft/actions/workflows/tests.yml/badge.svg?branch=v0.37.x
 [tests-badge-v034x]: https://github.com/cometbft/cometbft/actions/workflows/tests.yml/badge.svg?branch=v0.34.x
 [lint-badge]: https://github.com/cometbft/cometbft/actions/workflows/lint.yml/badge.svg?branch=main
 [lint-badge-v034x]: https://github.com/cometbft/cometbft/actions/workflows/lint.yml/badge.svg?branch=v0.34.x
 [lint-badge-v037x]: https://github.com/cometbft/cometbft/actions/workflows/lint.yml/badge.svg?branch=v0.37.x
+[lint-badge-v038x]: https://github.com/cometbft/cometbft/actions/workflows/lint.yml/badge.svg?branch=v0.38.x
 [lint-url]: https://github.com/cometbft/cometbft/actions/workflows/lint.yml
+[lint-url-v034x]: https://github.com/cometbft/cometbft/actions/workflows/lint.yml?query=branch%3Av0.34.x
+[lint-url-v037x]: https://github.com/cometbft/cometbft/actions/workflows/lint.yml?query=branch%3Av0.37.x
+[lint-url-v038x]: https://github.com/cometbft/cometbft/actions/workflows/lint.yml?query=branch%3Av0.38.x
 [tm-core]: https://github.com/tendermint/tendermint

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -93,6 +93,15 @@ the 0.38.x line.
    Be sure to merge this PR before making other changes on the newly-created
    backport branch.
 
+5. Ensure that the RPC docs' `version` field in `rpc/openapi/openapi.yaml` has
+   been updated from `main` to the backport branch version.
+
+6. Prepare the [CometBFT documentation
+   repository](https://github.com/cometbft/cometbft-docs) to build the release
+   branch's version by updating the
+   [VERSIONS](https://github.com/cometbft/cometbft-docs/blob/main/VERSIONS)
+   file.
+
 After doing these steps, go back to `main` and do the following:
 
 1. Create a new workflow to run e2e nightlies for the new backport branch. (See


### PR DESCRIPTION
Partially addresses #595.

Updates the CI config (adding nightly E2Es for the `v0.38.x` branch), as well as configures Mergify and Dependabot to behave in the same way as our `v0.37.x` and `v0.34.x` branches.

Also updates the `README.md` and `RELEASES.md` with some minor fixes (some of which we should partially propagate back to `v0.37.x` and `v0.34.x` at some point).

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

