### PR TITLE
fix: rollback set incorrect `LastHeightValidatorsChanged`

### DIFF
--- a/.changelog/unreleased/bug-fixes/1075-fix-rollback-validator-set.md
+++ b/.changelog/unreleased/bug-fixes/1075-fix-rollback-validator-set.md
@@ -1,0 +1,1 @@
+- `[state]` \#1075 When rollback, persist the new validator set if changed. (@yihuang)

--- a/state/rollback.go
+++ b/state/rollback.go
@@ -66,9 +66,9 @@ func Rollback(bs BlockStore, ss Store, removeBlock bool) (int64, []byte, error) 
 	}
 
 	valChangeHeight := invalidState.LastHeightValidatorsChanged
-	// this can only happen if the validator set changed since the last block
-	if valChangeHeight > rollbackHeight {
-		valChangeHeight = rollbackHeight + 1
+	// if validator set was changed in the last block, we just persist the new validator set,
+	if valChangeHeight > rollbackHeight+2 {
+		valChangeHeight = rollbackHeight + 2
 	}
 
 	paramsChangeHeight := invalidState.LastHeightConsensusParamsChanged

--- a/state/rollback_test.go
+++ b/state/rollback_test.go
@@ -263,7 +263,7 @@ func setupStateStore(t *testing.T, height int64) state.Store {
 		LastValidators:                   valSet,
 		Validators:                       valSet.CopyIncrementProposerPriority(1),
 		NextValidators:                   valSet.CopyIncrementProposerPriority(2),
-		LastHeightValidatorsChanged:      height + 1,
+		LastHeightValidatorsChanged:      height + 2,
 		ConsensusParams:                  *params,
 		LastHeightConsensusParamsChanged: height + 1,
 	}


### PR DESCRIPTION
Closes: #1074

Solution:
- persist the new validator set if changed.

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

