### PR TITLE
ADR101:Fixing the retain height set logic

### DIFF
--- a/state/pruner.go
+++ b/state/pruner.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/libs/service"
-	"github.com/oasisprotocol/curve25519-voi/curve"
 )
 
 var (


### PR DESCRIPTION
This PR addresses comments made internally on potential corner cases where the retain height is not accepted in case any height height is set , even though it is not the height used for pruning. 

Example
```
appRetainHeight:100
dataCompanionRetainHeight:20
```
Data companion wants to set the height to `50`. 
The old logic would refuse this because the application retain height is set to 100 and we assume blocks to 100 are pruned. However, we will prune only up until the lower of the two retain heights (20) in this case. So it makes sense to accept this value. 

If the application retain height  was the only one set, we would then refuse this as a way to signal to the data companion that the request height is invalid and those blocks might have indeed been pruned.