### PR TITLE
test/e2e: Fix Docker image build

### DIFF
--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -1,7 +1,7 @@
 # We need to build in a Linux environment to support C libraries, e.g. RocksDB.
 # We use Debian instead of Alpine, so that we can use binary database packages
 # instead of spending time compiling them.
-FROM golang:1.20
+FROM golang:1.20-bullseye
 
 RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
 RUN apt-get -qq install -y libleveldb-dev librocksdb-dev >/dev/null


### PR DESCRIPTION
Explicitly sets the base image to Debian Bullseye for now to get the E2E Docker image building again.

Builds have been failing on `main` and `v0.38.x` as a result of the recent base image change for the `golang:1.20` image from Debian Bullseye to Bookworm. This has already been fixed on `v0.37.x` and `v0.34.x` in #972 and #973.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

