### PR TITLE
Fix race condition in `gossipVotesRoutine`

### DIFF
--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"runtime"
 	"sync"
 	"time"
 
@@ -747,7 +746,7 @@ OUTER_LOOP:
 			var ec *types.ExtendedCommit
 			var veEnabled bool
 			for i := 0; i < 10000; i++ {
-				runtime.Gosched()
+				time.Sleep(30 * time.Microsecond)
 				veEnabled = conR.conS.state.ConsensusParams.ABCI.VoteExtensionsEnabled(prs.Height)
 			}
 			if veEnabled {

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -744,9 +744,12 @@ OUTER_LOOP:
 			// Load the block's extended commit for prs.Height,
 			// which contains precommit signatures for prs.Height.
 			var ec *types.ExtendedCommit
-			conR.conS.mtx.RLock()
-			veEnabled := conR.conS.state.ConsensusParams.ABCI.VoteExtensionsEnabled(prs.Height)
-			conR.conS.mtx.RUnlock()
+			var veEnabled bool
+			func() {
+				conR.conS.mtx.RLock()
+				defer conR.conS.mtx.RUnlock()
+				veEnabled = conR.conS.state.ConsensusParams.ABCI.VoteExtensionsEnabled(prs.Height)
+			}()
 			if veEnabled {
 				ec = conR.conS.blockStore.LoadBlockExtendedCommit(prs.Height)
 			} else {

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -744,12 +744,8 @@ OUTER_LOOP:
 			// Load the block's extended commit for prs.Height,
 			// which contains precommit signatures for prs.Height.
 			var ec *types.ExtendedCommit
-			var veEnabled bool
 			conR.conS.mtx.RLock()
-			for i := 0; i < 10000; i++ {
-				time.Sleep(30 * time.Microsecond)
-				veEnabled = conR.conS.state.ConsensusParams.ABCI.VoteExtensionsEnabled(prs.Height)
-			}
+			veEnabled := conR.conS.state.ConsensusParams.ABCI.VoteExtensionsEnabled(prs.Height)
 			conR.conS.mtx.RUnlock()
 			if veEnabled {
 				ec = conR.conS.blockStore.LoadBlockExtendedCommit(prs.Height)

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -745,10 +745,12 @@ OUTER_LOOP:
 			// which contains precommit signatures for prs.Height.
 			var ec *types.ExtendedCommit
 			var veEnabled bool
+			conR.conS.mtx.RLock()
 			for i := 0; i < 10000; i++ {
 				time.Sleep(30 * time.Microsecond)
 				veEnabled = conR.conS.state.ConsensusParams.ABCI.VoteExtensionsEnabled(prs.Height)
 			}
+			conR.conS.mtx.RUnlock()
 			if veEnabled {
 				ec = conR.conS.blockStore.LoadBlockExtendedCommit(prs.Height)
 			} else {

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"runtime"
 	"sync"
 	"time"
 
@@ -744,7 +745,12 @@ OUTER_LOOP:
 			// Load the block's extended commit for prs.Height,
 			// which contains precommit signatures for prs.Height.
 			var ec *types.ExtendedCommit
-			if conR.conS.state.ConsensusParams.ABCI.VoteExtensionsEnabled(prs.Height) {
+			var veEnabled bool
+			for i := 0; i < 10000; i++ {
+				runtime.Gosched()
+				veEnabled = conR.conS.state.ConsensusParams.ABCI.VoteExtensionsEnabled(prs.Height)
+			}
+			if veEnabled {
 				ec = conR.conS.blockStore.LoadBlockExtendedCommit(prs.Height)
 			} else {
 				ec = conR.conS.blockStore.LoadBlockCommit(prs.Height).WrappedExtendedCommit()

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -14,7 +14,7 @@ docker:
 # order to build a binary with a CometBFT node in it (for built-in
 # ABCI testing).
 node:
-	go build $(BUILD_FLAGS) -tags '$(BUILD_TAGS)' -o build/node ./node
+	go build -race $(BUILD_FLAGS) -tags '$(BUILD_TAGS)' -o build/node ./node
 
 generator:
 	go build -o build/generator ./generator

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -25,6 +25,7 @@ RUN cd test/e2e && make node && cp build/node /usr/bin/app
 WORKDIR /cometbft
 VOLUME /cometbft
 ENV CMTHOME=/cometbft
+ENV GORACE "halt_on_error=1"
 
 EXPOSE 26656 26657 26660 6060
 ENTRYPOINT ["/usr/bin/entrypoint"]


### PR DESCRIPTION
Closes #674

This PR contains changes in the test infra to repro #674, and the the fix needed to avoid the race condition.
Similarly to #673 I have pushed the commits that make up this PR one by one, so that those interested can track how I repro'ed the race condition using e2e tests, and how the fix prevents the race from happening again. To do so, click on the little ❌ or ✅ next to the relevant commits.

* Commit#1: Add race option to e2e tests for builtin app. We also activate "halt on error", so e2e tests are able to catch this (otherwise it just shows up in the logs, but the tests pass).
* Commit#2 (pushed together with Commit#1): Added a for loop to increase the probability of the race condition happening.
* Commit#3: Commit#2 was enough to repro the race locally, but e2e tests passed in this PR for Commit#2. This commit is a second attempt at hitting the race condition. This time, however, almost all nodes are hitting it (check the corresponding ❌).
* Commit#4: Fix the race condition (1st version, see Commit#6). The first e2e run from this commit stalled (from the logs, it looks like the for introduced to exacerbate the race condition seems to also have side effects on peers' connectivity), however the race condition didn't show up. The second e2e run, although extremely slow, passed.
* Commit#5: Reverts Commit#2, to get the PR ready for merging (after approval)
* Commit#6 (pushed together with Commit#5): turned the locking added into RAII-style

Note that, unlike #673, we are leaving the race detection in e2e tests in place. Several runs in my local environment show no other _obvious_ race conditions are lurking, so leaving the race detection is useful to detect any further race condition early on in the process.

---

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

