### PR TITLE
node: Revert removal of public reactor accessors

### DIFF
--- a/.changelog/unreleased/breaking-changes/1120-node-api-cleanup.md
+++ b/.changelog/unreleased/breaking-changes/1120-node-api-cleanup.md
@@ -1,0 +1,3 @@
+- `[node]` Removed `ConsensusState()` accessor from `Node`
+  package - all access to consensus state should go via the reactor
+  ([\#1120](https://github.com/cometbft/cometbft/pull/1120))

--- a/.changelog/unreleased/breaking-changes/1120-node-api-cleanup.md
+++ b/.changelog/unreleased/breaking-changes/1120-node-api-cleanup.md
@@ -1,3 +1,3 @@
 - `[node]` Removed `ConsensusState()` accessor from `Node`
-  package - all access to consensus state should go via the reactor
+  struct - all access to consensus state should go via the reactor
   ([\#1120](https://github.com/cometbft/cometbft/pull/1120))

--- a/node/node.go
+++ b/node/node.go
@@ -676,11 +676,6 @@ func (n *Node) BlockStore() *store.BlockStore {
 	return n.blockStore
 }
 
-// ConsensusState returns the Node's ConsensusState.
-func (n *Node) ConsensusState() *cs.State {
-	return n.consensusState
-}
-
 // ConsensusReactor returns the Node's ConsensusReactor.
 func (n *Node) ConsensusReactor() *cs.Reactor {
 	return n.consensusReactor

--- a/node/node.go
+++ b/node/node.go
@@ -61,6 +61,7 @@ type Node struct {
 	stateStore        sm.Store
 	blockStore        *store.BlockStore // store the blockchain to disk
 	bcReactor         p2p.Reactor       // for block-syncing
+	mempoolReactor    p2p.Reactor       // for gossipping transactions
 	mempool           mempl.Mempool
 	stateSync         bool                    // whether the node should state sync on startup
 	stateSyncReactor  *statesync.Reactor      // for hosting and restoring state sync snapshots
@@ -68,6 +69,7 @@ type Node struct {
 	stateSyncGenesis  sm.State                // provides the genesis state for state sync
 	consensusState    *cs.State               // latest consensus state
 	consensusReactor  *cs.Reactor             // for participating in the consensus
+	pexReactor        *pex.Reactor            // for exchanging peer addresses
 	evidencePool      *evidence.Pool          // tracking evidence
 	proxyApp          proxy.AppConns          // connection to the application
 	rpcListeners      []net.Listener          // rpc servers
@@ -323,8 +325,9 @@ func NewNode(ctx context.Context,
 	//
 	// If PEX is on, it should handle dialing the seeds. Otherwise the switch does it.
 	// Note we currently use the addrBook regardless at least for AddOurAddress
+	var pexReactor *pex.Reactor
 	if config.P2P.PexReactor {
-		createPEXReactorAndAddToSwitch(addrBook, config, sw, logger)
+		pexReactor = createPEXReactorAndAddToSwitch(addrBook, config, sw, logger)
 	}
 
 	// Add private IDs to addrbook to block those peers being added
@@ -344,12 +347,14 @@ func NewNode(ctx context.Context,
 		stateStore:       stateStore,
 		blockStore:       blockStore,
 		bcReactor:        bcReactor,
+		mempoolReactor:   mempoolReactor,
 		mempool:          mempool,
 		consensusState:   consensusState,
 		consensusReactor: consensusReactor,
 		stateSyncReactor: stateSyncReactor,
 		stateSync:        stateSync,
 		stateSyncGenesis: state, // Shouldn't be necessary, but need a way to pass the genesis state
+		pexReactor:       pexReactor,
 		evidencePool:     evidencePool,
 		proxyApp:         proxyApp,
 		txIndexer:        txIndexer,
@@ -666,9 +671,39 @@ func (n *Node) Switch() *p2p.Switch {
 	return n.sw
 }
 
+// BlockStore returns the Node's BlockStore.
+func (n *Node) BlockStore() *store.BlockStore {
+	return n.blockStore
+}
+
+// ConsensusState returns the Node's ConsensusState.
+func (n *Node) ConsensusState() *cs.State {
+	return n.consensusState
+}
+
+// ConsensusReactor returns the Node's ConsensusReactor.
+func (n *Node) ConsensusReactor() *cs.Reactor {
+	return n.consensusReactor
+}
+
+// MempoolReactor returns the Node's mempool reactor.
+func (n *Node) MempoolReactor() p2p.Reactor {
+	return n.mempoolReactor
+}
+
 // Mempool returns the Node's mempool.
 func (n *Node) Mempool() mempl.Mempool {
 	return n.mempool
+}
+
+// PEXReactor returns the Node's PEXReactor. It returns nil if PEX is disabled.
+func (n *Node) PEXReactor() *pex.Reactor {
+	return n.pexReactor
+}
+
+// EvidencePool returns the Node's EvidencePool.
+func (n *Node) EvidencePool() *evidence.Pool {
+	return n.evidencePool
 }
 
 // EventBus returns the Node's EventBus.
@@ -685,6 +720,11 @@ func (n *Node) PrivValidator() types.PrivValidator {
 // GenesisDoc returns the Node's GenesisDoc.
 func (n *Node) GenesisDoc() *types.GenesisDoc {
 	return n.genesisDoc
+}
+
+// ProxyApp returns the Node's AppConns, representing its connections to the ABCI application.
+func (n *Node) ProxyApp() proxy.AppConns {
+	return n.proxyApp
 }
 
 // Config returns the Node's config.

--- a/node/setup.go
+++ b/node/setup.go
@@ -453,7 +453,7 @@ func createAddrBookAndSetOnSwitch(config *cfg.Config, sw *p2p.Switch,
 
 func createPEXReactorAndAddToSwitch(addrBook pex.AddrBook, config *cfg.Config,
 	sw *p2p.Switch, logger log.Logger,
-) {
+) *pex.Reactor {
 	// TODO persistent peers ? so we can have their DNS addrs saved
 	pexReactor := pex.NewReactor(addrBook,
 		&pex.ReactorConfig{
@@ -469,6 +469,7 @@ func createPEXReactorAndAddToSwitch(addrBook pex.AddrBook, config *cfg.Config,
 		})
 	pexReactor.SetLogger(logger.With("module", "pex"))
 	sw.AddReactor("PEX", pexReactor)
+	return pexReactor
 }
 
 // startStateSync starts an asynchronous state sync process, then switches to block sync mode.

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -161,7 +161,7 @@ func WithMetrics(metrics *Metrics) SwitchOption {
 
 // AddReactor adds the given reactor to the switch.
 // NOTE: Not goroutine safe.
-func (sw *Switch) AddReactor(name string, reactor Reactor) {
+func (sw *Switch) AddReactor(name string, reactor Reactor) Reactor {
 	for _, chDesc := range reactor.GetChannels() {
 		chID := chDesc.ID
 		// No two reactors can share the same channel.
@@ -174,6 +174,7 @@ func (sw *Switch) AddReactor(name string, reactor Reactor) {
 	}
 	sw.reactors[name] = reactor
 	reactor.SetSwitch(sw)
+	return reactor
 }
 
 // RemoveReactor removes the given Reactor from the Switch.


### PR DESCRIPTION
Reverts #286 to reintroduce access to reactors via the `Node`.

To be backported to v0.38.

---

#### PR checklist

- [ ] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

