### PR TITLE
rpc/jsonrpc: Handle unqouted non-json string argument

### DIFF
--- a/rpc/jsonrpc/server/http_uri_handler.go
+++ b/rpc/jsonrpc/server/http_uri_handler.go
@@ -206,6 +206,10 @@ func _nonJSONStringToArg(rt reflect.Type, arg string) (reflect.Value, bool, erro
 		return reflect.ValueOf([]byte(v.String())), true, nil
 	}
 
+	if !isQuotedString && expectingString {
+		return reflect.ValueOf(arg), true, nil
+	}
+
 	return reflect.ValueOf(nil), false, nil
 }
 

--- a/rpc/jsonrpc/server/http_uri_handler_test.go
+++ b/rpc/jsonrpc/server/http_uri_handler_test.go
@@ -1,0 +1,18 @@
+package server
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test__nonJSONStringToArg(t *testing.T) {
+	s := "foo"
+	v, ok, err := _nonJSONStringToArg(reflect.TypeOf(""), s)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	assert.Equal(t, v.String(), s)
+}


### PR DESCRIPTION
Closes #666

This PR fixes the handling of unquoted non-json string argument in jsonrpc handler, as described in #666.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

