### PR TITLE
E2E: Add support for fast prototyping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -180,6 +180,7 @@ require (
 	github.com/jinzhu/copier v0.3.5 // indirect
 	github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af // indirect
 	github.com/jmhodges/levigo v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/julz/importas v0.1.0 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/kisielk/errcheck v1.6.3 // indirect
@@ -207,6 +208,8 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/moby/term v0.5.0 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/moricho/tparallel v0.3.1 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/nakabonne/nestif v0.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -515,6 +515,7 @@ github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlT
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
@@ -606,9 +607,11 @@ github.com/moby/sys/mountinfo v0.5.0/go.mod h1:3bMD3Rg+zkqx8MRYPi7Pyb0Ie97QEBmdx
 github.com/moby/term v0.5.0 h1:xt8Q1nalod/v7BqbG21f8mQPqH+xAaC9C3N3wfWbVP0=
 github.com/moby/term v0.5.0/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/moricho/tparallel v0.3.1 h1:fQKD4U1wRMAYNngDonW5XupoB/ZGJHdpzrWqgyg9krA=
 github.com/moricho/tparallel v0.3.1/go.mod h1:leENX2cUv7Sv2qDgdi0D0fCftN8fRC67Bcn8pqzeYNI=
@@ -912,6 +915,7 @@ go.tmz.dev/musttag v0.7.0/go.mod h1:oTFPvgOkJmp5kYL02S8+jrH0eLrBIl57rzWeA26zDEM=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
 go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.1.11 h1:wy28qYRKZgnJTxGxvye5/wgWr1EKjmUDGYox5mGlRlI=
+go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.24.0 h1:FiJd5l1UOLj0wCgbSE0rwwXHzEdAZS6hiiSnxJN/D60=
@@ -961,6 +965,7 @@ golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRu
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -11,7 +11,7 @@ import (
 	abcicli "github.com/cometbft/cometbft/abci/client"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/libs/log"
-	"github.com/cometbft/cometbft/types"
+	types "github.com/cometbft/cometbft/types"
 )
 
 const (
@@ -221,6 +221,14 @@ type Entry struct {
 
 func (memE *Entry) Height() int64 {
 	return atomic.LoadInt64(&memE.height)
+}
+
+func (memE *Entry) GetTxKey() types.TxKey {
+	return memE.tx.Key()
+}
+
+func (memE *Entry) GetTx() types.Tx {
+	return memE.tx
 }
 
 type Iterator interface {

--- a/p2p/mock/reactor.go
+++ b/p2p/mock/reactor.go
@@ -1,7 +1,6 @@
 package mock
 
 import (
-	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/p2p"
 	"github.com/cometbft/cometbft/p2p/conn"
 )
@@ -15,7 +14,6 @@ type Reactor struct {
 func NewReactor() *Reactor {
 	r := &Reactor{}
 	r.BaseReactor = *p2p.NewBaseReactor("Mock-PEX", r)
-	r.SetLogger(log.TestingLogger())
 	return r
 }
 

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -1,8 +1,6 @@
-COMETBFT_BUILD_OPTIONS += badgerdb,boltdb,cleveldb,rocksdb
-
 include ../../common.mk
 
-all: docker generator runner
+all: node generator runner docker
 
 docker:
 	@echo "Building E2E Docker image"
@@ -16,17 +14,22 @@ docker-debug:
 		--tag cometbft/e2e-node:local-version \
 		-f docker/Dockerfile.debug ../..
 
+docker-fast:
+	@echo "Building fast-prototyping E2E Docker image"
+	@docker build \
+		--tag cometbft/e2e-node:local-version \
+		-f docker/Dockerfile.fast .
+
 # We need to build support for database backends into the app in
 # order to build a binary with a CometBFT node in it (for built-in
 # ABCI testing).
 node:
-	go build -race $(BUILD_FLAGS) -tags '$(BUILD_TAGS)' -o build/node ./node
-
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o build/node ./node
 
 generator:
-	go build -o build/generator ./generator
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o build/generator ./generator
 
 runner:
-	go build -o build/runner ./runner
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o build/runner ./runner
 
-.PHONY: all node docker generator runner 
+.PHONY: all node docker generator runner

--- a/test/e2e/app/app.go
+++ b/test/e2e/app/app.go
@@ -101,6 +101,12 @@ type Config struct {
 
 	// Vote extension padding size, to simulate different vote extension sizes.
 	VoteExtensionSize uint `toml:"vote_extension_size"`
+
+	// Inject custom reactors (see node/main.go#startNode for a list of possibilities)
+	ExperimentalCustomReactors map[string]string `toml:"experimental_custom_reactors"`
+
+	// Set gossip propagation rate (experimental mempool)
+	ExperimentalGossipPropagationRate float32 `toml:"experimental_gossip_propagation_rate"`
 }
 
 func DefaultConfig(dir string) *Config {

--- a/test/e2e/docker/Dockerfile.fast
+++ b/test/e2e/docker/Dockerfile.fast
@@ -1,0 +1,13 @@
+FROM gcr.io/distroless/static-debian11:debug
+
+COPY build/node /app
+COPY docker/entrypoint-fast /entrypoint
+
+WORKDIR /cometbft
+VOLUME /cometbft
+ENV CMTHOME=/cometbft
+ENV GORACE "halt_on_error=1"
+
+EXPOSE 26656 26657 26660 6060
+ENTRYPOINT ["/entrypoint"]
+STOPSIGNAL SIGTERM

--- a/test/e2e/docker/entrypoint-fast
+++ b/test/e2e/docker/entrypoint-fast
@@ -1,0 +1,5 @@
+#!/busybox/sh
+
+rm -rf /var/run/privval.sock /var/run/app.sock
+/app /cometbft/config/app.toml # > /dev/null
+

--- a/test/e2e/fast-prototyping/README.md
+++ b/test/e2e/fast-prototyping/README.md
@@ -1,0 +1,40 @@
+## Fast Prototyping
+
+This directory contains a set of scripts to run experiments for fast-prototyping cometbft reactors.
+Please note that (to date) these scripts are mostly oriented toward prototyping mempool reactors.
+
+For the impatient
+
+	cd path/to/cometbft/
+	E2E_DIR=$(pwd)/test/e2e
+	(cd ${E2E_DIR} && make node generator runner docker-fast)
+	${E2E_DIR}/fast-prototyping/experiments.sh ${E2E_DIR}/fast-prototyping/render/results.csv # takes around two minutes
+	${E2E_DIR}/fast-prototyping/render.sh
+
+## Injecting a custom reactor
+
+A new reactor is to be added under `fast-prototyping/reactors`.
+Then, the reactor may be referenced in `e2e/node/main.go`.
+More precisely, it has to be added in the `registry` variable.
+This variable holds a mapping between a name and a reactor (because there is no reflexive API in golang).
+
+Once this is done, we can inject the reactor in the TOML configuration file of the test network.
+An injection is using the mapping (json-encoded) `experimental_custom_reactors`.
+For instance, the mapping `CONSENSUS = p2p.mock.reactor` indicates that we mock the consensus reactor.
+
+## Running a (custom) benchmark
+
+The entry point for benchmarking a reactor is the `custom` benchmark.
+This benchmark is accessible through the command line of the runner.
+It is also possible to use the usual sequence, that is `start`, `load`, `stop` then `cleanup`.
+The `custom` benchmark reports several metrics of interest, in particular to assess the bandwidth consumption of the system.
+Part of these metrics are also output using the (new) `stats` command.
+
+## Running an experiment
+
+We may run an experiment in full with the help of `experiments.sh`.
+
+## Plotting 
+
+To plot the result of an experiment, we use `render.sh`.
+This starts a web server to display the experimental results using Apache Echarts.

--- a/test/e2e/fast-prototyping/experiments.sh
+++ b/test/e2e/fast-prototyping/experiments.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+DIR=$(dirname "${BASH_SOURCE[0]}")
+source ${DIR}/utils.sh
+
+if [ $# -ne 1 ]; then
+    echo "usage: experiments output.csv"
+    exit 1
+fi
+
+FILE=$1
+TMPL="custom"
+
+echo "nodes;propagation_rate;sent;seen;completion;total_bandwidth;useful_bandwidth;overhead;redundancy;degree;bandwidth" > ${FILE}
+for r in $(seq 50 50 100);
+do
+    for i in $(geometric 4 2 2);
+    do
+			${DIR}/tmpl-gen.sh ${i} ${r} > ${NETDIR}/${TMPL}.toml
+			${BINDIR}/runner -f ${NETDIR}/${TMPL}.toml custom > ${TMPDIR}/log
+			sent=$(grep "txs sent" ${TMPDIR}/log | awk -F= '{print $2}' | sed -r 's/\s+//g')
+			seen=$(grep "txs seen" ${TMPDIR}/log | awk -F= '{print $2}' | sed -r 's/\s+//g')
+			completion=$(grep "completion" ${TMPDIR}/log | awk -F= '{print $2}' | sed -r 's/\s+//g')
+			totalBandwidth=$(grep "total bandwidth" ${TMPDIR}/log | awk -F= '{print $2}' | sed -r 's/\s+//g')
+			usefulBandwidth=$(grep "useful bandwidth" ${TMPDIR}/log | awk -F= '{print $2}' | sed -r 's/\s+//g')
+			overhead=$(grep "overhead" ${TMPDIR}/log | awk -F= '{print $2}' | sed -r 's/\s+//g')
+			redundancy=$(grep "redundancy" ${TMPDIR}/log | awk -F= '{print $2}' | sed -r 's/\s+//g')
+			degree=$(grep "degree" ${TMPDIR}/log | awk -F= '{print $2}' | sed -r 's/\s+//g')
+			bandwidth=$(grep "bandwidth graph" ${TMPDIR}/log | awk -F= '{print $2}' | sed -r 's/\s+//g')
+			echo ${i}";"${r}";"${sent}";"${seen}";"${completion}";"${totalBandwidth}";"${usefulBandwidth}";"${overhead}";"${redundancy}";"${degree}";"${bandwidth} >> ${FILE}
+			${BINDIR}/runner -f ${NETDIR}/${TMPL}.toml cleanup >> /dev/null
+			sleep 1
+    done
+done
+
+cat ${FILE}

--- a/test/e2e/fast-prototyping/reactors/mempool/gossip/ids.go
+++ b/test/e2e/fast-prototyping/reactors/mempool/gossip/ids.go
@@ -1,0 +1,72 @@
+package gossip
+
+import (
+	"fmt"
+
+	cmtsync "github.com/cometbft/cometbft/libs/sync"
+	mempool "github.com/cometbft/cometbft/mempool"
+	"github.com/cometbft/cometbft/p2p"
+)
+
+type mempoolIDs struct {
+	mtx       cmtsync.RWMutex
+	peerMap   map[p2p.ID]uint16
+	nextID    uint16              // assumes that a node will never have over 65536 active peers
+	activeIDs map[uint16]struct{} // used to check if a given peerID key is used, the value doesn't matter
+}
+
+// Reserve searches for the next unused ID and assigns it to the
+// peer.
+func (ids *mempoolIDs) ReserveForPeer(peer p2p.Peer) {
+	ids.mtx.Lock()
+	defer ids.mtx.Unlock()
+
+	curID := ids.nextPeerID()
+	ids.peerMap[peer.ID()] = curID
+	ids.activeIDs[curID] = struct{}{}
+}
+
+// nextPeerID returns the next unused peer ID to use.
+// This assumes that ids's mutex is already locked.
+func (ids *mempoolIDs) nextPeerID() uint16 {
+	if len(ids.activeIDs) == mempool.MaxActiveIDs {
+		panic(fmt.Sprintf("node has maximum %d active IDs and wanted to get one more", mempool.MaxActiveIDs))
+	}
+
+	_, idExists := ids.activeIDs[ids.nextID]
+	for idExists {
+		ids.nextID++
+		_, idExists = ids.activeIDs[ids.nextID]
+	}
+	curID := ids.nextID
+	ids.nextID++
+	return curID
+}
+
+// Reclaim returns the ID reserved for the peer back to unused pool.
+func (ids *mempoolIDs) Reclaim(peer p2p.Peer) {
+	ids.mtx.Lock()
+	defer ids.mtx.Unlock()
+
+	removedID, ok := ids.peerMap[peer.ID()]
+	if ok {
+		delete(ids.activeIDs, removedID)
+		delete(ids.peerMap, peer.ID())
+	}
+}
+
+// GetForPeer returns an ID reserved for the peer.
+func (ids *mempoolIDs) GetForPeer(peer p2p.Peer) uint16 {
+	ids.mtx.RLock()
+	defer ids.mtx.RUnlock()
+
+	return ids.peerMap[peer.ID()]
+}
+
+func newMempoolIDs() *mempoolIDs {
+	return &mempoolIDs{
+		peerMap:   make(map[p2p.ID]uint16),
+		activeIDs: map[uint16]struct{}{0: {}},
+		nextID:    1, // reserve unknownPeerID(0) for mempoolReactor.BroadcastTx
+	}
+}

--- a/test/e2e/fast-prototyping/reactors/mempool/gossip/mempoolTx.go
+++ b/test/e2e/fast-prototyping/reactors/mempool/gossip/mempoolTx.go
@@ -1,0 +1,34 @@
+package gossip
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/cometbft/cometbft/types"
+)
+
+// mempoolTx is an entry in the mempool
+type mempoolTx struct {
+	height    int64    // height that this tx had been validated in
+	gasWanted int64    // amount of gas this tx states it will require
+	tx        types.Tx // validated by the application
+
+	// ids of peers who've sent us this tx (as a map for quick lookups).
+	// senders: PeerID -> bool
+	senders sync.Map
+}
+
+// Height returns the height for this transaction
+func (memTx *mempoolTx) Height() int64 {
+	return atomic.LoadInt64(&memTx.height)
+}
+
+func (memTx *mempoolTx) isSender(peerID uint16) bool {
+	_, ok := memTx.senders.Load(peerID)
+	return ok
+}
+
+func (memTx *mempoolTx) addSender(senderID uint16) bool {
+	_, added := memTx.senders.LoadOrStore(senderID, true)
+	return added
+}

--- a/test/e2e/fast-prototyping/reactors/mempool/gossip/reactor.go
+++ b/test/e2e/fast-prototyping/reactors/mempool/gossip/reactor.go
@@ -1,0 +1,238 @@
+package gossip
+
+import (
+	"errors"
+	"github.com/cometbft/cometbft/libs/rand"
+	"time"
+
+	"fmt"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+	cfg "github.com/cometbft/cometbft/config"
+	"github.com/cometbft/cometbft/libs/log"
+	cmtsync "github.com/cometbft/cometbft/libs/sync"
+	mempool "github.com/cometbft/cometbft/mempool"
+	"github.com/cometbft/cometbft/p2p"
+	protomem "github.com/cometbft/cometbft/proto/tendermint/mempool"
+	"github.com/cometbft/cometbft/types"
+)
+
+// Reactor handles mempool tx broadcasting amongst peers.
+// It maintains a map from peer ID to counter, to prevent gossiping txs to the
+// peers you received it from.
+type Reactor struct {
+	p2p.BaseReactor
+	config          *cfg.MempoolConfig
+	mempool         mempool.Mempool
+	ids             *mempoolIDs
+	txSenders       map[types.TxKey]map[uint16]bool
+	txSendersMtx    cmtsync.RWMutex
+	propagationRate float32
+}
+
+// NewReactor returns a new Reactor with the given config and mempool.
+// The mempool's channel TxsAvailable will be initialized only when notifyAvailable is true.
+func NewReactor(config *cfg.MempoolConfig, mempool mempool.Mempool, rate float32) *Reactor {
+	memR := &Reactor{
+		config:          config,
+		mempool:         mempool,
+		ids:             newMempoolIDs(),
+		txSenders:       make(map[types.TxKey]map[uint16]bool),
+		propagationRate: rate,
+	}
+	memR.BaseReactor = *p2p.NewBaseReactor("Mempool", memR)
+	fmt.Println("starting with ", "propagation rate ", memR.propagationRate)
+	return memR
+}
+
+// InitPeer implements Reactor by creating a state for the peer.
+func (memR *Reactor) InitPeer(peer p2p.Peer) p2p.Peer {
+	memR.ids.ReserveForPeer(peer)
+	return peer
+}
+
+// SetLogger sets the Logger on the reactor and the underlying mempool.
+func (memR *Reactor) SetLogger(l log.Logger) {
+	memR.Logger = l
+	memR.mempool.SetLogger(l)
+}
+
+// OnStart implements p2p.BaseReactor.
+func (memR *Reactor) OnStart() error {
+	if !memR.config.Broadcast {
+		memR.Logger.Info("Tx broadcasting is disabled")
+	}
+
+	go memR.updateSendersRoutine()
+
+	return nil
+}
+
+// OnStop stops the reactor by signaling to all spawned goroutines to exit and
+// blocking until they all exit.
+func (memR *Reactor) OnStop() {
+	if err := memR.mempool.Stop(); err != nil {
+		memR.Logger.Error("Shutting down mempool reactor", "err", err)
+	}
+	// TODO: to complete
+}
+
+// GetChannels implements Reactor by returning the list of channels for this
+// reactor.
+func (memR *Reactor) GetChannels() []*p2p.ChannelDescriptor {
+	largestTx := make([]byte, memR.config.MaxTxBytes)
+	batchMsg := protomem.Message{
+		Sum: &protomem.Message_Txs{
+			Txs: &protomem.Txs{Txs: [][]byte{largestTx}},
+		},
+	}
+
+	return []*p2p.ChannelDescriptor{
+		{
+			ID:                  mempool.MempoolChannel,
+			Priority:            5,
+			RecvMessageCapacity: batchMsg.Size(),
+			MessageType:         &protomem.Message{},
+		},
+	}
+}
+
+// AddPeer implements Reactor.
+// It starts a broadcast routine ensuring all txs are forwarded to the given peer.
+func (memR *Reactor) AddPeer(peer p2p.Peer) {
+	if memR.config.Broadcast {
+		go memR.broadcastTxRoutine(peer)
+	}
+}
+
+// RemovePeer implements Reactor.
+func (memR *Reactor) RemovePeer(peer p2p.Peer, _ interface{}) {
+	memR.ids.Reclaim(peer)
+	// broadcast routine checks if peer is gone and returns
+}
+
+// Receive implements Reactor.
+// It adds any received transactions to the mempool.
+func (memR *Reactor) Receive(e p2p.Envelope) {
+	memR.Logger.Debug("Receive", "src", e.Src, "chId", e.ChannelID, "msg", e.Message)
+	switch msg := e.Message.(type) {
+	case *protomem.Txs:
+		protoTxs := msg.GetTxs()
+		if len(protoTxs) == 0 {
+			memR.Logger.Error("received empty txs from peer", "src", e.Src)
+			return
+		}
+
+		for _, txBytes := range protoTxs {
+			tx := types.Tx(txBytes)
+			reqRes, err := memR.mempool.CheckTx(tx)
+			if errors.Is(err, mempool.ErrTxInCache) {
+				memR.Logger.Debug("Tx already exists in cache", "tx", tx.String())
+			} else if err != nil {
+				memR.Logger.Info("Could not check tx", "tx", tx.String(), "err", err)
+			} else {
+				// Record the sender only when the transaction is valid and, as
+				// a consequence, added to the mempool. Senders are stored until
+				// the transaction is removed from the mempool. Note that it's
+				// possible a tx is still in the cache but no longer in the
+				// mempool. For example, after committing a block, txs are
+				// removed from mempool but not the cache.
+				reqRes.SetCallback(func(res *abci.Response) {
+					if res.GetCheckTx().Code == abci.CodeTypeOK {
+						memR.addSender(tx.Key(), memR.ids.GetForPeer(e.Src))
+					}
+				})
+			}
+		}
+	default:
+		memR.Logger.Error("unknown message type", "src", e.Src, "chId", e.ChannelID, "msg", e.Message)
+		memR.Switch.StopPeerForError(e.Src, fmt.Errorf("mempool cannot handle message of type: %T", e.Message))
+		return
+	}
+
+	// broadcasting happens from go routines per peer
+}
+
+// PeerState describes the state of a peer.
+type PeerState interface {
+	GetHeight() int64
+}
+
+// Send new mempool txs to peer.
+func (memR *Reactor) broadcastTxRoutine(peer p2p.Peer) {
+	peerID := memR.ids.GetForPeer(peer)
+
+	var entry *mempool.Entry
+	iter := memR.mempool.NewIterator()
+
+	for {
+		if !memR.IsRunning() || !peer.IsRunning() {
+			return
+		}
+
+		select {
+		case <-iter.WaitNext():
+			entry = iter.NextEntry()
+			if entry == nil {
+				// There is no next entry, or the entry we found got removed in the
+				// meantime. Try again.
+				continue
+			}
+		case <-peer.Quit():
+			return
+		case <-memR.Quit():
+			return
+		}
+
+		if !memR.isSender(entry.GetTxKey(), peerID) {
+			if float32(rand.Intn(101)) <= memR.propagationRate {
+				success := peer.Send(p2p.Envelope{
+					ChannelID: mempool.MempoolChannel,
+					Message:   &protomem.Txs{Txs: [][]byte{entry.GetTx()}},
+				})
+				if !success {
+					time.Sleep(mempool.PeerCatchupSleepIntervalMS * time.Millisecond)
+					continue
+				}
+			}
+		}
+	}
+}
+
+func (memR *Reactor) isSender(txKey types.TxKey, peerID uint16) bool {
+	memR.txSendersMtx.RLock()
+	defer memR.txSendersMtx.RUnlock()
+
+	sendersSet, ok := memR.txSenders[txKey]
+	return ok && sendersSet[peerID]
+}
+
+func (memR *Reactor) addSender(txKey types.TxKey, senderID uint16) bool {
+	memR.txSendersMtx.Lock()
+	defer memR.txSendersMtx.Unlock()
+
+	if sendersSet, ok := memR.txSenders[txKey]; ok {
+		sendersSet[senderID] = true
+		return false
+	}
+	memR.txSenders[txKey] = map[uint16]bool{senderID: true}
+	return true
+}
+
+func (memR *Reactor) removeSenders(txKey types.TxKey) {
+	memR.txSendersMtx.Lock()
+	defer memR.txSendersMtx.Unlock()
+
+	delete(memR.txSenders, txKey)
+}
+
+func (memR *Reactor) updateSendersRoutine() {
+	for {
+		select {
+		case txKey := <-memR.mempool.TxsRemoved():
+			memR.removeSenders(txKey)
+		case <-memR.Quit():
+			return
+		}
+	}
+}

--- a/test/e2e/fast-prototyping/render.sh
+++ b/test/e2e/fast-prototyping/render.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+DIR=$(dirname "${BASH_SOURCE[0]}")
+source ${DIR}/utils.sh
+
+trap "pkill -KILL -P $$; exit 255" SIGINT SIGTERM
+
+python3 -m http.server --directory ${DIR}/render 8080 &
+browse http://localhost:8080/experiments.html &
+
+wait
+

--- a/test/e2e/fast-prototyping/render/experiments.css
+++ b/test/e2e/fast-prototyping/render/experiments.css
@@ -1,0 +1,56 @@
+.experiments {
+    display: inline-block;
+    width: 45%;
+    height: 80vh;
+    margin: 2em;
+    /* background-color: green; */
+}
+
+.graph {
+    display: inline-block;
+    width: 45%;
+    height: 80vh;
+    margin: 2em;
+    /* background-color: blue; */
+}
+
+/* Dropdown Button */
+.dropbtn {
+    background-color: #528AAE; 
+    color: white;
+    padding: 16px;
+    font-size: 16px;
+    border: none;
+}
+
+/* The container <div> - needed to position the dropdown content */
+.dropdown {
+    margin: 1em;
+}
+
+/* Dropdown Content (Hidden by Default) */
+.dropdown-content {
+    display: none;
+    position: absolute;
+    background-color: #f1f1f1;
+    min-width: 160px;
+    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+    z-index: 1;
+}
+
+/* Links inside the dropdown */
+.dropdown-content a {
+    color: black;
+    padding: 12px 16px;
+    text-decoration: none;
+    display: block;
+}
+
+/* Change color of dropdown links on hover */
+.dropdown-content a:hover {background-color: #ddd;}
+
+/* Show the dropdown menu on hover */
+.dropdown:hover .dropdown-content {display: block;}
+
+/* Change the background color of the dropdown button when the dropdown content is shown */
+.dropdown:hover .dropbtn {background-color: #91BAD6;}

--- a/test/e2e/fast-prototyping/render/experiments.html
+++ b/test/e2e/fast-prototyping/render/experiments.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta charset="utf-8" />
+    <title>Experiments</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/echarts/5.4.2/echarts.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/echarts-gl/2.0.8/echarts-gl.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.0/jquery.min.js"></script>
+    <link rel="stylesheet" href="experiments.css?q=15"/>
+  </head>
+  <body>
+    <div class="dropdown">
+      <button class="dropbtn">metric</button>
+      <div class="dropdown-content"></div>
+    </div>
+    <div id="main" class="experiments"></div>
+    <div id="graph" class="graph"></div>
+    <script type="text/javascript">
+      document.write('<scr'+'ipt src="experiments.js?'+Math.random()+'" type="text/javascript"></scr'+'ipt>');
+    </script>
+  </body>
+</html>

--- a/test/e2e/fast-prototyping/render/experiments.js
+++ b/test/e2e/fast-prototyping/render/experiments.js
@@ -1,0 +1,213 @@
+var mainElt = document.getElementById('main');
+var graphElt = document.getElementById('graph');
+var mainChart = echarts.init(mainElt);
+var graphChart = echarts.init(graphElt);
+
+var headers = []
+var headersMap = {
+    "nodes" : "#nodes",
+    "propagation_rate" : "propagation rate (%)",
+    "sent" : "#sent",
+    "seen" : "#seen (avg)",
+    "completion" : "completion",
+    "total_bandwidth" : "total bw. (KB)",
+    "useful_bandwidth" : "useful bw. (KB)",
+    "overhead" : "overhead",
+    "redundancy" : "redundancy (avg)",
+    "degree" : "degree (avg)",
+    "bandwidth" : "bandwidth"
+}
+var dataset = []
+var graphs = []
+
+function plotExperiments(dimension) {
+    var symbolSize = 2.5;
+    var option = {}
+    option = {
+	title: {
+	    text: 'Experiments',
+	    subtext: 'e2e - fast prototyping',
+	    left: 'center'
+	},
+	grid3D: {},
+	xAxis3D: {
+	    name: headersMap['nodes']
+	},
+	yAxis3D: {
+	    name: headersMap['propagation_rate']
+	},
+	zAxis3D: {
+	    name: headersMap[dimension],
+
+	},
+	dataset: {
+	    dimensions: headers,
+	    source: dataset
+	},
+	series: [
+	    {
+		name: 'experiments',
+		type: 'scatter3D',
+		symbolSize: 10,
+		encode: {
+		    x: 'nodes',
+		    y: 'propagation_rate',
+		    z: dimension,
+		    tooltip: [0, 1, 2, 3, 4]
+		}
+	    }
+	]
+    };
+
+    option && mainChart.setOption(option);
+
+    mainChart.on('click', {seriesName: 'experiments'}, function (params) {
+	graphChart.clear();
+	plotGraph(params.dataIndex);
+    });
+
+}
+
+function plotGraph(idx) {
+    var data = graphs[idx];
+
+    var max = 0
+    var min = Number.MAX_SAFE_INTEGER
+
+    var option = {}
+    var nodes = [];
+    var edges = [];
+
+    $.each(data, function (n, peers) {
+        $.each(peers, function (m, bw) {
+            max = Math.max(max, bw)
+            min = Math.min(min, bw)
+        });
+    });
+
+    var i = 0;
+
+    $.each(data, function (n, peers) {
+        r = Math.floor(Math.min(200,100 + Math.random() * 156));
+        g = Math.floor(Math.min(200, 100 + Math.random() * 156));
+        b = Math.floor(Math.min(200, 100 + Math.random() * 156));
+        nodes.push(
+            {
+                name: n,
+                label: {
+                    show: true,
+                    position: 'inside',
+                    fontSize: 20
+                },
+                symbolSize: 50,
+                itemStyle: {
+                    color: 'rgb('+r+','+g+','+b+')'
+                }
+            }
+        );
+        var j = 0;
+        $.each(peers, function (m, bw) {
+            if (i != j && bw != 0) {
+                edges.push(
+                    {
+                        source: n,
+                        target: j,
+                        lineStyle: {
+                            width: 1,
+                            curveness: 0.05,
+                            opacity: 0.05 + ((bw-min)/(max-min)*0.3),
+                            color: '#444'
+                        },
+                        label: {
+                            show: true,
+                            position: 'middle',
+                            fontSize: '20',
+                            opacity: 1,
+                            color: '#000',
+                            formatter: function () {
+                                return Math.floor(bw / 100) + " KB";
+                            }
+                        }
+                    }
+                );
+            }
+            j++
+        });
+        i++;
+    });
+
+    var datas = [];
+    datas.push({
+        nodes: nodes,
+        edges: edges
+    });
+
+    option = {
+	title: {
+	    text: 'Bandwidth usage',
+	    subtext: "(#nodes = " + dataset[idx]["nodes"] + ", propagation rate = " + dataset[idx]["propagation_rate"] + ")",
+	    left: 'center'
+	},
+        tooltip: {},
+        animationDurationUpdate: 1500,
+        animationEasingUpdate: 'quinticInOut',
+        series: {
+	    name: 'graph',
+            type: 'graph',
+            layout: 'circular',
+            data: nodes,
+            links: edges,
+            roam: true,
+            edgeSymbol: ['circle', 'arrow'],
+            edgeSymbolSize: [4, 10],
+            labelLayout: {
+                hideOverlap: true
+            },
+            emphasis: {
+                focus: 'self'
+            },
+        }
+    }
+
+    option && graphChart.setOption(option);
+
+}
+
+jQuery.get(
+    'results.csv?'+Math.random(),
+    function (csv) {
+	var lines = csv.split("\n");
+	var results = [];
+	headers=lines[0].split(";");
+	for(var i=1; i<lines.length; i++){
+	    var obj = {};
+	    var currentline=lines[i].split(";");
+	    // skip empty lines
+	    if (currentline.length > 1) {
+		for(var j=0; j<headers.length-1; j++){
+		    obj[headers[j]] = currentline[j];
+		}
+		dataset.push(JSON.parse(JSON.stringify(obj)));
+		var graph = JSON.parse(currentline[j]);
+		graphs.push(graph);
+	    }
+	}
+
+	var dropdown = document.getElementsByClassName('dropdown-content')[0];
+	for(var i=1; i<headers.length; i++){
+	    if ( i != 0 && i != 1 && i != headers.length-1 ) {
+		console.log(headers[i]);
+		var child = document.createElement('a');
+		child.setAttribute('onClick',"plotExperiments(\'"+headers[i]+"\')");
+		child.innerHTML = headersMap[headers[i]];
+		dropdown.appendChild(child);
+	    }
+	}
+
+	plotExperiments('overhead')
+
+	plotGraph(0)
+
+
+    }
+);

--- a/test/e2e/fast-prototyping/tmpl-gen.sh
+++ b/test/e2e/fast-prototyping/tmpl-gen.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+if [ $# -ne 2 ]; then
+    echo "usage: gen.sh #nodes propagation_rate"
+    exit 1
+fi
+
+NODES=$1
+RATE=$2
+PREAMBLE="\
+prometheus = true\n\
+load_tx_size_bytes = 100\n\
+load_tx_to_send = 100\n\
+load_tx_batch_size = 10\n\
+pex = false\n\
+experimental_gossip_propagation_rate = ${RATE}\n\
+experimental_custom_reactors = {CONSENSUS = \"p2p.mock.reactor\", MEMPOOL = \"experimental.reactors.mempool.gossip\"}\
+"
+
+# let's form a clique
+
+ALL_NODES=$(seq -f "%02g" 1 ${NODES})
+echo -e $PREAMBLE
+for i in ${ALL_NODES}
+do
+    echo "[node.validator${i}]"    
+    echo "  persistent_peers = ["$(echo ${ALL_NODES} | sed -r 's/([0-9]*)/"validator\1"/g' | sed s/\ /,/g )"]"
+done

--- a/test/e2e/fast-prototyping/utils.sh
+++ b/test/e2e/fast-prototyping/utils.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+DIR=$(dirname "${BASH_SOURCE[0]}")
+TMPDIR=/tmp
+BINDIR=${DIR}/../build/
+NETDIR=${DIR}/../networks/
+
+info() {
+    local message=$1
+    echo >& 2 "["$(date +%s:%N)"] ${message}"
+}
+
+log() {
+    if [[ $(config verbose) -eq 1 ]]
+    then
+	local message=$1
+	echo >& 2 "["$(date +%s:%N)"] ${message}"
+    fi
+}
+
+function geometric {
+    if [ $# -ne 3 ]; then
+	echo "usage: genometric #initialValue #factor #times"
+	exit 1
+    fi
+
+    ((val = $1))
+    ((mult = $2))
+    ((count = $3))
+
+    while [[ ${count} -gt 0 ]] ; do
+        echo ${val}
+        ((val *= mult))
+        ((count -= 1))
+    done
+}

--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -65,10 +65,11 @@ var (
 )
 
 type generateConfig struct {
-	randSource   *rand.Rand
-	outputDir    string
-	multiVersion string
-	prometheus   bool
+	randSource                         *rand.Rand
+	outputDir                          string
+	multiVersion                       string
+	prometheus                         bool
+	experimentalGossipPropagationRatio float32
 }
 
 // Generate generates random testnets using the given RNG.
@@ -110,7 +111,7 @@ func Generate(cfg *generateConfig) ([]e2e.Manifest, error) {
 	}
 	manifests := []e2e.Manifest{}
 	for _, opt := range combinations(testnetCombinations) {
-		manifest, err := generateTestnet(cfg.randSource, opt, upgradeVersion, cfg.prometheus)
+		manifest, err := generateTestnet(cfg.randSource, opt, upgradeVersion, cfg.prometheus, cfg.experimentalGossipPropagationRatio)
 		if err != nil {
 			return nil, err
 		}
@@ -120,18 +121,19 @@ func Generate(cfg *generateConfig) ([]e2e.Manifest, error) {
 }
 
 // generateTestnet generates a single testnet with the given options.
-func generateTestnet(r *rand.Rand, opt map[string]interface{}, upgradeVersion string, prometheus bool) (e2e.Manifest, error) {
+func generateTestnet(r *rand.Rand, opt map[string]interface{}, upgradeVersion string, prometheus bool, propagationRatio float32) (e2e.Manifest, error) {
 	manifest := e2e.Manifest{
-		IPv6:             ipv6.Choose(r).(bool),
-		ABCIProtocol:     nodeABCIProtocols.Choose(r).(string),
-		InitialHeight:    int64(opt["initialHeight"].(int)),
-		InitialState:     opt["initialState"].(map[string]string),
-		Validators:       &map[string]int64{},
-		ValidatorUpdates: map[string]map[string]int64{},
-		Evidence:         evidence.Choose(r).(int),
-		Nodes:            map[string]*e2e.ManifestNode{},
-		UpgradeVersion:   upgradeVersion,
-		Prometheus:       prometheus,
+		IPv6:                              ipv6.Choose(r).(bool),
+		ABCIProtocol:                      nodeABCIProtocols.Choose(r).(string),
+		InitialHeight:                     int64(opt["initialHeight"].(int)),
+		InitialState:                      opt["initialState"].(map[string]string),
+		Validators:                        &map[string]int64{},
+		ValidatorUpdates:                  map[string]map[string]int64{},
+		Evidence:                          evidence.Choose(r).(int),
+		Nodes:                             map[string]*e2e.ManifestNode{},
+		UpgradeVersion:                    upgradeVersion,
+		Prometheus:                        prometheus,
+		ExperimentalGossipPropagationRate: propagationRatio,
 	}
 
 	switch abciDelays.Choose(r).(string) {

--- a/test/e2e/node/config.go
+++ b/test/e2e/node/config.go
@@ -33,23 +33,29 @@ type Config struct {
 	VoteExtensionDelay   time.Duration `toml:"vote_extension_delay"`
 
 	VoteExtensionSize uint `toml:"vote_extension_size"`
+
+	// Experimental
+	ExperimentalCustomReactors        map[string]string `toml:"experimental_custom_reactors"`
+	ExperimentalGossipPropagationRate float32           `toml:"experimental_gossip_propagation_rate"`
 }
 
 // App extracts out the application specific configuration parameters
 func (cfg *Config) App() *app.Config {
 	return &app.Config{
-		Dir:                  cfg.Dir,
-		SnapshotInterval:     cfg.SnapshotInterval,
-		RetainBlocks:         cfg.RetainBlocks,
-		KeyType:              cfg.KeyType,
-		ValidatorUpdates:     cfg.ValidatorUpdates,
-		PersistInterval:      cfg.PersistInterval,
-		PrepareProposalDelay: cfg.PrepareProposalDelay,
-		ProcessProposalDelay: cfg.ProcessProposalDelay,
-		CheckTxDelay:         cfg.CheckTxDelay,
-		FinalizeBlockDelay:   cfg.FinalizeBlockDelay,
-		VoteExtensionDelay:   cfg.VoteExtensionDelay,
-		VoteExtensionSize:    cfg.VoteExtensionSize,
+		Dir:                               cfg.Dir,
+		SnapshotInterval:                  cfg.SnapshotInterval,
+		RetainBlocks:                      cfg.RetainBlocks,
+		KeyType:                           cfg.KeyType,
+		ValidatorUpdates:                  cfg.ValidatorUpdates,
+		PersistInterval:                   cfg.PersistInterval,
+		PrepareProposalDelay:              cfg.PrepareProposalDelay,
+		ProcessProposalDelay:              cfg.ProcessProposalDelay,
+		CheckTxDelay:                      cfg.CheckTxDelay,
+		FinalizeBlockDelay:                cfg.FinalizeBlockDelay,
+		VoteExtensionDelay:                cfg.VoteExtensionDelay,
+		VoteExtensionSize:                 cfg.VoteExtensionSize,
+		ExperimentalCustomReactors:        cfg.ExperimentalCustomReactors,
+		ExperimentalGossipPropagationRate: cfg.ExperimentalGossipPropagationRate,
 	}
 }
 

--- a/test/e2e/node/main.go
+++ b/test/e2e/node/main.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	p2pmock "github.com/cometbft/cometbft/p2p/mock"
+	"github.com/cometbft/cometbft/test/e2e/fast-prototyping/reactors/mempool/gossip"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -141,6 +143,26 @@ func startNode(cfg *Config) error {
 		node.DefaultMetricsProvider(cmtcfg.Instrumentation),
 		nodeLogger,
 	)
+
+	// wave custom reactors here
+
+	registry := map[string]p2p.Reactor{}
+	registry["p2p.mock.reactor"] = p2pmock.NewReactor()
+	registry["experimental.reactors.mempool.gossip"] = gossip.NewReactor(cmtcfg.Mempool, n.Mempool(), cfg.ExperimentalGossipPropagationRate)
+
+	customReactors := map[string]p2p.Reactor{}
+	for k, v := range cfg.ExperimentalCustomReactors {
+		mock, ok := registry[v]
+		if ok {
+			customReactors[k] = mock
+			logger.Info("Mocking reactor: ", k, mock)
+		} else {
+			logger.Info("Not found: ", registry[k])
+		}
+	}
+
+	node.CustomReactors(customReactors)(n)
+
 	if err != nil {
 		return err
 	}

--- a/test/e2e/pkg/manifest.go
+++ b/test/e2e/pkg/manifest.go
@@ -88,6 +88,7 @@ type Manifest struct {
 	LoadTxSizeBytes   int `toml:"load_tx_size_bytes"`
 	LoadTxBatchSize   int `toml:"load_tx_batch_size"`
 	LoadTxConnections int `toml:"load_tx_connections"`
+	LoadTxToSend      int `toml:"load_tx_to_send"`
 
 	// Enable or disable Prometheus metrics on all nodes.
 	// Defaults to false (disabled).
@@ -96,8 +97,11 @@ type Manifest struct {
 	// Defines a minimum size for the vote extensions.
 	VoteExtensionSize uint `toml:"vote_extension_size"`
 
-	// Upper bound of sleep duration then gossipping votes and block parts
-	PeerGossipIntraloopSleepDuration time.Duration `toml:"peer_gossip_intraloop_sleep_duration"`
+	// Likeliness to propagate a message
+	ExperimentalGossipPropagationRate float32 `toml:"experimental_gossip_propagation_rate"`
+
+	// Inject custom reactors (see node/main.go#startNode for a list of possibilities)
+	ExperimentalCustomReactors map[string]string `toml:"experimental_custom_reactors"`
 }
 
 // ManifestNode represents a node in a testnet manifest.

--- a/test/e2e/runner/benchmark.go
+++ b/test/e2e/runner/benchmark.go
@@ -33,7 +33,7 @@ func Benchmark(ctx context.Context, testnet *e2e.Testnet, benchmarkLength int64)
 	// wait for the length of the benchmark period in blocks to pass. We allow 5 seconds for each block
 	// which should be sufficient.
 	waitingTime := time.Duration(benchmarkLength*5) * time.Second
-	endHeight, err := waitForAllNodes(ctx, testnet, block.Height+benchmarkLength, waitingTime)
+	endHeight, err := WaitForAllNodes(ctx, testnet, block.Height+benchmarkLength, waitingTime)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/runner/cleanup.go
+++ b/test/e2e/runner/cleanup.go
@@ -73,7 +73,7 @@ func cleanupDir(dir string) error {
 		return err
 	}
 	err = docker.Exec(context.Background(), "run", "--rm", "--entrypoint", "", "-v", fmt.Sprintf("%v:/network", absDir),
-		"cometbft/e2e-node", "sh", "-c", "rm -rf /network/*/")
+		"cometbft/e2e-node:local-version", "sh", "-c", "rm -rf /network/*/")
 	if err != nil {
 		return err
 	}

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -173,7 +173,6 @@ func MakeConfig(node *e2e.Node) (*config.Config, error) {
 	cfg.DBBackend = node.Database
 	cfg.StateSync.DiscoveryTime = 5 * time.Second
 	cfg.BlockSync.Version = node.BlockSyncVersion
-	cfg.Consensus.PeerGossipIntraloopSleepDuration = node.Testnet.PeerGossipIntraloopSleepDuration
 
 	switch node.ABCIProtocol {
 	case e2e.ProtocolUNIX:
@@ -259,21 +258,23 @@ func MakeConfig(node *e2e.Node) (*config.Config, error) {
 // MakeAppConfig generates an ABCI application config for a node.
 func MakeAppConfig(node *e2e.Node) ([]byte, error) {
 	cfg := map[string]interface{}{
-		"chain_id":               node.Testnet.Name,
-		"dir":                    "data/app",
-		"listen":                 AppAddressUNIX,
-		"mode":                   node.Mode,
-		"protocol":               "socket",
-		"persist_interval":       node.PersistInterval,
-		"snapshot_interval":      node.SnapshotInterval,
-		"retain_blocks":          node.RetainBlocks,
-		"key_type":               node.PrivvalKey.Type(),
-		"prepare_proposal_delay": node.Testnet.PrepareProposalDelay,
-		"process_proposal_delay": node.Testnet.ProcessProposalDelay,
-		"check_tx_delay":         node.Testnet.CheckTxDelay,
-		"vote_extension_delay":   node.Testnet.VoteExtensionDelay,
-		"finalize_block_delay":   node.Testnet.FinalizeBlockDelay,
-		"vote_extension_size":    node.Testnet.VoteExtensionSize,
+		"chain_id":                             node.Testnet.Name,
+		"dir":                                  "data/app",
+		"listen":                               AppAddressUNIX,
+		"mode":                                 node.Mode,
+		"protocol":                             "socket",
+		"persist_interval":                     node.PersistInterval,
+		"snapshot_interval":                    node.SnapshotInterval,
+		"retain_blocks":                        node.RetainBlocks,
+		"key_type":                             node.PrivvalKey.Type(),
+		"prepare_proposal_delay":               node.Testnet.PrepareProposalDelay,
+		"process_proposal_delay":               node.Testnet.ProcessProposalDelay,
+		"check_tx_delay":                       node.Testnet.CheckTxDelay,
+		"vote_extension_delay":                 node.Testnet.VoteExtensionDelay,
+		"finalize_block_delay":                 node.Testnet.FinalizeBlockDelay,
+		"vote_extension_size":                  node.Testnet.VoteExtensionSize,
+		"experimental_custom_reactors":         node.Testnet.ExperimentalCustomReactors,
+		"experimental_gossip_propagation_rate": node.Testnet.ExperimentalGossipPropagationRate,
 	}
 	switch node.ABCIProtocol {
 	case e2e.ProtocolUNIX:

--- a/test/e2e/runner/stats.go
+++ b/test/e2e/runner/stats.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/prometheus/client_golang/api"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"strconv"
+	"time"
+
+	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
+)
+
+type Stats struct {
+	peers     map[*e2e.Node]int
+	bandwidth map[*e2e.Node]map[*e2e.Node]int
+	seen      map[*e2e.Node]int
+	redundant map[*e2e.Node]int
+}
+
+func Fetch(testnet *e2e.Testnet) (Stats, error) {
+	timeout := 1 * time.Second
+
+	peers := map[*e2e.Node]int{}
+	bw := map[*e2e.Node]map[*e2e.Node]int{}
+	seen := map[*e2e.Node]int{}
+	redundant := map[*e2e.Node]int{}
+
+	client, err := api.NewClient(api.Config{
+		Address: "http://localhost:9090",
+	})
+	if err != nil {
+		fmt.Printf("Error creating client: %v\n", err)
+	}
+	v1api := v1.NewAPI(client)
+
+	for _, n := range testnet.Nodes {
+
+		seen[n] = 0
+
+		if seen[n], err = query(v1api, timeout, "cometbft_mempool_size", n.String(), ""); err != nil {
+			return Stats{}, err
+		}
+
+		if redundant[n], err = query(v1api, timeout, "cometbft_mempool_already_received_txs", n.String(), ""); err != nil {
+			return Stats{}, err
+		}
+
+		if peers[n], err = query(v1api, timeout, "cometbft_p2p_peers", n.String(), ""); err != nil {
+			return Stats{}, err
+		}
+
+		bw[n] = map[*e2e.Node]int{}
+		for _, m := range testnet.Nodes {
+			if n == m {
+				continue
+			}
+			if bw[n][m], err = query(v1api, timeout, "cometbft_p2p_peer_receive_bytes_total", n.String(), "chID="+"'"+"0x30"+"', "+"peer_id="+"'"+string(m.ID)+"'"); err != nil {
+				return Stats{}, err
+			}
+		}
+	}
+	return Stats{peers: peers, bandwidth: bw, seen: seen, redundant: redundant}, err
+}
+
+func (t *Stats) Output() string {
+	jsn, err := json.Marshal(t)
+	if err != nil {
+		fmt.Errorf("failed to marshal state: %w")
+		return ""
+	}
+	return string(jsn)
+}
+
+func (t *Stats) String() string {
+	return fmt.Sprintf(`bandwidth="%v", seen="%v"`, t.bandwidth, t.seen)
+}
+
+func (t *Stats) TotalBandwidth(testnet *e2e.Testnet) int {
+	total := 0
+	for _, n := range testnet.Nodes {
+		for _, m := range testnet.Nodes {
+			total += t.bandwidth[n][m]
+		}
+	}
+	return total
+}
+
+func (t *Stats) TxsSeen(testnet *e2e.Testnet) float32 {
+	count := 0
+	for _, n := range testnet.Nodes {
+		count += t.seen[n]
+	}
+	return float32(count) / float32(len(testnet.Nodes))
+}
+
+func (t *Stats) Completion(testnet *e2e.Testnet, txsSent int) float32 {
+	total := float32(0)
+	for _, n := range testnet.Nodes {
+		total += float32(t.seen[n]) / float32(txsSent)
+	}
+	return float32(100) * (total / float32(len(testnet.Nodes)))
+}
+
+func (t *Stats) BandwidthGraph(testnet *e2e.Testnet, computeRatio bool) map[string]map[string]float32 {
+	result := map[string]map[string]float32{}
+	for i, n := range testnet.Nodes {
+		sum := 1
+		if computeRatio {
+			sum := 0
+			for _, m := range testnet.Nodes {
+				sum += t.bandwidth[n][m]
+			}
+		}
+		result[strconv.Itoa(i)] = map[string]float32{}
+		for j, m := range testnet.Nodes {
+			result[strconv.Itoa(i)][strconv.Itoa(j)] = float32(t.bandwidth[n][m]) / float32(sum)
+		}
+	}
+	return result
+}
+
+func (t *Stats) Duplicates(testnet *e2e.Testnet) map[string]int {
+	result := map[string]int{}
+	for i, n := range testnet.Nodes {
+		result[strconv.Itoa(i)] = t.redundant[n]
+	}
+	return result
+}
+
+func (t *Stats) Peers(testnet *e2e.Testnet) map[string]int {
+	result := map[string]int{}
+	for i, n := range testnet.Nodes {
+		result[strconv.Itoa(i)] = t.peers[n]
+	}
+	return result
+}
+
+func (t *Stats) Redundancy(testnet *e2e.Testnet) float32 {
+	rtotal := float32(0)
+	stotal := float32(0)
+	for _, n := range testnet.Nodes {
+		rtotal += float32(t.redundant[n])
+		stotal += float32(t.seen[n])
+	}
+	return rtotal / stotal
+}
+
+func (t *Stats) Degree(testnet *e2e.Testnet) float32 {
+	rtotal := float32(0)
+	for _, n := range testnet.Nodes {
+		rtotal += float32(t.peers[n])
+	}
+	return rtotal / float32(len(testnet.Nodes))
+}
+
+func query(v1api v1.API, timeout time.Duration, field string, node string, extra string) (int, error) {
+
+	if extra != "" {
+		extra = ", " + extra
+	}
+
+	q := field +
+		"{" +
+		"job=" + "'" + node + "'" +
+		extra +
+		"}"
+
+	if result, _, err := v1api.Query(context.TODO(), q, time.Now(), v1.WithTimeout(timeout)); err == nil {
+		if len(result.(model.Vector)) != 0 {
+			return strconv.Atoi(result.(model.Vector)[0].Value.String())
+		} else {
+			return 0, nil
+		}
+	}
+
+	return 0, fmt.Errorf("Query (" + q + ") has failed")
+
+}

--- a/test/e2e/runner/wait.go
+++ b/test/e2e/runner/wait.go
@@ -21,7 +21,7 @@ func Wait(ctx context.Context, testnet *e2e.Testnet, blocks int64) error {
 // WaitUntil waits until a given height has been reached.
 func WaitUntil(ctx context.Context, testnet *e2e.Testnet, height int64) error {
 	logger.Info("wait until", "msg", log.NewLazySprintf("Waiting for all nodes to reach height %v...", height))
-	_, err := waitForAllNodes(ctx, testnet, height, waitingTime(len(testnet.Nodes), height))
+	_, err := WaitForAllNodes(ctx, testnet, height, waitingTime(len(testnet.Nodes), height))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR addresses issue #1059.

It is built atop #1043.

**Summary:**
This PR adds a support for fast prototyping to the E2E test suite. Please read the REAME.md located [here](https://github.com/otrack/cometbft/blob/pierre/fast-prototyping-1059/test/e2e/fast-prototyping/README.md)  to start using this code.

**Progress:**
To date, the following goals are in full (or partially) done:
- [x] Speed-up docker image construction
- [x] Add new small docker image (new make target)
- [x] Include Prometheus server support to docker compose
- [ ] Provide manifests for medium-scale experiments (#1082)
- [x] (_partial)_ Allow customizing manifests to choose reactors (#1083)
- [x] (_partial)_ Provide scripts to collect and process metrics (#1084)
- [x] _(partial)_ Add full support for e2e tests in fast-prototyping mode (#1085))

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
