### PR TITLE
Fix race condition in Consensus code

### DIFF
--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -14,7 +14,7 @@ docker:
 # order to build a binary with a CometBFT node in it (for built-in
 # ABCI testing).
 node:
-	go build $(BUILD_FLAGS) -tags '$(BUILD_TAGS)' -o build/node ./node
+	go build -race $(BUILD_FLAGS) -tags '$(BUILD_TAGS)' -o build/node ./node
 
 generator:
 	go build -o build/generator ./generator

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -25,6 +25,7 @@ RUN cd test/e2e && make node && cp build/node /usr/bin/app
 WORKDIR /cometbft
 VOLUME /cometbft
 ENV CMTHOME=/cometbft
+ENV GORACE "halt_on_error=1"
 
 EXPOSE 26656 26657 26660 6060
 ENTRYPOINT ["/usr/bin/entrypoint"]


### PR DESCRIPTION
Closes #487

This PR contains changes in the test infra to repro #487, and the the fix needed to avoid the race condition.
Similarly to #539, I have pushed the commits that make up this PR one by one, so that those interested can track how I reproed the race condition using e2e tests, and how the fix prevents the race from happening again.

* Commit#1: Add race option to e2e tests for builtin app. We also activate "halt on error", so e2e test are able to catch this (otherwise it just shows up in the logs, but the tests pass)
* Commit#2: The fix.

---

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

