### PR TITLE
Sort the report list

### DIFF
--- a/test/loadtime/report/report.go
+++ b/test/loadtime/report/report.go
@@ -2,6 +2,7 @@ package report
 
 import (
 	"math"
+	"sort"
 	"sync"
 	"time"
 
@@ -112,6 +113,16 @@ func (rs *Reports) calculateAll() {
 		r.StdDev = time.Duration(int64(stat.StdDev(toFloat(r.All), nil)))
 		rs.l = append(rs.l, r)
 	}
+	sort.Slice(rs.l, func(i, j int) bool {
+		if rs.l[i].Connections < rs.l[j].Connections {
+			return true
+		}
+		if rs.l[i].Connections > rs.l[j].Connections {
+			return false
+		}
+		return rs.l[i].Rate < rs.l[j].Rate
+	})
+
 }
 
 func (rs *Reports) addError() {


### PR DESCRIPTION
This PR sorts the report produced by the `loadtime` tool:

* First by connections
* Then by rate

This makes it easier to produce the tabbed report, used to identify the saturation point (rather, saturation diagonal)

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

