### PR TITLE
Update codeowners to include DevRel team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,6 @@
 # global owners are only requested if there isn't a more specific
 # codeowner specified below. For this reason, the global codeowners
 # are often repeated in package-level definitions.
-*     @CometBFT/engineering
+*     @cometbft/engineering @cometbft/devrel
 
-/spec @CometBFT/research @CometBFT/engineering
+/spec @cometbft/research @cometbft/engineering


### PR DESCRIPTION
I noticed that we hadn't added the DevRel team to our CODEOWNERS file yet. This PR updates it.

Also, our org name was changed from "CometBFT" to "cometbft" some time ago, and while this is a purely cosmetic change it probably makes sense to keep it consistent.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

