### PR TITLE
Release v0.38.0-rc3

### DIFF
--- a/.changelog/unreleased/features/9680-config-introduce-bootstrappeers.md
+++ b/.changelog/unreleased/features/9680-config-introduce-bootstrappeers.md
@@ -1,3 +1,0 @@
-- `[config]` Introduce `BootstrapPeers` to the config to allow
-  nodes to list peers to be added to the addressbook upon start up.
-  ([\#9680](https://github.com/tendermint/tendermint/pull/9680))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,9 +98,6 @@ for people who forked CometBFT and interact directly with the indexers kvstore.
 
 ### FEATURES
 
-- `[config]` Introduce `BootstrapPeers` to the config to allow
-  nodes to list peers to be added to the addressbook upon start up.
-  ([\#9680](https://github.com/tendermint/tendermint/pull/9680))
 - `[proxy]` Introduce `NewUnsyncLocalClientCreator`, which allows local ABCI
   clients to have the same concurrency model as remote clients (i.e. one
   mutex per client "connection", for each of the four ABCI "connections").

--- a/version/version.go
+++ b/version/version.go
@@ -3,7 +3,7 @@ package version
 const (
 	// TMVersionDefault is the used as the fallback version of CometBFT
 	// when not using git describe. It is formatted with semantic versioning.
-	TMCoreSemVer = "0.38.0-rc2"
+	TMCoreSemVer = "0.38.0-rc3"
 	// ABCISemVer is the semantic version of the ABCI protocol
 	ABCISemVer  = "2.0.0"
 	ABCIVersion = ABCISemVer


### PR DESCRIPTION
:book: [CHANGELOG rendered](https://github.com/cometbft/cometbft/blob/release/v0.38.0-rc3/CHANGELOG.md)

Applies two reverts:
- #1120 
- #1121 

E2E nightlies manual run for this branch: https://github.com/cometbft/cometbft/actions/runs/5555876254

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

