### PR TITLE
style: use gci to deterministically sort imports

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,6 +34,15 @@ issues:
   max-same-issues: 50
 
 linters-settings:
+  gci:
+    custom-order: true
+    sections:
+      - standard # Standard section: captures all standard packages.
+      - default # Default section: contains all imports that could not be matched to another section type.
+      - blank # blank imports
+      - dot # dot imports
+      - prefix(github.com/cometbft)
+      - prefix(github.com/cometbft/cometbft)
   dogsled:
     max-blank-identifiers: 3
   golint:

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -494,7 +494,7 @@ func (cs *State) AddProposalBlockPart(height int64, round int32, part *types.Par
 // SetProposalAndBlock inputs the proposal and all block parts.
 func (cs *State) SetProposalAndBlock(
 	proposal *types.Proposal,
-	block *types.Block, //nolint:revive
+	block *types.Block, 
 	parts *types.PartSet,
 	peerID p2p.ID,
 ) error {

--- a/evidence/verify.go
+++ b/evidence/verify.go
@@ -111,8 +111,8 @@ func VerifyLightClientAttack(
 	e *types.LightClientAttackEvidence,
 	commonHeader, trustedHeader *types.SignedHeader,
 	commonVals *types.ValidatorSet,
-	now time.Time, //nolint:revive
-	trustPeriod time.Duration, //nolint:revive
+	now time.Time, 
+	trustPeriod time.Duration, 
 ) error {
 	// TODO: Should the current time and trust period be used in this method?
 	// If not, why were the parameters present?

--- a/p2p/conn/connection.go
+++ b/p2p/conn/connection.go
@@ -659,7 +659,7 @@ FOR_LOOP:
 
 	// Cleanup
 	close(c.pong)
-	//nolint:revive
+	
 	for range c.pong {
 		// Drain
 	}

--- a/p2p/upnp/upnp.go
+++ b/p2p/upnp/upnp.go
@@ -381,7 +381,7 @@ func (n *upnpNAT) AddPortMapping(
 	return mappedExternalPort, err
 }
 
-//nolint:revive
+
 func (n *upnpNAT) DeletePortMapping(protocol string, externalPort, internalPort int) (err error) {
 	message := "<u:DeletePortMapping xmlns:u=\"urn:" + n.urnDomain + ":service:WANIPConnection:1\">\r\n" +
 		"<NewRemoteHost></NewRemoteHost><NewExternalPort>" + strconv.Itoa(externalPort) +

--- a/scripts/metricsgen/metricsgen.go
+++ b/scripts/metricsgen/metricsgen.go
@@ -170,7 +170,7 @@ func ParseMetricsDir(dir string, structName string) (TemplateData, error) {
 	var pkgName string
 	var pkg *ast.Package
 	// TODO(thane): Figure out a more readable way of implementing this.
-	//nolint:revive
+	
 	for pkgName, pkg = range d {
 	}
 	td := TemplateData{


### PR DESCRIPTION
This PR introduces the gci linter, which sorts all of cometbft's imports deterministically
