### PR TITLE
ci: Trigger workflows on merge group

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ name: Build
 # All jobs will pass without running if no *{.go, .mod, .sum} files have been modified
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - main

--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,6 +13,7 @@ name: "CodeQL"
 
 on:
   workflow_dispatch:
+  merge_group:
   push:
     branches: ["main"]
   pull_request:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,6 +4,7 @@ name: e2e
 on:
   workflow_dispatch:  # allow running workflow manually
   pull_request:
+  merge_group:
   push:
     branches:
       - main

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -6,6 +6,7 @@ name: Check for Go vulnerabilities
 # Run `make vulncheck` from the root of the repo to run this workflow locally.
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - main

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,7 @@ name: Golang Linter
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - main

--- a/.github/workflows/proto-lint.yml
+++ b/.github/workflows/proto-lint.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - 'proto/**'
+  merge_group:
   push:
     branches:
       - main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,7 @@
 name: Test
 on:
   pull_request:
+  merge_group:
   push:
     paths:
       - "**.go"


### PR DESCRIPTION
In order to enable merge queues on `main`, we first need to add the `merge_group` workflow trigger.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

