### PR TITLE
ci: Disable CodeQL check in merge queues

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,7 +13,6 @@ name: "CodeQL"
 
 on:
   workflow_dispatch:
-  merge_group:
   push:
     branches: ["main"]
   pull_request:


### PR DESCRIPTION
Seems as though the CodeQL checks are failing on `merge_group` for some reason: https://github.com/cometbft/cometbft/actions/runs/5555159575/jobs/10145922428 - seems like it can't find the code it's supposed to check.

I'm not sure if that check's compatible with merge queues, so I'll disable this check for now. It still gets run on pull requests and pushes to `main` as it always was.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

