### PR TITLE
New metrics to track duplicate votes and block parts 

### DIFF
--- a/consensus/metrics.go
+++ b/consensus/metrics.go
@@ -64,6 +64,9 @@ type Metrics struct {
 	// Number of block parts transmitted by each peer.
 	BlockParts metrics.Counter `metrics_labels:"peer_id"`
 
+	// Number of times we received a duplicate vote
+	DuplicateVote metrics.Counter
+
 	// Histogram of durations for each step in the consensus protocol.
 	StepDurationSeconds metrics.Histogram `metrics_labels:"step" metrics_buckettype:"exprange" metrics_bucketsizes:"0.1, 100, 8"`
 	stepStart           time.Time

--- a/consensus/metrics.go
+++ b/consensus/metrics.go
@@ -64,6 +64,9 @@ type Metrics struct {
 	// Number of block parts transmitted by each peer.
 	BlockParts metrics.Counter `metrics_labels:"peer_id"`
 
+	// Number of times we received a duplicate block part
+	DuplicateBlockPart metrics.Counter
+
 	// Number of times we received a duplicate vote
 	DuplicateVote metrics.Counter
 

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1940,6 +1940,11 @@ func (cs *State) addProposalBlockPart(msg *BlockPartMessage, peerID p2p.ID) (add
 	}
 
 	cs.metrics.BlockGossipPartsReceived.With("matches_current", "true").Add(1)
+	if !added {
+		// NOTE: we are disregarding possible duplicates above where heights dont match or we're not expecting block parts yet
+		// but between the matches_current = true and false, we have all the info.
+		cs.metrics.DuplicateBlockPart.Add(1)
+	}
 
 	if cs.ProposalBlockParts.ByteSize() > cs.state.ConsensusParams.Block.MaxBytes {
 		return added, fmt.Errorf("total size of proposal block parts exceeds maximum block bytes (%d > %d)",

--- a/types/part_set.go
+++ b/types/part_set.go
@@ -270,9 +270,12 @@ func (ps *PartSet) Total() uint32 {
 }
 
 func (ps *PartSet) AddPart(part *Part) (bool, error) {
+	// TODO: remove this? would be preferable if this only returned (false, nil)
+	// when its a duplicate block part
 	if ps == nil {
 		return false, nil
 	}
+
 	ps.mtx.Lock()
 	defer ps.mtx.Unlock()
 


### PR DESCRIPTION
Related to https://github.com/cometbft/cometbft/issues/26

Add metrics to track duplicate votes and block parts in preparation for changes to reduce bandwidth :) 

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

