### PR TITLE
Fix build on mac

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -6,7 +6,9 @@ COMMIT_HASH := $(shell git rev-parse --short HEAD)
 LD_FLAGS = -X github.com/cometbft/cometbft/version.TMGitCommitHash=$(COMMIT_HASH)
 BUILD_FLAGS = -mod=readonly -ldflags "$(LD_FLAGS)"
 # allow users to pass additional flags via the conventional LDFLAGS variable
-LD_FLAGS += $(LDFLAGS)
+ifneq ($(strip $(LDFLAGS)),)
+	LD_FLAGS+=-extldflags=$(LDFLAGS)
+endif
 
 # handle nostrip
 ifeq (nostrip,$(findstring nostrip,$(COMETBFT_BUILD_OPTIONS)))


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

Run `make build` on Mac encountered the following error:
```
CGO_ENABLED=0 go build -mod=readonly -ldflags "-X github.com/cometbft/cometbft/version.TMGitCommitHash=b23ef56f8 -L/opt/homebrew/opt/llvm@15/lib -s -w" -trimpath -tags 'cometbft' -o /Users/zc/Desktop/Workspace/zhongtai/github/cometbft/cometbft/build/cometbft ./cmd/cometbft/
# github.com/cometbft/cometbft/cmd/cometbft
flag provided but not defined: -L/opt/homebrew/opt/llvm@15/lib
usage: link [options] main.o
```

Added a fix that may solve this.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

