### PR TITLE
Fill `time` field in `ExecCommitBlock`

### DIFF
--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -612,7 +612,7 @@ func (mem *CListMempool) Update(
 		//   100
 		// https://github.com/tendermint/tendermint/issues/3322.
 		if err := mem.RemoveTxByKey(tx.Key()); err != nil {
-			mem.logger.Debug("Committed transaction not in local mempool (not an error)", "key", tx.Key(), err.Error())
+			mem.logger.Error("Committed transaction could not be removed from mempool", "key", tx.Key(), err.Error())
 		}
 	}
 

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -612,7 +612,7 @@ func (mem *CListMempool) Update(
 		//   100
 		// https://github.com/tendermint/tendermint/issues/3322.
 		if err := mem.RemoveTxByKey(tx.Key()); err != nil {
-			mem.logger.Error("Committed transaction could not be removed from mempool", "key", tx.Key(), err.Error())
+			mem.logger.Debug("Committed transaction not in local mempool (not an error)", "key", tx.Key(), err.Error())
 		}
 	}
 

--- a/state/execution.go
+++ b/state/execution.go
@@ -681,6 +681,7 @@ func ExecCommitBlock(
 		NextValidatorsHash: block.NextValidatorsHash,
 		ProposerAddress:    block.ProposerAddress,
 		Height:             block.Height,
+		Time:               block.Time,
 		DecidedLastCommit:  commitInfo,
 		Misbehavior:        block.Evidence.Evidence.ToABCI(),
 		Txs:                block.Txs.ToSliceOfBytes(),

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -223,7 +223,8 @@ func TestFinalizeBlockValidators(t *testing.T) {
 		block := makeBlock(state, 2, lastCommit.ToCommit())
 
 		_, err = sm.ExecCommitBlock(proxyApp.Consensus(), block, log.TestingLogger(), stateStore, 1)
-		require.Nil(t, err, tc.desc)
+		require.NoError(t, err, tc.desc)
+		require.True(t, app.LastTime.After(now), "last_time %v now %v", app.LastTime, now)
 
 		// -> app receives a list of validators with a bool indicating if they signed
 		ctr := 0

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -206,7 +206,7 @@ func TestFinalizeBlockValidators(t *testing.T) {
 		desc                     string
 		lastCommitSigs           []types.ExtendedCommitSig
 		expectedAbsentValidators []int
-		shouldHaveTs             bool
+		shouldHaveTime           bool
 	}{
 		{"none absent", []types.ExtendedCommitSig{commitSig0, commitSig1}, []int{}, true},
 		{"one absent", []types.ExtendedCommitSig{commitSig0, absentSig}, []int{1}, true},
@@ -226,7 +226,7 @@ func TestFinalizeBlockValidators(t *testing.T) {
 		_, err = sm.ExecCommitBlock(proxyApp.Consensus(), block, log.TestingLogger(), stateStore, 1)
 		require.NoError(t, err, tc.desc)
 		require.True(t,
-			!tc.shouldHaveTs ||
+			!tc.shouldHaveTime ||
 				app.LastTime.Equal(now) || app.LastTime.After(now),
 			"'last_time' should be at or after 'now'; tc %v, last_time %v, now %v", tc.desc, app.LastTime, now,
 		)


### PR DESCRIPTION
Closes #739

Similar to #687, `ExecCommitBlock` is not filling the `time` field. Further, there was no UT catching this.
This PR add logic to an existing test case to check for that field. The test case is initially failing. When added the production fix (and fixing the test case logic), the test case passes.


---

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

