### PR TITLE
ci: Bump Go version for govulncheck to v1.20.3

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.20.2"
+          go-version: "1.20.3"
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6
         with:


### PR DESCRIPTION
Fixes the failing govulncheck workflows until such time that GitHub's runners catch up with the latest security release.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

