### PR TITLE
mempool: slight refactor for improving readability

### DIFF
--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -100,15 +100,15 @@ func NewCListMempool(
 	return mp
 }
 
-func (mem *CListMempool) getElement(txKey types.TxKey) (*clist.CElement, bool) {
+func (mem *CListMempool) getCElement(txKey types.TxKey) (*clist.CElement, bool) {
 	if e, ok := mem.txsMap.Load(txKey); ok {
 		return e.(*clist.CElement), true
 	}
 	return nil, false
 }
 
-func (mem *CListMempool) getEntry(txKey types.TxKey) *mempoolTx {
-	if e, ok := mem.getElement(txKey); ok {
+func (mem *CListMempool) getMemTx(txKey types.TxKey) *mempoolTx {
+	if e, ok := mem.getCElement(txKey); ok {
 		return e.Value.(*mempoolTx)
 	}
 	return nil
@@ -258,7 +258,7 @@ func (mem *CListMempool) CheckTx(
 		// Note it's possible a tx is still in the cache but no longer in the mempool
 		// (eg. after committing a block, txs are removed from mempool but not cache),
 		// so we only record the sender for txs still in the mempool.
-		if memTx := mem.getEntry(tx.Key()); memTx != nil {
+		if memTx := mem.getMemTx(tx.Key()); memTx != nil {
 			memTx.AddSender(txInfo.SenderID)
 			// TODO: consider punishing peer for dups,
 			// its non-trivial since invalid txs can become valid,
@@ -343,7 +343,7 @@ func (mem *CListMempool) addTx(memTx *mempoolTx) {
 //   - Update (lock held) if tx was committed
 //   - resCbRecheck (lock not held) if tx was invalidated
 func (mem *CListMempool) RemoveTxByKey(txKey types.TxKey) error {
-	if elem, ok := mem.getElement(txKey); ok {
+	if elem, ok := mem.getCElement(txKey); ok {
 		mem.txs.Remove(elem)
 		elem.DetachPrev()
 		mem.txsMap.Delete(txKey)

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -337,6 +337,7 @@ func (mem *CListMempool) addTx(memTx *mempoolTx) {
 	mem.metrics.TxSizeBytes.Observe(float64(len(memTx.tx)))
 }
 
+// RemoveTxByKey removes a transaction from the mempool by its TxKey index.
 // Called from:
 //   - Update (lock held) if tx was committed
 //   - resCbRecheck (lock not held) if tx was invalidated
@@ -479,7 +480,7 @@ func (mem *CListMempool) resCbRecheck(req *abci.Request, res *abci.Response) {
 			// Tx became invalidated due to newly committed block.
 			mem.logger.Debug("tx is no longer valid", "tx", types.Tx(tx).Hash(), "res", r, "err", postCheckErr)
 			if err := mem.RemoveTxByKey(memTx.tx.Key()); err != nil {
-				mem.logger.Debug("Transaction could not be removed from mempool", err)
+				mem.logger.Debug("Transaction could not be removed from mempool", "err", err)
 			}
 			// We remove the invalid tx from the cache because it might be good later
 			if !mem.config.KeepInvalidTxsInCache {

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -258,7 +258,7 @@ func (mem *CListMempool) CheckTx(
 		// (eg. after committing a block, txs are removed from mempool but not cache),
 		// so we only record the sender for txs still in the mempool.
 		if memTx := mem.getMemTx(tx.Key()); memTx != nil {
-			memTx.AddSender(txInfo.SenderID)
+			memTx.addSender(txInfo.SenderID)
 			// TODO: consider punishing peer for dups,
 			// its non-trivial since invalid txs can become valid,
 			// but they can spam the same tx with little cost to them atm.
@@ -400,7 +400,7 @@ func (mem *CListMempool) resCbFirstTime(
 				gasWanted: r.CheckTx.GasWanted,
 				tx:        tx,
 			}
-			memTx.AddSender(txInfo.SenderID)
+			memTx.addSender(txInfo.SenderID)
 			mem.addTx(memTx)
 			mem.logger.Debug(
 				"added good transaction",

--- a/mempool/mempoolTx.go
+++ b/mempool/mempoolTx.go
@@ -1,0 +1,34 @@
+package mempool
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/cometbft/cometbft/types"
+)
+
+// mempoolTx is an entry in the mempool
+type mempoolTx struct {
+	height    int64    // height that this tx had been validated in
+	gasWanted int64    // amount of gas this tx states it will require
+	tx        types.Tx // validated by the application
+
+	// ids of peers who've sent us this tx (as a map for quick lookups).
+	// senders: PeerID -> bool
+	senders sync.Map
+}
+
+// Height returns the height for this transaction
+func (memTx *mempoolTx) Height() int64 {
+	return atomic.LoadInt64(&memTx.height)
+}
+
+func (memTx *mempoolTx) IsSender(peerID uint16) bool {
+	_, ok := memTx.senders.Load(peerID)
+	return ok
+}
+
+func (memTx *mempoolTx) AddSender(senderID uint16) bool {
+	_, added := memTx.senders.LoadOrStore(senderID, true)
+	return added
+}

--- a/mempool/mempoolTx.go
+++ b/mempool/mempoolTx.go
@@ -23,12 +23,12 @@ func (memTx *mempoolTx) Height() int64 {
 	return atomic.LoadInt64(&memTx.height)
 }
 
-func (memTx *mempoolTx) IsSender(peerID uint16) bool {
+func (memTx *mempoolTx) isSender(peerID uint16) bool {
 	_, ok := memTx.senders.Load(peerID)
 	return ok
 }
 
-func (memTx *mempoolTx) AddSender(senderID uint16) bool {
+func (memTx *mempoolTx) addSender(senderID uint16) bool {
 	_, added := memTx.senders.LoadOrStore(senderID, true)
 	return added
 }

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -181,7 +181,7 @@ func (memR *Reactor) broadcastTxRoutine(peer p2p.Peer) {
 		// NOTE: Transaction batching was disabled due to
 		// https://github.com/tendermint/tendermint/issues/5796
 
-		if !memTx.IsSender(peerID) {
+		if !memTx.isSender(peerID) {
 			success := peer.Send(p2p.Envelope{
 				ChannelID: MempoolChannel,
 				Message:   &protomem.Txs{Txs: [][]byte{memTx.tx}},

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -181,7 +181,7 @@ func (memR *Reactor) broadcastTxRoutine(peer p2p.Peer) {
 		// NOTE: Transaction batching was disabled due to
 		// https://github.com/tendermint/tendermint/issues/5796
 
-		if _, ok := memTx.senders.Load(peerID); !ok {
+		if !memTx.IsSender(peerID) {
 			success := peer.Send(p2p.Envelope{
 				ChannelID: MempoolChannel,
 				Message:   &protomem.Txs{Txs: [][]byte{memTx.tx}},


### PR DESCRIPTION
- Move `mempoolTx` struct to its own file and add methods `isSender` and `addSender` for handling the field `senders`.
- The content of the data structures `txs` and `txsMap` should be consistent.  
  - We add new methods `getCElement`, `getMemTx`, and `removeAllTxs` to handle transactions that affect both this data structures.
  -  We move all the logic of removing a tx to `RemoveTxByKey`.
- Some functions pass as argument the individual fields of `TxInfo` separately; we change these functions to pass `TxInfo` instead.

This PR is the first step to #895