### PR TITLE
Update contributing to draft PRS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,9 +45,11 @@ Find the largest existing ADR number and bump it by 1.
 When the problem as well as proposed solution are well understood,
 changes should start with a [draft
 pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
-against `main`. The draft signals that work is underway. When the work
-is ready for feedback, hitting "Ready for Review" will signal to the
-maintainers to take a look.
+against `main`. The draft signals that work is underway and is not ready for
+review. Only users that are familiar with the issue or have some context are
+expected to write comments at this point. When the work is ready for feedback,
+hitting "Ready for Review" will signal to the maintainers to take a look, and to
+the rest of the community that feedback is welcome.
 
 ![Contributing flow](./docs/imgs/contributing.png)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,10 @@ are expected to write comments at this point. When the work is ready for feedbac
 hitting "Ready for Review" will signal to the maintainers to take a look, and to
 the rest of the community that feedback is welcome.
 
+**The team may opt to ignore unsolicited comments/feedback on draft PRs**, as having to
+respond to feedback on work that is not marked as "Ready for Review" interferes with the
+process of getting the work to the point that it is ready to review.
+
 ![Contributing flow](./docs/imgs/contributing.png)
 
 Each stage of the process is aimed at creating feedback cycles which align contributors and maintainers to make sure:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,8 @@ When the problem as well as proposed solution are well understood,
 changes should start with a [draft
 pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
 against `main`. The draft signals that work is underway and is not ready for
-review. Only users that are familiar with the issue or have some context are
-expected to write comments at this point. When the work is ready for feedback,
+review. Only users that are familiar with the issue, or those that the author explicitly requested a review from
+are expected to write comments at this point. When the work is ready for feedback,
 hitting "Ready for Review" will signal to the maintainers to take a look, and to
 the rest of the community that feedback is welcome.
 


### PR DESCRIPTION
Make explicit the team's policy for expected feedback on draft PRs.
