### PR TITLE
ADR 101: Refactor height check-related logic and tests

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -254,13 +254,14 @@ func NewNode(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	pruner := sm.NewPruner(
-		stateStore,
-		blockStore,
-		logger,
+	prunerOpts := []sm.PrunerOption{
 		sm.WithPrunerInterval(config.Storage.Pruning.Interval),
 		sm.WithPrunerMetrics(smMetrics),
-	)
+	}
+	if config.Storage.Pruning.DataCompanion.Enabled {
+		prunerOpts = append(prunerOpts, sm.WithPrunerCompanionEnabled())
+	}
+	pruner := sm.NewPruner(stateStore, blockStore, logger, prunerOpts...)
 
 	// make block executor for consensus and blocksync reactors to execute blocks
 	blockExec := sm.NewBlockExecutor(

--- a/node/node.go
+++ b/node/node.go
@@ -871,9 +871,9 @@ func makeNodeInfo(
 	return nodeInfo, err
 }
 
-// Set the initial application retain height to 0 to avoid the data companion pruning blocks
-// before the application indicates it is ok
-// We set this to 0 only if the retain height was not set before by the application
+// Set the initial application retain height to 0 to avoid the data companion
+// pruning blocks before the application indicates it is OK. We set this to 0
+// only if the retain height was not set before by the application.
 func initApplicationRetainHeight(stateStore sm.Store) error {
 	if _, err := stateStore.GetApplicationRetainHeight(); err != nil {
 		if errors.Is(err, sm.ErrKeyNotFound) {

--- a/node/node.go
+++ b/node/node.go
@@ -905,22 +905,25 @@ func initApplicationRetainHeight(stateStore sm.Store) error {
 	return nil
 }
 
-// Sets the data companion retain heights if one of two possible conditions is met:
+// Sets the data companion retain heights if one of two possible conditions is
+// met:
 // 1. One or more of the retain heights has not yet been set.
 // 2. One or more of the retain heights is currently 0.
 func initCompanionRetainHeights(stateStore sm.Store, initBlockRH, initBlockResultsRH int64) error {
-	if curBlockRH, err := stateStore.GetCompanionBlockRetainHeight(); err != nil || curBlockRH == 0 {
-		if !errors.Is(err, sm.ErrKeyNotFound) {
-			return fmt.Errorf("failed to obtain companion block retain height: %w", err)
-		}
+	curBlockRH, err := stateStore.GetCompanionBlockRetainHeight()
+	if err != nil && !errors.Is(err, sm.ErrKeyNotFound) {
+		return fmt.Errorf("failed to obtain companion block retain height: %w", err)
+	}
+	if curBlockRH == 0 {
 		if err := stateStore.SaveCompanionBlockRetainHeight(initBlockRH); err != nil {
 			return fmt.Errorf("failed to set initial data companion block retain height: %w", err)
 		}
 	}
-	if curBlockResultsRH, err := stateStore.GetABCIResRetainHeight(); err != nil || curBlockResultsRH == 0 {
-		if !errors.Is(err, sm.ErrKeyNotFound) {
-			return fmt.Errorf("failed to obtain companion block results retain height: %w", err)
-		}
+	curBlockResultsRH, err := stateStore.GetABCIResRetainHeight()
+	if err != nil && !errors.Is(err, sm.ErrKeyNotFound) {
+		return fmt.Errorf("failed to obtain companion block results retain height: %w", err)
+	}
+	if curBlockResultsRH == 0 {
 		if err := stateStore.SaveABCIResRetainHeight(initBlockResultsRH); err != nil {
 			return fmt.Errorf("failed to set initial data companion block results retain height: %w", err)
 		}

--- a/node/node.go
+++ b/node/node.go
@@ -246,13 +246,15 @@ func NewNode(ctx context.Context,
 		return nil, err
 	}
 
-	err = initCompanionBlockRetainHeight(
-		stateStore,
-		config.Storage.Pruning.DataCompanion.Enabled,
-		config.Storage.Pruning.DataCompanion.InitialBlockRetainHeight,
-	)
-	if err != nil {
-		return nil, err
+	if config.Storage.Pruning.DataCompanion.Enabled {
+		err = initCompanionRetainHeights(
+			stateStore,
+			config.Storage.Pruning.DataCompanion.InitialBlockRetainHeight,
+			config.Storage.Pruning.DataCompanion.InitialBlockResultsRetainHeight,
+		)
+		if err != nil {
+			return nil, err
+		}
 	}
 	prunerOpts := []sm.PrunerOption{
 		sm.WithPrunerInterval(config.Storage.Pruning.Interval),
@@ -885,27 +887,24 @@ func initApplicationRetainHeight(stateStore sm.Store) error {
 	return nil
 }
 
-func initCompanionBlockRetainHeight(stateStore sm.Store, companionEnabled bool, initialRetainHeight int64) error {
-	if _, err := stateStore.GetCompanionBlockRetainHeight(); err != nil {
-		// If the data companion block retain height has not yet been set in
-		// the database
-		if errors.Is(err, sm.ErrKeyNotFound) {
-			if companionEnabled && initialRetainHeight > 0 {
-				// This will set the data companion retain height into the
-				// database. We bypass the sanity checks by
-				// pruner.SetCompanionBlockRetainHeight. These checks do not
-				// allow a retain height below the current blockstore height or
-				// above the blockstore height  to be set. But this is a retain
-				// height that can be set before the chain starts to indicate
-				// potentially that no pruning should be done before the data
-				// companion comes online.
-				err = stateStore.SaveCompanionBlockRetainHeight(initialRetainHeight)
-				if err != nil {
-					return fmt.Errorf("failed to set initial data companion block retain height: %w", err)
-				}
-			}
-		} else {
-			return fmt.Errorf("failed to obtain companion retain height: %w", err)
+// Sets the data companion retain heights if one of two possible conditions is met:
+// 1. One or more of the retain heights has not yet been set.
+// 2. One or more of the retain heights is currently 0.
+func initCompanionRetainHeights(stateStore sm.Store, initBlockRH, initBlockResultsRH int64) error {
+	if curBlockRH, err := stateStore.GetCompanionBlockRetainHeight(); err != nil || curBlockRH == 0 {
+		if !errors.Is(err, sm.ErrKeyNotFound) {
+			return fmt.Errorf("failed to obtain companion block retain height: %w", err)
+		}
+		if err := stateStore.SaveCompanionBlockRetainHeight(initBlockRH); err != nil {
+			return fmt.Errorf("failed to set initial data companion block retain height: %w", err)
+		}
+	}
+	if curBlockResultsRH, err := stateStore.GetABCIResRetainHeight(); err != nil || curBlockResultsRH == 0 {
+		if !errors.Is(err, sm.ErrKeyNotFound) {
+			return fmt.Errorf("failed to obtain companion block results retain height: %w", err)
+		}
+		if err := stateStore.SaveABCIResRetainHeight(initBlockResultsRH); err != nil {
+			return fmt.Errorf("failed to set initial data companion block results retain height: %w", err)
 		}
 	}
 	return nil

--- a/node/node.go
+++ b/node/node.go
@@ -872,6 +872,11 @@ func createPruner(
 		return nil, err
 	}
 
+	prunerOpts := []sm.PrunerOption{
+		sm.WithPrunerInterval(config.Storage.Pruning.Interval),
+		sm.WithPrunerMetrics(metrics),
+	}
+
 	if config.Storage.Pruning.DataCompanion.Enabled {
 		err := initCompanionRetainHeights(
 			stateStore,
@@ -881,14 +886,9 @@ func createPruner(
 		if err != nil {
 			return nil, err
 		}
-	}
-	prunerOpts := []sm.PrunerOption{
-		sm.WithPrunerInterval(config.Storage.Pruning.Interval),
-		sm.WithPrunerMetrics(metrics),
-	}
-	if config.Storage.Pruning.DataCompanion.Enabled {
 		prunerOpts = append(prunerOpts, sm.WithPrunerCompanionEnabled())
 	}
+
 	return sm.NewPruner(stateStore, blockStore, logger, prunerOpts...), nil
 }
 

--- a/rpc/grpc/server/services/pruningservice/service.go
+++ b/rpc/grpc/server/services/pruningservice/service.go
@@ -42,7 +42,7 @@ func (s *pruningServiceServer) SetBlockRetainHeight(_ context.Context, req *v1.S
 	}
 	if err := s.pruner.SetCompanionBlockRetainHeight(int64(height)); err != nil {
 		logger.Error("Cannot set block retain height", "err", err, "traceID", traceID)
-		return nil, status.Error(codes.Internal, "Failed to set block retain height")
+		return nil, status.Errorf(codes.Internal, "Failed to set block retain height (see logs for trace ID: %s)", traceID)
 	}
 	return &v1.SetBlockRetainHeightResponse{}, nil
 }
@@ -58,12 +58,12 @@ func (s *pruningServiceServer) GetBlockRetainHeight(_ context.Context, _ *v1.Get
 	svcHeight, err := s.pruner.GetCompanionBlockRetainHeight()
 	if err != nil {
 		logger.Error("Cannot get block retain height stored by companion", "err", err, "traceID", traceID)
-		return nil, status.Error(codes.Internal, "Failed to get companion block retain height")
+		return nil, status.Errorf(codes.Internal, "Failed to get companion block retain height (see logs for trace ID: %s)", traceID)
 	}
 	appHeight, err := s.pruner.GetApplicationRetainHeight()
 	if err != nil {
 		logger.Error("Cannot get block retain height specified by application", "err", err, "traceID", traceID)
-		return nil, status.Error(codes.Internal, "Failed to get app block retain height")
+		return nil, status.Errorf(codes.Internal, "Failed to get app block retain height (see logs for trace ID: %s)", traceID)
 	}
 	return &v1.GetBlockRetainHeightResponse{
 		PruningServiceRetainHeight: uint64(svcHeight),
@@ -86,7 +86,7 @@ func (s *pruningServiceServer) SetBlockResultsRetainHeight(_ context.Context, re
 	}
 	if err := s.pruner.SetABCIResRetainHeight(int64(height)); err != nil {
 		logger.Error("Cannot set block results retain height", "err", err, "traceID", traceID)
-		return nil, status.Error(codes.Internal, "Failed to set block results retain height")
+		return nil, status.Errorf(codes.Internal, "Failed to set block results retain height (see logs for trace ID: %s)", traceID)
 	}
 	return &v1.SetBlockResultsRetainHeightResponse{}, nil
 }
@@ -102,7 +102,7 @@ func (s *pruningServiceServer) GetBlockResultsRetainHeight(_ context.Context, _ 
 	height, err := s.pruner.GetABCIResRetainHeight()
 	if err != nil {
 		logger.Error("Cannot get block results retain height", "err", err, "traceID", traceID)
-		return nil, status.Errorf(codes.Internal, "Failed to get block results retain height")
+		return nil, status.Errorf(codes.Internal, "Failed to get block results retain height (see logs for trace ID: %s)", traceID)
 	}
 	return &v1.GetBlockResultsRetainHeightResponse{PruningServiceRetainHeight: uint64(height)}, nil
 }

--- a/rpc/grpc/server/services/pruningservice/service.go
+++ b/rpc/grpc/server/services/pruningservice/service.go
@@ -40,7 +40,7 @@ func (s *pruningServiceServer) SetBlockRetainHeight(_ context.Context, req *v1.S
 		logger.Error("Error generating RPC trace ID", "err", err)
 		return nil, status.Error(codes.Internal, "Internal server error - see logs for details")
 	}
-	if err := s.pruner.SetCompanionRetainHeight(int64(height)); err != nil {
+	if err := s.pruner.SetCompanionBlockRetainHeight(int64(height)); err != nil {
 		logger.Error("Cannot set block retain height", "err", err, "traceID", traceID)
 		return nil, status.Error(codes.Internal, "Failed to set block retain height")
 	}

--- a/state/errors.go
+++ b/state/errors.go
@@ -52,6 +52,10 @@ type (
 		Height int64
 	}
 
+	ErrPrunerFailedToGetRetainHeight struct {
+		Err error
+	}
+
 	ErrPrunerFailedToLoadState struct {
 		Err error
 	}
@@ -115,6 +119,14 @@ func (e ErrNoConsensusParamsForHeight) Error() string {
 
 func (e ErrNoABCIResponsesForHeight) Error() string {
 	return fmt.Sprintf("could not find results for height #%d", e.Height)
+}
+
+func (e ErrPrunerFailedToGetRetainHeight) Error() string {
+	return fmt.Sprintf("pruner failed to get existing retain height: %s", e.Err.Error())
+}
+
+func (e ErrPrunerFailedToGetRetainHeight) Unwrap() error {
+	return e.Err
 }
 
 func (e ErrPrunerFailedToLoadState) Error() string {

--- a/state/errors.go
+++ b/state/errors.go
@@ -53,7 +53,8 @@ type (
 	}
 
 	ErrPrunerFailedToGetRetainHeight struct {
-		Err error
+		Which string
+		Err   error
 	}
 
 	ErrPrunerFailedToLoadState struct {
@@ -122,7 +123,7 @@ func (e ErrNoABCIResponsesForHeight) Error() string {
 }
 
 func (e ErrPrunerFailedToGetRetainHeight) Error() string {
-	return fmt.Sprintf("pruner failed to get existing retain height: %s", e.Err.Error())
+	return fmt.Sprintf("pruner failed to get existing %s retain height: %s", e.Which, e.Err.Error())
 }
 
 func (e ErrPrunerFailedToGetRetainHeight) Unwrap() error {

--- a/state/execution.go
+++ b/state/execution.go
@@ -304,9 +304,9 @@ func (blockExec *BlockExecutor) ApplyBlock(
 
 	// Prune old heights, if requested by ABCI app.
 	if retainHeight > 0 && blockExec.pruner != nil {
-		err := blockExec.pruner.SetApplicationRetainHeight(retainHeight)
+		err := blockExec.pruner.SetApplicationBlockRetainHeight(retainHeight)
 		if err != nil {
-			blockExec.logger.Error("Failed to set application retain height", "retainHeight", retainHeight, "err", err)
+			blockExec.logger.Error("Failed to set application block retain height", "retainHeight", retainHeight, "err", err)
 		}
 	}
 

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -45,10 +45,11 @@ func SaveValidatorsInfo(db dbm.DB, height, lastHeightChanged int64, valSet *type
 	return stateStore.saveValidatorsInfo(height, lastHeightChanged, valSet)
 }
 
-// FindMinRetainHeight is an alias for the private findMinRetainHeight method
-// in pruner.go, exported exclusively and expicitly for testing.
+// FindMinBlockRetainHeight is an alias for the private
+// findMinBlockRetainHeight method in pruner.go, exported exclusively and
+// expicitly for testing.
 func (p *Pruner) FindMinRetainHeight() int64 {
-	return p.findMinRetainHeight()
+	return p.findMinBlockRetainHeight()
 }
 
 func (p *Pruner) PruneABCIResToRetainHeight(lastRetainHeight int64) int64 {

--- a/state/pruner.go
+++ b/state/pruner.go
@@ -135,7 +135,7 @@ func (p *Pruner) SetApplicationBlockRetainHeight(height int64) error {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 
-	if !p.checkHeightBound(height) {
+	if !p.heightWithinBounds(height) {
 		return ErrInvalidHeightValue
 	}
 	currentAppRetainHeight, err := p.stateStore.GetApplicationRetainHeight()
@@ -163,7 +163,7 @@ func (p *Pruner) SetApplicationBlockRetainHeight(height int64) error {
 	return nil
 }
 
-func (p *Pruner) checkHeightBound(height int64) bool {
+func (p *Pruner) heightWithinBounds(height int64) bool {
 	if height <= 0 || height < p.bs.Base() || height > p.bs.Height() {
 		return false
 	}
@@ -184,7 +184,7 @@ func (p *Pruner) SetCompanionBlockRetainHeight(height int64) error {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 
-	if !p.checkHeightBound(height) {
+	if !p.heightWithinBounds(height) {
 		return ErrInvalidHeightValue
 	}
 	currentCompanionRetainHeight, err := p.stateStore.GetCompanionBlockRetainHeight()

--- a/state/pruner.go
+++ b/state/pruner.go
@@ -187,14 +187,14 @@ func (p *Pruner) SetCompanionBlockRetainHeight(height int64) error {
 	if !p.heightWithinBounds(height) {
 		return ErrInvalidHeightValue
 	}
-	currentCompanionRetainHeight, err := p.stateStore.GetCompanionBlockRetainHeight()
+	curCompanionRetainHeight, err := p.stateStore.GetCompanionBlockRetainHeight()
 	if err != nil {
 		if !errors.Is(err, ErrKeyNotFound) {
 			return err
 		}
-		currentCompanionRetainHeight = height
+		curCompanionRetainHeight = height
 	}
-	currentAppRetainHeight, err := p.stateStore.GetApplicationRetainHeight()
+	curAppRetainHeight, err := p.stateStore.GetApplicationRetainHeight()
 	appRetainHeightSet := true
 	if err != nil {
 		if !errors.Is(err, ErrKeyNotFound) {
@@ -202,7 +202,7 @@ func (p *Pruner) SetCompanionBlockRetainHeight(height int64) error {
 		}
 		appRetainHeightSet = false
 	}
-	if currentCompanionRetainHeight > height || (appRetainHeightSet && currentAppRetainHeight > height) {
+	if curCompanionRetainHeight > height || (appRetainHeightSet && curAppRetainHeight > height) {
 		return ErrPrunerCannotLowerRetainHeight
 	}
 	if err := p.stateStore.SaveCompanionBlockRetainHeight(height); err != nil {

--- a/state/pruner.go
+++ b/state/pruner.go
@@ -111,7 +111,11 @@ func (p *Pruner) SetObserver(obs PrunerObserver) {
 
 func (p *Pruner) OnStart() error {
 	go p.pruneBlocksRoutine()
-	go p.pruneABCIResRoutine()
+	// We only care about pruning ABCI results if the data companion has been
+	// enabled.
+	if p.dcEnabled {
+		go p.pruneABCIResRoutine()
+	}
 	p.observer.PrunerStarted(p.interval)
 	return nil
 }

--- a/state/pruner.go
+++ b/state/pruner.go
@@ -120,8 +120,8 @@ func (p *Pruner) OnStart() error {
 	return nil
 }
 
-// SetApplicationRetainHeight sets the application retain height with some
-// basic checks on the requested height.
+// SetApplicationBlockRetainHeight sets the application block retain height
+// with some basic checks on the requested height.
 //
 // If a higher retain height is already set, we cannot accept the requested
 // height because the blocks might have been pruned.
@@ -129,7 +129,7 @@ func (p *Pruner) OnStart() error {
 // If the data companion has already set a retain height to a higher value we
 // also cannot accept the requested height as the blocks might have been
 // pruned.
-func (p *Pruner) SetApplicationRetainHeight(height int64) error {
+func (p *Pruner) SetApplicationBlockRetainHeight(height int64) error {
 	// Ensure that all requests to set retain heights via the application are
 	// serialized.
 	p.mtx.Lock()

--- a/state/pruner.go
+++ b/state/pruner.go
@@ -132,7 +132,7 @@ func (p *Pruner) SetApplicationBlockRetainHeight(height int64) error {
 	}
 	curRetainHeight, err := p.stateStore.GetApplicationRetainHeight()
 	if err != nil {
-		return ErrPrunerFailedToGetRetainHeight{Err: err}
+		return ErrPrunerFailedToGetRetainHeight{Which: "application block", Err: err}
 	}
 	if height < curRetainHeight {
 		return ErrPrunerCannotLowerRetainHeight
@@ -167,7 +167,7 @@ func (p *Pruner) SetCompanionBlockRetainHeight(height int64) error {
 	}
 	curRetainHeight, err := p.stateStore.GetCompanionBlockRetainHeight()
 	if err != nil {
-		return ErrPrunerFailedToGetRetainHeight{Err: err}
+		return ErrPrunerFailedToGetRetainHeight{Which: "companion block", Err: err}
 	}
 	if height < curRetainHeight {
 		return ErrPrunerCannotLowerRetainHeight
@@ -194,7 +194,7 @@ func (p *Pruner) SetABCIResRetainHeight(height int64) error {
 	}
 	curRetainHeight, err := p.stateStore.GetABCIResRetainHeight()
 	if err != nil {
-		return ErrPrunerFailedToGetRetainHeight{Err: err}
+		return ErrPrunerFailedToGetRetainHeight{Which: "ABCI results", Err: err}
 	}
 	if height < curRetainHeight {
 		return ErrPrunerCannotLowerRetainHeight

--- a/state/pruner.go
+++ b/state/pruner.go
@@ -164,7 +164,7 @@ func (p *Pruner) SetApplicationBlockRetainHeight(height int64) error {
 }
 
 func (p *Pruner) heightWithinBounds(height int64) bool {
-	if height <= 0 || height < p.bs.Base() || height > p.bs.Height() {
+	if height < p.bs.Base() || height > p.bs.Height() {
 		return false
 	}
 	return true

--- a/state/pruner.go
+++ b/state/pruner.go
@@ -170,15 +170,15 @@ func (p *Pruner) checkHeightBound(height int64) bool {
 	return true
 }
 
-// SetCompanionRetainHeight sets the application retain height with some basic
-// checks on the requested height.
+// SetCompanionBlockRetainHeight sets the application block retain height with
+// some basic checks on the requested height.
 //
 // If a higher retain height is already set, we cannot accept the requested
 // height because the blocks might have been pruned.
 //
 // If the application has already set a retain height to a higher value we also
 // cannot accept the requested height as the blocks might have been pruned.
-func (p *Pruner) SetCompanionRetainHeight(height int64) error {
+func (p *Pruner) SetCompanionBlockRetainHeight(height int64) error {
 	// Ensure that all requests to set retain heights via the pruner are
 	// serialized.
 	p.mtx.Lock()

--- a/state/pruner.go
+++ b/state/pruner.go
@@ -226,18 +226,18 @@ func (p *Pruner) GetABCIResRetainHeight() (int64, error) {
 
 func (p *Pruner) pruneABCIResRoutine() {
 	p.logger.Info("Started pruning ABCI results", "interval", p.interval.String())
-	lastABCIResRetainHeight := int64(0)
+	lastRetainHeight := int64(0)
 	for {
 		select {
 		case <-p.Quit():
 			return
 		default:
-			newABCIResRetainHeight := p.pruneABCIResToRetainHeight(lastABCIResRetainHeight)
+			newRetainHeight := p.pruneABCIResToRetainHeight(lastRetainHeight)
 			p.observer.PrunerPrunedABCIRes(&ABCIResponsesPrunedInfo{
-				FromHeight: lastABCIResRetainHeight,
-				ToHeight:   newABCIResRetainHeight - 1,
+				FromHeight: lastRetainHeight,
+				ToHeight:   newRetainHeight - 1,
 			})
-			lastABCIResRetainHeight = newABCIResRetainHeight
+			lastRetainHeight = newRetainHeight
 			time.Sleep(p.interval)
 		}
 	}

--- a/state/pruner.go
+++ b/state/pruner.go
@@ -299,7 +299,7 @@ func (p *Pruner) pruneBlocksRoutine() {
 }
 
 func (p *Pruner) pruneBlocksToRetainHeight(lastRetainHeight int64) int64 {
-	targetRetainHeight := p.findMinRetainHeight()
+	targetRetainHeight := p.findMinBlockRetainHeight()
 	if targetRetainHeight == lastRetainHeight {
 		return lastRetainHeight
 	}
@@ -347,7 +347,7 @@ func (p *Pruner) pruneABCIResToRetainHeight(lastRetainHeight int64) int64 {
 	return newRetainHeight
 }
 
-func (p *Pruner) findMinRetainHeight() int64 {
+func (p *Pruner) findMinBlockRetainHeight() int64 {
 	appRetainHeight, err := p.stateStore.GetApplicationRetainHeight()
 	if err != nil {
 		if !errors.Is(err, ErrKeyNotFound) {

--- a/state/pruner.go
+++ b/state/pruner.go
@@ -138,14 +138,14 @@ func (p *Pruner) SetApplicationBlockRetainHeight(height int64) error {
 	if !p.heightWithinBounds(height) {
 		return ErrInvalidHeightValue
 	}
-	currentAppRetainHeight, err := p.stateStore.GetApplicationRetainHeight()
+	curAppRetainHeight, err := p.stateStore.GetApplicationRetainHeight()
 	if err != nil {
 		if !errors.Is(err, ErrKeyNotFound) {
 			return err
 		}
-		currentAppRetainHeight = height
+		curAppRetainHeight = height
 	}
-	currentCompanionRetainHeight, err := p.stateStore.GetCompanionBlockRetainHeight()
+	curCompanionRetainHeight, err := p.stateStore.GetCompanionBlockRetainHeight()
 	companionRetainHeightSet := true
 	if err != nil {
 		if !errors.Is(err, ErrKeyNotFound) {
@@ -153,7 +153,7 @@ func (p *Pruner) SetApplicationBlockRetainHeight(height int64) error {
 		}
 		companionRetainHeightSet = false
 	}
-	if currentAppRetainHeight > height || (companionRetainHeightSet && currentCompanionRetainHeight > height) {
+	if curAppRetainHeight > height || (companionRetainHeightSet && curCompanionRetainHeight > height) {
 		return ErrPrunerCannotLowerRetainHeight
 	}
 	if err := p.stateStore.SaveApplicationRetainHeight(height); err != nil {

--- a/state/pruner.go
+++ b/state/pruner.go
@@ -207,9 +207,9 @@ func (p *Pruner) SetABCIResRetainHeight(height int64) error {
 		if !errors.Is(err, ErrKeyNotFound) {
 			return err
 		}
-		return p.stateStore.SaveABCIResRetainHeight(height)
+		curRetainHeight = height
 	}
-	if curRetainHeight > height {
+	if height < curRetainHeight {
 		return ErrPrunerCannotLowerRetainHeight
 	}
 	if err := p.stateStore.SaveABCIResRetainHeight(height); err != nil {

--- a/state/pruner.go
+++ b/state/pruner.go
@@ -225,14 +225,14 @@ func (p *Pruner) SetABCIResRetainHeight(height int64) error {
 	if height <= 0 || height > p.bs.Height() {
 		return ErrInvalidHeightValue
 	}
-	currentRetainHeight, err := p.stateStore.GetABCIResRetainHeight()
+	curRetainHeight, err := p.stateStore.GetABCIResRetainHeight()
 	if err != nil {
 		if !errors.Is(err, ErrKeyNotFound) {
 			return err
 		}
 		return p.stateStore.SaveABCIResRetainHeight(height)
 	}
-	if currentRetainHeight > height {
+	if curRetainHeight > height {
 		return ErrPrunerCannotLowerRetainHeight
 	}
 	if err := p.stateStore.SaveABCIResRetainHeight(height); err != nil {

--- a/state/pruner.go
+++ b/state/pruner.go
@@ -134,14 +134,14 @@ func (p *Pruner) SetApplicationBlockRetainHeight(height int64) error {
 	if !p.heightWithinBounds(height) {
 		return ErrInvalidHeightValue
 	}
-	curAppRetainHeight, err := p.stateStore.GetApplicationRetainHeight()
+	curRetainHeight, err := p.stateStore.GetApplicationRetainHeight()
 	if err != nil {
 		if !errors.Is(err, ErrKeyNotFound) {
 			return err
 		}
-		curAppRetainHeight = height
+		curRetainHeight = height
 	}
-	if height < curAppRetainHeight {
+	if height < curRetainHeight {
 		return ErrPrunerCannotLowerRetainHeight
 	}
 	if err := p.stateStore.SaveApplicationRetainHeight(height); err != nil {
@@ -172,14 +172,14 @@ func (p *Pruner) SetCompanionBlockRetainHeight(height int64) error {
 	if !p.heightWithinBounds(height) {
 		return ErrInvalidHeightValue
 	}
-	curCompanionRetainHeight, err := p.stateStore.GetCompanionBlockRetainHeight()
+	curRetainHeight, err := p.stateStore.GetCompanionBlockRetainHeight()
 	if err != nil {
 		if !errors.Is(err, ErrKeyNotFound) {
 			return err
 		}
-		curCompanionRetainHeight = height
+		curRetainHeight = height
 	}
-	if height < curCompanionRetainHeight {
+	if height < curRetainHeight {
 		return ErrPrunerCannotLowerRetainHeight
 	}
 	if err := p.stateStore.SaveCompanionBlockRetainHeight(height); err != nil {

--- a/state/pruner.go
+++ b/state/pruner.go
@@ -222,7 +222,7 @@ func (p *Pruner) SetABCIResRetainHeight(height int64) error {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 
-	if height <= 0 || height > p.bs.Height() {
+	if !p.heightWithinBounds(height) {
 		return ErrInvalidHeightValue
 	}
 	curRetainHeight, err := p.stateStore.GetABCIResRetainHeight()

--- a/state/pruner.go
+++ b/state/pruner.go
@@ -163,9 +163,6 @@ func (p *Pruner) heightWithinBounds(height int64) bool {
 //
 // If a higher retain height is already set, we cannot accept the requested
 // height because the blocks might have been pruned.
-//
-// If the application has already set a retain height to a higher value we also
-// cannot accept the requested height as the blocks might have been pruned.
 func (p *Pruner) SetCompanionBlockRetainHeight(height int64) error {
 	// Ensure that all requests to set retain heights via the pruner are
 	// serialized.
@@ -182,15 +179,7 @@ func (p *Pruner) SetCompanionBlockRetainHeight(height int64) error {
 		}
 		curCompanionRetainHeight = height
 	}
-	curAppRetainHeight, err := p.stateStore.GetApplicationRetainHeight()
-	appRetainHeightSet := true
-	if err != nil {
-		if !errors.Is(err, ErrKeyNotFound) {
-			return err
-		}
-		appRetainHeightSet = false
-	}
-	if curCompanionRetainHeight > height || (appRetainHeightSet && curAppRetainHeight > height) {
+	if height < curCompanionRetainHeight {
 		return ErrPrunerCannotLowerRetainHeight
 	}
 	if err := p.stateStore.SaveCompanionBlockRetainHeight(height); err != nil {

--- a/state/pruner.go
+++ b/state/pruner.go
@@ -125,10 +125,6 @@ func (p *Pruner) OnStart() error {
 //
 // If a higher retain height is already set, we cannot accept the requested
 // height because the blocks might have been pruned.
-//
-// If the data companion has already set a retain height to a higher value we
-// also cannot accept the requested height as the blocks might have been
-// pruned.
 func (p *Pruner) SetApplicationBlockRetainHeight(height int64) error {
 	// Ensure that all requests to set retain heights via the application are
 	// serialized.
@@ -145,15 +141,7 @@ func (p *Pruner) SetApplicationBlockRetainHeight(height int64) error {
 		}
 		curAppRetainHeight = height
 	}
-	curCompanionRetainHeight, err := p.stateStore.GetCompanionBlockRetainHeight()
-	companionRetainHeightSet := true
-	if err != nil {
-		if !errors.Is(err, ErrKeyNotFound) {
-			return err
-		}
-		companionRetainHeightSet = false
-	}
-	if curAppRetainHeight > height || (companionRetainHeightSet && curCompanionRetainHeight > height) {
+	if height < curAppRetainHeight {
 		return ErrPrunerCannotLowerRetainHeight
 	}
 	if err := p.stateStore.SaveApplicationRetainHeight(height); err != nil {

--- a/state/store_test.go
+++ b/state/store_test.go
@@ -254,9 +254,22 @@ func makeStateAndBlockStore() (sm.State, *store.BlockStore, func(), sm.Store) {
 	})
 	state, err := stateStore.LoadFromDBOrGenesisFile(config.GenesisFile())
 	if err != nil {
-		panic(fmt.Errorf("error constructing state from genesis file: %w", err))
+		panic(fmt.Sprintf("error constructing state from genesis file: %s", err.Error()))
 	}
 	return state, store.NewBlockStore(blockDB), func() { os.RemoveAll(config.RootDir) }, stateStore
+}
+
+func initStateStoreRetainHeights(stateStore sm.Store, appBlockRH, dcBlockRH, dcBlockResultsRH int64) error {
+	if err := stateStore.SaveApplicationRetainHeight(appBlockRH); err != nil {
+		return fmt.Errorf("failed to set initial application block retain height: %w", err)
+	}
+	if err := stateStore.SaveCompanionBlockRetainHeight(dcBlockRH); err != nil {
+		return fmt.Errorf("failed to set initial companion block retain height: %w", err)
+	}
+	if err := stateStore.SaveABCIResRetainHeight(dcBlockResultsRH); err != nil {
+		return fmt.Errorf("failed to set initial ABCI results retain height: %w", err)
+	}
+	return nil
 }
 
 func fillStore(t *testing.T, height int64, stateStore sm.Store, bs *store.BlockStore, state sm.State, response1 *abci.ResponseFinalizeBlock) {
@@ -288,17 +301,21 @@ func TestSaveRetainHeight(t *testing.T) {
 	state.LastBlockHeight = height - 1
 
 	fillStore(t, height, stateStore, bs, state, nil)
+	err := initStateStoreRetainHeights(stateStore, 0, 0, 0)
+	require.NoError(t, err)
 
 	pruner := sm.NewPruner(stateStore, bs, log.TestingLogger())
 
 	// We should not save a height that is 0
-	err := pruner.SetApplicationBlockRetainHeight(0)
+	err = pruner.SetApplicationBlockRetainHeight(0)
 	require.Error(t, err)
 
-	// We should not save a height above the blockstore's height
+	// We should not save a height above the block store's height.
 	err = pruner.SetApplicationBlockRetainHeight(11)
 	require.Error(t, err)
 
+	// We should allow saving a retain height equal to the block store's
+	// height.
 	err = pruner.SetApplicationBlockRetainHeight(10)
 	require.NoError(t, err)
 
@@ -440,6 +457,8 @@ func TestFinalizeBlockResponsePruning(t *testing.T) {
 		state.LastBlockHeight = height - 1
 
 		fillStore(t, height, stateStore, bs, state, response1)
+		err = initStateStoreRetainHeights(stateStore, 0, 0, 0)
+		require.NoError(t, err)
 
 		obs := newPrunerObserver(1)
 		pruner := sm.NewPruner(

--- a/state/store_test.go
+++ b/state/store_test.go
@@ -467,6 +467,7 @@ func TestFinalizeBlockResponsePruning(t *testing.T) {
 			log.TestingLogger(),
 			sm.WithPrunerInterval(1*time.Second),
 			sm.WithPrunerObserver(obs),
+			sm.WithPrunerCompanionEnabled(),
 		)
 
 		// Check that we have written a finalize block result at height 'height - 1'

--- a/state/store_test.go
+++ b/state/store_test.go
@@ -292,14 +292,14 @@ func TestSaveRetainHeight(t *testing.T) {
 	pruner := sm.NewPruner(stateStore, bs, log.TestingLogger())
 
 	// We should not save a height that is 0
-	err := pruner.SetApplicationRetainHeight(0)
+	err := pruner.SetApplicationBlockRetainHeight(0)
 	require.Error(t, err)
 
 	// We should not save a height above the blockstore's height
-	err = pruner.SetApplicationRetainHeight(11)
+	err = pruner.SetApplicationBlockRetainHeight(11)
 	require.Error(t, err)
 
-	err = pruner.SetApplicationRetainHeight(10)
+	err = pruner.SetApplicationBlockRetainHeight(10)
 	require.NoError(t, err)
 
 	err = pruner.SetCompanionRetainHeight(10)
@@ -414,6 +414,7 @@ func newPrunerObserver(infoChCap int) *prunerObserver {
 func (o *prunerObserver) PrunerPrunedABCIRes(info *sm.ABCIResponsesPrunedInfo) {
 	o.prunedABCIResInfoCh <- info
 }
+
 func (o *prunerObserver) PrunerPrunedBlocks(info *sm.BlocksPrunedInfo) {
 	o.prunedBlocksResInfoCh <- info
 }
@@ -468,9 +469,7 @@ func TestFinalizeBlockResponsePruning(t *testing.T) {
 		require.Error(t, err)
 		_, err = stateStore.LoadFinalizeBlockResponse(height)
 		require.NoError(t, err)
-
 	})
-
 }
 
 func TestLastFinalizeBlockResponses(t *testing.T) {

--- a/state/store_test.go
+++ b/state/store_test.go
@@ -302,7 +302,7 @@ func TestSaveRetainHeight(t *testing.T) {
 	err = pruner.SetApplicationBlockRetainHeight(10)
 	require.NoError(t, err)
 
-	err = pruner.SetCompanionRetainHeight(10)
+	err = pruner.SetCompanionBlockRetainHeight(10)
 	require.NoError(t, err)
 }
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -659,10 +659,10 @@ func TestPruningService(t *testing.T) {
 	require.NoError(t, err)
 	// We should not be able to set a retain height lower than the currently
 	// existing retain heights
-	err = pruner.SetCompanionRetainHeight(1200)
+	err = pruner.SetCompanionBlockRetainHeight(1200)
 	assert.Error(t, err)
 
-	err = pruner.SetCompanionRetainHeight(1350)
+	err = pruner.SetCompanionBlockRetainHeight(1350)
 	assert.NoError(t, err)
 
 	select {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -539,6 +539,7 @@ func newPrunerObserver(infoChCap int) *prunerObserver {
 func (o *prunerObserver) PrunerPrunedABCIRes(info *sm.ABCIResponsesPrunedInfo) {
 	o.prunedABCIResInfoCh <- info
 }
+
 func (o *prunerObserver) PrunerPrunedBlocks(info *sm.BlocksPrunedInfo) {
 	o.prunedBlocksResInfoCh <- info
 }
@@ -571,9 +572,9 @@ func TestPruningService(t *testing.T) {
 		sm.WithPrunerObserver(obs),
 	)
 
-	err = pruner.SetApplicationRetainHeight(1)
+	err = pruner.SetApplicationBlockRetainHeight(1)
 	require.Error(t, err)
-	err = pruner.SetApplicationRetainHeight(0)
+	err = pruner.SetApplicationBlockRetainHeight(0)
 	require.Error(t, err)
 
 	// make more than 1000 blocks, to test batch deletions
@@ -614,7 +615,7 @@ func TestPruningService(t *testing.T) {
 	err = stateStore.Save(state)
 	require.NoError(t, err)
 	// Check that basic pruning works
-	err = pruner.SetApplicationRetainHeight(1200)
+	err = pruner.SetApplicationBlockRetainHeight(1200)
 	require.NoError(t, err)
 	err = pruner.Start()
 	require.NoError(t, err)
@@ -646,15 +647,15 @@ func TestPruningService(t *testing.T) {
 	}
 
 	// Pruning below the current base should error
-	err = pruner.SetApplicationRetainHeight(1199)
+	err = pruner.SetApplicationBlockRetainHeight(1199)
 	require.Error(t, err)
 
 	// Pruning to the current base should work
-	err = pruner.SetApplicationRetainHeight(1200)
+	err = pruner.SetApplicationBlockRetainHeight(1200)
 	require.NoError(t, err)
 
 	// Pruning again should work
-	err = pruner.SetApplicationRetainHeight(1300)
+	err = pruner.SetApplicationBlockRetainHeight(1300)
 	require.NoError(t, err)
 	// We should not be able to set a retain height lower than the currently
 	// existing retain heights
@@ -679,11 +680,11 @@ func TestPruningService(t *testing.T) {
 		require.Fail(t, "timed out waiting for pruning run to complete")
 	}
 	// Setting the pruning height beyond the current height should error
-	err = pruner.SetApplicationRetainHeight(1501)
+	err = pruner.SetApplicationBlockRetainHeight(1501)
 	require.Error(t, err)
 
 	// Pruning to the current height should work
-	err = pruner.SetApplicationRetainHeight(1500)
+	err = pruner.SetApplicationBlockRetainHeight(1500)
 	require.NoError(t, err)
 
 	select {
@@ -699,7 +700,6 @@ func TestPruningService(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		require.Fail(t, "timed out waiting for pruning run to complete")
 	}
-
 }
 
 func TestPruneBlocks(t *testing.T) {

--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -48,9 +48,10 @@ var (
 		2 * int(e2e.EvidenceAgeHeight),
 		4 * int(e2e.EvidenceAgeHeight),
 	}
-	evidence          = uniformChoice{0, 1, 10}
-	abciDelays        = uniformChoice{"none", "small", "large"}
-	nodePerturbations = probSetChoice{
+	nodeEnableCompanionPruning = uniformChoice{true, false}
+	evidence                   = uniformChoice{0, 1, 10}
+	abciDelays                 = uniformChoice{"none", "small", "large"}
+	nodePerturbations          = probSetChoice{
 		"disconnect": 0.1,
 		"pause":      0.1,
 		"kill":       0.1,
@@ -62,7 +63,7 @@ var (
 	}
 	voteExtensionEnableHeightOffset = uniformChoice{int64(0), int64(10), int64(100)}
 	voteExtensionEnabled            = uniformChoice{true, false}
-	voteExtensionSize               = uniformChoice{uint(128), uint(512), uint(2048), uint(8192)} //TODO: define the right values depending on experiment results.
+	voteExtensionSize               = uniformChoice{uint(128), uint(512), uint(2048), uint(8192)} // TODO: define the right values depending on experiment results.
 )
 
 type generateConfig struct {
@@ -286,17 +287,18 @@ func generateNode(
 	r *rand.Rand, mode e2e.Mode, startAt int64, forceArchive bool,
 ) *e2e.ManifestNode {
 	node := e2e.ManifestNode{
-		Version:          nodeVersions.Choose(r).(string),
-		Mode:             string(mode),
-		StartAt:          startAt,
-		Database:         nodeDatabases.Choose(r).(string),
-		PrivvalProtocol:  nodePrivvalProtocols.Choose(r).(string),
-		BlockSyncVersion: nodeBlockSyncs.Choose(r).(string),
-		StateSync:        nodeStateSyncs.Choose(r).(bool) && startAt > 0,
-		PersistInterval:  ptrUint64(uint64(nodePersistIntervals.Choose(r).(int))),
-		SnapshotInterval: uint64(nodeSnapshotIntervals.Choose(r).(int)),
-		RetainBlocks:     uint64(nodeRetainBlocks.Choose(r).(int)),
-		Perturb:          nodePerturbations.Choose(r),
+		Version:                nodeVersions.Choose(r).(string),
+		Mode:                   string(mode),
+		StartAt:                startAt,
+		Database:               nodeDatabases.Choose(r).(string),
+		PrivvalProtocol:        nodePrivvalProtocols.Choose(r).(string),
+		BlockSyncVersion:       nodeBlockSyncs.Choose(r).(string),
+		StateSync:              nodeStateSyncs.Choose(r).(bool) && startAt > 0,
+		PersistInterval:        ptrUint64(uint64(nodePersistIntervals.Choose(r).(int))),
+		SnapshotInterval:       uint64(nodeSnapshotIntervals.Choose(r).(int)),
+		RetainBlocks:           uint64(nodeRetainBlocks.Choose(r).(int)),
+		EnableCompanionPruning: false,
+		Perturb:                nodePerturbations.Choose(r),
 	}
 
 	// If this node is forced to be an archive node, retain all blocks and
@@ -325,6 +327,12 @@ func generateNode(
 		if node.RetainBlocks < node.SnapshotInterval {
 			node.RetainBlocks = node.SnapshotInterval
 		}
+	}
+
+	// Only randomly enable data companion-related pruning on 50% of the full
+	// nodes and validators.
+	if mode == e2e.ModeFull || mode == e2e.ModeValidator {
+		node.EnableCompanionPruning = nodeEnableCompanionPruning.Choose(r).(bool)
 	}
 
 	return &node

--- a/test/e2e/networks/ci.toml
+++ b/test/e2e/networks/ci.toml
@@ -56,6 +56,7 @@ database = "badgerdb"
 privval_protocol = "unix"
 persist_interval = 3
 retain_blocks = 10
+enable_companion_pruning = true
 perturb = ["kill"]
 
 [node.validator04]
@@ -75,6 +76,7 @@ start_at = 1010
 mode = "full"
 persistent_peers = ["validator01", "validator02", "validator03", "validator04", "validator05"]
 retain_blocks = 10
+enable_companion_pruning = true
 perturb = ["restart"]
 
 [node.full02]

--- a/test/e2e/pkg/manifest.go
+++ b/test/e2e/pkg/manifest.go
@@ -161,6 +161,10 @@ type ManifestNode struct {
 	// SnapshotInterval and EvidenceAgeHeight.
 	RetainBlocks uint64 `toml:"retain_blocks"`
 
+	// EnableCompanionPruning specifies whether or not storage pruning on the
+	// node should take a data companion into account.
+	EnableCompanionPruning bool `toml:"enable_companion_pruning"`
+
 	// Perturb lists perturbations to apply to the node after it has been
 	// started and synced with the network:
 	//

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -117,6 +117,7 @@ type Node struct {
 	PersistInterval         uint64
 	SnapshotInterval        uint64
 	RetainBlocks            uint64
+	EnableCompanionPruning  bool
 	Seeds                   []*Node
 	PersistentPeers         []*Node
 	Perturbations           []Perturbation
@@ -234,6 +235,7 @@ func NewTestnetFromManifest(manifest Manifest, file string, ifd InfrastructureDa
 			PersistInterval:         1,
 			SnapshotInterval:        nodeManifest.SnapshotInterval,
 			RetainBlocks:            nodeManifest.RetainBlocks,
+			EnableCompanionPruning:  nodeManifest.EnableCompanionPruning,
 			Perturbations:           []Perturbation{},
 			SendNoLoad:              nodeManifest.SendNoLoad,
 			Prometheus:              testnet.Prometheus,

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -166,21 +166,31 @@ func MakeConfig(node *e2e.Node) (*config.Config, error) {
 	cfg := config.DefaultConfig()
 	cfg.Moniker = node.Name
 	cfg.ProxyApp = AppAddressTCP
+
 	cfg.RPC.ListenAddress = "tcp://0.0.0.0:26657"
+	cfg.RPC.PprofListenAddress = ":6060"
+
 	cfg.GRPC.ListenAddress = "tcp://0.0.0.0:26670"
 	cfg.GRPC.VersionService.Enabled = true
-	cfg.GRPC.Privileged.ListenAddress = "tcp://0.0.0.0:26671"
-	cfg.GRPC.Privileged.PruningService.Enabled = true
-	cfg.RPC.PprofListenAddress = ":6060"
+	cfg.GRPC.BlockService.Enabled = true
+	cfg.GRPC.BlockResultsService.Enabled = true
+
 	cfg.P2P.ExternalAddress = fmt.Sprintf("tcp://%v", node.AddressP2P(false))
 	cfg.P2P.AddrBookStrict = false
+
 	cfg.DBBackend = node.Database
 	cfg.StateSync.DiscoveryTime = 5 * time.Second
 	cfg.BlockSync.Version = node.BlockSyncVersion
 	cfg.Consensus.PeerGossipIntraloopSleepDuration = node.Testnet.PeerGossipIntraloopSleepDuration
 
-	if node.Mode == e2e.ModeValidator || node.Mode == e2e.ModeFull {
+	// Assume that full nodes and validators will have a data companion
+	// attached, which will need access to the privileged gRPC endpoint.
+	if (node.Mode == e2e.ModeValidator || node.Mode == e2e.ModeFull) && node.EnableCompanionPruning {
 		cfg.Storage.Pruning.DataCompanion.Enabled = true
+		cfg.Storage.Pruning.DataCompanion.InitialBlockRetainHeight = 0
+		cfg.Storage.Pruning.DataCompanion.InitialBlockResultsRetainHeight = 0
+		cfg.GRPC.Privileged.ListenAddress = "tcp://0.0.0.0:26671"
+		cfg.GRPC.Privileged.PruningService.Enabled = true
 	}
 
 	switch node.ABCIProtocol {

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -178,6 +178,7 @@ func MakeConfig(node *e2e.Node) (*config.Config, error) {
 	cfg.StateSync.DiscoveryTime = 5 * time.Second
 	cfg.BlockSync.Version = node.BlockSyncVersion
 	cfg.Consensus.PeerGossipIntraloopSleepDuration = node.Testnet.PeerGossipIntraloopSleepDuration
+	cfg.Storage.Pruning.DataCompanion.Enabled = true
 
 	switch node.ABCIProtocol {
 	case e2e.ProtocolUNIX:

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -178,7 +178,10 @@ func MakeConfig(node *e2e.Node) (*config.Config, error) {
 	cfg.StateSync.DiscoveryTime = 5 * time.Second
 	cfg.BlockSync.Version = node.BlockSyncVersion
 	cfg.Consensus.PeerGossipIntraloopSleepDuration = node.Testnet.PeerGossipIntraloopSleepDuration
-	cfg.Storage.Pruning.DataCompanion.Enabled = true
+
+	if node.Mode == e2e.ModeValidator || node.Mode == e2e.ModeFull {
+		cfg.Storage.Pruning.DataCompanion.Enabled = true
+	}
 
 	switch node.ABCIProtocol {
 	case e2e.ProtocolUNIX:

--- a/test/e2e/runner/test.go
+++ b/test/e2e/runner/test.go
@@ -27,5 +27,12 @@ func Test(testnet *e2e.Testnet, ifd *e2e.InfrastructureData) error {
 		return err
 	}
 
-	return exec.CommandVerbose(context.Background(), "go", "test", "-count", "1", "./tests/...")
+	cmd := []string{"go", "test", "-count", "1"}
+	verbose := os.Getenv("VERBOSE")
+	if verbose == "1" {
+		cmd = append(cmd, "-v")
+	}
+	cmd = append(cmd, "./tests/...")
+
+	return exec.CommandVerbose(context.Background(), cmd...)
 }

--- a/test/e2e/tests/block_test.go
+++ b/test/e2e/tests/block_test.go
@@ -50,7 +50,9 @@ func TestBlock_Header(t *testing.T) {
 // Tests that the node contains the expected block range.
 func TestBlock_Range(t *testing.T) {
 	testNode(t, func(t *testing.T, node e2e.Node) {
-		if node.Mode == e2e.ModeSeed {
+		// We do not run this test on seed nodes or nodes with data
+		// companion-related pruning enabled.
+		if node.Mode == e2e.ModeSeed || node.EnableCompanionPruning {
 			return
 		}
 

--- a/test/e2e/tests/grpc_test.go
+++ b/test/e2e/tests/grpc_test.go
@@ -217,12 +217,10 @@ func TestGRPC_BlockRetainHeight(t *testing.T) {
 		require.NoError(t, err)
 
 		err = grpcClient.SetBlockRetainHeight(ctx, uint64(status.SyncInfo.LatestBlockHeight-1))
-		t.Log(err)
-		require.NoError(t, err, "Unexpected error for SetBlockRetainHeight")
+		require.NoError(t, err)
 
 		res, err := grpcClient.GetBlockRetainHeight(ctx)
-
-		require.NoError(t, err, "Unexpected error for GetBlockRetainHeight")
+		require.NoError(t, err)
 		require.NotNil(t, res)
 		require.Equal(t, res.PruningService, uint64(status.SyncInfo.LatestBlockHeight-1))
 	})

--- a/test/e2e/tests/grpc_test.go
+++ b/test/e2e/tests/grpc_test.go
@@ -12,11 +12,7 @@ import (
 )
 
 func TestGRPC_Version(t *testing.T) {
-	testNode(t, func(t *testing.T, node e2e.Node) {
-		if node.Mode != e2e.ModeFull && node.Mode != e2e.ModeValidator {
-			return
-		}
-
+	testFullNodesOrValidators(t, 0, func(t *testing.T, node e2e.Node) {
 		ctx, ctxCancel := context.WithTimeout(context.Background(), time.Minute)
 		defer ctxCancel()
 		client, err := node.GRPCClient(ctx)
@@ -34,11 +30,7 @@ func TestGRPC_Version(t *testing.T) {
 }
 
 func TestGRPC_Block_GetByHeight(t *testing.T) {
-	testNode(t, func(t *testing.T, node e2e.Node) {
-		if node.Mode != e2e.ModeFull && node.Mode != e2e.ModeValidator {
-			return
-		}
-
+	testFullNodesOrValidators(t, 0, func(t *testing.T, node e2e.Node) {
 		blocks := fetchBlockChain(t)
 
 		client, err := node.Client()
@@ -143,11 +135,7 @@ func TestGRPC_Block_GetLatestHeight(t *testing.T) {
 }
 
 func TestGRPC_GetBlockResults(t *testing.T) {
-	testNode(t, func(t *testing.T, node e2e.Node) {
-		if node.Mode != e2e.ModeFull && node.Mode != e2e.ModeValidator {
-			return
-		}
-
+	testFullNodesOrValidators(t, 0, func(t *testing.T, node e2e.Node) {
 		client, err := node.Client()
 		require.NoError(t, err)
 		status, err := client.Status(ctx)
@@ -200,8 +188,8 @@ func TestGRPC_GetBlockResults(t *testing.T) {
 }
 
 func TestGRPC_BlockRetainHeight(t *testing.T) {
-	testNode(t, func(t *testing.T, node e2e.Node) {
-		if node.Mode != e2e.ModeFull && node.Mode != e2e.ModeValidator {
+	testFullNodesOrValidators(t, 0, func(t *testing.T, node e2e.Node) {
+		if !node.EnableCompanionPruning {
 			return
 		}
 
@@ -227,8 +215,8 @@ func TestGRPC_BlockRetainHeight(t *testing.T) {
 }
 
 func TestGRPC_BlockResultsRetainHeight(t *testing.T) {
-	testNode(t, func(t *testing.T, node e2e.Node) {
-		if node.Mode != e2e.ModeFull && node.Mode != e2e.ModeValidator {
+	testFullNodesOrValidators(t, 0, func(t *testing.T, node e2e.Node) {
+		if !node.EnableCompanionPruning {
 			return
 		}
 


### PR DESCRIPTION
Alternative to #1261.

When we make the assumption that the retain heights will be available in the state store, and the pruner knows whether or not the data companion is enabled, we can simplify the code to a certain degree.

I've tried to structure this PR such that it can be reviewed commit by commit, but it may be easier to just review it in one go. I'm happy to also walk folks through it.

~The CI E2E test has been failing for me locally, so I'll mark this as ready to review once it passes.~

---

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

