### PR TITLE
Bump logs on non-fatal vote validation failures to Info level

### DIFF
--- a/.changelog/unreleased/improvements/1022-log-invalid-vote-extension.md
+++ b/.changelog/unreleased/improvements/1022-log-invalid-vote-extension.md
@@ -1,0 +1,2 @@
+- `[consensus]` Log vote validation failures at info level
+  ([\#1022](https://github.com/cometbft/cometbft/pull/1022))

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -2057,9 +2057,9 @@ func (cs *State) tryAddVote(vote *types.Vote, peerID p2p.ID) (bool, error) {
 
 			return added, err
 		} else if errors.Is(err, types.ErrVoteNonDeterministicSignature) {
-			cs.Logger.Debug("vote has non-deterministic signature", "err", err)
+			cs.Logger.Info("vote has non-deterministic signature", "err", err)
 		} else if errors.Is(err, types.ErrInvalidVoteExtension) {
-			cs.Logger.Debug("vote has invalid extension")
+			cs.Logger.Info("vote has invalid extension")
 		} else {
 			// Either
 			// 1) bad peer OR


### PR DESCRIPTION
When vote validation errors are processed and "swallowed" without adding the vote, it's important to report them in the logs at level that is normally enabled by operators. This also helps troubleshooting e2e test failures.

---

#### PR checklist

- [ ] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

