### PR TITLE
Release `v0.38.0-alpha.2`

### DIFF
--- a/.changelog/unreleased/breaking-changes/774-state-indexerevent-remove-function-type.md
+++ b/.changelog/unreleased/breaking-changes/774-state-indexerevent-remove-function-type.md
@@ -1,3 +1,3 @@
-- `[state/kvindexer]` Remove the function type from the event key stored in the database. This should be breaking only 
+- `[state/kvindexer]` Remove the function type from the event key stored in the database. This should be breaking only
 for people who forked CometBFT and interact directly with the indexers kvstore.
   ([\#774](https://github.com/cometbft/cometbft/pull/774))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@
   ([\#385](https://github.com/cometbft/cometbft/issues/385))
 - `[crypto/merkle]` Do not allow verification of Merkle Proofs against empty trees (`nil` root). `Proof.ComputeRootHash` now panics when it encounters an error, but `Proof.Verify` does not panic
   ([\#558](https://github.com/cometbft/cometbft/issues/558))
+- `[state/kvindexer]` Remove the function type from the event key stored in the database. This should be breaking only
+for people who forked CometBFT and interact directly with the indexers kvstore.
+  ([\#774](https://github.com/cometbft/cometbft/pull/774))
+- `[pubsub]` Added support for big integers and big floats in the pubsub event query system.
+  Breaking changes: function `Number` in package `libs/pubsub/query/syntax` changed its return value.
+  ([\#797](https://github.com/cometbft/cometbft/pull/797))
+- `[kvindexer]` Added support for big integers and big floats in the kvindexer.
+  Breaking changes: function `Number` in package `libs/pubsub/query/syntax` changed its return value.
+  ([\#797](https://github.com/cometbft/cometbft/pull/797))
 - `[state]` Move pruneBlocks from node/state to state/execution.
   ([\#6541](https://github.com/tendermint/tendermint/pull/6541))
 - `[abci]` Move `app_hash` parameter from `Commit` to `FinalizeBlock`
@@ -96,6 +105,12 @@
 - `[jsonrpc/client]` Improve the error message for client errors stemming from
   bad HTTP responses.
   ([cometbft/cometbft\#638](https://github.com/cometbft/cometbft/pull/638))
+- `[rpc]` Remove response data from response failure logs in order
+  to prevent large quantities of log data from being produced
+  ([\#654](https://github.com/cometbft/cometbft/issues/654))
+- `[pubsub/kvindexer]` Numeric query conditions and event values are represented as big floats with default precision of 125.
+  Integers are read as "big ints" and represented with as many bits as they need when converting to floats.
+  ([\#797](https://github.com/cometbft/cometbft/pull/797))
 - `[crypto/merkle]` Improve HashAlternatives performance
   ([\#6443](https://github.com/tendermint/tendermint/pull/6443))
 - `[p2p/pex]` Improve addrBook.hash performance

--- a/version/version.go
+++ b/version/version.go
@@ -3,7 +3,7 @@ package version
 const (
 	// TMVersionDefault is the used as the fallback version of CometBFT
 	// when not using git describe. It is formatted with semantic versioning.
-	TMCoreSemVer = "0.38.0-alpha.1"
+	TMCoreSemVer = "0.38.0-alpha.2"
 	// ABCISemVer is the semantic version of the ABCI protocol
 	ABCISemVer  = "2.0.0"
 	ABCIVersion = ABCISemVer


### PR DESCRIPTION
Changes in preparation for our second alpha release of v0.38.0:

- [CHANGELOG rendered](https://github.com/cometbft/cometbft/blob/release/v0.38.0-alpha.2/CHANGELOG.md)
- [Manual E2E run](https://github.com/cometbft/cometbft/actions/runs/5006380514) (for the `release/v0.38.0-alpha.2` branch)

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

