### PR TITLE
Rephrase log when committed TX not in local mempool + make it debug

### DIFF
--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -612,7 +612,7 @@ func (mem *CListMempool) Update(
 		//   100
 		// https://github.com/tendermint/tendermint/issues/3322.
 		if err := mem.RemoveTxByKey(tx.Key()); err != nil {
-			mem.logger.Error("Committed transaction could not be removed from mempool", "key", tx.Key(), err.Error())
+			mem.logger.Debug("Committed transaction not in local mempool (not an error)", "key", tx.Key(), err.Error())
 		}
 	}
 


### PR DESCRIPTION
If the execution hits the log line changed in this PR, it doesn't mean there is an error condition.
A TX included in a block does not need to be present in the local mempool of a nodes at the time it is processing the new block.
As the info is still useful, we re-word the message and turn it into a Debug log

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

