### PR TITLE
Update the type annotations in the light client spec

### DIFF
--- a/.changelog/unreleased/improvements/955-lightclient-spec.md
+++ b/.changelog/unreleased/improvements/955-lightclient-spec.md
@@ -1,0 +1,1 @@
+- Update Apalache type annotations in the light client spec ([#955](https://github.com/cometbft/cometbft/pull/955))

--- a/spec/light-client/verification/Blockchain_003_draft.tla
+++ b/spec/light-client/verification/Blockchain_003_draft.tla
@@ -6,17 +6,23 @@
   voting powers, introduce multiple copies of the same validator
   (do not forget to give them unique names though).
  *)
-EXTENDS Integers, FiniteSets
+EXTENDS Integers, FiniteSets, typedefs
 
 Min(a, b) == IF a < b THEN a ELSE b
 
 CONSTANT
+  \* a set of all nodes that can act as validators (correct and faulty)
+  \*
+  \* @type: Set($node);
   AllNodes,
-    (* a set of all nodes that can act as validators (correct and faulty) *)
+  \* a maximal height that can be ever reached (modelling artifact)
+  \*
+  \* @type: Int;
   ULTIMATE_HEIGHT,
-    (* a maximal height that can be ever reached (modelling artifact) *)
+  \* the period within which the validators are trusted
+  \*
+  \* @type: Int;
   TRUSTING_PERIOD
-    (* the period within which the validators are trusted *)
 
 Heights == 1..ULTIMATE_HEIGHT   (* possible heights *)
 
@@ -44,14 +50,17 @@ BlockHeaders == [
 LightBlocks == [header: BlockHeaders, Commits: Commits]
 
 VARIABLES
+    \* the current global time in integer units as perceived by the reference chain
+    \* @type: Int;
     refClock,
-        (* the current global time in integer units as perceived by the reference chain *)
+    \* A sequence of BlockHeaders, which gives us a bird view of the blockchain
+    \* @type: Int -> $header;
     blockchain,
-    (* A sequence of BlockHeaders, which gives us a bird view of the blockchain. *)
+    \* A set of faulty nodes, which can act as validators.
+    \* We assume that the set of faulty processes is non-decreasing.
+    \* If a process has recovered, it should connect using a different id.
+    \* @type: Set($node);
     Faulty
-    (* A set of faulty nodes, which can act as validators. We assume that the set
-       of faulty processes is non-decreasing. If a process has recovered, it should
-       connect using a different id. *)
        
 (* all variables, to be used with UNCHANGED *)       
 vars == <<refClock, blockchain, Faulty>>         
@@ -59,21 +68,11 @@ vars == <<refClock, blockchain, Faulty>>
 (* The set of all correct nodes in a state *)
 Corr == AllNodes \ Faulty
 
-(* APALACHE annotations *)
-a <: b == a \* type annotation
-
-NT == STRING
-NodeSet(S) == S <: {NT}
-EmptyNodeSet == NodeSet({})
-
-BT == [height |-> Int, time |-> Int, lastCommit |-> {NT}, VS |-> {NT}, NextVS |-> {NT}]
-
-LBT == [header |-> BT, Commits |-> {NT}]
-(* end of APALACHE annotations *)       
-
 (****************************** BLOCKCHAIN ************************************)
 
-(* the header is still within the trusting period *)
+\* the header is still within the trusting period
+\*
+\* @type: $header => Bool;
 InTrustingPeriod(header) ==
     refClock < header.time + TRUSTING_PERIOD
 
@@ -97,6 +96,8 @@ TwoThirds(pVS, pNodes) ==
    - pVS is a set of all validators, maybe including Faulty, intersecting with it, etc.
    - pMaxFaultRatio is a pair <<a, b>> that limits the ratio a / b of the faulty
      validators from above (exclusive)
+
+ @type: (Set($node), Set($node), <<Int, Int>>) => Bool;
  *)
 FaultyValidatorsFewerThan(pFaultyNodes, pVS, maxRatio) ==
     LET FN == pFaultyNodes \intersect pVS   \* faulty nodes in pNodes
@@ -108,7 +109,9 @@ FaultyValidatorsFewerThan(pFaultyNodes, pVS, maxRatio) ==
     LET TP == CP + FP IN
     FP * maxRatio[2] < TP * maxRatio[1]
 
-(* Can a block be produced by a correct peer, or an authenticated Byzantine peer *)
+\* Can a block be produced by a correct peer, or an authenticated Byzantine peer
+\*
+\* @type: (Int, $lightHeader) => Bool;
 IsLightBlockAllowedByDigitalSignatures(ht, block) == 
     \/ block.header = blockchain[ht] \* signed by correct and faulty (maybe)
     \/ /\ block.Commits \subseteq Faulty
@@ -122,6 +125,8 @@ IsLightBlockAllowedByDigitalSignatures(ht, block) ==
  Parameters:
     - pMaxFaultyRatioExclusive is a pair <<a, b>> that bound the number of
         faulty validators in each block by the ratio a / b (exclusive)
+
+ @type: <<Int, Int>> => Bool;
  *)            
 InitToHeight(pMaxFaultyRatioExclusive) ==
   /\ Faulty \in SUBSET AllNodes \* some nodes may fail
@@ -133,7 +138,7 @@ InitToHeight(pMaxFaultyRatioExclusive) ==
         \* the genesis starts on day 1     
         /\ timestamp[1] = 1
         /\ vs[1] = AllNodes
-        /\ lastCommit[1] = EmptyNodeSet
+        /\ lastCommit[1] = {}
         /\ \A h \in Heights \ {1}:
           /\ lastCommit[h] \subseteq vs[h - 1]   \* the non-validators cannot commit 
           /\ TwoThirds(vs[h - 1], lastCommit[h]) \* the commit has >2/3 of validator votes

--- a/spec/light-client/verification/Lightclient_003_draft.tla
+++ b/spec/light-client/verification/Lightclient_003_draft.tla
@@ -6,38 +6,60 @@
  * https://github.com/informalsystems/tendermint-rs/blob/master/docs/spec/lightclient/verification.md
  *) 
 
-EXTENDS Integers, FiniteSets
+EXTENDS Integers, FiniteSets, typedefs
 
 \* the parameters of Light Client
 CONSTANTS
+  \* an index of the block header that the light client trusts by social consensus
+  \* @type: Int;
   TRUSTED_HEIGHT,
-    (* an index of the block header that the light client trusts by social consensus *)
+  \* an index of the block header that the light client tries to verify
+  \* @type: Int;
   TARGET_HEIGHT,
-    (* an index of the block header that the light client tries to verify *)
+  \* the period within which the validators are trusted
+  \* @type: Int;
   TRUSTING_PERIOD,
-    (* the period within which the validators are trusted *)
+  \* the assumed precision of the clock
+  \* @type: Int;
   CLOCK_DRIFT,
-    (* the assumed precision of the clock *)
+  \* the actual clock drift, which under normal circumstances should not
+  \* be larger than CLOCK_DRIFT (otherwise, there will be a bug)
+  \*
+  \* @type: Int;
   REAL_CLOCK_DRIFT,
-    (* the actual clock drift, which under normal circumstances should not
-       be larger than CLOCK_DRIFT (otherwise, there will be a bug) *)
+  \* is primary correct?
+  \* @type: Bool;
   IS_PRIMARY_CORRECT,
-    (* is primary correct? *)  
+  \* a pair <<a, b>> that limits that ratio of faulty validator in the blockchain
+  \* from above (exclusive). Cosmos security model prescribes 1 / 3
+  \* @type: <<Int, Int>>;
   FAULTY_RATIO
-    (* a pair <<a, b>> that limits that ratio of faulty validator in the blockchain
-       from above (exclusive). Cosmos security model prescribes 1 / 3. *)
 
-VARIABLES       (* see TypeOK below for the variable types *)
-  localClock,   (* the local clock of the light client *)
-  state,        (* the current state of the light client *)
-  nextHeight,   (* the next height to explore by the light client *)
-  nprobes       (* the lite client iteration, or the number of block tests *)
+VARIABLES
+  \* current time as measured by the light client
+  \* @type: Int;
+  localClock,
+  \* the current state of the light client
+  \* @type: Str;
+  state,
+  \* the next height to explore by the light client
+  \* @type: Int;
+  nextHeight,
+  \* the lite client iteration, or the number of block tests
+  \* @type: Int;
+  nprobes
   
 (* the light store *)
 VARIABLES  
-  fetchedLightBlocks, (* a function from heights to LightBlocks *)
-  lightBlockStatus,   (* a function from heights to block statuses *)
-  latestVerified      (* the latest verified block *)
+  \* a function from heights to LightBlocks
+  \* @type: Int -> $lightHeader;
+  fetchedLightBlocks,
+  \* a function from heights to block statuses
+  \* @type: Int -> Str;
+  lightBlockStatus,
+  \* the latest verified block
+  \* @type: $lightHeader;
+  latestVerified
 
 (* the variables of the lite client *)
 lcvars == <<localClock, state, nextHeight,
@@ -45,9 +67,13 @@ lcvars == <<localClock, state, nextHeight,
 
 (* the light client previous state components, used for monitoring *)
 VARIABLES
+  \* @type: $lightHeader;
   prevVerified,
+  \* @type: $lightHeader;
   prevCurrent,
+  \* @type: Int;
   prevLocalClock,
+  \* @type: Str;
   prevVerdict
 
 InitMonitor(verified, current, pLocalClock, verdict) ==
@@ -67,11 +93,23 @@ NextMonitor(verified, current, pLocalClock, verdict) ==
 
 \* the parameters that are propagated into Blockchain
 CONSTANTS
+  \* a set of all nodes that can act as validators (correct and faulty)
+  \* @type: Set($node);
   AllNodes
-    (* a set of all nodes that can act as validators (correct and faulty) *)
 
 \* the state variables of Blockchain, see Blockchain.tla for the details
-VARIABLES refClock, blockchain, Faulty
+VARIABLES
+    \* the current global time in integer units as perceived by the reference chain
+    \* @type: Int;
+    refClock,
+    \* A sequence of BlockHeaders, which gives us a bird view of the blockchain
+    \* @type: Int -> $header;
+    blockchain,
+    \* A set of faulty nodes, which can act as validators.
+    \* We assume that the set of faulty processes is non-decreasing.
+    \* If a process has recovered, it should connect using a different id.
+    \* @type: Set($node);
+    Faulty
 
 \* All the variables of Blockchain. For some reason, BC!vars does not work
 bcvars == <<refClock, blockchain, Faulty>>
@@ -141,6 +179,8 @@ FetchLightBlockInto(block, height) ==
 \* add a block into the light store    
 \*
 \* [LCV-FUNC-UPDATE.1::TLA.1]
+\*
+\* @type: (Int -> $lightHeader, $lightHeader) => (Int -> $lightHeader);
 LightStoreUpdateBlocks(lightBlocks, block) ==
     LET ht == block.header.height IN    
     [h \in DOMAIN lightBlocks \union {ht} |->
@@ -149,6 +189,8 @@ LightStoreUpdateBlocks(lightBlocks, block) ==
 \* update the state of a light block      
 \*
 \* [LCV-FUNC-UPDATE.1::TLA.1]
+\*
+\* @type: (Int -> Str, Int, Str) => (Int -> Str);
 LightStoreUpdateStates(statuses, ht, blockState) ==
     [h \in DOMAIN statuses \union {ht} |->
         IF h = ht THEN blockState ELSE statuses[h]]      
@@ -156,6 +198,8 @@ LightStoreUpdateStates(statuses, ht, blockState) ==
 \* Check, whether newHeight is a possible next height for the light client.
 \*
 \* [LCV-FUNC-SCHEDULE.1::TLA.1]
+\*
+\* @type: (Int, $lightHeader, Int, Int) => Bool;
 CanScheduleTo(newHeight, pLatestVerified, pNextHeight, pTargetHeight) ==
     LET ht == pLatestVerified.header.height IN
     \/ /\ ht = pNextHeight

--- a/spec/light-client/verification/MC4_3_correct.tla
+++ b/spec/light-client/verification/MC4_3_correct.tla
@@ -7,19 +7,40 @@ TRUSTING_PERIOD == 1400 \* two weeks, one day is 100 time units :-)
 CLOCK_DRIFT == 10       \* how much we assume the local clock is drifting
 REAL_CLOCK_DRIFT == 3   \* how much the local clock is actually drifting
 IS_PRIMARY_CORRECT == TRUE
+\* @type: <<Int, Int>>;
 FAULTY_RATIO == <<1, 3>>    \* < 1 / 3 faulty validators
 
 VARIABLES
-  state, nextHeight, fetchedLightBlocks, lightBlockStatus, latestVerified,
+  \* @type: Str;
+  state,
+  \* @type: Int;
+  nextHeight,
+  \* @type: Int -> $lightHeader;
+  fetchedLightBlocks,
+  \* @type: Int -> Str;
+  lightBlockStatus,
+  \* @type: $lightHeader;
+  latestVerified,
+  \* @type: Int;
   nprobes,
+  \* @type: Int;
   localClock,
-  refClock, blockchain, Faulty
+  \* @type: Int;
+  refClock,
+  \* @type: Int -> $header;
+  blockchain,
+  \* @type: Set($node);
+  Faulty
 
 (* the light client previous state components, used for monitoring *)
 VARIABLES
+  \* @type: $lightHeader;
   prevVerified,
+  \* @type: $lightHeader;
   prevCurrent,
+  \* @type: Int;
   prevLocalClock,
+  \* @type: Str;
   prevVerdict
 
 INSTANCE Lightclient_003_draft

--- a/spec/light-client/verification/MC4_3_faulty.tla
+++ b/spec/light-client/verification/MC4_3_faulty.tla
@@ -7,19 +7,40 @@ TRUSTING_PERIOD == 1400 \* two weeks, one day is 100 time units :-)
 CLOCK_DRIFT == 10       \* how much we assume the local clock is drifting
 REAL_CLOCK_DRIFT == 3   \* how much the local clock is actually drifting
 IS_PRIMARY_CORRECT == FALSE
+\* @type: <<Int, Int>>;
 FAULTY_RATIO == <<1, 3>>    \* < 1 / 3 faulty validators
 
 VARIABLES
-  state, nextHeight, fetchedLightBlocks, lightBlockStatus, latestVerified,
+  \* @type: Str;
+  state,
+  \* @type: Int;
+  nextHeight,
+  \* @type: Int -> $lightHeader;
+  fetchedLightBlocks,
+  \* @type: Int -> Str;
+  lightBlockStatus,
+  \* @type: $lightHeader;
+  latestVerified,
+  \* @type: Int;
   nprobes,
+  \* @type: Int;
   localClock,
-  refClock, blockchain, Faulty
+  \* @type: Int;
+  refClock,
+  \* @type: Int -> $header;
+  blockchain,
+  \* @type: Set($node);
+  Faulty
 
 (* the light client previous state components, used for monitoring *)
 VARIABLES
+  \* @type: $lightHeader;
   prevVerified,
+  \* @type: $lightHeader;
   prevCurrent,
+  \* @type: Int;
   prevLocalClock,
+  \* @type: Str;
   prevVerdict
 
 INSTANCE Lightclient_003_draft

--- a/spec/light-client/verification/MC4_4_correct.tla
+++ b/spec/light-client/verification/MC4_4_correct.tla
@@ -7,19 +7,40 @@ TRUSTING_PERIOD == 1400 \* two weeks, one day is 100 time units :-)
 CLOCK_DRIFT == 10       \* how much we assume the local clock is drifting
 REAL_CLOCK_DRIFT == 3   \* how much the local clock is actually drifting
 IS_PRIMARY_CORRECT == TRUE
+\* @type: <<Int, Int>>;
 FAULTY_RATIO == <<1, 3>>    \* < 1 / 3 faulty validators
 
 VARIABLES
-  state, nextHeight, fetchedLightBlocks, lightBlockStatus, latestVerified,
+  \* @type: Str;
+  state,
+  \* @type: Int;
+  nextHeight,
+  \* @type: Int -> $lightHeader;
+  fetchedLightBlocks,
+  \* @type: Int -> Str;
+  lightBlockStatus,
+  \* @type: $lightHeader;
+  latestVerified,
+  \* @type: Int;
   nprobes,
+  \* @type: Int;
   localClock,
-  refClock, blockchain, Faulty
+  \* @type: Int;
+  refClock,
+  \* @type: Int -> $header;
+  blockchain,
+  \* @type: Set($node);
+  Faulty
 
 (* the light client previous state components, used for monitoring *)
 VARIABLES
+  \* @type: $lightHeader;
   prevVerified,
+  \* @type: $lightHeader;
   prevCurrent,
+  \* @type: Int;
   prevLocalClock,
+  \* @type: Str;
   prevVerdict
 
 INSTANCE Lightclient_003_draft

--- a/spec/light-client/verification/MC4_4_correct_drifted.tla
+++ b/spec/light-client/verification/MC4_4_correct_drifted.tla
@@ -7,19 +7,40 @@ TRUSTING_PERIOD == 1400 \* two weeks, one day is 100 time units :-)
 CLOCK_DRIFT == 10       \* how much we assume the local clock is drifting
 REAL_CLOCK_DRIFT == 30  \* how much the local clock is actually drifting
 IS_PRIMARY_CORRECT == TRUE
+\* @type: <<Int, Int>>;
 FAULTY_RATIO == <<1, 3>>    \* < 1 / 3 faulty validators
 
 VARIABLES
-  state, nextHeight, fetchedLightBlocks, lightBlockStatus, latestVerified,
+  \* @type: Str;
+  state,
+  \* @type: Int;
+  nextHeight,
+  \* @type: Int -> $lightHeader;
+  fetchedLightBlocks,
+  \* @type: Int -> Str;
+  lightBlockStatus,
+  \* @type: $lightHeader;
+  latestVerified,
+  \* @type: Int;
   nprobes,
+  \* @type: Int;
   localClock,
-  refClock, blockchain, Faulty
+  \* @type: Int;
+  refClock,
+  \* @type: Int -> $header;
+  blockchain,
+  \* @type: Set($node);
+  Faulty
 
 (* the light client previous state components, used for monitoring *)
 VARIABLES
+  \* @type: $lightHeader;
   prevVerified,
+  \* @type: $lightHeader;
   prevCurrent,
+  \* @type: Int;
   prevLocalClock,
+  \* @type: Str;
   prevVerdict
 
 INSTANCE Lightclient_003_draft

--- a/spec/light-client/verification/MC4_4_faulty.tla
+++ b/spec/light-client/verification/MC4_4_faulty.tla
@@ -7,19 +7,40 @@ TRUSTING_PERIOD == 1400 \* two weeks, one day is 100 time units :-)
 CLOCK_DRIFT == 10       \* how much we assume the local clock is drifting
 REAL_CLOCK_DRIFT == 3   \* how much the local clock is actually drifting
 IS_PRIMARY_CORRECT == FALSE
+\* @type: <<Int, Int>>;
 FAULTY_RATIO == <<1, 3>>    \* < 1 / 3 faulty validators
 
 VARIABLES
-  state, nextHeight, fetchedLightBlocks, lightBlockStatus, latestVerified,
+  \* @type: Str;
+  state,
+  \* @type: Int;
+  nextHeight,
+  \* @type: Int -> $lightHeader;
+  fetchedLightBlocks,
+  \* @type: Int -> Str;
+  lightBlockStatus,
+  \* @type: $lightHeader;
+  latestVerified,
+  \* @type: Int;
   nprobes,
+  \* @type: Int;
   localClock,
-  refClock, blockchain, Faulty
+  \* @type: Int;
+  refClock,
+  \* @type: Int -> $header;
+  blockchain,
+  \* @type: Set($node);
+  Faulty
 
 (* the light client previous state components, used for monitoring *)
 VARIABLES
+  \* @type: $lightHeader;
   prevVerified,
+  \* @type: $lightHeader;
   prevCurrent,
+  \* @type: Int;
   prevLocalClock,
+  \* @type: Str;
   prevVerdict
 
 INSTANCE Lightclient_003_draft

--- a/spec/light-client/verification/MC4_4_faulty_drifted.tla
+++ b/spec/light-client/verification/MC4_4_faulty_drifted.tla
@@ -7,19 +7,40 @@ TRUSTING_PERIOD == 1400 \* two weeks, one day is 100 time units :-)
 CLOCK_DRIFT == 10       \* how much we assume the local clock is drifting
 REAL_CLOCK_DRIFT == 30  \* how much the local clock is actually drifting
 IS_PRIMARY_CORRECT == FALSE
+\* @type: <<Int, Int>>;
 FAULTY_RATIO == <<1, 3>>    \* < 1 / 3 faulty validators
 
 VARIABLES
-  state, nextHeight, fetchedLightBlocks, lightBlockStatus, latestVerified,
+  \* @type: Str;
+  state,
+  \* @type: Int;
+  nextHeight,
+  \* @type: Int -> $lightHeader;
+  fetchedLightBlocks,
+  \* @type: Int -> Str;
+  lightBlockStatus,
+  \* @type: $lightHeader;
+  latestVerified,
+  \* @type: Int;
   nprobes,
+  \* @type: Int;
   localClock,
-  refClock, blockchain, Faulty
+  \* @type: Int;
+  refClock,
+  \* @type: Int -> $header;
+  blockchain,
+  \* @type: Set($node);
+  Faulty
 
 (* the light client previous state components, used for monitoring *)
 VARIABLES
+  \* @type: $lightHeader;
   prevVerified,
+  \* @type: $lightHeader;
   prevCurrent,
+  \* @type: Int;
   prevLocalClock,
+  \* @type: Str;
   prevVerdict
 
 INSTANCE Lightclient_003_draft

--- a/spec/light-client/verification/MC4_5_correct.tla
+++ b/spec/light-client/verification/MC4_5_correct.tla
@@ -7,19 +7,40 @@ TRUSTING_PERIOD == 1400 \* two weeks, one day is 100 time units :-)
 CLOCK_DRIFT == 10       \* how much we assume the local clock is drifting
 REAL_CLOCK_DRIFT == 3   \* how much the local clock is actually drifting
 IS_PRIMARY_CORRECT == TRUE
+\* @type: <<Int, Int>>;
 FAULTY_RATIO == <<1, 3>>    \* < 1 / 3 faulty validators
 
 VARIABLES
-  state, nextHeight, fetchedLightBlocks, lightBlockStatus, latestVerified,
+  \* @type: Str;
+  state,
+  \* @type: Int;
+  nextHeight,
+  \* @type: Int -> $lightHeader;
+  fetchedLightBlocks,
+  \* @type: Int -> Str;
+  lightBlockStatus,
+  \* @type: $lightHeader;
+  latestVerified,
+  \* @type: Int;
   nprobes,
+  \* @type: Int;
   localClock,
-  refClock, blockchain, Faulty
+  \* @type: Int;
+  refClock,
+  \* @type: Int -> $header;
+  blockchain,
+  \* @type: Set($node);
+  Faulty
 
 (* the light client previous state components, used for monitoring *)
 VARIABLES
+  \* @type: $lightHeader;
   prevVerified,
+  \* @type: $lightHeader;
   prevCurrent,
+  \* @type: Int;
   prevLocalClock,
+  \* @type: Str;
   prevVerdict
 
 INSTANCE Lightclient_003_draft

--- a/spec/light-client/verification/MC4_5_faulty.tla
+++ b/spec/light-client/verification/MC4_5_faulty.tla
@@ -7,19 +7,40 @@ TRUSTING_PERIOD == 1400 \* two weeks, one day is 100 time units :-)
 IS_PRICLOCK_DRIFT == 10       \* how much we assume the local clock is drifting
 REAL_CLOCK_DRIFT == 3   \* how much the local clock is actually drifting
 MARY_CORRECT == FALSE
+\* @type: <<Int, Int>>;
 FAULTY_RATIO == <<1, 3>>    \* < 1 / 3 faulty validators
 
 VARIABLES
-  state, nextHeight, fetchedLightBlocks, lightBlockStatus, latestVerified,
+  \* @type: Str;
+  state,
+  \* @type: Int;
+  nextHeight,
+  \* @type: Int -> $lightHeader;
+  fetchedLightBlocks,
+  \* @type: Int -> Str;
+  lightBlockStatus,
+  \* @type: $lightHeader;
+  latestVerified,
+  \* @type: Int;
   nprobes,
+  \* @type: Int;
   localClock,
-  refClock, blockchain, Faulty
+  \* @type: Int;
+  refClock,
+  \* @type: Int -> $header;
+  blockchain,
+  \* @type: Set($node);
+  Faulty
 
 (* the light client previous state components, used for monitoring *)
 VARIABLES
+  \* @type: $lightHeader;
   prevVerified,
+  \* @type: $lightHeader;
   prevCurrent,
+  \* @type: Int;
   prevLocalClock,
+  \* @type: Str;
   prevVerdict
 
 INSTANCE Lightclient_003_draft

--- a/spec/light-client/verification/MC4_6_faulty.tla
+++ b/spec/light-client/verification/MC4_6_faulty.tla
@@ -7,19 +7,40 @@ TRUSTING_PERIOD == 1400 \* two weeks, one day is 100 time units :-)
 IS_PRCLOCK_DRIFT == 10       \* how much we assume the local clock is drifting
 REAL_CLOCK_DRIFT == 3   \* how much the local clock is actually drifting
 IMARY_CORRECT == FALSE
+\* @type: <<Int, Int>>;
 FAULTY_RATIO == <<1, 3>>    \* < 1 / 3 faulty validators
 
 VARIABLES
-  state, nextHeight, fetchedLightBlocks, lightBlockStatus, latestVerified,
+  \* @type: Str;
+  state,
+  \* @type: Int;
+  nextHeight,
+  \* @type: Int -> $lightHeader;
+  fetchedLightBlocks,
+  \* @type: Int -> Str;
+  lightBlockStatus,
+  \* @type: $lightHeader;
+  latestVerified,
+  \* @type: Int;
   nprobes,
+  \* @type: Int;
   localClock,
-  refClock, blockchain, Faulty
+  \* @type: Int;
+  refClock,
+  \* @type: Int -> $header;
+  blockchain,
+  \* @type: Set($node);
+  Faulty
 
 (* the light client previous state components, used for monitoring *)
 VARIABLES
+  \* @type: $lightHeader;
   prevVerified,
+  \* @type: $lightHeader;
   prevCurrent,
+  \* @type: Int;
   prevLocalClock,
+  \* @type: Str;
   prevVerdict
 
 INSTANCE Lightclient_003_draft

--- a/spec/light-client/verification/MC4_7_faulty.tla
+++ b/spec/light-client/verification/MC4_7_faulty.tla
@@ -7,19 +7,40 @@ TRUSTING_PERIOD == 1400 \* two weeks, one day is 100 time units :-)
 CLOCK_DRIFT == 10       \* how much we assume the local clock is drifting
 REAL_CLOCK_DRIFT == 3   \* how much the local clock is actually drifting
 IS_PRIMARY_CORRECT == FALSE
+\* @type: <<Int, Int>>;
 FAULTY_RATIO == <<1, 3>>    \* < 1 / 3 faulty validators
 
 VARIABLES
-  state, nextHeight, fetchedLightBlocks, lightBlockStatus, latestVerified,
+  \* @type: Str;
+  state,
+  \* @type: Int;
+  nextHeight,
+  \* @type: Int -> $lightHeader;
+  fetchedLightBlocks,
+  \* @type: Int -> Str;
+  lightBlockStatus,
+  \* @type: $lightHeader;
+  latestVerified,
+  \* @type: Int;
   nprobes,
+  \* @type: Int;
   localClock,
-  refClock, blockchain, Faulty
+  \* @type: Int;
+  refClock,
+  \* @type: Int -> $header;
+  blockchain,
+  \* @type: Set($node);
+  Faulty
 
 (* the light client previous state components, used for monitoring *)
 VARIABLES
+  \* @type: $lightHeader;
   prevVerified,
+  \* @type: $lightHeader;
   prevCurrent,
+  \* @type: Int;
   prevLocalClock,
+  \* @type: Str;
   prevVerdict
 
 INSTANCE Lightclient_003_draft

--- a/spec/light-client/verification/MC5_5_correct.tla
+++ b/spec/light-client/verification/MC5_5_correct.tla
@@ -7,19 +7,40 @@ TRUSTING_PERIOD == 1400     \* two weeks, one day is 100 time units :-)
 CLOCK_DRIFT == 10       \* how much we assume the local clock is drifting
 REAL_CLOCK_DRIFT == 3   \* how much the local clock is actually drifting
 IS_PRIMARY_CORRECT == TRUE
+\* @type: <<Int, Int>>;
 FAULTY_RATIO == <<1, 3>>    \* < 1 / 3 faulty validators
 
 VARIABLES
-  state, nextHeight, fetchedLightBlocks, lightBlockStatus, latestVerified,
+  \* @type: Str;
+  state,
+  \* @type: Int;
+  nextHeight,
+  \* @type: Int -> $lightHeader;
+  fetchedLightBlocks,
+  \* @type: Int -> Str;
+  lightBlockStatus,
+  \* @type: $lightHeader;
+  latestVerified,
+  \* @type: Int;
   nprobes,
+  \* @type: Int;
   localClock,
-  refClock, blockchain, Faulty
+  \* @type: Int;
+  refClock,
+  \* @type: Int -> $header;
+  blockchain,
+  \* @type: Set($node);
+  Faulty
 
 (* the light client previous state components, used for monitoring *)
 VARIABLES
+  \* @type: $lightHeader;
   prevVerified,
+  \* @type: $lightHeader;
   prevCurrent,
+  \* @type: Int;
   prevLocalClock,
+  \* @type: Str;
   prevVerdict
 
 INSTANCE Lightclient_003_draft

--- a/spec/light-client/verification/MC5_5_correct_peer_two_thirds_faulty.tla
+++ b/spec/light-client/verification/MC5_5_correct_peer_two_thirds_faulty.tla
@@ -7,19 +7,40 @@ TRUSTING_PERIOD == 1400     \* two weeks, one day is 100 time units :-)
 CLOCK_DRIFT == 10       \* how much we assume the local clock is drifting
 REAL_CLOCK_DRIFT == 3   \* how much the local clock is actually drifting
 IS_PRIMARY_CORRECT == TRUE
+\* @type: <<Int, Int>>;
 FAULTY_RATIO == <<2, 3>>    \* < 1 / 3 faulty validators
 
 VARIABLES
-  state, nextHeight, fetchedLightBlocks, lightBlockStatus, latestVerified,
+  \* @type: Str;
+  state,
+  \* @type: Int;
+  nextHeight,
+  \* @type: Int -> $lightHeader;
+  fetchedLightBlocks,
+  \* @type: Int -> Str;
+  lightBlockStatus,
+  \* @type: $lightHeader;
+  latestVerified,
+  \* @type: Int;
   nprobes,
+  \* @type: Int;
   localClock,
-  refClock, blockchain, Faulty
+  \* @type: Int;
+  refClock,
+  \* @type: Int -> $header;
+  blockchain,
+  \* @type: Set($node);
+  Faulty
 
 (* the light client previous state components, used for monitoring *)
 VARIABLES
+  \* @type: $lightHeader;
   prevVerified,
+  \* @type: $lightHeader;
   prevCurrent,
+  \* @type: Int;
   prevLocalClock,
+  \* @type: Str;
   prevVerdict
 
 INSTANCE Lightclient_003_draft

--- a/spec/light-client/verification/MC5_7_faulty.tla
+++ b/spec/light-client/verification/MC5_7_faulty.tla
@@ -7,19 +7,40 @@ TRUSTING_PERIOD == 1400 \* two weeks, one day is 100 time units :-)
 CLOCK_DRIFT == 10       \* how much we assume the local clock is drifting
 REAL_CLOCK_DRIFT == 3   \* how much the local clock is actually drifting
 IS_PRIMARY_CORRECT == FALSE
+\* @type: <<Int, Int>>;
 FAULTY_RATIO == <<1, 3>>    \* < 1 / 3 faulty validators
 
 VARIABLES
-  state, nextHeight, fetchedLightBlocks, lightBlockStatus, latestVerified,
+  \* @type: Str;
+  state,
+  \* @type: Int;
+  nextHeight,
+  \* @type: Int -> $lightHeader;
+  fetchedLightBlocks,
+  \* @type: Int -> Str;
+  lightBlockStatus,
+  \* @type: $lightHeader;
+  latestVerified,
+  \* @type: Int;
   nprobes,
+  \* @type: Int;
   localClock,
-  refClock, blockchain, Faulty
+  \* @type: Int;
+  refClock,
+  \* @type: Int -> $header;
+  blockchain,
+  \* @type: Set($node);
+  Faulty
 
 (* the light client previous state components, used for monitoring *)
 VARIABLES
+  \* @type: $lightHeader;
   prevVerified,
+  \* @type: $lightHeader;
   prevCurrent,
+  \* @type: Int;
   prevLocalClock,
+  \* @type: Str;
   prevVerdict
 
 INSTANCE Lightclient_003_draft

--- a/spec/light-client/verification/MC7_5_faulty.tla
+++ b/spec/light-client/verification/MC7_5_faulty.tla
@@ -7,19 +7,40 @@ TRUSTING_PERIOD == 1400 \* two weeks, one day is 100 time units :-)
 CLOCK_DRIFT == 10       \* how much we assume the local clock is drifting
 REAL_CLOCK_DRIFT == 3   \* how much the local clock is actually drifting
 IS_PRIMARY_CORRECT == FALSE
+\* @type: <<Int, Int>>;
 FAULTY_RATIO == <<1, 3>>    \* < 1 / 3 faulty validators
 
 VARIABLES
-  state, nextHeight, fetchedLightBlocks, lightBlockStatus, latestVerified,
+  \* @type: Str;
+  state,
+  \* @type: Int;
+  nextHeight,
+  \* @type: Int -> $lightHeader;
+  fetchedLightBlocks,
+  \* @type: Int -> Str;
+  lightBlockStatus,
+  \* @type: $lightHeader;
+  latestVerified,
+  \* @type: Int;
   nprobes,
+  \* @type: Int;
   localClock,
-  refClock, blockchain, Faulty
+  \* @type: Int;
+  refClock,
+  \* @type: Int -> $header;
+  blockchain,
+  \* @type: Set($node);
+  Faulty
 
 (* the light client previous state components, used for monitoring *)
 VARIABLES
+  \* @type: $lightHeader;
   prevVerified,
+  \* @type: $lightHeader;
   prevCurrent,
+  \* @type: Int;
   prevLocalClock,
+  \* @type: Str;
   prevVerdict
 
 INSTANCE Lightclient_003_draft

--- a/spec/light-client/verification/MC7_7_faulty.tla
+++ b/spec/light-client/verification/MC7_7_faulty.tla
@@ -7,19 +7,40 @@ TRUSTING_PERIOD == 1400 \* two weeks, one day is 100 time units :-)
 CLOCK_DRIFT == 10       \* how much we assume the local clock is drifting
 REAL_CLOCK_DRIFT == 3   \* how much the local clock is actually drifting
 IS_PRIMARY_CORRECT == FALSE
+\* @type: <<Int, Int>>;
 FAULTY_RATIO == <<1, 3>>    \* < 1 / 3 faulty validators
 
 VARIABLES
-  state, nextHeight, fetchedLightBlocks, lightBlockStatus, latestVerified,
+  \* @type: Str;
+  state,
+  \* @type: Int;
+  nextHeight,
+  \* @type: Int -> $lightHeader;
+  fetchedLightBlocks,
+  \* @type: Int -> Str;
+  lightBlockStatus,
+  \* @type: $lightHeader;
+  latestVerified,
+  \* @type: Int;
   nprobes,
+  \* @type: Int;
   localClock,
-  refClock, blockchain, Faulty
+  \* @type: Int;
+  refClock,
+  \* @type: Int -> $header;
+  blockchain,
+  \* @type: Set($node);
+  Faulty
 
 (* the light client previous state components, used for monitoring *)
 VARIABLES
+  \* @type: $lightHeader;
   prevVerified,
+  \* @type: $lightHeader;
   prevCurrent,
+  \* @type: Int;
   prevLocalClock,
+  \* @type: Str;
   prevVerdict
 
 INSTANCE Lightclient_003_draft

--- a/spec/light-client/verification/typedefs.tla
+++ b/spec/light-client/verification/typedefs.tla
@@ -1,0 +1,25 @@
+--------------------------- MODULE typedefs ----------------------------
+(*
+ // a node id, just a string
+ @typeAlias: node = Str;
+
+ // a block header
+ @typeAlias: header = {
+   height: Int,
+   time: Int,
+   lastCommit: Set($node),
+   VS: Set($node),
+   NextVS: Set($node)
+ };
+
+ // the blockchain is a function of heights to blocks
+ @typeAlias: blockchain = Int -> $header;
+
+ // a light-client block header
+ @typeAlias: lightHeader = {
+   header: $header,
+   Commits: Set($node)
+ };
+ *)
+typedefs == TRUE
+========================================================================


### PR DESCRIPTION
This PR updates the type annotations in the TLA+ specification of the light client, so it works with the latest version of Apalache v0.40.2. I did not open any issue, as this is simply about updating the annotations.

#### PR checklist

- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments

