### PR TITLE
Release v0.38.0-alpha.1

### DIFF
--- a/.changelog/unreleased/breaking-changes/260-remove-priority-mempool-config.md
+++ b/.changelog/unreleased/breaking-changes/260-remove-priority-mempool-config.md
@@ -1,2 +1,2 @@
-- `[mempool]` Remove priority mempool.
+- `[config]` Remove `Version` field from `MempoolConfig`.
   ([\#260](https://github.com/cometbft/cometbft/issues/260))

--- a/.changelog/unreleased/breaking-changes/260-remove-priority-mempool-proto.md
+++ b/.changelog/unreleased/breaking-changes/260-remove-priority-mempool-proto.md
@@ -1,0 +1,2 @@
+- `[protobuf]` Remove fields `sender`, `priority`, and `mempool_error` from
+  `ResponseCheckTx`. ([\#260](https://github.com/cometbft/cometbft/issues/260))

--- a/.changelog/unreleased/breaking-changes/6498-signerharness-set-home-dir.md
+++ b/.changelog/unreleased/breaking-changes/6498-signerharness-set-home-dir.md
@@ -1,2 +1,0 @@
-- `[tools/tm-signer-harness]` Set OS home dir to instead of the hardcoded PATH.
-  ([\#6498](https://github.com/tendermint/tendermint/pull/6498))

--- a/.changelog/unreleased/breaking-changes/8664-move-app-hash-to-commit.md
+++ b/.changelog/unreleased/breaking-changes/8664-move-app-hash-to-commit.md
@@ -1,2 +1,2 @@
-- `[abci]` Move `app_hash` parameter from `Commit` to `FinalizeBlock` (@sergio-mena)
+- `[abci]` Move `app_hash` parameter from `Commit` to `FinalizeBlock`
   ([\#8664](https://github.com/tendermint/tendermint/pull/8664))

--- a/.changelog/unreleased/breaking-changes/9468-finalize-block.md
+++ b/.changelog/unreleased/breaking-changes/9468-finalize-block.md
@@ -1,2 +1,3 @@
-- `[abci]` Introduce `FinalizeBlock` which condenses `BeginBlock`, `DeliverTx` and `EndBlock` into a single method call (@cmwaters)
+- `[abci]` Introduce `FinalizeBlock` which condenses `BeginBlock`, `DeliverTx`
+  and `EndBlock` into a single method call
   ([\#9468](https://github.com/tendermint/tendermint/pull/9468))

--- a/.changelog/unreleased/bug-fixes/386-quick-fix-needproofblock.md
+++ b/.changelog/unreleased/bug-fixes/386-quick-fix-needproofblock.md
@@ -1,2 +1,5 @@
-- `[consensus]` ([\#386](https://github.com/cometbft/cometbft/pull/386)) Short-term fix for the case when `needProofBlock` cannot find previous block meta by defaulting to the creation of a new proof block. (@adizere)
-  - Special thanks to the [Vega.xyz](https://vega.xyz/) team, and in particular to Zohar (@ze97286), for reporting the problem and working with us to get to a fix.
+- `[consensus]` Short-term fix for the case when `needProofBlock` cannot find
+  previous block meta by defaulting to the creation of a new proof block.
+  Special thanks to the [Vega.xyz](https://vega.xyz/) team, and in particular to
+  Zohar (@ze97286), for reporting the problem and working with us to get to a
+  fix. ([\#386](https://github.com/cometbft/cometbft/pull/386))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@
 
 - The `TMHOME` environment variable was renamed to `CMTHOME`, and all environment variables starting with `TM_` are instead prefixed with `CMT_`
   ([\#211](https://github.com/cometbft/cometbft/issues/211))
-- [mempool] Remove priority mempool. 
-  ([\#260](https://github.com/cometbft/cometbft/issues/260))
-- [config] Remove `Version` field from `MempoolConfig`. 
-  ([\#260](https://github.com/cometbft/cometbft/issues/260))
-- [protobuf] Remove fields `sender`, `priority`, and `mempool_error` from
+- `[protobuf]` Remove fields `sender`, `priority`, and `mempool_error` from
   `ResponseCheckTx`. ([\#260](https://github.com/cometbft/cometbft/issues/260))
+- `[mempool]` Remove priority mempool.
+  ([\#260](https://github.com/cometbft/cometbft/issues/260))
+- `[config]` Remove `Version` field from `MempoolConfig`.
+  ([\#260](https://github.com/cometbft/cometbft/issues/260))
 - Bump minimum Go version to 1.20
   ([\#385](https://github.com/cometbft/cometbft/issues/385))
 - `[tools/tm-signer-harness]` Set OS home dir to instead of the hardcoded PATH.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,12 @@
   ([\#260](https://github.com/cometbft/cometbft/issues/260))
 - Bump minimum Go version to 1.20
   ([\#385](https://github.com/cometbft/cometbft/issues/385))
-- `[tools/tm-signer-harness]` Set OS home dir to instead of the hardcoded PATH.
-  ([\#6498](https://github.com/tendermint/tendermint/pull/6498))
 - `[state]` Move pruneBlocks from node/state to state/execution.
   ([\#6541](https://github.com/tendermint/tendermint/pull/6541))
-- `[abci]` Move `app_hash` parameter from `Commit` to `FinalizeBlock` (@sergio-mena)
+- `[abci]` Move `app_hash` parameter from `Commit` to `FinalizeBlock`
   ([\#8664](https://github.com/tendermint/tendermint/pull/8664))
-- `[abci]` Introduce `FinalizeBlock` which condenses `BeginBlock`, `DeliverTx` and `EndBlock` into a single method call (@cmwaters)
+- `[abci]` Introduce `FinalizeBlock` which condenses `BeginBlock`, `DeliverTx`
+  and `EndBlock` into a single method call
   ([\#9468](https://github.com/tendermint/tendermint/pull/9468))
 - `[p2p]` Remove unused p2p/trust package
   ([\#9625](https://github.com/tendermint/tendermint/pull/9625))
@@ -40,8 +39,11 @@
 
 - `[consensus]` Fixed a busy loop that happened when sending of a block part failed by sleeping in case of error.
   ([\#4](https://github.com/informalsystems/tendermint/pull/4))
-- `[consensus]` ([\#386](https://github.com/cometbft/cometbft/pull/386)) Short-term fix for the case when `needProofBlock` cannot find previous block meta by defaulting to the creation of a new proof block. (@adizere)
-  - Special thanks to the [Vega.xyz](https://vega.xyz/) team, and in particular to Zohar (@ze97286), for reporting the problem and working with us to get to a fix.
+- `[consensus]` Short-term fix for the case when `needProofBlock` cannot find
+  previous block meta by defaulting to the creation of a new proof block.
+  Special thanks to the [Vega.xyz](https://vega.xyz/) team, and in particular to
+  Zohar (@ze97286), for reporting the problem and working with us to get to a
+  fix. ([\#386](https://github.com/cometbft/cometbft/pull/386))
 - `[kvindexer]` Forward porting the fixes done to the kvindexer in 0.37 in PR \#77
   ([\#423](https://github.com/cometbft/cometbft/pull/423))
 - `[consensus]` Unexpected error conditions in `ApplyBlock` are non-recoverable, so ignoring the error and carrying on is a bug. We replaced a `return` that disregarded the error by a `panic`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,87 @@
 # CHANGELOG
 
+## Unreleased
+
+### BREAKING CHANGES
+
+- The `TMHOME` environment variable was renamed to `CMTHOME`, and all environment variables starting with `TM_` are instead prefixed with `CMT_`
+  ([\#211](https://github.com/cometbft/cometbft/issues/211))
+- [mempool] Remove priority mempool. 
+  ([\#260](https://github.com/cometbft/cometbft/issues/260))
+- [config] Remove `Version` field from `MempoolConfig`. 
+  ([\#260](https://github.com/cometbft/cometbft/issues/260))
+- [protobuf] Remove fields `sender`, `priority`, and `mempool_error` from
+  `ResponseCheckTx`. ([\#260](https://github.com/cometbft/cometbft/issues/260))
+- Bump minimum Go version to 1.20
+  ([\#385](https://github.com/cometbft/cometbft/issues/385))
+- `[tools/tm-signer-harness]` Set OS home dir to instead of the hardcoded PATH.
+  ([\#6498](https://github.com/tendermint/tendermint/pull/6498))
+- `[state]` Move pruneBlocks from node/state to state/execution.
+  ([\#6541](https://github.com/tendermint/tendermint/pull/6541))
+- `[abci]` Move `app_hash` parameter from `Commit` to `FinalizeBlock` (@sergio-mena)
+  ([\#8664](https://github.com/tendermint/tendermint/pull/8664))
+- `[abci]` Introduce `FinalizeBlock` which condenses `BeginBlock`, `DeliverTx` and `EndBlock` into a single method call (@cmwaters)
+  ([\#9468](https://github.com/tendermint/tendermint/pull/9468))
+- `[p2p]` Remove unused p2p/trust package
+  ([\#9625](https://github.com/tendermint/tendermint/pull/9625))
+- `[rpc]` Remove global environment and replace with constructor
+  ([\#9655](https://github.com/tendermint/tendermint/pull/9655))
+- `[inspect]` Add a new `inspect` command for introspecting
+  the state and block store of a crashed tendermint node.
+  ([\#9655](https://github.com/tendermint/tendermint/pull/9655))
+- `[node]` Move DBContext and DBProvider from the node package to the config
+  package. ([\#9655](https://github.com/tendermint/tendermint/pull/9655))
+- `[metrics]` Move state-syncing and block-syncing metrics to
+  their respective packages. Move labels from block_syncing
+  -> blocksync_syncing and state_syncing -> statesync_syncing
+  ([\#9682](https://github.com/tendermint/tendermint/pull/9682))
+
+### BUG FIXES
+
+- `[consensus]` Fixed a busy loop that happened when sending of a block part failed by sleeping in case of error.
+  ([\#4](https://github.com/informalsystems/tendermint/pull/4))
+- `[consensus]` ([\#386](https://github.com/cometbft/cometbft/pull/386)) Short-term fix for the case when `needProofBlock` cannot find previous block meta by defaulting to the creation of a new proof block. (@adizere)
+  - Special thanks to the [Vega.xyz](https://vega.xyz/) team, and in particular to Zohar (@ze97286), for reporting the problem and working with us to get to a fix.
+- `[kvindexer]` Forward porting the fixes done to the kvindexer in 0.37 in PR \#77
+  ([\#423](https://github.com/cometbft/cometbft/pull/423))
+- `[consensus]` Unexpected error conditions in `ApplyBlock` are non-recoverable, so ignoring the error and carrying on is a bug. We replaced a `return` that disregarded the error by a `panic`.
+  ([\#496](https://github.com/cometbft/cometbft/pull/496))
+- `[consensus]` Rename `(*PeerState).ToJSON` to `MarshalJSON` to fix a logging data race
+  ([\#524](https://github.com/cometbft/cometbft/pull/524))
+- `[docker]` Ensure Docker image uses consistent version of Go.
+  ([\#9462](https://github.com/tendermint/tendermint/pull/9462))
+- `[abci-cli]` Fix broken abci-cli help command.
+  ([\#9717](https://github.com/tendermint/tendermint/pull/9717))
+
+### FEATURES
+
+- `[config]` Introduce `BootstrapPeers` to the config to allow
+  nodes to list peers to be added to the addressbook upon start up.
+  ([\#9680](https://github.com/tendermint/tendermint/pull/9680))
+- `[proxy]` Introduce `NewUnsyncLocalClientCreator`, which allows local ABCI
+  clients to have the same concurrency model as remote clients (i.e. one
+  mutex per client "connection", for each of the four ABCI "connections").
+  ([\#9830](https://github.com/tendermint/tendermint/pull/9830))
+
+### IMPROVEMENTS
+
+- `[e2e]` Add functionality for uncoordinated (minor) upgrades
+  ([\#56](https://github.com/tendermint/tendermint/pull/56))
+- `[tools/tm-signer-harness]` Remove the folder as it is unused
+  ([\#136](https://github.com/cometbft/cometbft/issues/136))
+- `[blocksync]` Generate new metrics during BlockSync
+  ([\#543](https://github.com/cometbft/cometbft/pull/543))
+- `[crypto/merkle]` Improve HashAlternatives performance
+  ([\#6443](https://github.com/tendermint/tendermint/pull/6443))
+- `[p2p/pex]` Improve addrBook.hash performance
+  ([\#6509](https://github.com/tendermint/tendermint/pull/6509))
+- `[crypto/merkle]` Improve HashAlternatives performance
+  ([\#6513](https://github.com/tendermint/tendermint/pull/6513))
+- `[pubsub]` Performance improvements for the event query API
+  ([\#7319](https://github.com/tendermint/tendermint/pull/7319))
+- `[rpc]` Enable caching of RPC responses
+  ([\#9650](https://github.com/tendermint/tendermint/pull/9650))
+
 ## v0.37.0
 
 *March 6, 2023*

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,22 +6,22 @@ This guide provides instructions for upgrading to specific versions of CometBFT.
 
 ### Config Changes
 
-* A new config field, `BootstrapPeers` has been introduced as a means of
-  adding a list of addresses to the addressbook upon initializing a node. This is an
+* A new config field, `BootstrapPeers` has been introduced as a means of adding
+  a list of addresses to the addressbook upon initializing a node. This is an
   alternative to `PersistentPeers`. `PersistentPeers` shold be only used for
   nodes that you want to keep a constant connection with i.e. sentry nodes
 * The field `Version` in the mempool section has been removed. The priority
   mempool (what was called version `v1`) has been removed (see below), thus
   there is only one implementation of the mempool available (what was called
   `v0`).
-* Config fields `TTLDuration` and `TTLNumBlocks`, which were only used by the priority
-  mempool, have been removed.
+* Config fields `TTLDuration` and `TTLNumBlocks`, which were only used by the
+  priority mempool, have been removed.
 
 ### Mempool Changes
 
 * The priority mempool (what was referred in the code as version `v1`) has been
   removed. There is now only one mempool (what was called version `v0`), that
-  is, the default implementation as a queue of transactions. 
+  is, the default implementation as a queue of transactions.
 * In the protobuf message `ResponseCheckTx`, fields `sender`, `priority`, and
   `mempool_error`, which were only used by the priority mempool, were removed
   but still kept in the message as "reserved".

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,6 +4,10 @@ This guide provides instructions for upgrading to specific versions of CometBFT.
 
 ## Unreleased
 
+This release introduces state machine-breaking changes, as well as substantial changes
+on the ABCI interface and indexing. It therefore requires a
+coordinated upgrade.
+
 ### Config Changes
 
 * A new config field, `BootstrapPeers` has been introduced as a means of adding
@@ -33,13 +37,17 @@ This guide provides instructions for upgrading to specific versions of CometBFT.
   Applications upgrading to v0.38.0 must implement these methods as described
   [here](./spec/abci/abci%2B%2B_comet_expected_behavior.md#adapting-existing-applications-that-use-abci)
 * Removed methods `BeginBlock`, `DeliverTx`, `EndBlock`, and replaced them by
-  method `FinalizeBlock`. Applications upgrading to v0.38.0 must refactor
+  method `FinalizeBlock`. Applications upgrading to `v0.38.0` must refactor
   the logic handling the methods removed to handle `FinalizeBlock`.
 * The Application's hash (or any data representing the Application's current state)
   is known by the time `FinalizeBlock` finishes its execution.
   Accordingly, the `app_hash` parameter has been moved from `ResponseCommit`
   to `ResponseFinalizeBlock`.
-* For details, please see the updated [specification](spec/abci/README.md)
+* Field `signed_last_block` in structure `VoteInfo` has been replaced by the
+  more expressive `block_id_flag`. Applications willing to keep the semantics
+  of `signed_last_block` can now use the following predicate
+    * `voteInfo.block_id_flag != BlockIDFlagAbsent`
+* For further details, please see the updated [specification](spec/abci/README.md)
 
 ## v0.37.0
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -26,16 +26,6 @@ This guide provides instructions for upgrading to specific versions of CometBFT.
   `mempool_error`, which were only used by the priority mempool, were removed
   but still kept in the message as "reserved".
 
-## v0.37.0
-
-This release introduces state machine-breaking changes, and therefore requires a
-coordinated upgrade.
-
-### Go API
-
-When upgrading from the v0.34 release series, please note that the Go module has
-now changed to `github.com/cometbft/cometbft`.
-
 ### ABCI Changes
 
 * The `ABCIVersion` is now `2.0.0`.
@@ -51,6 +41,41 @@ now changed to `github.com/cometbft/cometbft`.
   to `ResponseFinalizeBlock`.
 * For details, please see the updated [specification](spec/abci/README.md)
 
+## v0.37.0
+
+This release introduces state machine-breaking changes, and therefore requires a
+coordinated upgrade.
+
+### Go API
+
+When upgrading from the v0.34 release series, please note that the Go module has
+now changed to `github.com/cometbft/cometbft`.
+
+### ABCI Changes
+
+* The `ABCIVersion` is now `1.0.0`.
+* Added new ABCI methods `PrepareProposal` and `ProcessProposal`. For details,
+  please see the [spec](spec/abci/README.md). Applications upgrading to
+  v0.37.0 must implement these methods, at the very minimum, as described
+  [here](./spec/abci/abci++_app_requirements.md)
+* Deduplicated `ConsensusParams` and `BlockParams`.
+  In the v0.34 branch they are defined both in `abci/types.proto` and `types/params.proto`.
+  The definitions in `abci/types.proto` have been removed.
+  In-process applications should make sure they are not using the deleted
+  version of those structures.
+* In v0.34, messages on the wire used to be length-delimited with `int64` varint
+  values, which was inconsistent with the `uint64` varint length delimiters used
+  in the P2P layer. Both now consistently use `uint64` varint length delimiters.
+* Added `AbciVersion` to `RequestInfo`.
+  Applications should check that CometBFT's ABCI version matches the one they expect
+  in order to ensure compatibility.
+* The `SetOption` method has been removed from the ABCI `Client` interface.
+  The corresponding Protobuf types have been deprecated.
+* The `key` and `value` fields in the `EventAttribute` type have been changed
+  from type `bytes` to `string`. As per the [Protocol Buffers updating
+  guidelines](https://developers.google.com/protocol-buffers/docs/proto3#updating),
+  this should have no effect on the wire-level encoding for UTF8-encoded
+  strings.
 
 ### RPC
 

--- a/version/version.go
+++ b/version/version.go
@@ -3,7 +3,7 @@ package version
 const (
 	// TMVersionDefault is the used as the fallback version of CometBFT
 	// when not using git describe. It is formatted with semantic versioning.
-	TMCoreSemVer = "0.38.0-dev"
+	TMCoreSemVer = "0.38.0-alpha.1"
 	// ABCISemVer is the semantic version of the ABCI protocol
 	ABCISemVer  = "2.0.0"
 	ABCIVersion = ABCISemVer

--- a/version/version.go
+++ b/version/version.go
@@ -5,7 +5,7 @@ const (
 	// when not using git describe. It is formatted with semantic versioning.
 	TMCoreSemVer = "0.38.0-dev"
 	// ABCISemVer is the semantic version of the ABCI protocol
-	ABCISemVer  = "1.0.0"
+	ABCISemVer  = "2.0.0"
 	ABCIVersion = ABCISemVer
 	// P2PProtocol versions all p2p behavior and msgs.
 	// This includes proposer selection.
@@ -16,8 +16,6 @@ const (
 	BlockProtocol uint64 = 11
 )
 
-var (
-	// TMGitCommitHash uses git rev-parse HEAD to find commit hash which is helpful
-	// for the engineering team when working with the cometbft binary. See Makefile
-	TMGitCommitHash = ""
-)
+// TMGitCommitHash uses git rev-parse HEAD to find commit hash which is helpful
+// for the engineering team when working with the cometbft binary. See Makefile
+var TMGitCommitHash = ""


### PR DESCRIPTION
Prepares for our first alpha release of v0.38.0 with ABCI 2.0:

- [CHANGELOG rendered](https://github.com/cometbft/cometbft/blob/release/v0.38.0-alpha.1/CHANGELOG.md)
- [Upgrading guidelines rendered](https://github.com/cometbft/cometbft/blob/release/v0.38.0-alpha.1/UPGRADING.md)
- [Manual E2E run](https://github.com/cometbft/cometbft/actions/runs/4547643615) (for the `release/v0.38.0-alpha.1` branch) :heavy_check_mark: 

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

