### PR TITLE
Unsafe int cast in `kill` command

### DIFF
--- a/cmd/cometbft/commands/debug/kill.go
+++ b/cmd/cometbft/commands/debug/kill.go
@@ -3,6 +3,7 @@ package debug
 import (
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -123,11 +124,15 @@ func killProc(pid uint64, dir string) error {
 	go func() {
 		// Killing the CometBFT process with the '-ABRT|-6' signal will result in
 		// a goroutine stacktrace.
-		p, err := os.FindProcess(int(pid))
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "failed to find PID to kill CometBFT process: %s", err)
-		} else if err = p.Signal(syscall.SIGABRT); err != nil {
-			fmt.Fprintf(os.Stderr, "failed to kill CometBFT process: %s", err)
+		if pid <= math.MaxInt {
+			p, err := os.FindProcess(int(pid))
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "failed to find PID to kill CometBFT process: %s", err)
+			} else if err = p.Signal(syscall.SIGABRT); err != nil {
+				fmt.Fprintf(os.Stderr, "failed to kill CometBFT process: %s", err)
+			}
+		} else {
+			fmt.Fprintf(os.Stderr, "failed to convert PID to int (%v > %v)", pid, math.MaxInt)
 		}
 
 		// allow some time to allow the CometBFT process to be killed

--- a/cmd/cometbft/commands/debug/kill.go
+++ b/cmd/cometbft/commands/debug/kill.go
@@ -3,7 +3,6 @@ package debug
 import (
 	"errors"
 	"fmt"
-	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -124,15 +123,11 @@ func killProc(pid uint64, dir string) error {
 	go func() {
 		// Killing the CometBFT process with the '-ABRT|-6' signal will result in
 		// a goroutine stacktrace.
-		if pid <= math.MaxInt {
-			p, err := os.FindProcess(int(pid))
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "failed to find PID to kill CometBFT process: %s", err)
-			} else if err = p.Signal(syscall.SIGABRT); err != nil {
-				fmt.Fprintf(os.Stderr, "failed to kill CometBFT process: %s", err)
-			}
-		} else {
-			fmt.Fprintf(os.Stderr, "failed to convert PID to int (%v > %v)", pid, math.MaxInt)
+		p, err := os.FindProcess(int(pid))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to find PID to kill CometBFT process: %s", err)
+		} else if err = p.Signal(syscall.SIGABRT); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to kill CometBFT process: %s", err)
 		}
 
 		// allow some time to allow the CometBFT process to be killed

--- a/cmd/cometbft/commands/debug/kill.go
+++ b/cmd/cometbft/commands/debug/kill.go
@@ -33,7 +33,7 @@ $ cometbft debug 34255 /path/to/cmt-debug.zip`,
 }
 
 func killCmdHandler(_ *cobra.Command, args []string) error {
-	pid, err := strconv.ParseUint(args[0], 10, 64)
+	pid, err := strconv.Atoi(args[0])
 	if err != nil {
 		return err
 	}
@@ -100,7 +100,7 @@ func killCmdHandler(_ *cobra.Command, args []string) error {
 // is tailed and piped to a file under the directory dir. An error is returned
 // if the output file cannot be created or the tail command cannot be started.
 // An error is not returned if any subsequent syscall fails.
-func killProc(pid uint64, dir string) error {
+func killProc(pid int, dir string) error {
 	// pipe STDERR output from tailing the CometBFT process to a file
 	//
 	// NOTE: This will only work on UNIX systems.
@@ -123,7 +123,7 @@ func killProc(pid uint64, dir string) error {
 	go func() {
 		// Killing the CometBFT process with the '-ABRT|-6' signal will result in
 		// a goroutine stacktrace.
-		p, err := os.FindProcess(int(pid))
+		p, err := os.FindProcess(pid)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to find PID to kill CometBFT process: %s", err)
 		} else if err = p.Signal(syscall.SIGABRT); err != nil {


### PR DESCRIPTION
This addresses a [warning](https://github.com/cometbft/cometbft/security/code-scanning/2) from CodeQL

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

