### PR TITLE
ci: Remove Mergify automerge

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,22 +1,4 @@
-queue_rules:
-  - name: default
-    conditions:
-      - base=main
-      - label=automerge
-
 pull_request_rules:
-  - name: Automerge to main
-    conditions:
-      - base=main
-      - label=automerge
-    actions:
-      queue:
-        method: squash
-        name: default
-        commit_message_template: |
-          {{ title }} (#{{ number }})
-
-          {{ body }}
   - name: backport patches to v0.38.x branch
     conditions:
       - base=main


### PR DESCRIPTION
Mergify's automerge functionality clashes with merge queues and automatic Dependabot updates sometimes, which is particularly annoying. We don't need it on `main` any more.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

