### PR TITLE
Digital Ocean implementation of `StartNodes` and `StopTestnet`

### DIFF
--- a/test/e2e/pkg/infra/digitalocean/digitalocean.go
+++ b/test/e2e/pkg/infra/digitalocean/digitalocean.go
@@ -1,9 +1,15 @@
 package digitalocean
 
 import (
+	"bytes"
 	"context"
+	"html/template"
+	"os"
+	"path/filepath"
+	"strings"
 
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
+	"github.com/cometbft/cometbft/test/e2e/pkg/exec"
 	"github.com/cometbft/cometbft/test/e2e/pkg/infra"
 )
 
@@ -19,11 +25,68 @@ func (p *Provider) Setup() error {
 	return nil
 }
 
-func (p Provider) StartNodes(_ context.Context, _ ...*e2e.Node) error {
-	//TODO Not implemented (next PR)
-	return nil
+func (p Provider) StartNodes(ctx context.Context, nodes ...*e2e.Node) error {
+	nodeNames := make([]string, len(nodes))
+	for i, n := range nodes {
+		nodeNames[i] = n.Name
+	}
+	const yml = "start-network.yml"
+	if err := p.writePlaybook(yml); err != nil {
+		return err
+	}
+
+	return execAnsible(ctx, p.Testnet.Dir, yml, "--limit", strings.Join(nodeNames, ","))
 }
 func (p Provider) StopTestnet(_ context.Context) error {
 	//TODO Not implemented (next PR)
 	return nil
+}
+
+func (p Provider) writePlaybook(yaml string) error {
+	playbook, err := ansibleStartBytes(p.Testnet)
+	if err != nil {
+		return err
+	}
+	//nolint: gosec
+	// G306: Expect WriteFile permissions to be 0600 or less
+	err = os.WriteFile(filepath.Join(p.Testnet.Dir, yaml), playbook, 0o644)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// file as bytes to be written out to disk.
+// ansibleStartBytes generates an Ansible playbook to start the network
+func ansibleStartBytes(testnet *e2e.Testnet) ([]byte, error) {
+	tmpl, err := template.New("ansible-start").Parse(`- name: start testapp
+  hosts: validators
+  gather_facts: yes
+  vars:
+    ansible_host_key_checking: false
+
+  tasks:
+  - name: start the systemd-unit
+    ansible.builtin.systemd:
+      name: testappd
+      state: started
+      enabled: yes`)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, testnet)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// ExecCompose runs a Docker Compose command for a testnet.
+func execAnsible(ctx context.Context, dir, playbook string, args ...string) error {
+	playbook = filepath.Join(dir, playbook)
+	hostsFile := filepath.Join(dir, "hosts")
+	return exec.Command(ctx, append(
+		[]string{"ansible-playbook", playbook, "-f", "50", "-u", "root", "-i", hostsFile},
+		args...)...)
 }


### PR DESCRIPTION
Contributes to #55

This PR is completing #796 (and tendermint/tendermint#9801) with the implementation of methods `StartNodes` and `StopTestnet` for the Digital Ocean infrastructure provider.
It uses ansible, matching the infra used in `cometbft/qa-infra`.

See how this will be used by the pre-release QA logic in cometbft/qa-infra#16

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

