### PR TITLE
Fill time in `FinalizeBlock`

### DIFF
--- a/state/execution.go
+++ b/state/execution.go
@@ -208,6 +208,7 @@ func (blockExec *BlockExecutor) ApplyBlock(
 		NextValidatorsHash: block.NextValidatorsHash,
 		ProposerAddress:    block.ProposerAddress,
 		Height:             block.Height,
+		Time:               block.Time,
 		DecidedLastCommit:  commitInfo,
 		Misbehavior:        block.Evidence.Evidence.ToABCI(),
 		Txs:                block.Txs.ToSliceOfBytes(),

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -85,6 +85,7 @@ func TestApplyBlock(t *testing.T) {
 // block.
 func TestFinalizeBlockDecidedLastCommit(t *testing.T) {
 	app := &testApp{}
+	baseTime := time.Now()
 	cc := proxy.NewLocalClientCreator(app)
 	proxyApp := proxy.NewAppConns(cc, proxy.NopMetrics())
 	err := proxyApp.Start()
@@ -146,6 +147,7 @@ func TestFinalizeBlockDecidedLastCommit(t *testing.T) {
 			blockID := types.BlockID{Hash: block.Hash(), PartSetHeader: bps.Header()}
 			_, err = blockExec.ApplyBlock(state, blockID, block)
 			require.NoError(t, err)
+			require.True(t, app.LastTime.After(baseTime))
 
 			// -> app receives a list of validators with a bool indicating if they signed
 			for i, v := range app.CommitVotes {

--- a/state/helpers_test.go
+++ b/state/helpers_test.go
@@ -238,6 +238,7 @@ type testApp struct {
 
 	CommitVotes      []abci.VoteInfo
 	Misbehavior      []abci.Misbehavior
+	LastTime         time.Time
 	ValidatorUpdates []abci.ValidatorUpdate
 	AppHash          []byte
 }
@@ -247,6 +248,7 @@ var _ abci.Application = (*testApp)(nil)
 func (app *testApp) FinalizeBlock(_ context.Context, req *abci.RequestFinalizeBlock) (*abci.ResponseFinalizeBlock, error) {
 	app.CommitVotes = req.DecidedLastCommit.Votes
 	app.Misbehavior = req.Misbehavior
+	app.LastTime = req.Time
 	txResults := make([]*abci.ExecTxResult, len(req.Txs))
 	for idx := range req.Txs {
 		txResults[idx] = &abci.ExecTxResult{


### PR DESCRIPTION
Closes #687 

Field `Time` was not being filled by `ApplyBlock`, and no UT was catching this.

---

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

