### PR TITLE
cmd: Remove snake case deprecation warning

### DIFF
--- a/cmd/cometbft/commands/compact.go
+++ b/cmd/cometbft/commands/compact.go
@@ -14,8 +14,9 @@ import (
 )
 
 var CompactGoLevelDBCmd = &cobra.Command{
-	Use:   "experimental-compact-goleveldb",
-	Short: "force compacts the CometBFT storage engine (only GoLevelDB supported)",
+	Use:     "experimental-compact-goleveldb",
+	Aliases: []string{"experimental_compact_goleveldb"},
+	Short:   "force compacts the CometBFT storage engine (only GoLevelDB supported)",
 	Long: `
 This is a temporary utility command that performs a force compaction on the state 
 and blockstores to reduce disk space for a pruning node. This should only be run 

--- a/cmd/cometbft/commands/gen_node_key.go
+++ b/cmd/cometbft/commands/gen_node_key.go
@@ -15,7 +15,6 @@ var GenNodeKeyCmd = &cobra.Command{
 	Use:     "gen-node-key",
 	Aliases: []string{"gen_node_key"},
 	Short:   "Generate a node key for this node and print its ID",
-	PreRun:  deprecateSnakeCase,
 	RunE:    genNodeKey,
 }
 

--- a/cmd/cometbft/commands/gen_validator.go
+++ b/cmd/cometbft/commands/gen_validator.go
@@ -15,7 +15,6 @@ var GenValidatorCmd = &cobra.Command{
 	Use:     "gen-validator",
 	Aliases: []string{"gen_validator"},
 	Short:   "Generate new validator keypair",
-	PreRun:  deprecateSnakeCase,
 	Run:     genValidator,
 }
 

--- a/cmd/cometbft/commands/probe_upnp.go
+++ b/cmd/cometbft/commands/probe_upnp.go
@@ -15,7 +15,6 @@ var ProbeUpnpCmd = &cobra.Command{
 	Aliases: []string{"probe_upnp"},
 	Short:   "Test UPnP functionality",
 	RunE:    probeUpnp,
-	PreRun:  deprecateSnakeCase,
 }
 
 func probeUpnp(*cobra.Command, []string) error {

--- a/cmd/cometbft/commands/reindex_event.go
+++ b/cmd/cometbft/commands/reindex_event.go
@@ -32,8 +32,9 @@ var (
 
 // ReIndexEventCmd constructs a command to re-index events in a block height interval.
 var ReIndexEventCmd = &cobra.Command{
-	Use:   "reindex-event",
-	Short: "reindex events to the event store backends",
+	Use:     "reindex-event",
+	Aliases: []string{"reindex_event"},
+	Short:   "reindex events to the event store backends",
 	Long: `
 reindex-event is an offline tooling to re-index block and tx events to the eventsinks,
 you can run this command when the event store backend dropped/disconnected or you want to 

--- a/cmd/cometbft/commands/replay.go
+++ b/cmd/cometbft/commands/replay.go
@@ -24,5 +24,4 @@ var ReplayConsoleCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		consensus.RunReplayFile(config.BaseConfig, config.Consensus, true)
 	},
-	PreRun: deprecateSnakeCase,
 }

--- a/cmd/cometbft/commands/reset.go
+++ b/cmd/cometbft/commands/reset.go
@@ -24,8 +24,9 @@ var keepAddrBook bool
 
 // ResetStateCmd removes the database of the specified CometBFT core instance.
 var ResetStateCmd = &cobra.Command{
-	Use:   "reset-state",
-	Short: "Remove all the data and WAL",
+	Use:     "reset-state",
+	Aliases: []string{"reset_state"},
+	Short:   "Remove all the data and WAL",
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		config, err = ParseConfig(cmd)
 		if err != nil {

--- a/cmd/cometbft/commands/reset.go
+++ b/cmd/cometbft/commands/reset.go
@@ -18,16 +18,14 @@ var ResetAllCmd = &cobra.Command{
 	Aliases: []string{"unsafe_reset_all"},
 	Short:   "(unsafe) Remove all the data and WAL, reset this node's validator to genesis state",
 	RunE:    resetAllCmd,
-	PreRun:  deprecateSnakeCase,
 }
 
 var keepAddrBook bool
 
 // ResetStateCmd removes the database of the specified CometBFT core instance.
 var ResetStateCmd = &cobra.Command{
-	Use:    "reset-state",
-	Short:  "Remove all the data and WAL",
-	PreRun: deprecateSnakeCase,
+	Use:   "reset-state",
+	Short: "Remove all the data and WAL",
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		config, err = ParseConfig(cmd)
 		if err != nil {
@@ -47,7 +45,6 @@ var ResetPrivValidatorCmd = &cobra.Command{
 	Use:     "unsafe-reset-priv-validator",
 	Aliases: []string{"unsafe_reset_priv_validator"},
 	Short:   "(unsafe) Reset this node's validator to genesis state",
-	PreRun:  deprecateSnakeCase,
 	RunE:    resetPrivValidator,
 }
 

--- a/cmd/cometbft/commands/root.go
+++ b/cmd/cometbft/commands/root.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -95,12 +94,4 @@ var RootCmd = &cobra.Command{
 		logger = logger.With("module", "main")
 		return nil
 	},
-}
-
-// deprecateSnakeCase is a util function for 0.34.1. Should be removed in 0.35
-// TODO(thane): Remove this across all releases
-func deprecateSnakeCase(cmd *cobra.Command, _ []string) {
-	if strings.Contains(cmd.CalledAs(), "_") {
-		fmt.Println("Deprecated: snake_case commands will be replaced by hyphen-case commands in the next major release")
-	}
 }

--- a/cmd/cometbft/commands/show_node_id.go
+++ b/cmd/cometbft/commands/show_node_id.go
@@ -14,7 +14,6 @@ var ShowNodeIDCmd = &cobra.Command{
 	Aliases: []string{"show_node_id"},
 	Short:   "Show this node's ID",
 	RunE:    showNodeID,
-	PreRun:  deprecateSnakeCase,
 }
 
 func showNodeID(*cobra.Command, []string) error {

--- a/cmd/cometbft/commands/show_validator.go
+++ b/cmd/cometbft/commands/show_validator.go
@@ -16,7 +16,6 @@ var ShowValidatorCmd = &cobra.Command{
 	Aliases: []string{"show_validator"},
 	Short:   "Show this node's validator info",
 	RunE:    showValidator,
-	PreRun:  deprecateSnakeCase,
 }
 
 func showValidator(*cobra.Command, []string) error {


### PR DESCRIPTION
While working on #625 I discovered this. We have aliases for both types of commands, so I don't think there's any need to issue a warning here.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

