### PR TITLE
reduce the block size limit

### DIFF
--- a/types/params.go
+++ b/types/params.go
@@ -96,7 +96,7 @@ func DefaultConsensusParams() *ConsensusParams {
 // DefaultBlockParams returns a default BlockParams.
 func DefaultBlockParams() BlockParams {
 	return BlockParams{
-		MaxBytes: 22020096, // 21MB
+		MaxBytes: 2000000, // 2MB
 		MaxGas:   -1,
 	}
 }


### PR DESCRIPTION
There's a congestion problem on the stride network. The mempool is filled with txs ( prolly ibc update client txs ), this causes the proposer node to propose very big block (with 336 block parts). The peers in the network can't receive all the block parts of the proposed block causing them to vote no for the block. The next proposer will prolly have the same problem if their mempool is also full, and so on. This problem causes stride block times to be 15-30s and commited blocks has 0 txs for some period of time.

I think a very simple, non-breaking solution, which is just reducing the block size limit should solves this problem.

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

