### PR TITLE
Remove duplicate function `deterministicExecTxResult`

### DIFF
--- a/abci/types/types.go
+++ b/abci/types/types.go
@@ -138,7 +138,7 @@ var _ jsonRoundTripper = (*ResponseCheckTx)(nil)
 
 var _ jsonRoundTripper = (*EventAttribute)(nil)
 
-// deterministicExecTxResult constructs a copy of response that omits
+// constructs a copy of response that omits
 // non-deterministic fields. The input response is not modified.
 func DeterministicExecTxResult(response *ExecTxResult) *ExecTxResult {
 	return &ExecTxResult{

--- a/abci/types/types.go
+++ b/abci/types/types.go
@@ -140,7 +140,7 @@ var _ jsonRoundTripper = (*EventAttribute)(nil)
 
 // deterministicExecTxResult constructs a copy of response that omits
 // non-deterministic fields. The input response is not modified.
-func deterministicExecTxResult(response *ExecTxResult) *ExecTxResult {
+func DeterministicExecTxResult(response *ExecTxResult) *ExecTxResult {
 	return &ExecTxResult{
 		Code:      response.Code,
 		Data:      response.Data,

--- a/abci/types/types.go
+++ b/abci/types/types.go
@@ -156,7 +156,7 @@ func DeterministicExecTxResult(response *ExecTxResult) *ExecTxResult {
 func MarshalTxResults(r []*ExecTxResult) ([][]byte, error) {
 	s := make([][]byte, len(r))
 	for i, e := range r {
-		d := deterministicExecTxResult(e)
+		d := DeterministicExecTxResult(e)
 		b, err := d.Marshal()
 		if err != nil {
 			return nil, err

--- a/types/block.go
+++ b/types/block.go
@@ -342,7 +342,7 @@ type Header struct {
 	ConsensusHash      cmtbytes.HexBytes `json:"consensus_hash"`       // consensus params for current block
 	AppHash            cmtbytes.HexBytes `json:"app_hash"`             // state after txs from the previous block
 	// root hash of all results from the txs from the previous block
-	// see `deterministicExecTxResult` to understand which parts of a tx is hashed into here
+	// see `DeterministicExecTxResult` to understand which parts of a tx is hashed into here
 	LastResultsHash cmtbytes.HexBytes `json:"last_results_hash"`
 
 	// consensus info

--- a/types/results.go
+++ b/types/results.go
@@ -13,7 +13,7 @@ type ABCIResults []*abci.ExecTxResult
 func NewResults(responses []*abci.ExecTxResult) ABCIResults {
 	res := make(ABCIResults, len(responses))
 	for i, d := range responses {
-		res[i] = deterministicExecTxResult(d)
+		res[i] = abci.DeterministicExecTxResult(d)
 	}
 	return res
 }
@@ -40,15 +40,4 @@ func (a ABCIResults) toByteSlices() [][]byte {
 		bzs[i] = bz
 	}
 	return bzs
-}
-
-// deterministicExecTxResult strips non-deterministic fields from
-// ExecTxResult and returns another ExecTxResult.
-func deterministicExecTxResult(response *abci.ExecTxResult) *abci.ExecTxResult {
-	return &abci.ExecTxResult{
-		Code:      response.Code,
-		Data:      response.Data,
-		GasWanted: response.GasWanted,
-		GasUsed:   response.GasUsed,
-	}
 }


### PR DESCRIPTION
Closes #889

Remove one implementation of `deterministicExecTxResult` by deleting one copy and rendering the other visible outside its package.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

