### PR TITLE
consensus: test for precommit/locking corner case

### DIFF
--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -51,7 +51,7 @@ x * TestStateLockPOLDoesNotUnlock 4 vals, one precommits, other 3 polka nil at
 next round, so we precommit nil but maintain lock
 x * TestStateLockMissingProposalWhenPOLSeenDoesNotUpdateLock - 4 vals, 1 misses proposal but sees POL.
 x * TestStateLockMissingProposalWhenPOLSeenDoesNotUnlock - 4 vals, 1 misses proposal but sees POL.
-x * TestStateLockMissingProposalWhenPOLForLockedBlock - 4 vals, 1 misses proposal but sees POL for locked block.
+  * TestStateLockMissingProposalWhenPOLForLockedBlock - 4 vals, 1 misses proposal but sees POL for locked block.
 x * TestStateLockPOLSafety1 - 4 vals. We shouldn't change lock based on polka at earlier round
 x * TestStateLockPOLSafety2 - 4 vals. After unlocking, we shouldn't relock based on polka at earlier round
 x * TestStatePrevotePOLFromPreviousRound 4 vals, prevote a proposal if a POL was seen for it in a previous round.
@@ -1250,7 +1250,7 @@ func TestStateLockMissingProposalWhenPOLSeenDoesNotUpdateLock(t *testing.T) {
 
 // TestStateLockMissingProposalWhenPOLForLockedBlock tests that observing
 // a two thirds majority for a block that matches the validator's locked block
-// causes a validator to upate its lock round and Precommit for the locked block.
+// causes a validator to upate its lock round and Precommit the locked block.
 func TestStateLockMissingProposalWhenPOLForLockedBlock(t *testing.T) {
 	cs1, vss := randState(4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
@@ -1270,7 +1270,7 @@ func TestStateLockMissingProposalWhenPOLForLockedBlock(t *testing.T) {
 		Send a prevote for B from each of the validators to cs1.
 		Send a precommit for nil from all of the validators to cs1.
 
-		This ensures that cs1 will lock on B in this round but not precommit it.
+		This ensures that cs1 will lock on B in this round but not commit it.
 	*/
 	t.Log("### Starting Round 0")
 	startTestRound(cs1, height, round)
@@ -1278,16 +1278,16 @@ func TestStateLockMissingProposalWhenPOLForLockedBlock(t *testing.T) {
 	ensureNewRound(newRoundCh, height, round)
 	ensureNewProposal(proposalCh, height, round)
 	rs := cs1.GetRoundState()
-	firstBlockHash := rs.ProposalBlock.Hash()
-	firstBlockParts := rs.ProposalBlockParts.Header()
+	blockHash := rs.ProposalBlock.Hash()
+	blockParts := rs.ProposalBlockParts.Header()
 
 	ensurePrevote(voteCh, height, round) // prevote
 
-	signAddVotes(cs1, cmtproto.PrevoteType, firstBlockHash, firstBlockParts, false, vs2, vs3, vs4)
+	signAddVotes(cs1, cmtproto.PrevoteType, blockHash, blockParts, false, vs2, vs3, vs4)
 
 	ensurePrecommit(voteCh, height, round) // our precommit
 	// the proposed block should now be locked and our precommit added
-	validatePrecommit(t, cs1, round, round, vss[0], firstBlockHash, firstBlockHash)
+	validatePrecommit(t, cs1, round, round, vss[0], blockHash, blockHash)
 
 	// add precommits from the rest
 	signAddVotes(cs1, cmtproto.PrecommitType, nil, types.PartSetHeader{}, true, vs2, vs3, vs4)
@@ -1300,7 +1300,8 @@ func TestStateLockMissingProposalWhenPOLForLockedBlock(t *testing.T) {
 		The same block B is re-proposed, but it is not sent to cs1.
 		Send a prevote for B from each of the validators to cs1.
 
-		Check that cs1 maintain its locked block and updates the locked round to 1.
+		Check that cs1 precommits B, since B matches its locked value.
+		Check that cs1 maintains its lock on block B but updates its locked round.
 	*/
 	t.Log("### Starting Round 1")
 	incrementRound(vs2, vs3, vs4)
@@ -1313,13 +1314,15 @@ func TestStateLockMissingProposalWhenPOLForLockedBlock(t *testing.T) {
 	validatePrevote(t, cs1, round, vss[0], nil)
 
 	// now lets add prevotes from everyone else for the locked block
-	signAddVotes(cs1, cmtproto.PrevoteType, firstBlockHash, firstBlockParts, false, vs2, vs3, vs4)
+	signAddVotes(cs1, cmtproto.PrevoteType, blockHash, blockParts, false, vs2, vs3, vs4)
 
 	ensurePrecommit(voteCh, height, round)
-	// the validator precommits the block and updates its locked round
-	validatePrecommit(t, cs1, round, 1, vss[0], firstBlockHash, firstBlockHash)
 
-	// NOTE: the last behavior is inconsistent with Tendermint consensus pseudo-code.
+	// the validator precommits the block, because it matches its locked block,
+	// maintains the same locked block and updates its locked round
+	validatePrecommit(t, cs1, round, 1, vss[0], blockHash, blockHash)
+
+	// NOTE: this behavior is inconsistent with Tendermint consensus pseudo-code.
 	// In the pseudo-code, if a process does not receive the proposal (and block) for
 	// the current round, it cannot Precommit the proposed block ID, even thought it
 	// sees a POL for that block that matches the locked value (block).


### PR DESCRIPTION
This PR adds a unit test that highlights and documents a corner case in the operation of the consensus protocol.

## Pseudo-code

Considering the abstract description of Tendermint consensus algorithm ([here](https://arxiv.org/pdf/1807.04938.pdf)), the conditions for a node to issue a `Precommit` for a value (block) and update its locked value to this value are:

```
36:  upon 〈PROPOSAL, h_p , round_p, v, ∗〉 from proposer(hp , round_p) AND 2f + 1 〈PREVOTE, hp, round_p , id(v)〉 while valid(v) ∧ step_p ≥ prevote for the first time do
```

This means that for issuing a `Precommit` and locking a value in a round, the node needs to receive a matching `PROPOSAL` message from the round's proposer. In terms of the implementation, this means that the node has to receive a `Proposal` message proposing the `BlockID` that is going to be voted, plus all the corresponding `BlockPart` messages, so that the node is able to build the full `Block` identified by `BlockID`.

## Implementation

The consensus protocol implementation, however, allows the above represented action to take place when the `BlockID` for which a 2/3+ majority of `Prevote` votes is received matches the node's `lockedValue`, which in the implementation is the `LockedBlock`. As mentioned in the [code](https://github.com/cometbft/cometbft/blob/147a47d892ec88c9d3857f335a1565dc17962403/consensus/state.go#L1543), since the value that received 2/3+ `Prevote` votes matches the current `LockedBlock`,  the node can issue a `Precommit` for this block again (the locked value is the last value for which this has happened) and has only to updated its `LockedRound` to the current round.

In practical terms, this approach allows re-using the `LockedBlock` proposed, constructed, and accepted in a previous round to replace the `ProposalBlock` field, which stores the block proposed and constructed in the current round. Observe that a similar approach is also taken when [committing a block](https://github.com/cometbft/cometbft/blob/147a47d892ec88c9d3857f335a1565dc17962403/consensus/state.go#L1657): if the decided `BlockID` matches the `LockedBlock`, we can use this block as it was the `ProposalBlock` for the round.

## Context

In historical terms, this approach of using the block stored in `LockedBlock` as a fallback when the `ProposalBlock` (from the current round) is missing can be tracked back to this [commit](https://github.com/cometbft/cometbft/blame/f6093caac9b5ba7291e681fb5f98210c77f00763/consensus/state.go#L360) from 2014. This behavior, however, is not covered by any of the implemented consensus test units.

The motivation for this PR was an attempt to, among other chances, remove this approach as part of PR #1235.