### PR TITLE
e2e: Add thread-safe getters to app state

### DIFF
--- a/test/e2e/app/app.go
+++ b/test/e2e/app/app.go
@@ -129,8 +129,8 @@ func (app *Application) Info(_ context.Context, _ *abci.RequestInfo) (*abci.Resp
 	return &abci.ResponseInfo{
 		Version:          version.ABCIVersion,
 		AppVersion:       appVersion,
-		LastBlockHeight:  int64(app.state.Height),
-		LastBlockAppHash: app.state.Hash,
+		LastBlockHeight:  int64(app.state.GetHeight()),
+		LastBlockAppHash: app.state.GetHash(),
 	}, nil
 }
 
@@ -160,7 +160,7 @@ func (app *Application) InitChain(_ context.Context, req *abci.RequestInitChain)
 		}
 	}
 	resp := &abci.ResponseInitChain{
-		AppHash: app.state.Hash,
+		AppHash: app.state.GetHash(),
 	}
 	if resp.Validators, err = app.validatorUpdates(0); err != nil {
 		return nil, err
@@ -262,7 +262,7 @@ func (app *Application) Commit(_ context.Context, _ *abci.RequestCommit) (*abci.
 // Query implements ABCI.
 func (app *Application) Query(_ context.Context, req *abci.RequestQuery) (*abci.ResponseQuery, error) {
 	return &abci.ResponseQuery{
-		Height: int64(app.state.Height),
+		Height: int64(app.state.GetHeight()),
 		Key:    req.Data,
 		Value:  []byte(app.state.Get(string(req.Data))),
 	}, nil
@@ -502,7 +502,7 @@ func (app *Application) getAppHeight() int64 {
 		panic(fmt.Errorf("malformed initial height %q in database", initialHeightStr))
 	}
 
-	appHeight := int64(app.state.Height)
+	appHeight := int64(app.state.GetHeight())
 	if appHeight == 0 {
 		appHeight = initialHeight - 1
 	}

--- a/test/e2e/app/app.go
+++ b/test/e2e/app/app.go
@@ -262,7 +262,7 @@ func (app *Application) Commit(_ context.Context, _ *abci.RequestCommit) (*abci.
 
 // Query implements ABCI.
 func (app *Application) Query(_ context.Context, req *abci.RequestQuery) (*abci.ResponseQuery, error) {
-	height, value := app.state.Query(string(req.Data))
+	value, height := app.state.Query(string(req.Data))
 	return &abci.ResponseQuery{
 		Height: int64(height),
 		Key:    req.Data,
@@ -495,7 +495,7 @@ func (app *Application) Rollback() error {
 }
 
 func (app *Application) getAppHeight() int64 {
-	height, initialHeightStr := app.state.Query(prefixReservedKey + suffixInitialHeight)
+	initialHeightStr, height := app.state.Query(prefixReservedKey + suffixInitialHeight)
 	if len(initialHeightStr) == 0 {
 		panic("initial height not set in database")
 	}

--- a/test/e2e/app/snapshots.go
+++ b/test/e2e/app/snapshots.go
@@ -84,15 +84,14 @@ func (s *SnapshotStore) saveMetadata() error {
 func (s *SnapshotStore) Create(state *State) (abci.Snapshot, error) {
 	s.Lock()
 	defer s.Unlock()
-	bz, err := state.Export()
+	bz, height, stateHash, err := state.Export()
 	if err != nil {
 		return abci.Snapshot{}, err
 	}
-	height := state.GetHeight()
 	snapshot := abci.Snapshot{
 		Height: height,
 		Format: 1,
-		Hash:   hashItems(state.GetValues(), height),
+		Hash:   stateHash,
 		Chunks: byteChunks(bz),
 	}
 	err = os.WriteFile(filepath.Join(s.dir, fmt.Sprintf("%v.json", height)), bz, 0o644) //nolint:gosec

--- a/test/e2e/app/snapshots.go
+++ b/test/e2e/app/snapshots.go
@@ -31,7 +31,7 @@ type SnapshotStore struct {
 // NewSnapshotStore creates a new snapshot store.
 func NewSnapshotStore(dir string) (*SnapshotStore, error) {
 	store := &SnapshotStore{dir: dir}
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, err
 	}
 	if err := store.loadMetadata(); err != nil {
@@ -88,13 +88,14 @@ func (s *SnapshotStore) Create(state *State) (abci.Snapshot, error) {
 	if err != nil {
 		return abci.Snapshot{}, err
 	}
+	height := state.GetHeight()
 	snapshot := abci.Snapshot{
-		Height: state.Height,
+		Height: height,
 		Format: 1,
-		Hash:   hashItems(state.Values, state.Height),
+		Hash:   hashItems(state.GetValues(), height),
 		Chunks: byteChunks(bz),
 	}
-	err = os.WriteFile(filepath.Join(s.dir, fmt.Sprintf("%v.json", state.Height)), bz, 0o644) //nolint:gosec
+	err = os.WriteFile(filepath.Join(s.dir, fmt.Sprintf("%v.json", height)), bz, 0o644) //nolint:gosec
 	if err != nil {
 		return abci.Snapshot{}, err
 	}

--- a/test/e2e/app/state.go
+++ b/test/e2e/app/state.go
@@ -218,10 +218,14 @@ func (s *State) Rollback() error {
 	if err != nil {
 		return fmt.Errorf("failed to read state from %q: %w", s.previousFile, err)
 	}
-	err = json.Unmarshal(bz, s)
+	var ss serializedState
+	err = json.Unmarshal(bz, &ss)
 	if err != nil {
 		return fmt.Errorf("invalid state data in %q: %w", s.previousFile, err)
 	}
+	s.height = ss.Height
+	s.hash = ss.Hash
+	s.values = ss.Values
 	return nil
 }
 

--- a/test/e2e/app/state.go
+++ b/test/e2e/app/state.go
@@ -174,12 +174,12 @@ func (s *State) Set(key, value string) {
 
 // Query is used in the ABCI Query call, and provides both the current height
 // and the value associated with the given key.
-func (s *State) Query(key string) (uint64, string) {
+func (s *State) Query(key string) (string, uint64) {
 	s.RLock()
 	defer s.RUnlock()
 	height := s.height
 	value := s.values[key]
-	return height, value
+	return value, height
 }
 
 // Finalize is called after applying a block, updating the height and returning the new app_hash

--- a/test/e2e/app/state.go
+++ b/test/e2e/app/state.go
@@ -31,7 +31,6 @@ type State struct {
 	values map[string]string
 	hash   []byte
 
-	// private fields aren't marshaled to disk.
 	currentFile string
 	// app saves current and previous state for rollback functionality
 	previousFile    string

--- a/test/e2e/app/state.go
+++ b/test/e2e/app/state.go
@@ -124,18 +124,6 @@ func (s *State) Info() (uint64, []byte) {
 	return height, hash
 }
 
-// GetValues provides a thread-safe way of obtaining a copy of the current
-// state values.
-func (s *State) GetValues() map[string]string {
-	s.RLock()
-	defer s.RUnlock()
-	values := make(map[string]string, len(s.values))
-	for k, v := range s.values {
-		values[k] = v
-	}
-	return values
-}
-
 // Export exports key/value pairs as JSON, used for state sync snapshots.
 // Additionally returns the current height and hash of the state.
 func (s *State) Export() ([]byte, uint64, []byte, error) {


### PR DESCRIPTION
Attempts to close #712.

It appears as though a race condition has been triggered in the E2E app itself due to directly accessing application state inner variables.

Make the application state variables private to remove the temptation to access them directly from outside of the package and to highlight their use, and provide thread-safe getters to access the application state properties.

Running the full set of nightlies manually here: https://github.com/cometbft/cometbft/actions/runs/4698777347 :heavy_check_mark: 

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

