### PR TITLE
e2e tests are being skipped; `INFRASTRUCTURE-*` bug; portGen inconsistency bug

### DIFF
--- a/test/e2e/pkg/infrastructure.go
+++ b/test/e2e/pkg/infrastructure.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"sort"
 )
 
 const (
@@ -43,6 +44,16 @@ type InstanceData struct {
 	Port         uint32 `json:"port"`
 }
 
+func sortNodeNames(m Manifest) []string {
+	// Set up nodes, in alphabetical order (IPs and ports get same order).
+	nodeNames := []string{}
+	for name := range m.Nodes {
+		nodeNames = append(nodeNames, name)
+	}
+	sort.Strings(nodeNames)
+	return nodeNames
+}
+
 func NewDockerInfrastructureData(m Manifest) (InfrastructureData, error) {
 	netAddress := dockerIPv4CIDR
 	if m.IPv6 {
@@ -61,12 +72,13 @@ func NewDockerInfrastructureData(m Manifest) (InfrastructureData, error) {
 		Network:   netAddress,
 	}
 	localHostIP := net.ParseIP("127.0.0.1")
-	for name := range m.Nodes {
+	for _, name := range sortNodeNames(m) {
 		ifd.Instances[name] = InstanceData{
 			IPAddress:    ipGen.Next(),
 			ExtIPAddress: localHostIP,
 			Port:         portGen.Next(),
 		}
+
 	}
 	return ifd, nil
 }

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -7,7 +7,6 @@ import (
 	"math/rand"
 	"net"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -186,14 +185,7 @@ func NewTestnetFromManifest(manifest Manifest, file string, ifd InfrastructureDa
 		testnet.LoadTxSizeBytes = defaultTxSizeBytes
 	}
 
-	// Set up nodes, in alphabetical order (IPs and ports get same order).
-	nodeNames := []string{}
-	for name := range manifest.Nodes {
-		nodeNames = append(nodeNames, name)
-	}
-	sort.Strings(nodeNames)
-
-	for _, name := range nodeNames {
+	for _, name := range sortNodeNames(manifest) {
 		nodeManifest := manifest.Nodes[name]
 		ind, ok := ifd.Instances[name]
 		if !ok {

--- a/test/e2e/runner/test.go
+++ b/test/e2e/runner/test.go
@@ -17,7 +17,7 @@ func Test(testnet *e2e.Testnet, ifd *e2e.InfrastructureData) error {
 		return err
 	}
 	if p := ifd.Path; p != "" {
-		err = os.Setenv("INFRASTRUCTURE_DATA", p)
+		err = os.Setenv("INFRASTRUCTURE_FILE", p)
 		if err != nil {
 			return err
 		}

--- a/test/e2e/tests/e2e_test.go
+++ b/test/e2e/tests/e2e_test.go
@@ -73,10 +73,10 @@ func loadTestnet(t *testing.T) e2e.Testnet {
 	if !filepath.IsAbs(manifestFile) {
 		manifestFile = filepath.Join("..", manifestFile)
 	}
-	ifdType := os.Getenv("INFRASTRUCTURE_DATA")
+	ifdType := os.Getenv("INFRASTRUCTURE_TYPE")
 	ifdFile := os.Getenv("INFRASTRUCTURE_FILE")
-	if ifdFile == "" && ifdType != "docker" {
-		t.Fatalf("INFRASTRUCTURE_DATA not set and INFRASTRUCTURE_TYPE is not docker")
+	if ifdType != "docker" && ifdFile == "" {
+		t.Fatalf("INFRASTRUCTURE_FILE not set and INFRASTRUCTURE_TYPE is not 'docker'")
 	}
 	testnetCacheMtx.Lock()
 	defer testnetCacheMtx.Unlock()

--- a/test/e2e/tests/e2e_test.go
+++ b/test/e2e/tests/e2e_test.go
@@ -76,7 +76,7 @@ func loadTestnet(t *testing.T) e2e.Testnet {
 	ifdType := os.Getenv("INFRASTRUCTURE_DATA")
 	ifdFile := os.Getenv("INFRASTRUCTURE_FILE")
 	if ifdFile == "" && ifdType != "docker" {
-		t.Skip("INFRASTRUCTURE_DATA not set and INFRASTRUCTURE_TYPE is not docker")
+		t.Fatalf("INFRASTRUCTURE_DATA not set and INFRASTRUCTURE_TYPE is not docker")
 	}
 	testnetCacheMtx.Lock()
 	defer testnetCacheMtx.Unlock()


### PR DESCRIPTION
Closes #929

This PR fixes three problems:

* When there is a problem in env variables `INFRASTRUCTURE_FILE` and `INFRASTRUCTURE_TYPE`, we shouldn't _skip_ but fail. Otherwise we just hide a problem we should fix
* The code introducing `INFRASTRUCTURE_FILE` and `INFRASTRUCTURE_TYPE` (#796) had a couple of typos and so, didn't work (we didn't see this because of the first bullet, and so, e2e tests were not run)
* There was an ordering inconsistency problem in manifest- and testnet-related code, which caused the e2e tests to fail

---

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

