### PR TITLE
Struct `Client` exposes sensitive data

### DIFF
--- a/rpc/jsonrpc/client/http_json_client.go
+++ b/rpc/jsonrpc/client/http_json_client.go
@@ -139,6 +139,8 @@ var _ HTTPClient = (*Client)(nil)
 var _ Caller = (*Client)(nil)
 var _ Caller = (*RequestBatch)(nil)
 
+var _ fmt.Stringer = (*Client)(nil)
+
 // New returns a Client pointed at the given address.
 // An error is returned on invalid remote. The function panics when remote is nil.
 func New(remote string) (*Client, error) {
@@ -230,6 +232,10 @@ func (c *Client) Call(
 
 func getHTTPRespErrPrefix(resp *http.Response) string {
 	return fmt.Sprintf("error in json rpc client, with http response metadata: (Status: %s, Protocol %s)", resp.Status, resp.Proto)
+}
+
+func (c *Client) String() string {
+	return fmt.Sprintf("&Client{user=%v, addr=%v, client=%v, nextReqID=%v}", c.username, c.address, c.client, c.nextReqID)
 }
 
 // NewRequestBatch starts a batch of requests for this client.


### PR DESCRIPTION
This addresses a [warning](https://github.com/cometbft/cometbft/security/code-scanning/1) from CodeQL

Struct `Client` defined [here](https://github.com/cometbft/cometbft/blob/feac56b62/rpc/jsonrpc/client/http_json_client.go#L124-L133) is used in some print/log functions.
As it contains a "password" field, we need to make sure it is not printed. This PR addresses that problem by having `Client` implement `fmt.Stringer`.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

