### PR TITLE
backport: Fix lint failures on `v0.38.x`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,3 +42,55 @@ linters-settings:
     suggest-new: true
   misspell:
     locale: US
+  depguard:
+    rules:
+      main:
+        files:
+          - $all
+          - "!$test"
+        allow:
+          - $gostd
+          - github.com/cometbft
+          - github.com/cosmos
+          - github.com/btcsuite/btcd/btcec/v2
+          - github.com/BurntSushi/toml
+          - github.com/go-git/go-git/v5
+          - github.com/go-kit
+          - github.com/go-logfmt/logfmt
+          - github.com/gofrs/uuid
+          - github.com/google
+          - github.com/gorilla/websocket
+          - github.com/informalsystems/tm-load-test/pkg/loadtest
+          - github.com/lib/pq
+          - github.com/libp2p/go-buffer-pool
+          - github.com/Masterminds/semver/v3
+          - github.com/minio/highwayhash
+          - github.com/oasisprotocol/curve25519-voi
+          - github.com/pkg/errors
+          - github.com/prometheus
+          - github.com/rcrowley/go-metrics
+          - github.com/rs/cors
+          - github.com/snikch/goodman
+          - github.com/spf13
+          - github.com/stretchr/testify/require
+          - github.com/syndtr/goleveldb
+      test:
+        files:
+          - "$test"
+        allow:
+          - $gostd
+          - github.com/cosmos
+          - github.com/cometbft
+          - github.com/adlio/schema
+          - github.com/btcsuite/btcd
+          - github.com/fortytw2/leaktest
+          - github.com/go-kit
+          - github.com/google/uuid
+          - github.com/gorilla/websocket
+          - github.com/lib/pq
+          - github.com/oasisprotocol/curve25519-voi/primitives/merlin
+          - github.com/ory/dockertest
+          - github.com/pkg/errors
+          - github.com/prometheus/client_golang/prometheus/promhttp
+          - github.com/spf13
+          - github.com/stretchr/testify

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -2018,7 +2018,6 @@ func (cs *State) handleCompleteProposal(blockHeight int64) {
 // Attempt to add the vote. if its a duplicate signature, dupeout the validator
 func (cs *State) tryAddVote(vote *types.Vote, peerID p2p.ID) (bool, error) {
 	added, err := cs.addVote(vote, peerID)
-
 	// NOTE: some of these errors are swallowed here
 	if err != nil {
 		// If the vote height is off, we'll just ignore it,
@@ -2089,7 +2088,7 @@ func (cs *State) addVote(vote *types.Vote, peerID p2p.ID) (added bool, err error
 		if cs.Step != cstypes.RoundStepNewHeight {
 			// Late precommit at prior height is ignored
 			cs.Logger.Debug("precommit vote came in after commit timeout and has been ignored", "vote", vote)
-			return
+			return added, err
 		}
 
 		added, err = cs.LastCommit.AddVote(vote)
@@ -2098,7 +2097,7 @@ func (cs *State) addVote(vote *types.Vote, peerID p2p.ID) (added bool, err error
 			if err == nil {
 				cs.metrics.DuplicateVote.Add(1)
 			}
-			return
+			return added, err
 		}
 
 		cs.Logger.Debug("added vote to last precommits", "last_commit", cs.LastCommit.StringShort())
@@ -2115,14 +2114,14 @@ func (cs *State) addVote(vote *types.Vote, peerID p2p.ID) (added bool, err error
 			cs.enterNewRound(cs.Height, 0)
 		}
 
-		return
+		return added, err
 	}
 
 	// Height mismatch is ignored.
 	// Not necessarily a bad peer, but not favorable behavior.
 	if vote.Height != cs.Height {
 		cs.Logger.Debug("vote ignored and not added", "vote_height", vote.Height, "cs_height", cs.Height, "peer", peerID)
-		return
+		return added, err
 	}
 
 	// Check to see if the chain is configured to extend votes.
@@ -2177,7 +2176,7 @@ func (cs *State) addVote(vote *types.Vote, peerID p2p.ID) (added bool, err error
 		if err == nil {
 			cs.metrics.DuplicateVote.Add(1)
 		}
-		return
+		return added, err
 	}
 	if vote.Round == cs.Round {
 		vals := cs.state.Validators

--- a/p2p/conn/secret_connection.go
+++ b/p2p/conn/secret_connection.go
@@ -235,7 +235,7 @@ func (sc *SecretConnection) Read(data []byte) (n int, err error) {
 	if 0 < len(sc.recvBuffer) {
 		n = copy(data, sc.recvBuffer)
 		sc.recvBuffer = sc.recvBuffer[n:]
-		return
+		return n, err
 	}
 
 	// read off the conn
@@ -243,7 +243,7 @@ func (sc *SecretConnection) Read(data []byte) (n int, err error) {
 	defer pool.Put(sealedFrame)
 	_, err = io.ReadFull(sc.conn, sealedFrame)
 	if err != nil {
-		return
+		return n, err
 	}
 
 	// decrypt the frame.
@@ -324,7 +324,7 @@ func shareEphPubKey(conn io.ReadWriter, locEphPub *[32]byte) (remEphPub *[32]byt
 	// If error:
 	if trs.FirstError() != nil {
 		err = trs.FirstError()
-		return
+		return remEphPub, err
 	}
 
 	// Otherwise:
@@ -437,7 +437,7 @@ func shareAuthSignature(sc io.ReadWriter, pubKey crypto.PubKey, signature []byte
 	// If error:
 	if trs.FirstError() != nil {
 		err = trs.FirstError()
-		return
+		return recvMsg, err
 	}
 
 	var _recvMsg = trs.FirstValue().(authSigMessage)

--- a/p2p/upnp/probe.go
+++ b/p2p/upnp/probe.go
@@ -72,13 +72,13 @@ func testHairpin(listener net.Listener, extAddr string, logger log.Logger) (supp
 	outConn, err := net.Dial("tcp", extAddr)
 	if err != nil {
 		logger.Info("test hair pin", "msg", log.NewLazySprintf("Outgoing connection dial error: %v", err))
-		return
+		return supportsHairpin
 	}
 
 	n, err := outConn.Write([]byte("test data"))
 	if err != nil {
 		logger.Info("test hair pin", "msg", log.NewLazySprintf("Outgoing connection write error: %v", err))
-		return
+		return supportsHairpin
 	}
 	logger.Info("test hair pin", "msg", log.NewLazySprintf("Outgoing connection wrote %v bytes", n))
 

--- a/p2p/upnp/upnp.go
+++ b/p2p/upnp/upnp.go
@@ -39,17 +39,17 @@ type NAT interface {
 func Discover() (nat NAT, err error) {
 	ssdp, err := net.ResolveUDPAddr("udp4", "239.255.255.250:1900")
 	if err != nil {
-		return
+		return nat, err
 	}
 	conn, err := net.ListenPacket("udp4", ":0")
 	if err != nil {
-		return
+		return nat, err
 	}
 	socket := conn.(*net.UDPConn)
 	defer socket.Close()
 
 	if err := socket.SetDeadline(time.Now().Add(3 * time.Second)); err != nil {
-		return nil, err
+		return nat, err
 	}
 
 	st := "InternetGatewayDevice:1"
@@ -65,12 +65,12 @@ func Discover() (nat NAT, err error) {
 	for i := 0; i < 3; i++ {
 		_, err = socket.WriteToUDP(message, ssdp)
 		if err != nil {
-			return
+			return nat, err
 		}
 		var n int
 		_, _, err = socket.ReadFromUDP(answerBytes)
 		if err != nil {
-			return
+			return nat, err
 		}
 		for {
 			n, _, err = socket.ReadFromUDP(answerBytes)
@@ -98,15 +98,15 @@ func Discover() (nat NAT, err error) {
 			var serviceURL, urnDomain string
 			serviceURL, urnDomain, err = getServiceURL(locURL)
 			if err != nil {
-				return
+				return nat, err
 			}
 			var ourIP net.IP
 			ourIP, err = localIPv4()
 			if err != nil {
-				return
+				return nat, err
 			}
 			nat = &upnpNAT{serviceURL: serviceURL, ourIP: ourIP.String(), urnDomain: urnDomain}
-			return
+			return nat, err
 		}
 	}
 	err = errors.New("upnp port discovery failed")
@@ -204,33 +204,33 @@ func localIPv4() (net.IP, error) {
 func getServiceURL(rootURL string) (url, urnDomain string, err error) {
 	r, err := http.Get(rootURL) //nolint: gosec
 	if err != nil {
-		return
+		return url, urnDomain, err
 	}
 	defer r.Body.Close()
 
 	if r.StatusCode >= 400 {
 		err = errors.New(string(rune(r.StatusCode)))
-		return
+		return url, urnDomain, err
 	}
 	var root Root
 	err = xml.NewDecoder(r.Body).Decode(&root)
 	if err != nil {
-		return
+		return url, urnDomain, err
 	}
 	a := &root.Device
 	if !strings.Contains(a.DeviceType, "InternetGatewayDevice:1") {
 		err = errors.New("no InternetGatewayDevice")
-		return
+		return url, urnDomain, err
 	}
 	b := getChildDevice(a, "WANDevice:1")
 	if b == nil {
 		err = errors.New("no WANDevice")
-		return
+		return url, urnDomain, err
 	}
 	c := getChildDevice(b, "WANConnectionDevice:1")
 	if c == nil {
 		err = errors.New("no WANConnectionDevice")
-		return
+		return url, urnDomain, err
 	}
 	d := getChildService(c, "WANIPConnection:1")
 	if d == nil {
@@ -240,7 +240,7 @@ func getServiceURL(rootURL string) (url, urnDomain string, err error) {
 
 		if d == nil {
 			err = errors.New("no WANIPConnection")
-			return
+			return url, urnDomain, err
 		}
 	}
 	// Extract the domain name, which isn't always 'schemas-upnp-org'
@@ -289,7 +289,7 @@ func soapRequest(url, function, message, domain string) (r *http.Response, err e
 		// log.Stderr(function, r.StatusCode)
 		err = errors.New("error " + strconv.Itoa(r.StatusCode) + " for " + function)
 		r = nil
-		return
+		return r, err
 	}
 	return r, err
 }
@@ -368,7 +368,7 @@ func (n *upnpNAT) AddPortMapping(
 		defer response.Body.Close()
 	}
 	if err != nil {
-		return
+		return mappedExternalPort, err
 	}
 
 	// TODO: check response to see if the port was forwarded


### PR DESCRIPTION
Backport of #908 to `v0.38.x`

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

