### PR TITLE
Prevent a transaction to appear twice in the mempool

### DIFF
--- a/.changelog/unreleased/bug-fixes/890-mempool-fix-cache.md
+++ b/.changelog/unreleased/bug-fixes/890-mempool-fix-cache.md
@@ -1,0 +1,1 @@
+- `[mempool/clist_mempool]` \#890 Prevent a transaction to appear twice in the mempool  (@otrack)

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -399,7 +399,7 @@ func (mem *CListMempool) resCbFirstTime(
 			// Check transaction not already in the mempool
 			if e, ok := mem.txsMap.Load(types.Tx(tx).Key()); ok {
 				memTx := e.(*clist.CElement).Value.(*mempoolTx)
-				memTx.senders.LoadOrStore(peerID, true)
+				memTx.addSender(txInfo.SenderID)
 				mem.logger.Debug(
 					"transaction already there, not adding it again",
 					"tx", types.Tx(tx).Hash(),

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -396,6 +396,18 @@ func (mem *CListMempool) resCbFirstTime(
 				return
 			}
 
+			// Check transaction not already in the mempool
+			if _, ok := mem.txsMap.Load(types.Tx(tx).Key()); ok {
+				mem.logger.Debug(
+					"transaction already there",
+					"tx", types.Tx(tx).Hash(),
+					"res", r,
+					"height", mem.height,
+					"total", mem.Size(),
+				)
+				return
+			}
+
 			memTx := &mempoolTx{
 				height:    mem.height,
 				gasWanted: r.CheckTx.GasWanted,

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -397,7 +397,9 @@ func (mem *CListMempool) resCbFirstTime(
 			}
 
 			// Check transaction not already in the mempool
-			if _, ok := mem.txsMap.Load(types.Tx(tx).Key()); ok {
+			if e, ok := mem.txsMap.Load(types.Tx(tx).Key()); ok {
+				memTx := e.(*clist.CElement).Value.(*mempoolTx)
+				memTx.senders.LoadOrStore(peerID, true)
 				mem.logger.Debug(
 					"transaction already there, not adding it again",
 					"tx", types.Tx(tx).Hash(),

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -399,7 +399,7 @@ func (mem *CListMempool) resCbFirstTime(
 			// Check transaction not already in the mempool
 			if _, ok := mem.txsMap.Load(types.Tx(tx).Key()); ok {
 				mem.logger.Debug(
-					"transaction already there",
+					"transaction already there, not adding it again",
 					"tx", types.Tx(tx).Hash(),
 					"res", r,
 					"height", mem.height,

--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -632,6 +632,51 @@ func TestMempoolTxsBytes(t *testing.T) {
 	assert.EqualValues(t, 10, mp.SizeBytes())
 }
 
+func TestMempoolNoCacheOverflow(t *testing.T) {
+	sockPath := fmt.Sprintf("unix:///tmp/echo_%v.sock", cmtrand.Str(6))
+	app := kvstore.NewInMemoryApplication()
+	_, server := newRemoteApp(t, sockPath, app)
+	t.Cleanup(func() {
+		if err := server.Stop(); err != nil {
+			t.Error(err)
+		}
+	})
+	cfg := test.ResetTestRoot("mempool_test")
+	mp, cleanup := newMempoolWithAppAndConfig(proxy.NewRemoteClientCreator(sockPath, "socket", true), cfg)
+	defer cleanup()
+
+	// add tx0
+	var tx0 = kvstore.NewTxFromID(0)
+	err := mp.CheckTx(tx0, nil, TxInfo{})
+	require.NoError(t, err)
+	err = mp.FlushAppConn()
+	require.NoError(t, err)
+
+	// saturate the cache to remove tx0
+	for i := 1; i <= mp.config.CacheSize; i++ {
+		err = mp.CheckTx(kvstore.NewTxFromID(i), nil, TxInfo{})
+		require.NoError(t, err)
+	}
+	err = mp.FlushAppConn()
+	require.NoError(t, err)
+	assert.False(t, mp.cache.Has(kvstore.NewTxFromID(0)))
+
+	// add again tx0
+	err = mp.CheckTx(tx0, nil, TxInfo{})
+	require.NoError(t, err)
+	err = mp.FlushAppConn()
+	require.NoError(t, err)
+
+	// tx0 should appear only once in mp.txs
+	found := 0
+	for e := mp.txs.Front(); e != nil; e = e.Next() {
+		if types.Tx.Key(e.Value.(*mempoolTx).tx) == types.Tx.Key(tx0) {
+			found++
+		}
+	}
+	assert.True(t, found == 1)
+}
+
 // This will non-deterministically catch some concurrency failures like
 // https://github.com/tendermint/tendermint/issues/3509
 // TODO: all of the tests should probably also run using the remote proxy app


### PR DESCRIPTION
**Summary**
A transaction might appear twice in the mempool, i.e., it is present more than once in `txs`, while `txsMap` only links a single of these occurrences.  The bug happens when the cache overflows. 

**Context**
The bug is related to issues [#3865](https://github.com/tendermint/tendermint/issues/3865) and [#5281](https://github.com/tendermint/tendermint/issues/5281) in Tendermint. Both issues are closed with this fix. One may reproduce them easily in e2e, e.g.,

```
./build/generator -m v0.37.1:1 -d networks/generated/
./build/runner -f networks/generated/gen-0003.toml setup
find networks/generated/gen-0003/ -iname "config.toml" | xargs sed -i s,"cache_size = 10000","cache_size = 100", 
find networks/generated/gen-0003/ -iname "config.toml" | xargs sed -i s,"prepare_proposal_delay = 200ms","prepare_proposal_delay = 3000ms",
./build/runner -f networks/generated/gen-0003.toml start
curl -s http://localhost:5701/broadcast_tx_sync?tx=\"apple=100\"; for i in $(seq 1 1001); do curl -s http://localhost:5701/broadcast_tx_sync?tx=\"orange=${i}\"; done; curl -s http://localhost:5701/broadcast_tx_sync?tx=\"apple=100\"
```

**Remark**
The present fix works because the mempool receives _in order and sequentially_ all the asynchronous ABCI callbacks. Notice that in the past, this was not the case for the grpc client, as outlined [here](https://github.com/tendermint/tendermint/pull/5520). Sidestepping such a constraint is feasible, yet presently [open](https://github.com/tendermint/tendermint/issues/5519).

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments

