### PR TITLE
Temporarily disable e2e long tests

### DIFF
--- a/.github/workflows/e2e-long-main.yml
+++ b/.github/workflows/e2e-long-main.yml
@@ -7,8 +7,8 @@
 name: e2e-long-main
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 3 * * 4'
+  #schedule:
+  #  - cron: '0 3 * * 4'
 
 jobs:
   e2e-long-test:

--- a/.github/workflows/e2e-long-main.yml
+++ b/.github/workflows/e2e-long-main.yml
@@ -7,8 +7,6 @@
 name: e2e-long-main
 on:
   workflow_dispatch:
-  #schedule:
-  #  - cron: '0 3 * * 4'
 
 jobs:
   e2e-long-test:


### PR DESCRIPTION
I didn't have the time to root case why there is an app mismatch.
Therefore, I'm disabling the scheduler on this workflow.
We I'm back, I'll keep on digging.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

