### PR TITLE
chore: log `app_hash` as hex

### DIFF
--- a/.changelog/unreleased/improvements/1264-log-app-hash-as-hex.md
+++ b/.changelog/unreleased/improvements/1264-log-app-hash-as-hex.md
@@ -1,0 +1,2 @@
+- `[state]` Make logging `block_app_hash` and `app_hash` consistent by logging them both as hex.
+  ([\#1264](https://github.com/cometbft/cometbft/pull/1264))

--- a/state/execution.go
+++ b/state/execution.go
@@ -242,7 +242,7 @@ func (blockExec *BlockExecutor) ApplyBlock(
 		return state, fmt.Errorf("expected tx results length to match size of transactions in block. Expected %d, got %d", len(block.Data.Txs), len(abciResponse.TxResults))
 	}
 
-	blockExec.logger.Info("executed block", "height", block.Height, "app_hash", abciResponse.AppHash)
+	blockExec.logger.Info("executed block", "height", block.Height, "app_hash", fmt.Sprintf("%X", abciResponse.AppHash))
 
 	fail.Fail() // XXX
 
@@ -705,7 +705,7 @@ func ExecCommitBlock(
 		return nil, fmt.Errorf("expected tx results length to match size of transactions in block. Expected %d, got %d", len(block.Data.Txs), len(resp.TxResults))
 	}
 
-	logger.Info("executed block", "height", block.Height, "app_hash", resp.AppHash)
+	logger.Info("executed block", "height", block.Height, "app_hash", fmt.Sprintf("%X", resp.AppHash))
 
 	// Commit block
 	_, err = appConnConsensus.Commit(context.TODO())


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

@tac0turtle noticed that the logging of the app hashes was inconsistent in our v0.50 beta.
This only affects logs event with the key `app_hash` while `block_app_hash` was displaying correctly.

```sh
2:24AM INF executed block app_hash="\x1f'��ģ\x1a�$�\x1ei�\x01F\x1a�n�$�������=��E\x04" height=184782 module=state
```

This was due to an inconsistency in CometBFT logging:

https://github.com/cometbft/cometbft/blob/866b74211f680f5b9b38ca13f6a6a71547b15ff4/state/execution.go#L237

Could we get this backported in v0.38?

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

