### PR TITLE
RFC 104: Rename proto versions to pre-v1 betas

### DIFF
--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -46,3 +46,4 @@ relating to Tendermint Core prior to forking, please see
 - [RFC-101: Banning peers based on ResponseCheckTx](./rfc-101-p2p-bad-peers-checktx.md)
 - [RFC-102: Improve forward compatibility of proto-generated Rust code](./rfc-102-rust-gen-builders.md)
 - [RFC-103: Incoming transactions when node is catching up](./rfc-103-incoming-txs-when-catching-up.md)
+- [RFC-104: Rename proto versions to pre-v1 betas](./rfc-104-betaize-proto-versions.md)

--- a/docs/rfc/rfc-104-betaize-proto-versions.md
+++ b/docs/rfc/rfc-104-betaize-proto-versions.md
@@ -1,0 +1,61 @@
+# RFC 104: Rename proto versions to pre-v1 betas
+
+## Changelog
+
+- 2023-07-05: Initial version
+
+## Abstract
+
+In process of introducing buf-approved versioning in protobuf, we have created
+versioned package suffixes starting at `v1` and climbing, in some cases,
+already to `v4`. Considering that in terms of general project versions, we are
+still in the 0.x phase, this storied history will look odd in the future
+where we arrive at the release 1.0 and eventually retire pre-1.0 APIs.
+As we have not yet released the proto modules as a semver-compliant buf module,
+we still have the freedom to rename the current version suffixes to
+`v1beta1`, `v1beta2`, ..., with the intent that the definitions in the 1.0
+release become `v1`.
+
+## Background
+
+The drive to introduce [protobuf versioning][cometbft#95] resulted in
+introducing versioned packages for protobuf definitions corresponding to
+each of the major CometBFT releases starting from 0.34. By the upcoming 0.39
+release, some of the packages will get up to `v4`, as the development churn
+and the intent to perform code style grooming have resulted in
+backward-incompatible changes every time. All this storied history
+has not yet been released with semver commitments on [buf schema registry][bsr]
+or even merged into the main branch at the time of this writing.
+
+Efforts to conform to the [buf style guide][buf-style]
+(started with [#736][cometbft#736]) have been confined to latter versions
+of the proto packages in order to preserve source code compatibility
+and ease migration for developers. The earlier packages, therefore, do not
+constitute exemplary protobuf material and may even be rejected by a schema
+repository linter.
+
+### References
+
+* [ADR 103]: Protobuf definition versioning
+* [cometbft#95], the meta tracking issue.
+
+[ADR 103]: https://github.com/cometbft/cometbft/blob/main/docs/architecture/adr-103-proto-versioning.md
+[cometbft#95]: https://github.com/cometbft/cometbft/issues/95
+[cometbft#736]: https://github.com/cometbft/cometbft/issues/736
+[bsr]: https://buf.build/product/bsr/
+[buf-style]: https://buf.build/docs/best-practices/style-guide
+
+## Discussion
+
+Come 1.0 release time, we should find ourselves with a storied collection of
+versioned protobuf packages going up to `v4` or `v5` for some packages,
+where earlier versions refer to pre-1.0 releases and are in places
+stylistically bad.
+This RFC proposes to make the historic status of these protocol versions
+explicit by renaming the current suffixes to `v1beta1`, `v1beta2`, and so on.
+The protobufs that make it to 1.0 will be consistently placed in new packages
+suffixed with `v1`, representing a long-term commitment to maintaining
+backward compatibility.
+
+The [ADR 103] will be updated with the proposed changes if the discussion
+resolves in agreement to proceed.


### PR DESCRIPTION
Improvement proposal for #95 to make protobuf versioning cleaner on the way to the 1.0 release.

[Rendered](https://github.com/cometbft/cometbft/blob/mikhail/rfc-104-betaize-proto-versions/docs/rfc/rfc-104-betaize-proto-versions.md)