### PR TITLE
ci: Bump Go version for govulncheck to v1.19.8

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.19.7"
+          go-version: "1.19.8"
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6
         with:


### PR DESCRIPTION
Similar to #661, but for our `v0.34.x` branch.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

