### PR TITLE
Porting fast-docker image from #1089

### DIFF
--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -16,12 +16,21 @@ docker-debug:
 		--tag cometbft/e2e-node:local-version \
 		-f docker/Dockerfile.debug ../..
 
+docker-fast:
+	@echo "Building fast-prototyping E2E Docker image"
+	@docker build \
+		--tag cometbft/e2e-node:local-version \
+		-f docker/Dockerfile.fast .
+
 # We need to build support for database backends into the app in
 # order to build a binary with a CometBFT node in it (for built-in
 # ABCI testing).
 node:
 	go build -race $(BUILD_FLAGS) -tags '$(BUILD_TAGS)' -o build/node ./node
 
+# There is some redundancy between this and the ../../Makefile#build-linux
+node-fast:
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o build/node ./node
 
 generator:
 	go build -o build/generator ./generator

--- a/test/e2e/docker/Dockerfile.fast
+++ b/test/e2e/docker/Dockerfile.fast
@@ -1,0 +1,13 @@
+FROM gcr.io/distroless/static-debian11:debug
+
+COPY build/node /app
+COPY docker/entrypoint-fast /usr/bin/entrypoint-builtin
+
+WORKDIR /cometbft
+VOLUME /cometbft
+ENV CMTHOME=/cometbft
+ENV GORACE "halt_on_error=1"
+
+EXPOSE 26656 26657 26660 6060
+ENTRYPOINT ["/usr/bin/entrypoint-builtin"]
+STOPSIGNAL SIGTERM

--- a/test/e2e/docker/entrypoint-fast
+++ b/test/e2e/docker/entrypoint-fast
@@ -1,0 +1,5 @@
+#!/busybox/sh
+
+rm -rf /var/run/privval.sock /var/run/app.sock
+/app /cometbft/config/app.toml # > /dev/null
+

--- a/test/e2e/fast-prototyping/README.md
+++ b/test/e2e/fast-prototyping/README.md
@@ -1,0 +1,21 @@
+# Fast Prototyping
+
+This directory contains a set of scripts to run experiments for fast-prototyping cometbft reactors.
+Please note that (to date) these scripts are mostly oriented toward prototyping mempool reactors.
+
+## Fast docker image
+
+To use the fast-prototyping feature and be able to run dozens of nodes in containers, you need a very lean docker image.
+To build it:
+- Have an updated docker installed
+- From the CometBFT clone, build
+   ```bash
+   E2E_DIR=$(pwd)/test/e2e
+   cd ${E2E_DIR}
+   make node-fast generator runner docker-fast
+   ```
+  
+- At this point you can run some tests using the fast docker image, but be aware that it is a very lean image.
+   ```
+   ./run-multiple.sh networks/long.toml
+   ```


### PR DESCRIPTION
Changes done in the context of #1059 resulted in changes in #1139 and branch `pierre/fast-prototyping-1059`
This PR isolates the changes related only building a lean image for fast prototyping.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

