### PR TITLE
mempool: test FIFO ordering when disseminating txs

### DIFF
--- a/consensus/replay_stubs.go
+++ b/consensus/replay_stubs.go
@@ -46,7 +46,7 @@ func (emptyMempool) TxsAvailable() <-chan struct{}          { return make(chan s
 func (emptyMempool) EnableTxsAvailable()                    {}
 func (emptyMempool) SetTxRemovedCallback(func(types.TxKey)) {}
 func (emptyMempool) TxsBytes() int64                        { return 0 }
-func (emptyMempool) InMempool(types.TxKey) bool             { return false }
+func (emptyMempool) Contains(types.TxKey) bool              { return false }
 
 func (emptyMempool) TxsFront() *clist.CElement    { return nil }
 func (emptyMempool) TxsWaitChan() <-chan struct{} { return nil }

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -112,7 +112,7 @@ func (mem *CListMempool) getCElement(txKey types.TxKey) (*clist.CElement, bool) 
 	return nil, false
 }
 
-func (mem *CListMempool) InMempool(txKey types.TxKey) bool {
+func (mem *CListMempool) Contains(txKey types.TxKey) bool {
 	_, ok := mem.getCElement(txKey)
 	return ok
 }
@@ -391,7 +391,7 @@ func (mem *CListMempool) resCbFirstTime(
 			}
 
 			// Check transaction not already in the mempool
-			if mem.InMempool(txKey) {
+			if mem.Contains(txKey) {
 				mem.logger.Debug(
 					"transaction already there, not adding it again",
 					"tx", types.Tx(tx).Hash(),

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -52,10 +52,12 @@ type CListMempool struct {
 	recheckCursor *clist.CElement // next expected response
 	recheckEnd    *clist.CElement // re-checking stops here
 
-	// Concurrent linked-list of valid txs.
-	// `txsMap`: txKey -> CElement is for quick access to txs.
-	// Transactions in both `txs` and `txsMap` must to be kept in sync.
-	txs    *clist.CList
+	// Concurrent linked-list of valid transactions.
+	// txs must to be kept in sync with txsMap.
+	txs *clist.CList
+
+	// txsMap is for quick access to txs and it must be kept in sync with txs.
+	// txsMap: txKey -> CElement
 	txsMap sync.Map
 
 	// Keep a cache of already-seen txs.

--- a/mempool/reactor_test.go
+++ b/mempool/reactor_test.go
@@ -306,7 +306,7 @@ func TestReactorTxSendersMultiNode(t *testing.T) {
 	config := cfg.TestConfig()
 	config.Mempool.Size = 1000
 	config.Mempool.CacheSize = 1000
-	const N = 3
+	const N = 5
 	reactors, _ := makeAndConnectReactors(config, N)
 	defer func() {
 		for _, r := range reactors {
@@ -371,7 +371,7 @@ func TestReactorPeerLagging(t *testing.T) {
 	config := cfg.TestConfig()
 	config.Mempool.Size = 1000
 	config.Mempool.CacheSize = 1000
-	const N = 3
+	const N = 4
 	reactors, _ := makeAndConnectReactors(config, N)
 	defer func() {
 		for _, r := range reactors {
@@ -402,7 +402,7 @@ func TestReactorPeerLagging(t *testing.T) {
 	// Add transactions to the first reactor.
 	callCheckTx(t, reactors[0].mempool, txs)
 	// Ensure the transactions were added in the right order.
-	waitForReactors(t, txs, reactors[:0], checkTxsInMempoolInOrder)
+	checkTxsInMempoolInOrder(t, txs, reactors[0], 0)
 
 	// Because the peers are lagging, the first reactor should keep sleeping and
 	// not broadcast the transactions even if it has had plenty of time.

--- a/mempool/reactor_test.go
+++ b/mempool/reactor_test.go
@@ -351,7 +351,7 @@ func TestReactorTxSendersMultiNode(t *testing.T) {
 		// Txs included in a block should have been removed from the mempool and
 		// have no senders.
 		for _, tx := range append(validTxs, invalidTxs...) {
-			require.False(t, r.mempool.InMempool(tx.Key()))
+			require.False(t, r.mempool.Contains(tx.Key()))
 			_, hasSenders := r.txSenders[tx.Key()]
 			require.False(t, hasSenders)
 		}
@@ -380,7 +380,7 @@ func checkTxsInMempoolAndSenders(t *testing.T, r *Reactor, txs types.Txs, reacto
 	// Each transaction is in the mempool and, if it's not the first reactor, it
 	// has a non-empty list of senders.
 	for _, tx := range txs {
-		assert.True(t, r.mempool.InMempool(tx.Key()))
+		assert.True(t, r.mempool.Contains(tx.Key()))
 		senders, hasSenders := r.txSenders[tx.Key()]
 		if reactorIndex == 0 {
 			require.False(t, hasSenders)


### PR DESCRIPTION
This code was originally in #1043, and extracted from there.

The main addition here is the test `TestReactorPeerLagging`. Also checking that transactions are in order in `TestReactorTxSendersMultiNode`.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

