### PR TITLE
replace internet route-able ipv4s in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ./build:/cometbft:Z
     networks:
       localnet:
-        ipv4_address: 192.167.10.2
+        ipv4_address: 192.168.10.2
 
   node1:
     container_name: node1
@@ -27,7 +27,7 @@ services:
       - ./build:/cometbft:Z
     networks:
       localnet:
-        ipv4_address: 192.167.10.3
+        ipv4_address: 192.168.10.3
 
   node2:
     container_name: node2
@@ -41,7 +41,7 @@ services:
       - ./build:/cometbft:Z
     networks:
       localnet:
-        ipv4_address: 192.167.10.4
+        ipv4_address: 192.168.10.4
 
   node3:
     container_name: node3
@@ -55,7 +55,7 @@ services:
       - ./build:/cometbft:Z
     networks:
       localnet:
-        ipv4_address: 192.167.10.5
+        ipv4_address: 192.168.10.5
 
 networks:
   localnet:
@@ -63,4 +63,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: 192.167.10.0/16
+        - subnet: 192.168.10.0/24


### PR DESCRIPTION
replace internet routeable ipv4s in docker-compose
ref: https://datatracker.ietf.org/doc/html/rfc1918
https://ip-netblocks.whoisxmlapi.com/lookup-report/8L2ojwyPRE

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

