### PR TITLE
Revert "config: add bootstrap peers (#9680)"

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,10 +6,6 @@ This guide provides instructions for upgrading to specific versions of CometBFT.
 
 ### Config Changes
 
-* A new config field, `BootstrapPeers` has been introduced as a means of
-  adding a list of addresses to the address book upon initializing a node. This is an
-  alternative to `PersistentPeers`. `PersistentPeers` should be only used for
-  nodes that you want to keep a constant connection with i.e. sentry nodes
 * The field `Version` in the mempool section has been removed. The priority
   mempool (what was called version `v1`) has been removed (see below), thus
   there is only one implementation of the mempool available (what was called

--- a/cmd/cometbft/commands/run_node.go
+++ b/cmd/cometbft/commands/run_node.go
@@ -59,7 +59,6 @@ func AddNodeFlags(cmd *cobra.Command) {
 	cmd.Flags().String("p2p.external-address", config.P2P.ExternalAddress, "ip:port address to advertise to peers for them to dial")
 	cmd.Flags().String("p2p.seeds", config.P2P.Seeds, "comma-delimited ID@host:port seed nodes")
 	cmd.Flags().String("p2p.persistent_peers", config.P2P.PersistentPeers, "comma-delimited ID@host:port persistent peers")
-	cmd.Flags().String("p2p.bootstrap_peers", config.P2P.BootstrapPeers, "comma-delimited ID@host:port peers to be added to the addressbook on startup")
 	cmd.Flags().String("p2p.unconditional_peer_ids",
 		config.P2P.UnconditionalPeerIDs, "comma-delimited IDs of unconditional peers")
 	cmd.Flags().Bool("p2p.upnp", config.P2P.UPNP, "enable/disable UPNP port forwarding")

--- a/config/config.go
+++ b/config/config.go
@@ -518,11 +518,6 @@ type P2PConfig struct { //nolint: maligned
 	// We only use these if we can’t connect to peers in the addrbook
 	Seeds string `mapstructure:"seeds"`
 
-	// Comma separated list of peers to be added to the peer store
-	// on startup. Either BootstrapPeers or PersistentPeers are
-	// needed for peer discovery
-	BootstrapPeers string `mapstructure:"bootstrap_peers"`
-
 	// Comma separated list of nodes to keep persistent connections to
 	PersistentPeers string `mapstructure:"persistent_peers"`
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -264,11 +264,6 @@ external_address = "{{ .P2P.ExternalAddress }}"
 # Comma separated list of seed nodes to connect to
 seeds = "{{ .P2P.Seeds }}"
 
-# Comma separated list of peers to be added to the peer store
-# on startup. Either bootstrap_peers or persistent_peers is
-# needed for peer discovery
-bootstrap_peers = "{{ .P2P.BootstrapPeers }}"
-
 # Comma separated list of nodes to keep persistent connections to
 persistent_peers = "{{ .P2P.PersistentPeers }}"
 

--- a/docs/core/configuration.md
+++ b/docs/core/configuration.md
@@ -215,11 +215,6 @@ external_address = ""
 # Comma separated list of seed nodes to connect to
 seeds = ""
 
-# Comma separated list of peers to be added to the peer store
-# on startup. Either bootstrap_peers or persistent_peers is
-# needed for peer discovery
-bootstrap_peers = ""
-
 # Comma separated list of nodes to keep persistent connections to
 persistent_peers = ""
 
@@ -298,7 +293,6 @@ broadcast = true
 # wal_dir (default: "") configures the location of the Write Ahead Log
 # (WAL) for the mempool. The WAL is disabled by default. To enable, set
 # wal_dir to where you want the WAL to be written (e.g.
-# "data/mempool.wal").
 # "data/mempool.wal").
 wal_dir = ""
 

--- a/node/node.go
+++ b/node/node.go
@@ -300,17 +300,6 @@ func NewNode(ctx context.Context,
 		return nil, fmt.Errorf("could not create addrbook: %w", err)
 	}
 
-	for _, addr := range splitAndTrimEmpty(config.P2P.BootstrapPeers, ",", " ") {
-		netAddrs, err := p2p.NewNetAddressString(addr)
-		if err != nil {
-			return nil, fmt.Errorf("invalid bootstrap peer address: %w", err)
-		}
-		err = addrBook.AddAddress(netAddrs, netAddrs)
-		if err != nil {
-			return nil, fmt.Errorf("adding bootstrap address to addressbook: %w", err)
-		}
-	}
-
 	// Optionally, start the pex reactor
 	//
 	// TODO:

--- a/spec/p2p/legacy-docs/config.md
+++ b/spec/p2p/legacy-docs/config.md
@@ -17,14 +17,6 @@ and upon incoming connection shares some peers and disconnects.
 Dials these seeds when we need more peers. They should return a list of peers and then disconnect.
 If we already have enough peers in the address book, we may never need to dial them.
 
-## Bootstrap Peers
-
-`--p2p.bootstrap_peers “id100000000000000000000000000000000@1.2.3.4:26656,id200000000000000000000000000000000@2.3.4.5:26656”`
-
-A list of peers to be added to the addressbook upon startup to ensure that the node has some peers to initially dial.
-Unlike persistent peers, these addresses don't have any extra privileges. The node may not necessarily connect on redial
-these peers.
-
 ## Persistent Peers
 
 `--p2p.persistent_peers “id100000000000000000000000000000000@1.2.3.4:26656,id200000000000000000000000000000000@2.3.4.5:26656”`


### PR DESCRIPTION
This reverts commit f12588aab1f1b52ffa82ed143676d69e2fab7bf4.

This configuration parameter was first introduced in the `v0.35.x` branch (https://github.com/tendermint/tendermint/pull/6372), then forward-ported to `main` after the retraction of this release (https://github.com/tendermint/tendermint/pull/9680).

More recently, users have requested its inclusion on the `v0.37.x` release branch (https://github.com/cometbft/cometbft/issues/1016). However, when backporting this commit from main (https://github.com/cometbft/cometbft/pull/1019), the reviewers have observed a number of minor issues both in the code and in the documentation of the introduced parameter: 

- The documentation of the introduced configuration parameter is imprecise and it is not following the proper naming adopted for CometBFT's configuration TOML file
- The configured bootstrap peer addresses are added to the address book using a source address that is likely incorrect, as it differs from the source address adopted when manually adding other addresses (e.g. persistent peers) to the address book
- Contrarily to other p2p parameters, there is not method inside the `p2p` package responsible for configuring the provided peer addresses, which in particular renders testing more complex
- No tests were provided to check the operation of the introduced configuration parameter

Given the above summarized issues and provided that this configuration parameter, while useful and good to have, it is not required for a proper operation of a CometBFT node, the team has decided to block the backporting of https://github.com/tendermint/tendermint/pull/9680 to the `v0.37.x` release and to revert it from both `main` and `v0.38.x` branches.