### PR TITLE
Add GH workflows to test quint specs

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -1,0 +1,17 @@
+name: Specs
+# Runs static analysis and tests (if defined) on quint specs
+
+jobs:
+  test-specs:
+    defaults:
+      run:
+        working-directory: spec
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 17
+          cache: "npm"
+      # --verbosity=3 shows traces explaining test failures
+      - run: for quint_spec in **/*.qnt; do quint test --verbosity=3 $quint_spec; done


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

Closes https://github.com/informalsystems/quint/pull/768

As per conversation with @josef-widder today, this adds CI tests to run against the p2p quint spec. In fact, it adds a one-liner to run quint on any specs in the `/spec/` directory.

:warning: This PR is into PR #616 
---

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

