### PR TITLE
Fix failing P2P spec test

### DIFF
--- a/spec/p2p/p2p.qnt
+++ b/spec/p2p/p2p.qnt
@@ -511,8 +511,7 @@ module p2p {
         })
     }
 
-    //should fail
-    run mixedDirectionsTest = {
+    run mixedDirectionsFailsTest = {
         val a = {ID: "alice", networkAddress: "127.0.0.111:10"}
         val node = {ID: "scully", networkAddress: "127.0.0.1177:10"}
         init

--- a/spec/p2p/p2p.qnt
+++ b/spec/p2p/p2p.qnt
@@ -519,9 +519,10 @@ module p2p {
         .then(actionTransportAccept(node,a))
         .then(lowerLevelTransportAcceptSuccess(node,a))
         .then(all{
-            assert(invDirectionsOut),
+            invDirectionsOut,
             allUnchanged,
         })
+        .fail()
     }
 
     action step = any {


### PR DESCRIPTION
This PR into #616 serves two purposes:

1. Demonstrate that with our latest quint release, the CI test for spec fails when a test does. See https://github.com/cometbft/cometbft/actions/runs/4611928328/jobs/8152229802#step:5:59
2. Fix the failing test from #616.

@josef-widder This is fine to merge if you are happy with it! :) Thanks!

---

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

