### PR TITLE
changelog: Import entries for v0.34.28, v0.34.29, v0.37.1 and v0.37.2 to `main`

### DIFF
--- a/.changelog/v0.34.28/breaking-changes/558-tm10011.md
+++ b/.changelog/v0.34.28/breaking-changes/558-tm10011.md
@@ -1,0 +1,2 @@
+- `[crypto/merkle]` Do not allow verification of Merkle Proofs against empty trees (`nil` root). `Proof.ComputeRootHash` now panics when it encounters an error, but `Proof.Verify` does not panic
+  ([\#558](https://github.com/cometbft/cometbft/issues/558))

--- a/.changelog/v0.34.28/bug-fixes/496-error-on-applyblock-should-panic.md
+++ b/.changelog/v0.34.28/bug-fixes/496-error-on-applyblock-should-panic.md
@@ -1,0 +1,2 @@
+- `[consensus]` Unexpected error conditions in `ApplyBlock` are non-recoverable, so ignoring the error and carrying on is a bug. We replaced a `return` that disregarded the error by a `panic`.
+  ([\#496](https://github.com/cometbft/cometbft/pull/496))

--- a/.changelog/v0.34.28/bug-fixes/524-rename-peerstate-tojson.md
+++ b/.changelog/v0.34.28/bug-fixes/524-rename-peerstate-tojson.md
@@ -1,0 +1,2 @@
+- `[consensus]` Rename `(*PeerState).ToJSON` to `MarshalJSON` to fix a logging data race
+  ([\#524](https://github.com/cometbft/cometbft/pull/524))

--- a/.changelog/v0.34.28/bug-fixes/575-fix-light-client-panic.md
+++ b/.changelog/v0.34.28/bug-fixes/575-fix-light-client-panic.md
@@ -1,0 +1,6 @@
+- `[light]` Fixed an edge case where a light client would panic when attempting
+  to query a node that (1) has started from a non-zero height and (2) does
+  not yet have any data. The light client will now, correctly, not panic
+  _and_ keep the node in its list of providers in the same way it would if
+  it queried a node starting from height zero that does not yet have data
+  ([\#575](https://github.com/cometbft/cometbft/issues/575))

--- a/.changelog/v0.34.28/improvements/475-upgrade-go-schnorrkel.md
+++ b/.changelog/v0.34.28/improvements/475-upgrade-go-schnorrkel.md
@@ -1,0 +1,1 @@
+- `[crypto/sr25519]` Upgrade to go-schnorrkel@v1.0.0 ([\#475](https://github.com/cometbft/cometbft/issues/475))

--- a/.changelog/v0.34.28/improvements/638-json-rpc-error-message.md
+++ b/.changelog/v0.34.28/improvements/638-json-rpc-error-message.md
@@ -1,0 +1,3 @@
+- `[jsonrpc/client]` Improve the error message for client errors stemming from
+  bad HTTP responses.
+  ([cometbft/cometbft\#638](https://github.com/cometbft/cometbft/pull/638))

--- a/.changelog/v0.34.28/summary.md
+++ b/.changelog/v0.34.28/summary.md
@@ -1,0 +1,6 @@
+*April 26, 2023*
+
+This release fixes several bugs, and has had to introduce one small Go
+API-breaking change in the `crypto/merkle` package in order to address what
+could be a security issue for some users who directly and explicitly make use of
+that code.

--- a/.changelog/v0.34.29/bug-fixes/771-kvindexer-parsing-big-ints.md
+++ b/.changelog/v0.34.29/bug-fixes/771-kvindexer-parsing-big-ints.md
@@ -1,0 +1,2 @@
+- `[state/kvindex]` Querying event attributes that are bigger than int64 is now
+  enabled. ([\#771](https://github.com/cometbft/cometbft/pull/771))

--- a/.changelog/v0.34.29/bug-fixes/771-pubsub-parsing-big-ints.md
+++ b/.changelog/v0.34.29/bug-fixes/771-pubsub-parsing-big-ints.md
@@ -1,0 +1,4 @@
+- `[pubsub]` Pubsub queries are now able to parse big integers (larger than
+  int64). Very big floats are also properly parsed into very big integers
+  instead of being truncated to int64.
+  ([\#771](https://github.com/cometbft/cometbft/pull/771))

--- a/.changelog/v0.34.29/improvements/654-rpc-rm-response-data-logs.md
+++ b/.changelog/v0.34.29/improvements/654-rpc-rm-response-data-logs.md
@@ -1,0 +1,3 @@
+- `[rpc]` Remove response data from response failure logs in order
+  to prevent large quantities of log data from being produced
+  ([\#654](https://github.com/cometbft/cometbft/issues/654))

--- a/.changelog/v0.34.29/security-fixes/788-rpc-client-pw.md
+++ b/.changelog/v0.34.29/security-fixes/788-rpc-client-pw.md
@@ -1,0 +1,3 @@
+- `[rpc/jsonrpc/client]` **Low severity** - Prevent RPC
+  client credentials from being inadvertently dumped to logs
+  ([\#788](https://github.com/cometbft/cometbft/pull/788))

--- a/.changelog/v0.34.29/security-fixes/794-cli-debug-kill-unsafe-cast.md
+++ b/.changelog/v0.34.29/security-fixes/794-cli-debug-kill-unsafe-cast.md
@@ -1,0 +1,2 @@
+- `[cmd/cometbft/commands/debug/kill]` **Low severity** - Fix unsafe int cast in
+  `debug kill` command ([\#794](https://github.com/cometbft/cometbft/pull/794))

--- a/.changelog/v0.34.29/security-fixes/865-fix-peerstate-marshaljson.md
+++ b/.changelog/v0.34.29/security-fixes/865-fix-peerstate-marshaljson.md
@@ -1,0 +1,3 @@
+- `[consensus]` **Low severity** - Avoid recursive call after rename to
+  `(*PeerState).MarshalJSON`
+  ([\#863](https://github.com/cometbft/cometbft/pull/863))

--- a/.changelog/v0.34.29/security-fixes/890-mempool-fix-cache.md
+++ b/.changelog/v0.34.29/security-fixes/890-mempool-fix-cache.md
@@ -1,0 +1,3 @@
+- `[mempool/clist_mempool]` **Low severity** - Prevent a transaction from
+  appearing twice in the mempool
+  ([\#890](https://github.com/cometbft/cometbft/pull/890): @otrack)

--- a/.changelog/v0.34.29/summary.md
+++ b/.changelog/v0.34.29/summary.md
@@ -1,0 +1,4 @@
+*June 14, 2023*
+
+Provides several minor bug fixes, as well as fixes for several low-severity
+security issues.

--- a/.changelog/v0.37.1/breaking-changes/558-tm10011.md
+++ b/.changelog/v0.37.1/breaking-changes/558-tm10011.md
@@ -1,0 +1,2 @@
+- `[crypto/merkle]` Do not allow verification of Merkle Proofs against empty trees (`nil` root). `Proof.ComputeRootHash` now panics when it encounters an error, but `Proof.Verify` does not panic
+  ([\#558](https://github.com/cometbft/cometbft/issues/558))

--- a/.changelog/v0.37.1/bug-fixes/496-error-on-applyblock-should-panic.md
+++ b/.changelog/v0.37.1/bug-fixes/496-error-on-applyblock-should-panic.md
@@ -1,0 +1,2 @@
+- `[consensus]` Unexpected error conditions in `ApplyBlock` are non-recoverable, so ignoring the error and carrying on is a bug. We replaced a `return` that disregarded the error by a `panic`.
+  ([\#496](https://github.com/cometbft/cometbft/pull/496))

--- a/.changelog/v0.37.1/bug-fixes/524-rename-peerstate-tojson.md
+++ b/.changelog/v0.37.1/bug-fixes/524-rename-peerstate-tojson.md
@@ -1,0 +1,2 @@
+- `[consensus]` Rename `(*PeerState).ToJSON` to `MarshalJSON` to fix a logging data race
+  ([\#524](https://github.com/cometbft/cometbft/pull/524))

--- a/.changelog/v0.37.1/bug-fixes/575-fix-light-client-panic.md
+++ b/.changelog/v0.37.1/bug-fixes/575-fix-light-client-panic.md
@@ -1,0 +1,6 @@
+- `[light]` Fixed an edge case where a light client would panic when attempting
+  to query a node that (1) has started from a non-zero height and (2) does
+  not yet have any data. The light client will now, correctly, not panic
+  _and_ keep the node in its list of providers in the same way it would if
+  it queried a node starting from height zero that does not yet have data
+  ([\#575](https://github.com/cometbft/cometbft/issues/575))

--- a/.changelog/v0.37.1/improvements/638-json-rpc-error-message.md
+++ b/.changelog/v0.37.1/improvements/638-json-rpc-error-message.md
@@ -1,0 +1,3 @@
+- `[jsonrpc/client]` Improve the error message for client errors stemming from
+  bad HTTP responses.
+  ([cometbft/cometbft\#638](https://github.com/cometbft/cometbft/pull/638))

--- a/.changelog/v0.37.1/summary.md
+++ b/.changelog/v0.37.1/summary.md
@@ -1,0 +1,6 @@
+*April 26, 2023*
+
+This release fixes several bugs, and has had to introduce one small Go
+API-breaking change in the `crypto/merkle` package in order to address what
+could be a security issue for some users who directly and explicitly make use of
+that code.

--- a/.changelog/v0.37.2/bug-fixes/771-kvindexer-parsing-big-ints.md
+++ b/.changelog/v0.37.2/bug-fixes/771-kvindexer-parsing-big-ints.md
@@ -1,0 +1,4 @@
+- `[state/kvindex]` Querying event attributes that are bigger than int64 is now
+  enabled. We are not supporting reading floats from the db into the indexer
+  nor parsing them into BigFloats to not introduce breaking changes in minor
+  releases. ([\#771](https://github.com/cometbft/cometbft/pull/771))

--- a/.changelog/v0.37.2/bug-fixes/771-pubsub-parsing-big-ints.md
+++ b/.changelog/v0.37.2/bug-fixes/771-pubsub-parsing-big-ints.md
@@ -1,0 +1,4 @@
+- `[pubsub]` Pubsub queries are now able to parse big integers (larger than
+  int64). Very big floats are also properly parsed into very big integers
+  instead of being truncated to int64.
+  ([\#771](https://github.com/cometbft/cometbft/pull/771))

--- a/.changelog/v0.37.2/improvements/654-rpc-rm-response-data-logs.md
+++ b/.changelog/v0.37.2/improvements/654-rpc-rm-response-data-logs.md
@@ -1,0 +1,3 @@
+- `[rpc]` Remove response data from response failure logs in order
+  to prevent large quantities of log data from being produced
+  ([\#654](https://github.com/cometbft/cometbft/issues/654))

--- a/.changelog/v0.37.2/security-fixes/787-rpc-client-pw.md
+++ b/.changelog/v0.37.2/security-fixes/787-rpc-client-pw.md
@@ -1,0 +1,3 @@
+- `[rpc/jsonrpc/client]` **Low severity** - Prevent RPC
+  client credentials from being inadvertently dumped to logs
+  ([\#787](https://github.com/cometbft/cometbft/pull/787))

--- a/.changelog/v0.37.2/security-fixes/793-cli-debug-kill-unsafe-cast.md
+++ b/.changelog/v0.37.2/security-fixes/793-cli-debug-kill-unsafe-cast.md
@@ -1,0 +1,2 @@
+- `[cmd/cometbft/commands/debug/kill]` **Low severity** - Fix unsafe int cast in
+  `debug kill` command ([\#793](https://github.com/cometbft/cometbft/pull/793))

--- a/.changelog/v0.37.2/security-fixes/865-fix-peerstate-marshaljson.md
+++ b/.changelog/v0.37.2/security-fixes/865-fix-peerstate-marshaljson.md
@@ -1,0 +1,3 @@
+- `[consensus]` **Low severity** - Avoid recursive call after rename to
+  `(*PeerState).MarshalJSON`
+  ([\#863](https://github.com/cometbft/cometbft/pull/863))

--- a/.changelog/v0.37.2/security-fixes/890-mempool-fix-cache.md
+++ b/.changelog/v0.37.2/security-fixes/890-mempool-fix-cache.md
@@ -1,0 +1,3 @@
+- `[mempool/clist_mempool]` **Low severity** - Prevent a transaction from
+  appearing twice in the mempool
+  ([\#890](https://github.com/cometbft/cometbft/pull/890): @otrack)

--- a/.changelog/v0.37.2/summary.md
+++ b/.changelog/v0.37.2/summary.md
@@ -1,0 +1,4 @@
+*June 14, 2023*
+
+Provides several minor bug fixes, as well as fixes for several low-severity
+security issues.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,76 @@
 # CHANGELOG
 
+## v0.37.2
+
+*June 14, 2023*
+
+Provides several minor bug fixes, as well as fixes for several low-severity
+security issues.
+
+### BUG FIXES
+
+- `[state/kvindex]` Querying event attributes that are bigger than int64 is now
+  enabled. We are not supporting reading floats from the db into the indexer
+  nor parsing them into BigFloats to not introduce breaking changes in minor
+  releases. ([\#771](https://github.com/cometbft/cometbft/pull/771))
+- `[pubsub]` Pubsub queries are now able to parse big integers (larger than
+  int64). Very big floats are also properly parsed into very big integers
+  instead of being truncated to int64.
+  ([\#771](https://github.com/cometbft/cometbft/pull/771))
+
+### IMPROVEMENTS
+
+- `[rpc]` Remove response data from response failure logs in order
+  to prevent large quantities of log data from being produced
+  ([\#654](https://github.com/cometbft/cometbft/issues/654))
+
+### SECURITY FIXES
+
+- `[rpc/jsonrpc/client]` **Low severity** - Prevent RPC
+  client credentials from being inadvertently dumped to logs
+  ([\#787](https://github.com/cometbft/cometbft/pull/787))
+- `[cmd/cometbft/commands/debug/kill]` **Low severity** - Fix unsafe int cast in
+  `debug kill` command ([\#793](https://github.com/cometbft/cometbft/pull/793))
+- `[consensus]` **Low severity** - Avoid recursive call after rename to
+  `(*PeerState).MarshalJSON`
+  ([\#863](https://github.com/cometbft/cometbft/pull/863))
+- `[mempool/clist_mempool]` **Low severity** - Prevent a transaction from
+  appearing twice in the mempool
+  ([\#890](https://github.com/cometbft/cometbft/pull/890): @otrack)
+
+## v0.37.1
+
+*April 26, 2023*
+
+This release fixes several bugs, and has had to introduce one small Go
+API-breaking change in the `crypto/merkle` package in order to address what
+could be a security issue for some users who directly and explicitly make use of
+that code.
+
+### BREAKING CHANGES
+
+- `[crypto/merkle]` Do not allow verification of Merkle Proofs against empty trees (`nil` root). `Proof.ComputeRootHash` now panics when it encounters an error, but `Proof.Verify` does not panic
+  ([\#558](https://github.com/cometbft/cometbft/issues/558))
+
+### BUG FIXES
+
+- `[consensus]` Unexpected error conditions in `ApplyBlock` are non-recoverable, so ignoring the error and carrying on is a bug. We replaced a `return` that disregarded the error by a `panic`.
+  ([\#496](https://github.com/cometbft/cometbft/pull/496))
+- `[consensus]` Rename `(*PeerState).ToJSON` to `MarshalJSON` to fix a logging data race
+  ([\#524](https://github.com/cometbft/cometbft/pull/524))
+- `[light]` Fixed an edge case where a light client would panic when attempting
+  to query a node that (1) has started from a non-zero height and (2) does
+  not yet have any data. The light client will now, correctly, not panic
+  _and_ keep the node in its list of providers in the same way it would if
+  it queried a node starting from height zero that does not yet have data
+  ([\#575](https://github.com/cometbft/cometbft/issues/575))
+
+### IMPROVEMENTS
+
+- `[jsonrpc/client]` Improve the error message for client errors stemming from
+  bad HTTP responses.
+  ([cometbft/cometbft\#638](https://github.com/cometbft/cometbft/pull/638))
+
 ## v0.37.0
 
 *March 6, 2023*
@@ -138,6 +209,76 @@ See below for more details.
   ([\#9650](https://github.com/tendermint/tendermint/pull/9650))
 - `[consensus]` Save peer LastCommit correctly to achieve 50% reduction in gossiped precommits.
   ([\#9760](https://github.com/tendermint/tendermint/pull/9760))
+
+## v0.34.29
+
+*June 14, 2023*
+
+Provides several minor bug fixes, as well as fixes for several low-severity
+security issues.
+
+### BUG FIXES
+
+- `[state/kvindex]` Querying event attributes that are bigger than int64 is now
+  enabled. ([\#771](https://github.com/cometbft/cometbft/pull/771))
+- `[pubsub]` Pubsub queries are now able to parse big integers (larger than
+  int64). Very big floats are also properly parsed into very big integers
+  instead of being truncated to int64.
+  ([\#771](https://github.com/cometbft/cometbft/pull/771))
+
+### IMPROVEMENTS
+
+- `[rpc]` Remove response data from response failure logs in order
+  to prevent large quantities of log data from being produced
+  ([\#654](https://github.com/cometbft/cometbft/issues/654))
+
+### SECURITY FIXES
+
+- `[rpc/jsonrpc/client]` **Low severity** - Prevent RPC
+  client credentials from being inadvertently dumped to logs
+  ([\#788](https://github.com/cometbft/cometbft/pull/788))
+- `[cmd/cometbft/commands/debug/kill]` **Low severity** - Fix unsafe int cast in
+  `debug kill` command ([\#794](https://github.com/cometbft/cometbft/pull/794))
+- `[consensus]` **Low severity** - Avoid recursive call after rename to
+  `(*PeerState).MarshalJSON`
+  ([\#863](https://github.com/cometbft/cometbft/pull/863))
+- `[mempool/clist_mempool]` **Low severity** - Prevent a transaction from
+  appearing twice in the mempool
+  ([\#890](https://github.com/cometbft/cometbft/pull/890): @otrack)
+
+## v0.34.28
+
+*April 26, 2023*
+
+This release fixes several bugs, and has had to introduce one small Go
+API-breaking change in the `crypto/merkle` package in order to address what
+could be a security issue for some users who directly and explicitly make use of
+that code.
+
+### BREAKING CHANGES
+
+- `[crypto/merkle]` Do not allow verification of Merkle Proofs against empty trees (`nil` root). `Proof.ComputeRootHash` now panics when it encounters an error, but `Proof.Verify` does not panic
+  ([\#558](https://github.com/cometbft/cometbft/issues/558))
+
+### BUG FIXES
+
+- `[consensus]` Unexpected error conditions in `ApplyBlock` are non-recoverable, so ignoring the error and carrying on is a bug. We replaced a `return` that disregarded the error by a `panic`.
+  ([\#496](https://github.com/cometbft/cometbft/pull/496))
+- `[consensus]` Rename `(*PeerState).ToJSON` to `MarshalJSON` to fix a logging data race
+  ([\#524](https://github.com/cometbft/cometbft/pull/524))
+- `[light]` Fixed an edge case where a light client would panic when attempting
+  to query a node that (1) has started from a non-zero height and (2) does
+  not yet have any data. The light client will now, correctly, not panic
+  _and_ keep the node in its list of providers in the same way it would if
+  it queried a node starting from height zero that does not yet have data
+  ([\#575](https://github.com/cometbft/cometbft/issues/575))
+
+### IMPROVEMENTS
+
+- `[crypto/sr25519]` Upgrade to go-schnorrkel@v1.0.0 ([\#475](https://github.com/cometbft/cometbft/issues/475))
+- `[jsonrpc/client]` Improve the error message for client errors stemming from
+  bad HTTP responses.
+  ([cometbft/cometbft\#638](https://github.com/cometbft/cometbft/pull/638))
 
 ## v0.34.27
 


### PR DESCRIPTION
Brings all the changelog entries from the latest v0.34.x and v0.37.x entries to `main` for ease of reference.

:book: [CHANGELOG rendered](https://github.com/cometbft/cometbft/blob/thane/update-changelog/CHANGELOG.md)

I've noticed that unclog builds all of the v0.34.x entries after all of the v0.37.x entries, which may or may not be the behaviour that we actually want. Do we want changelog entries sorted by semantic version, or by release date? If we need to sort by release date, we'll need to modify unclog accordingly.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

