### PR TITLE
Log proposer's address when correctly accepting a proposal

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1899,7 +1899,7 @@ func (cs *State) defaultSetProposal(proposal *types.Proposal) error {
 		cs.ProposalBlockParts = types.NewPartSetFromHeader(proposal.BlockID.PartSetHeader)
 	}
 
-	cs.Logger.Info("received proposal", "proposal", proposal)
+	cs.Logger.Info("received proposal", "proposal", proposal, "proposer", cs.Validators.GetProposer().Address)
 	return nil
 }
 

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1039,7 +1039,7 @@ func (cs *State) enterNewRound(height int64, round int32) {
 		logger.Debug("need to set a buffer and log message here for sanity", "start_time", cs.StartTime, "now", now)
 	}
 
-	logger.Debug("entering new round", "current", log.NewLazySprintf("%v/%v/%v", cs.Height, cs.Round, cs.Step))
+	prevHeight, prevRound, prevStep := cs.Height, cs.Round, cs.Step
 
 	// increment validators if necessary
 	validators := cs.Validators
@@ -1055,12 +1055,18 @@ func (cs *State) enterNewRound(height int64, round int32) {
 	cs.Validators = validators
 	// If round == 0, we've already reset these upon new height, and meanwhile
 	// we might have received a proposal for round 0.
+	propAddress := validators.GetProposer().PubKey.Address()
 	if round != 0 {
-		logger.Debug("resetting proposal info")
+		logger.Info("resetting proposal info", "proposer", propAddress)
 		cs.Proposal = nil
 		cs.ProposalBlock = nil
 		cs.ProposalBlockParts = nil
 	}
+
+	logger.Debug("entering new round",
+		"previous", log.NewLazySprintf("%v/%v/%v", prevHeight, prevRound, prevStep),
+		"proposer", propAddress,
+	)
 
 	cs.Votes.SetRound(cmtmath.SafeAddInt32(round, 1)) // also track next round (round+1) to allow round-skipping
 	cs.TriggeredTimeoutPrecommit = false
@@ -1884,7 +1890,8 @@ func (cs *State) defaultSetProposal(proposal *types.Proposal) error {
 
 	p := proposal.ToProto()
 	// Verify signature
-	if !cs.Validators.GetProposer().PubKey.VerifySignature(
+	pubKey := cs.Validators.GetProposer().PubKey
+	if !pubKey.VerifySignature(
 		types.ProposalSignBytes(cs.state.ChainID, p), proposal.Signature,
 	) {
 		return ErrInvalidProposalSignature
@@ -1899,7 +1906,7 @@ func (cs *State) defaultSetProposal(proposal *types.Proposal) error {
 		cs.ProposalBlockParts = types.NewPartSetFromHeader(proposal.BlockID.PartSetHeader)
 	}
 
-	cs.Logger.Info("received proposal", "proposal", proposal, "proposer", cs.Validators.GetProposer().Address)
+	cs.Logger.Info("received proposal", "proposal", proposal, "proposer", pubKey.Address())
 	return nil
 }
 

--- a/state/execution.go
+++ b/state/execution.go
@@ -264,7 +264,7 @@ func (blockExec *BlockExecutor) ApplyBlock(
 		return state, err
 	}
 	if len(validatorUpdates) > 0 {
-		blockExec.logger.Debug("updates to validators", "updates", types.ValidatorListString(validatorUpdates))
+		blockExec.logger.Info("updates to validators", "updates", types.ValidatorListString(validatorUpdates))
 		blockExec.metrics.ValidatorSetUpdates.Add(1)
 	}
 	if abciResponse.ConsensusParamUpdates != nil {


### PR DESCRIPTION
Contributes to #907 

While troubleshooting today, a key info we needed was missing in our Info logs

Tested via e2e:
```
full02       | I[2023-07-04|14:27:28.059] received proposal                            module=consensus proposal="Proposal{1059/1 (2DF98F8362C45180CEF86031DA7C5CBA7AAA2DBD52FF889DC80C508DFEC5CDC7:1:77AEA1FD157
2, -1) 24AD3C5810DE @ 2023-07-04T14:27:27.804019764Z}" proposer=07EB27AE0D0607DB338F1F102B3C25049FE04C68
```

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

