### PR TITLE
mempool: Fix mempool capacity when testing

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -745,6 +745,7 @@ func DefaultMempoolConfig() *MempoolConfig {
 // TestMempoolConfig returns a configuration for testing the CometBFT mempool
 func TestMempoolConfig() *MempoolConfig {
 	cfg := DefaultMempoolConfig()
+	cfg.Size = 1000
 	cfg.CacheSize = 1000
 	return cfg
 }
@@ -773,6 +774,9 @@ func (cfg *MempoolConfig) ValidateBasic() error {
 	}
 	if cfg.MaxTxBytes < 0 {
 		return errors.New("max_tx_bytes can't be negative")
+	}
+	if cfg.Size > cfg.CacheSize {
+		return errors.New("mempool's cache cannot be smaller than mempool's capacity")
 	}
 	return nil
 }

--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -646,21 +646,28 @@ func TestMempoolNoCacheOverflow(t *testing.T) {
 	mp, cleanup := newMempoolWithAppAndConfig(proxy.NewRemoteClientCreator(sockPath, "socket", true), cfg)
 	defer cleanup()
 
+	// create N + 1 transactions, with N = the capacity of the cache
+	txs := newUniqueTxs(mp.config.CacheSize)
+	tx0 := kvstore.NewTxFromID(mp.config.CacheSize)
+
 	// add tx0
-	var tx0 = kvstore.NewTxFromID(0)
 	err := mp.CheckTx(tx0, nil, TxInfo{})
 	require.NoError(t, err)
 	err = mp.FlushAppConn()
 	require.NoError(t, err)
 
 	// saturate the cache to remove tx0
-	for i := 1; i <= mp.config.CacheSize; i++ {
-		err = mp.CheckTx(kvstore.NewTxFromID(i), nil, TxInfo{})
+	for _, tx := range txs {
+		err = mp.CheckTx(tx, nil, TxInfo{})
 		require.NoError(t, err)
 	}
 	err = mp.FlushAppConn()
 	require.NoError(t, err)
-	assert.False(t, mp.cache.Has(kvstore.NewTxFromID(0)))
+	assert.False(t, mp.cache.Has(tx0))
+
+	// update one transaction to make space for tx0 in the mempool
+	err = mp.Update(1, txs[:1], abciResponses(1, abci.CodeTypeOK), nil, nil)
+	require.NoError(t, err)
 
 	// add again tx0
 	err = mp.CheckTx(tx0, nil, TxInfo{})
@@ -676,6 +683,14 @@ func TestMempoolNoCacheOverflow(t *testing.T) {
 		}
 	}
 	assert.True(t, found == 1)
+}
+
+func newUniqueTxs(n int) types.Txs {
+	txs := make(types.Txs, n)
+	for i := 0; i < n; i++ {
+		txs[i] = kvstore.NewTxFromID(i)
+	}
+	return txs
 }
 
 // This will non-deterministically catch some concurrency failures like
@@ -748,14 +763,18 @@ func doCommit(t require.TestingT, mp Mempool, app abci.Application, txs types.Tx
 	for i, tx := range txs {
 		rfb.Txs[i] = tx
 	}
-	_, e := app.FinalizeBlock(context.Background(), rfb)
-	require.True(t, e == nil)
+	_, err := app.FinalizeBlock(context.Background(), rfb)
+	require.Nil(t, err)
+
 	mp.Lock()
-	e = mp.FlushAppConn()
-	require.True(t, e == nil)
-	_, e = app.Commit(context.Background(), &abci.RequestCommit{})
-	require.True(t, e == nil)
-	e = mp.Update(height, txs, abciResponses(txs.Len(), abci.CodeTypeOK), nil, nil)
-	require.True(t, e == nil)
-	mp.Unlock()
+	defer mp.Unlock()
+
+	err = mp.FlushAppConn()
+	require.Nil(t, err)
+
+	_, err = app.Commit(context.Background(), &abci.RequestCommit{})
+	require.Nil(t, err)
+
+	err = mp.Update(height, txs, abciResponses(txs.Len(), abci.CodeTypeOK), nil, nil)
+	require.Nil(t, err)
 }


### PR DESCRIPTION
The mempool configuration used for testing has some values that are not realistic: the mempool size is 5000 (the default value) while the cache is set to 1000. 

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

