### PR TITLE
[backport to v0.37.x] config: add bootstrap peers (tendermint#9680)

### DIFF
--- a/.changelog/unreleased/features/9680-config-bootstrap-ppers.md
+++ b/.changelog/unreleased/features/9680-config-bootstrap-ppers.md
@@ -1,0 +1,3 @@
+- `[config]` Introduce `BootstrapPeers` to the config to allow
+  nodes to list peers to be added to the addressbook upon start up.
+  ([\#9680](https://github.com/tendermint/tendermint/pull/9680))

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -20,6 +20,15 @@ coordinated upgrade.
 When upgrading from the v0.34 release series, please note that the Go module has
 now changed to `github.com/cometbft/cometbft`.
 
+## Config Changes
+
+* A new config field, `BootstrapPeers` has been introduced as a means of
+  adding a list of addresses to the addressbook upon initializing a node. This is an
+  alternative to `PersistentPeers`. `PersistentPeers` shold be only used for
+  nodes that you want to keep a constant connection with i.e. sentry nodes
+
+----
+
 ### ABCI Changes
 
 * The `ABCIVersion` is now `1.0.0`.

--- a/cmd/cometbft/commands/run_node.go
+++ b/cmd/cometbft/commands/run_node.go
@@ -66,6 +66,7 @@ func AddNodeFlags(cmd *cobra.Command) {
 	cmd.Flags().String("p2p.external-address", config.P2P.ExternalAddress, "ip:port address to advertise to peers for them to dial")
 	cmd.Flags().String("p2p.seeds", config.P2P.Seeds, "comma-delimited ID@host:port seed nodes")
 	cmd.Flags().String("p2p.persistent_peers", config.P2P.PersistentPeers, "comma-delimited ID@host:port persistent peers")
+	cmd.Flags().String("p2p.bootstrap_peers", config.P2P.BootstrapPeers, "comma-delimited ID@host:port peers to be added to the addressbook on startup")
 	cmd.Flags().String("p2p.unconditional_peer_ids",
 		config.P2P.UnconditionalPeerIDs, "comma-delimited IDs of unconditional peers")
 	cmd.Flags().Bool("p2p.upnp", config.P2P.UPNP, "enable/disable UPNP port forwarding")

--- a/config/config.go
+++ b/config/config.go
@@ -558,6 +558,11 @@ type P2PConfig struct { //nolint: maligned
 	// We only use these if we can’t connect to peers in the addrbook
 	Seeds string `mapstructure:"seeds"`
 
+	// Comma separated list of peers to be added to the peer store
+	// on startup. Either BootstrapPeers or PersistentPeers are
+	// needed for peer discovery
+	BootstrapPeers string `mapstructure:"bootstrap_peers"`
+
 	// Comma separated list of nodes to keep persistent connections to
 	PersistentPeers string `mapstructure:"persistent_peers"`
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -284,6 +284,11 @@ external_address = "{{ .P2P.ExternalAddress }}"
 # Comma separated list of seed nodes to connect to
 seeds = "{{ .P2P.Seeds }}"
 
+# Comma separated list of peers to be added to the peer store
+# on startup. Either BootstrapPeers or PersistentPeers are
+# needed for peer discovery
+bootstrap_peers = "{{ .P2P.BootstrapPeers }}"
+
 # Comma separated list of nodes to keep persistent connections to
 persistent_peers = "{{ .P2P.PersistentPeers }}"
 

--- a/node/node.go
+++ b/node/node.go
@@ -873,6 +873,17 @@ func NewNode(config *cfg.Config,
 		return nil, fmt.Errorf("could not create addrbook: %w", err)
 	}
 
+	for _, addr := range splitAndTrimEmpty(config.P2P.BootstrapPeers, ",", " ") {
+		netAddrs, err := p2p.NewNetAddressString(addr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid bootstrap peer address: %w", err)
+		}
+		err = addrBook.AddAddress(netAddrs, netAddrs)
+		if err != nil {
+			return nil, fmt.Errorf("adding bootstrap address to addressbook: %w", err)
+		}
+	}
+
 	// Optionally, start the pex reactor
 	//
 	// TODO:

--- a/spec/p2p/config.md
+++ b/spec/p2p/config.md
@@ -17,6 +17,14 @@ and upon incoming connection shares some peers and disconnects.
 Dials these seeds when we need more peers. They should return a list of peers and then disconnect.
 If we already have enough peers in the address book, we may never need to dial them.
 
+## Bootstrap Peers
+
+`--p2p.bootstrap_peers “id100000000000000000000000000000000@1.2.3.4:26656,id200000000000000000000000000000000@2.3.4.5:26656”`
+
+A list of peers to be added to the addressbook upon startup to ensure that the node has some peers to initially dial.
+Unlike persistent peers, these addresses don't have any extra privileges. The node may not necessarily connect on redial
+these peers.
+
 ## Persistent Peers
 
 `--p2p.persistent_peers “id100000000000000000000000000000000@1.2.3.4:26656,id200000000000000000000000000000000@2.3.4.5:26656”`


### PR DESCRIPTION
Closes #1016.

Reviewers, please help with the `.changelog/` entry. The remain is just a simple backport from main.