### PR TITLE
Removes the public ComputeRootHash

### DIFF
--- a/.changelog/unreleased/breaking-changes/558-tm10011-B.md
+++ b/.changelog/unreleased/breaking-changes/558-tm10011-B.md
@@ -1,0 +1,2 @@
+- `[crypto/merkle]` The public `Proof.ComputeRootHash` function has been deleted.
+   ([\#558](https://github.com/cometbft/cometbft/issues/558))

--- a/crypto/merkle/proof.go
+++ b/crypto/merkle/proof.go
@@ -73,15 +73,6 @@ func (sp *Proof) Verify(rootHash []byte, leaf []byte) error {
 	return nil
 }
 
-// Compute the root hash given a leaf hash.  Panics in case of errors.
-func (sp *Proof) ComputeRootHash() []byte {
-	computedHash, err := sp.computeRootHash()
-	if err != nil {
-		panic(fmt.Errorf("ComputeRootHash errored %w", err))
-	}
-	return computedHash
-}
-
 // Compute the root hash given a leaf hash.
 func (sp *Proof) computeRootHash() ([]byte, error) {
 	return computeHashFromAunts(


### PR DESCRIPTION
Closes #557, complementing the work done in #558.

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments

