### PR TITLE
Prepare for v0.39.0-dev on `main`

### DIFF
--- a/.changelog/unreleased/breaking-changes/211-deprecate-tmhome.md
+++ b/.changelog/unreleased/breaking-changes/211-deprecate-tmhome.md
@@ -1,2 +1,0 @@
-- The `TMHOME` environment variable was renamed to `CMTHOME`, and all environment variables starting with `TM_` are instead prefixed with `CMT_`
-  ([\#211](https://github.com/cometbft/cometbft/issues/211))

--- a/.changelog/unreleased/breaking-changes/260-remove-priority-mempool.md
+++ b/.changelog/unreleased/breaking-changes/260-remove-priority-mempool.md
@@ -1,6 +1,0 @@
-- [mempool] Remove priority mempool. 
-  ([\#260](https://github.com/cometbft/cometbft/issues/260))
-- [config] Remove `Version` field from `MempoolConfig`. 
-  ([\#260](https://github.com/cometbft/cometbft/issues/260))
-- [protobuf] Remove fields `sender`, `priority`, and `mempool_error` from
-  `ResponseCheckTx`. ([\#260](https://github.com/cometbft/cometbft/issues/260))

--- a/.changelog/unreleased/breaking-changes/385-update-to-go1.20.md
+++ b/.changelog/unreleased/breaking-changes/385-update-to-go1.20.md
@@ -1,2 +1,0 @@
-- Bump minimum Go version to 1.20
-  ([\#385](https://github.com/cometbft/cometbft/issues/385))

--- a/.changelog/unreleased/breaking-changes/6498-signerharness-set-home-dir.md
+++ b/.changelog/unreleased/breaking-changes/6498-signerharness-set-home-dir.md
@@ -1,2 +1,0 @@
-- `[tools/tm-signer-harness]` Set OS home dir to instead of the hardcoded PATH.
-  ([\#6498](https://github.com/tendermint/tendermint/pull/6498))

--- a/.changelog/unreleased/breaking-changes/6541-state-move-pruneblocks-execution.md
+++ b/.changelog/unreleased/breaking-changes/6541-state-move-pruneblocks-execution.md
@@ -1,2 +1,0 @@
-- `[state]` Move pruneBlocks from node/state to state/execution.
-  ([\#6541](https://github.com/tendermint/tendermint/pull/6541))

--- a/.changelog/unreleased/breaking-changes/8664-move-app-hash-to-commit.md
+++ b/.changelog/unreleased/breaking-changes/8664-move-app-hash-to-commit.md
@@ -1,2 +1,0 @@
-- `[abci]` Move `app_hash` parameter from `Commit` to `FinalizeBlock` (@sergio-mena)
-  ([\#8664](https://github.com/tendermint/tendermint/pull/8664))

--- a/.changelog/unreleased/breaking-changes/9468-finalize-block.md
+++ b/.changelog/unreleased/breaking-changes/9468-finalize-block.md
@@ -1,2 +1,0 @@
-- `[abci]` Introduce `FinalizeBlock` which condenses `BeginBlock`, `DeliverTx` and `EndBlock` into a single method call (@cmwaters)
-  ([\#9468](https://github.com/tendermint/tendermint/pull/9468))

--- a/.changelog/unreleased/breaking-changes/9625-p2p-remove-trust-package.md
+++ b/.changelog/unreleased/breaking-changes/9625-p2p-remove-trust-package.md
@@ -1,2 +1,0 @@
-- `[p2p]` Remove unused p2p/trust package
-  ([\#9625](https://github.com/tendermint/tendermint/pull/9625))

--- a/.changelog/unreleased/breaking-changes/9655-inspect-add-command.md
+++ b/.changelog/unreleased/breaking-changes/9655-inspect-add-command.md
@@ -1,3 +1,0 @@
-- `[inspect]` Add a new `inspect` command for introspecting
-  the state and block store of a crashed tendermint node.
-  ([\#9655](https://github.com/tendermint/tendermint/pull/9655))

--- a/.changelog/unreleased/breaking-changes/9655-node-move-DB-vars-config.md
+++ b/.changelog/unreleased/breaking-changes/9655-node-move-DB-vars-config.md
@@ -1,2 +1,0 @@
-- `[node]` Move DBContext and DBProvider from the node package to the config
-  package. ([\#9655](https://github.com/tendermint/tendermint/pull/9655))

--- a/.changelog/unreleased/breaking-changes/9655-rpc-remove-environment-var.md
+++ b/.changelog/unreleased/breaking-changes/9655-rpc-remove-environment-var.md
@@ -1,2 +1,0 @@
-- `[rpc]` Remove global environment and replace with constructor
-  ([\#9655](https://github.com/tendermint/tendermint/pull/9655))

--- a/.changelog/unreleased/breaking-changes/9682-metrics-refactor-state-block-synching.md
+++ b/.changelog/unreleased/breaking-changes/9682-metrics-refactor-state-block-synching.md
@@ -1,4 +1,0 @@
-- `[metrics]` Move state-syncing and block-syncing metrics to
-  their respective packages. Move labels from block_syncing
-  -> blocksync_syncing and state_syncing -> statesync_syncing
-  ([\#9682](https://github.com/tendermint/tendermint/pull/9682))

--- a/.changelog/unreleased/bug-fixes/386-quick-fix-needproofblock.md
+++ b/.changelog/unreleased/bug-fixes/386-quick-fix-needproofblock.md
@@ -1,2 +1,0 @@
-- `[consensus]` ([\#386](https://github.com/cometbft/cometbft/pull/386)) Short-term fix for the case when `needProofBlock` cannot find previous block meta by defaulting to the creation of a new proof block. (@adizere)
-  - Special thanks to the [Vega.xyz](https://vega.xyz/) team, and in particular to Zohar (@ze97286), for reporting the problem and working with us to get to a fix.

--- a/.changelog/unreleased/bug-fixes/4-busy-loop-send-block-part.md
+++ b/.changelog/unreleased/bug-fixes/4-busy-loop-send-block-part.md
@@ -1,2 +1,0 @@
-- `[consensus]` Fixed a busy loop that happened when sending of a block part failed by sleeping in case of error.
-  ([\#4](https://github.com/informalsystems/tendermint/pull/4))

--- a/.changelog/unreleased/bug-fixes/423-forwardport-default-kvindexer-behaviour.md
+++ b/.changelog/unreleased/bug-fixes/423-forwardport-default-kvindexer-behaviour.md
@@ -1,2 +1,0 @@
-- `[kvindexer]` Forward porting the fixes done to the kvindexer in 0.37 in PR \#77
-  ([\#423](https://github.com/cometbft/cometbft/pull/423))

--- a/.changelog/unreleased/bug-fixes/496-error-on-applyblock-should-panic.md
+++ b/.changelog/unreleased/bug-fixes/496-error-on-applyblock-should-panic.md
@@ -1,2 +1,0 @@
-- `[consensus]` Unexpected error conditions in `ApplyBlock` are non-recoverable, so ignoring the error and carrying on is a bug. We replaced a `return` that disregarded the error by a `panic`.
-  ([\#496](https://github.com/cometbft/cometbft/pull/496))

--- a/.changelog/unreleased/bug-fixes/524-rename-peerstate-tojson.md
+++ b/.changelog/unreleased/bug-fixes/524-rename-peerstate-tojson.md
@@ -1,2 +1,0 @@
-- `[consensus]` Rename `(*PeerState).ToJSON` to `MarshalJSON` to fix a logging data race
-  ([\#524](https://github.com/cometbft/cometbft/pull/524))

--- a/.changelog/unreleased/bug-fixes/9462-docker-go-use-consistent-version.md
+++ b/.changelog/unreleased/bug-fixes/9462-docker-go-use-consistent-version.md
@@ -1,2 +1,0 @@
-- `[docker]` Ensure Docker image uses consistent version of Go.
-  ([\#9462](https://github.com/tendermint/tendermint/pull/9462))

--- a/.changelog/unreleased/bug-fixes/9717-abci-cli-fix-help.md
+++ b/.changelog/unreleased/bug-fixes/9717-abci-cli-fix-help.md
@@ -1,2 +1,0 @@
-- `[abci-cli]` Fix broken abci-cli help command.
-  ([\#9717](https://github.com/tendermint/tendermint/pull/9717))

--- a/.changelog/unreleased/features/9680-config-introduce-bootstrappeers.md
+++ b/.changelog/unreleased/features/9680-config-introduce-bootstrappeers.md
@@ -1,3 +1,0 @@
-- `[config]` Introduce `BootstrapPeers` to the config to allow
-  nodes to list peers to be added to the addressbook upon start up.
-  ([\#9680](https://github.com/tendermint/tendermint/pull/9680))

--- a/.changelog/unreleased/features/9830-proxy-introduce-newunsynclocalclientcreator.md
+++ b/.changelog/unreleased/features/9830-proxy-introduce-newunsynclocalclientcreator.md
@@ -1,4 +1,0 @@
-- `[proxy]` Introduce `NewUnsyncLocalClientCreator`, which allows local ABCI
-  clients to have the same concurrency model as remote clients (i.e. one
-  mutex per client "connection", for each of the four ABCI "connections").
-  ([\#9830](https://github.com/tendermint/tendermint/pull/9830))

--- a/.changelog/unreleased/improvements/136-remove-tm-signer-harness.md
+++ b/.changelog/unreleased/improvements/136-remove-tm-signer-harness.md
@@ -1,2 +1,0 @@
-- `[tools/tm-signer-harness]` Remove the folder as it is unused
-  ([\#136](https://github.com/cometbft/cometbft/issues/136))

--- a/.changelog/unreleased/improvements/543-metrics-for-blocksync.md
+++ b/.changelog/unreleased/improvements/543-metrics-for-blocksync.md
@@ -1,2 +1,0 @@
-- `[blocksync]` Generate new metrics during BlockSync
-  ([\#543](https://github.com/cometbft/cometbft/pull/543))

--- a/.changelog/unreleased/improvements/56-rpc-cache-rpc-responses.md
+++ b/.changelog/unreleased/improvements/56-rpc-cache-rpc-responses.md
@@ -1,2 +1,0 @@
-- `[e2e]` Add functionality for uncoordinated (minor) upgrades
-  ([\#56](https://github.com/tendermint/tendermint/pull/56))

--- a/.changelog/unreleased/improvements/6443-merkle-hashalternatives-perf-improv-a.md
+++ b/.changelog/unreleased/improvements/6443-merkle-hashalternatives-perf-improv-a.md
@@ -1,2 +1,0 @@
-- `[crypto/merkle]` Improve HashAlternatives performance
-  ([\#6443](https://github.com/tendermint/tendermint/pull/6443))

--- a/.changelog/unreleased/improvements/6509-pex-addrbook-perf-improv.md
+++ b/.changelog/unreleased/improvements/6509-pex-addrbook-perf-improv.md
@@ -1,2 +1,0 @@
-- `[p2p/pex]` Improve addrBook.hash performance
-  ([\#6509](https://github.com/tendermint/tendermint/pull/6509))

--- a/.changelog/unreleased/improvements/6513-merkle-hashalternatives-perf-improv-b.md
+++ b/.changelog/unreleased/improvements/6513-merkle-hashalternatives-perf-improv-b.md
@@ -1,2 +1,0 @@
-- `[crypto/merkle]` Improve HashAlternatives performance
-  ([\#6513](https://github.com/tendermint/tendermint/pull/6513))

--- a/.changelog/unreleased/improvements/7319-pubsub-query-perf-improv.md
+++ b/.changelog/unreleased/improvements/7319-pubsub-query-perf-improv.md
@@ -1,2 +1,0 @@
-- `[pubsub]` Performance improvements for the event query API
-  ([\#7319](https://github.com/tendermint/tendermint/pull/7319))

--- a/.changelog/unreleased/improvements/9650-rpc-cache-rpc-responses.md
+++ b/.changelog/unreleased/improvements/9650-rpc-cache-rpc-responses.md
@@ -1,2 +1,0 @@
-- `[rpc]` Enable caching of RPC responses
-  ([\#9650](https://github.com/tendermint/tendermint/pull/9650))

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -115,6 +115,9 @@ After doing these steps, go back to `main` and do the following:
    enable automatic update of Go dependencies on this branch. Copy and edit one
    of the existing branch configurations to set the correct `target-branch`.
 
+4. Remove all changelog entries from `.changelog/unreleased` that are destined
+   for release from the backport branch.
+
 [e2e]: https://github.com/cometbft/cometbft/blob/main/.github/workflows/e2e-nightly-main.yml
 
 ## Pre-releases

--- a/version/version.go
+++ b/version/version.go
@@ -3,7 +3,7 @@ package version
 const (
 	// TMVersionDefault is the used as the fallback version of CometBFT
 	// when not using git describe. It is formatted with semantic versioning.
-	TMCoreSemVer = "0.38.0-dev"
+	TMCoreSemVer = "0.39.0-dev"
 	// ABCISemVer is the semantic version of the ABCI protocol
 	ABCISemVer  = "1.0.0"
 	ABCIVersion = ABCISemVer
@@ -16,8 +16,6 @@ const (
 	BlockProtocol uint64 = 11
 )
 
-var (
-	// TMGitCommitHash uses git rev-parse HEAD to find commit hash which is helpful
-	// for the engineering team when working with the cometbft binary. See Makefile
-	TMGitCommitHash = ""
-)
+// TMGitCommitHash uses git rev-parse HEAD to find commit hash which is helpful
+// for the engineering team when working with the cometbft binary. See Makefile
+var TMGitCommitHash = ""

--- a/version/version.go
+++ b/version/version.go
@@ -5,7 +5,7 @@ const (
 	// when not using git describe. It is formatted with semantic versioning.
 	TMCoreSemVer = "0.39.0-dev"
 	// ABCISemVer is the semantic version of the ABCI protocol
-	ABCISemVer  = "1.0.0"
+	ABCISemVer  = "2.0.0"
 	ABCIVersion = ABCISemVer
 	// P2PProtocol versions all p2p behavior and msgs.
 	// This includes proposer selection.


### PR DESCRIPTION
As a follow-up to #595, we need to clear out all unreleased changelog entries from `main` that are already accounted for on `v0.38.x`, and ensure that our versions are correct.

I've also updated the release guidelines to take this step into account.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

