### PR TITLE
deps: Manually bump github.com/vektra/mockery/v2 from 2.29.0 to 2.30.1

### DIFF
--- a/abci/client/mocks/client.go
+++ b/abci/client/mocks/client.go
@@ -592,13 +592,12 @@ func (_m *Client) VerifyVoteExtension(_a0 context.Context, _a1 *types.RequestVer
 	return r0, r1
 }
 
-type mockConstructorTestingTNewClient interface {
+// NewClient creates a new instance of Client. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewClient(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewClient creates a new instance of Client. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewClient(t mockConstructorTestingTNewClient) *Client {
+}) *Client {
 	mock := &Client{}
 	mock.Mock.Test(t)
 

--- a/abci/types/mocks/application.go
+++ b/abci/types/mocks/application.go
@@ -378,13 +378,12 @@ func (_m *Application) VerifyVoteExtension(_a0 context.Context, _a1 *types.Reque
 	return r0, r1
 }
 
-type mockConstructorTestingTNewApplication interface {
+// NewApplication creates a new instance of Application. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewApplication(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewApplication creates a new instance of Application. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewApplication(t mockConstructorTestingTNewApplication) *Application {
+}) *Application {
 	mock := &Application{}
 	mock.Mock.Test(t)
 

--- a/evidence/mocks/block_store.go
+++ b/evidence/mocks/block_store.go
@@ -58,13 +58,12 @@ func (_m *BlockStore) LoadBlockMeta(height int64) *types.BlockMeta {
 	return r0
 }
 
-type mockConstructorTestingTNewBlockStore interface {
+// NewBlockStore creates a new instance of BlockStore. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewBlockStore(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewBlockStore creates a new instance of BlockStore. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewBlockStore(t mockConstructorTestingTNewBlockStore) *BlockStore {
+}) *BlockStore {
 	mock := &BlockStore{}
 	mock.Mock.Test(t)
 

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/google/uuid v1.3.0
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20220708102147-0a8a51822cae
-	github.com/vektra/mockery/v2 v2.29.0
+	github.com/vektra/mockery/v2 v2.30.1
 	golang.org/x/sync v0.3.0
 	gonum.org/v1/gonum v0.13.0
 	google.golang.org/protobuf v1.30.0

--- a/go.sum
+++ b/go.sum
@@ -860,8 +860,8 @@ github.com/uudashr/gocognit v1.0.6 h1:2Cgi6MweCsdB6kpcVQp7EW4U23iBFQWfTXiWlyp842
 github.com/uudashr/gocognit v1.0.6/go.mod h1:nAIUuVBnYU7pcninia3BHOvQkpQCeO76Uscky5BOwcY=
 github.com/vbatts/tar-split v0.11.3 h1:hLFqsOLQ1SsppQNTMpkpPXClLDfC2A3Zgy9OUU+RVck=
 github.com/vbatts/tar-split v0.11.3/go.mod h1:9QlHN18E+fEH7RdG+QAJJcuya3rqT7eXSTY7wGrAokY=
-github.com/vektra/mockery/v2 v2.29.0 h1:KSFga07FB0LPK6OzNoW8T7KQ2hFPhTykiwDSRFr3FSI=
-github.com/vektra/mockery/v2 v2.29.0/go.mod h1:S1G0O8RZ66tpqfwSiJvi4bzjpk4ces+qEy0xoUG8wRg=
+github.com/vektra/mockery/v2 v2.30.1 h1:IaJch1kGbsitOLzQCNncT9GpLHzJh6VxgXp4MwTHa08=
+github.com/vektra/mockery/v2 v2.30.1/go.mod h1:9lREs4VEeQiUS3rizYQx1saxHu2JiIhThP0q9+fDegM=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=

--- a/light/rpc/mocks/light_client.go
+++ b/light/rpc/mocks/light_client.go
@@ -109,13 +109,12 @@ func (_m *LightClient) VerifyLightBlockAtHeight(ctx context.Context, height int6
 	return r0, r1
 }
 
-type mockConstructorTestingTNewLightClient interface {
+// NewLightClient creates a new instance of LightClient. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewLightClient(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewLightClient creates a new instance of LightClient. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewLightClient(t mockConstructorTestingTNewLightClient) *LightClient {
+}) *LightClient {
 	mock := &LightClient{}
 	mock.Mock.Test(t)
 

--- a/mempool/mocks/mempool.go
+++ b/mempool/mocks/mempool.go
@@ -168,13 +168,12 @@ func (_m *Mempool) Update(blockHeight int64, blockTxs types.Txs, deliverTxRespon
 	return r0
 }
 
-type mockConstructorTestingTNewMempool interface {
+// NewMempool creates a new instance of Mempool. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewMempool(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewMempool creates a new instance of Mempool. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewMempool(t mockConstructorTestingTNewMempool) *Mempool {
+}) *Mempool {
 	mock := &Mempool{}
 	mock.Mock.Test(t)
 

--- a/p2p/mocks/peer.go
+++ b/p2p/mocks/peer.go
@@ -349,13 +349,12 @@ func (_m *Peer) TrySend(_a0 p2p.Envelope) bool {
 	return r0
 }
 
-type mockConstructorTestingTNewPeer interface {
+// NewPeer creates a new instance of Peer. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewPeer(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewPeer creates a new instance of Peer. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewPeer(t mockConstructorTestingTNewPeer) *Peer {
+}) *Peer {
 	mock := &Peer{}
 	mock.Mock.Test(t)
 

--- a/proxy/mocks/app_conn_consensus.go
+++ b/proxy/mocks/app_conn_consensus.go
@@ -211,13 +211,12 @@ func (_m *AppConnConsensus) VerifyVoteExtension(_a0 context.Context, _a1 *types.
 	return r0, r1
 }
 
-type mockConstructorTestingTNewAppConnConsensus interface {
+// NewAppConnConsensus creates a new instance of AppConnConsensus. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewAppConnConsensus(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewAppConnConsensus creates a new instance of AppConnConsensus. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewAppConnConsensus(t mockConstructorTestingTNewAppConnConsensus) *AppConnConsensus {
+}) *AppConnConsensus {
 	mock := &AppConnConsensus{}
 	mock.Mock.Test(t)
 

--- a/proxy/mocks/app_conn_mempool.go
+++ b/proxy/mocks/app_conn_mempool.go
@@ -102,13 +102,12 @@ func (_m *AppConnMempool) SetResponseCallback(_a0 abcicli.Callback) {
 	_m.Called(_a0)
 }
 
-type mockConstructorTestingTNewAppConnMempool interface {
+// NewAppConnMempool creates a new instance of AppConnMempool. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewAppConnMempool(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewAppConnMempool creates a new instance of AppConnMempool. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewAppConnMempool(t mockConstructorTestingTNewAppConnMempool) *AppConnMempool {
+}) *AppConnMempool {
 	mock := &AppConnMempool{}
 	mock.Mock.Test(t)
 

--- a/proxy/mocks/app_conn_query.go
+++ b/proxy/mocks/app_conn_query.go
@@ -107,13 +107,12 @@ func (_m *AppConnQuery) Query(_a0 context.Context, _a1 *types.RequestQuery) (*ty
 	return r0, r1
 }
 
-type mockConstructorTestingTNewAppConnQuery interface {
+// NewAppConnQuery creates a new instance of AppConnQuery. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewAppConnQuery(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewAppConnQuery creates a new instance of AppConnQuery. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewAppConnQuery(t mockConstructorTestingTNewAppConnQuery) *AppConnQuery {
+}) *AppConnQuery {
 	mock := &AppConnQuery{}
 	mock.Mock.Test(t)
 

--- a/proxy/mocks/app_conn_snapshot.go
+++ b/proxy/mocks/app_conn_snapshot.go
@@ -133,13 +133,12 @@ func (_m *AppConnSnapshot) OfferSnapshot(_a0 context.Context, _a1 *types.Request
 	return r0, r1
 }
 
-type mockConstructorTestingTNewAppConnSnapshot interface {
+// NewAppConnSnapshot creates a new instance of AppConnSnapshot. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewAppConnSnapshot(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewAppConnSnapshot creates a new instance of AppConnSnapshot. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewAppConnSnapshot(t mockConstructorTestingTNewAppConnSnapshot) *AppConnSnapshot {
+}) *AppConnSnapshot {
 	mock := &AppConnSnapshot{}
 	mock.Mock.Test(t)
 

--- a/proxy/mocks/client_creator.go
+++ b/proxy/mocks/client_creator.go
@@ -38,13 +38,12 @@ func (_m *ClientCreator) NewABCIClient() (abcicli.Client, error) {
 	return r0, r1
 }
 
-type mockConstructorTestingTNewClientCreator interface {
+// NewClientCreator creates a new instance of ClientCreator. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewClientCreator(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewClientCreator creates a new instance of ClientCreator. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewClientCreator(t mockConstructorTestingTNewClientCreator) *ClientCreator {
+}) *ClientCreator {
 	mock := &ClientCreator{}
 	mock.Mock.Test(t)
 

--- a/state/indexer/mocks/block_indexer.go
+++ b/state/indexer/mocks/block_indexer.go
@@ -88,13 +88,12 @@ func (_m *BlockIndexer) SetLogger(l log.Logger) {
 	_m.Called(l)
 }
 
-type mockConstructorTestingTNewBlockIndexer interface {
+// NewBlockIndexer creates a new instance of BlockIndexer. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewBlockIndexer(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewBlockIndexer creates a new instance of BlockIndexer. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewBlockIndexer(t mockConstructorTestingTNewBlockIndexer) *BlockIndexer {
+}) *BlockIndexer {
 	mock := &BlockIndexer{}
 	mock.Mock.Test(t)
 

--- a/state/mocks/block_store.go
+++ b/state/mocks/block_store.go
@@ -269,13 +269,12 @@ func (_m *BlockStore) Size() int64 {
 	return r0
 }
 
-type mockConstructorTestingTNewBlockStore interface {
+// NewBlockStore creates a new instance of BlockStore. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewBlockStore(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewBlockStore creates a new instance of BlockStore. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewBlockStore(t mockConstructorTestingTNewBlockStore) *BlockStore {
+}) *BlockStore {
 	mock := &BlockStore{}
 	mock.Mock.Test(t)
 

--- a/state/mocks/evidence_pool.go
+++ b/state/mocks/evidence_pool.go
@@ -73,13 +73,12 @@ func (_m *EvidencePool) Update(_a0 state.State, _a1 types.EvidenceList) {
 	_m.Called(_a0, _a1)
 }
 
-type mockConstructorTestingTNewEvidencePool interface {
+// NewEvidencePool creates a new instance of EvidencePool. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewEvidencePool(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewEvidencePool creates a new instance of EvidencePool. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewEvidencePool(t mockConstructorTestingTNewEvidencePool) *EvidencePool {
+}) *EvidencePool {
 	mock := &EvidencePool{}
 	mock.Mock.Test(t)
 

--- a/state/mocks/store.go
+++ b/state/mocks/store.go
@@ -260,13 +260,12 @@ func (_m *Store) SaveFinalizeBlockResponse(_a0 int64, _a1 *abcitypes.ResponseFin
 	return r0
 }
 
-type mockConstructorTestingTNewStore interface {
+// NewStore creates a new instance of Store. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewStore(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewStore creates a new instance of Store. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewStore(t mockConstructorTestingTNewStore) *Store {
+}) *Store {
 	mock := &Store{}
 	mock.Mock.Test(t)
 

--- a/state/txindex/mocks/tx_indexer.go
+++ b/state/txindex/mocks/tx_indexer.go
@@ -105,13 +105,12 @@ func (_m *TxIndexer) SetLogger(l log.Logger) {
 	_m.Called(l)
 }
 
-type mockConstructorTestingTNewTxIndexer interface {
+// NewTxIndexer creates a new instance of TxIndexer. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewTxIndexer(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewTxIndexer creates a new instance of TxIndexer. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewTxIndexer(t mockConstructorTestingTNewTxIndexer) *TxIndexer {
+}) *TxIndexer {
 	mock := &TxIndexer{}
 	mock.Mock.Test(t)
 

--- a/statesync/mocks/state_provider.go
+++ b/statesync/mocks/state_provider.go
@@ -92,13 +92,12 @@ func (_m *StateProvider) State(ctx context.Context, height uint64) (state.State,
 	return r0, r1
 }
 
-type mockConstructorTestingTNewStateProvider interface {
+// NewStateProvider creates a new instance of StateProvider. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewStateProvider(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewStateProvider creates a new instance of StateProvider. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewStateProvider(t mockConstructorTestingTNewStateProvider) *StateProvider {
+}) *StateProvider {
 	mock := &StateProvider{}
 	mock.Mock.Test(t)
 


### PR DESCRIPTION
Supersedes #995.

We have to do this manually because the code that the new version of mockery generates is subtly (but not meaningfully, afaict) different.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

