### PR TITLE
Only wait if a new timestamp is being generated

### DIFF
--- a/spec/consensus/proposer-based-timestamp/pbts-algorithm_002_draft.md
+++ b/spec/consensus/proposer-based-timestamp/pbts-algorithm_002_draft.md
@@ -88,10 +88,10 @@ function StartRound(round) {
  round_p ← round
  step_p ← propose
  if proposer(h_p, round_p) = p {
-  wait until now_p > decision_p[h_p-1].time // time monotonicity
   if validValue_p != nil {
    proposal ← validValue_p
   } else {
+   wait until now_p > decision_p[h_p-1].time // time monotonicity
    proposal ← getValue()
    proposal.time ← now_p // proposal time
   }


### PR DESCRIPTION
Only wait if a new timestamp is being generated. If the one in the valid value is being used, just speed things up

This change is made on master because the spec in main is not updated, which is another issue.



---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

