### PR TITLE
Mark the gRPC broadcast API as deprecated

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -639,6 +639,7 @@ func (n *Node) startRPC() ([]net.Listener, error) {
 			return nil, err
 		}
 		go func() {
+			//nolint:staticcheck // SA1019: core_grpc.StartGRPCClient is deprecated: A new gRPC API will be introduced after v0.38.
 			if err := grpccore.StartGRPCServer(env, listener); err != nil {
 				n.Logger.Error("Error starting gRPC server", "err", err)
 			}

--- a/proto/tendermint/rpc/grpc/types.proto
+++ b/proto/tendermint/rpc/grpc/types.proto
@@ -26,6 +26,10 @@ message ResponseBroadcastTx {
 //----------------------------------------
 // Service Definition
 
+// BroadcastAPI
+//
+// Deprecated: This API will be superseded by a more comprehensive gRPC-based
+// broadcast API, and is scheduled for removal after v0.38.
 service BroadcastAPI {
   rpc Ping(RequestPing) returns (ResponsePing);
   rpc BroadcastTx(RequestBroadcastTx) returns (ResponseBroadcastTx);

--- a/rpc/grpc/client_server.go
+++ b/rpc/grpc/client_server.go
@@ -11,6 +11,8 @@ import (
 )
 
 // Config is an gRPC server configuration.
+//
+// Deprecated: A new gRPC API will be introduced after v0.38.
 type Config struct {
 	MaxOpenConnections int
 }
@@ -18,6 +20,8 @@ type Config struct {
 // StartGRPCServer starts a new gRPC BroadcastAPIServer using the given
 // net.Listener.
 // NOTE: This function blocks - you may want to call it in a go-routine.
+//
+// Deprecated: A new gRPC API will be introduced after v0.38.
 func StartGRPCServer(env *core.Environment, ln net.Listener) error {
 	grpcServer := grpc.NewServer()
 	RegisterBroadcastAPIServer(grpcServer, &broadcastAPI{env: env})
@@ -26,8 +30,9 @@ func StartGRPCServer(env *core.Environment, ln net.Listener) error {
 
 // StartGRPCClient dials the gRPC server using protoAddr and returns a new
 // BroadcastAPIClient.
+//
+// Deprecated: A new gRPC API will be introduced after v0.38.
 func StartGRPCClient(protoAddr string) BroadcastAPIClient {
-	//nolint: staticcheck // SA1019 Existing use of deprecated but supported dial option.
 	conn, err := grpc.Dial(protoAddr, grpc.WithInsecure(), grpc.WithContextDialer(dialerFunc))
 	if err != nil {
 		panic(err)

--- a/rpc/test/helpers.go
+++ b/rpc/test/helpers.go
@@ -30,11 +30,13 @@ type Options struct {
 	recreateConfig bool
 }
 
-var globalConfig *cfg.Config
-var defaultOptions = Options{
-	suppressStdout: false,
-	recreateConfig: false,
-}
+var (
+	globalConfig   *cfg.Config
+	defaultOptions = Options{
+		suppressStdout: false,
+		recreateConfig: false,
+	}
+)
 
 func waitForRPC() {
 	laddr := GetConfig().RPC.ListenAddress
@@ -113,6 +115,7 @@ func GetConfig(forceCreate ...bool) *cfg.Config {
 
 func GetGRPCClient() core_grpc.BroadcastAPIClient {
 	grpcAddr := globalConfig.RPC.GRPCListenAddress
+	//nolint:staticcheck // SA1019: core_grpc.StartGRPCClient is deprecated: A new gRPC API will be introduced after v0.38.
 	return core_grpc.StartGRPCClient(grpcAddr)
 }
 

--- a/test/app/grpc_client.go
+++ b/test/app/grpc_client.go
@@ -1,11 +1,10 @@
 package main
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
 	"os"
-
-	"context"
 
 	cmtjson "github.com/cometbft/cometbft/libs/json"
 	coregrpc "github.com/cometbft/cometbft/rpc/grpc"
@@ -26,6 +25,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	//nolint:staticcheck // SA1019: core_grpc.StartGRPCClient is deprecated: A new gRPC API will be introduced after v0.38.
 	clientGRPC := coregrpc.StartGRPCClient(grpcAddr)
 	res, err := clientGRPC.BroadcastTx(context.Background(), &coregrpc.RequestBroadcastTx{Tx: txBytes})
 	if err != nil {


### PR DESCRIPTION
Partially addresses #650.

Changelog entry will be added to the v0.38.x backport.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

