### PR TITLE
refactor: remove redundant error return from mempool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,11 @@ security issues.
 
 ### IMPROVEMENTS
 
-- `[rpc]` Remove response data from response failure logs in order
-  to prevent large quantities of log data from being produced
+- `[mempool]` Remove redundant error return in `(*Mempool).Update`
   ([\#654](https://github.com/cometbft/cometbft/issues/654))
+- `[rpc]` Remove response data from response failure logs in order
+to prevent large quantities of log data from being produced
+([\#654](https://github.com/cometbft/cometbft/issues/654))
 
 ### SECURITY FIXES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ security issues.
 ### IMPROVEMENTS
 
 - `[mempool]` Remove redundant error return in `(*Mempool).Update`
-  ([\#654](https://github.com/cometbft/cometbft/issues/654))
+  ([\#1288](https://github.com/cometbft/cometbft/pull/1288)
 - `[rpc]` Remove response data from response failure logs in order
 to prevent large quantities of log data from being produced
 ([\#654](https://github.com/cometbft/cometbft/issues/654))

--- a/consensus/replay_stubs.go
+++ b/consensus/replay_stubs.go
@@ -37,8 +37,7 @@ func (emptyMempool) Update(
 	[]*abci.ExecTxResult,
 	mempl.PreCheckFunc,
 	mempl.PostCheckFunc,
-) error {
-	return nil
+) {
 }
 func (emptyMempool) Flush()                                 {}
 func (emptyMempool) FlushAppConn() error                    { return nil }

--- a/mempool/cache_test.go
+++ b/mempool/cache_test.go
@@ -75,8 +75,7 @@ func TestCacheAfterUpdate(t *testing.T) {
 			tx := kvstore.NewTx(fmt.Sprintf("%d", v), "value")
 			updateTxs = append(updateTxs, tx)
 		}
-		err := mp.Update(int64(tcIndex), updateTxs, abciResponses(len(updateTxs), abci.CodeTypeOK), nil, nil)
-		require.NoError(t, err)
+		mp.Update(int64(tcIndex), updateTxs, abciResponses(len(updateTxs), abci.CodeTypeOK), nil, nil)
 
 		for _, v := range tc.reAddIndices {
 			tx := kvstore.NewTx(fmt.Sprintf("%d", v), "value")

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -579,14 +579,13 @@ func (mem *CListMempool) ReapMaxTxs(max int) types.Txs {
 }
 
 // Lock() must be help by the caller during execution.
-// TODO: this function always returns nil; remove the return value
 func (mem *CListMempool) Update(
 	height int64,
 	txs types.Txs,
 	txResults []*abci.ExecTxResult,
 	preCheck PreCheckFunc,
 	postCheck PostCheckFunc,
-) error {
+) {
 	// Set height
 	mem.height = height
 	mem.notifiedTxsAvailable = false
@@ -639,8 +638,6 @@ func (mem *CListMempool) Update(
 
 	// Update metrics
 	mem.metrics.Size.Set(float64(mem.Size()))
-
-	return nil
 }
 
 func (mem *CListMempool) recheckTxs() {

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -72,7 +72,7 @@ type Mempool interface {
 		deliverTxResponses []*abci.ExecTxResult,
 		newPreFn PreCheckFunc,
 		newPostFn PostCheckFunc,
-	) error
+	)
 
 	// FlushAppConn flushes the mempool connection to ensure async callback calls
 	// are done, e.g. from CheckTx.

--- a/mempool/mocks/mempool.go
+++ b/mempool/mocks/mempool.go
@@ -175,13 +175,7 @@ func (_m *Mempool) Unlock() {
 
 // Update provides a mock function with given fields: blockHeight, blockTxs, deliverTxResponses, newPreFn, newPostFn
 func (_m *Mempool) Update(blockHeight int64, blockTxs types.Txs, deliverTxResponses []*abcitypes.ExecTxResult, newPreFn mempool.PreCheckFunc, newPostFn mempool.PostCheckFunc) {
-	ret := _m.Called(blockHeight, blockTxs, deliverTxResponses, newPreFn, newPostFn)
-
-	if rf, ok := ret.Get(0).(func(int64, types.Txs, []*abcitypes.ExecTxResult, mempool.PreCheckFunc, mempool.PostCheckFunc) error); ok {
-		rf(blockHeight, blockTxs, deliverTxResponses, newPreFn, newPostFn)
-	} else {
-		ret.Error(0)
-	}
+	_m.Called(blockHeight, blockTxs, deliverTxResponses, newPreFn, newPostFn)
 }
 
 // NewMempool creates a new instance of Mempool. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/mempool/mocks/mempool.go
+++ b/mempool/mocks/mempool.go
@@ -174,17 +174,14 @@ func (_m *Mempool) Unlock() {
 }
 
 // Update provides a mock function with given fields: blockHeight, blockTxs, deliverTxResponses, newPreFn, newPostFn
-func (_m *Mempool) Update(blockHeight int64, blockTxs types.Txs, deliverTxResponses []*abcitypes.ExecTxResult, newPreFn mempool.PreCheckFunc, newPostFn mempool.PostCheckFunc) error {
+func (_m *Mempool) Update(blockHeight int64, blockTxs types.Txs, deliverTxResponses []*abcitypes.ExecTxResult, newPreFn mempool.PreCheckFunc, newPostFn mempool.PostCheckFunc) {
 	ret := _m.Called(blockHeight, blockTxs, deliverTxResponses, newPreFn, newPostFn)
 
-	var r0 error
 	if rf, ok := ret.Get(0).(func(int64, types.Txs, []*abcitypes.ExecTxResult, mempool.PreCheckFunc, mempool.PostCheckFunc) error); ok {
-		r0 = rf(blockHeight, blockTxs, deliverTxResponses, newPreFn, newPostFn)
+		rf(blockHeight, blockTxs, deliverTxResponses, newPreFn, newPostFn)
 	} else {
-		r0 = ret.Error(0)
+		ret.Error(0)
 	}
-
-	return r0
 }
 
 // NewMempool creates a new instance of Mempool. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/mempool/reactor_test.go
+++ b/mempool/reactor_test.go
@@ -98,8 +98,7 @@ func TestReactorConcurrency(t *testing.T) {
 			reactors[0].mempool.Lock()
 			defer reactors[0].mempool.Unlock()
 
-			err := reactors[0].mempool.Update(1, txs, abciResponses(len(txs), abci.CodeTypeOK), nil, nil)
-			assert.NoError(t, err)
+			reactors[0].mempool.Update(1, txs, abciResponses(len(txs), abci.CodeTypeOK), nil, nil)
 		}()
 
 		// 1. submit a bunch of txs
@@ -110,8 +109,7 @@ func TestReactorConcurrency(t *testing.T) {
 
 			reactors[1].mempool.Lock()
 			defer reactors[1].mempool.Unlock()
-			err := reactors[1].mempool.Update(1, []types.Tx{}, make([]*abci.ExecTxResult, 0), nil, nil)
-			assert.NoError(t, err)
+			reactors[1].mempool.Update(1, []types.Tx{}, make([]*abci.ExecTxResult, 0), nil, nil)
 		}()
 
 		// 1. flush the mempool
@@ -496,10 +494,8 @@ func updateMempool(t *testing.T, mp Mempool, validTxs types.Txs, invalidTxs type
 	allResponses := append(validTxResponses, invalidTxResponses...)
 
 	mp.Lock()
-	err := mp.Update(1, allTxs, allResponses, nil, nil)
+	mp.Update(1, allTxs, allResponses, nil, nil)
 	mp.Unlock()
-
-	require.NoError(t, err)
 }
 
 // ensure no txs on reactor after some timeout

--- a/mempool/reactor_test.go
+++ b/mempool/reactor_test.go
@@ -343,7 +343,7 @@ func TestReactorTxSendersMultiNode(t *testing.T) {
 
 	// Update the mempools with a list of valid and invalid transactions.
 	for i, r := range reactors {
-		updateMempool(t, r.mempool, validTxs, invalidTxs)
+		updateMempool(r.mempool, validTxs, invalidTxs)
 
 		// Txs included in a block should have been removed from the mempool and
 		// have no senders.
@@ -486,7 +486,7 @@ func checkTxsInOrder(t *testing.T, txs types.Txs, reactor *Reactor, reactorIndex
 	}
 }
 
-func updateMempool(t *testing.T, mp Mempool, validTxs types.Txs, invalidTxs types.Txs) {
+func updateMempool(mp Mempool, validTxs types.Txs, invalidTxs types.Txs) {
 	allTxs := append(validTxs, invalidTxs...)
 
 	validTxResponses := abciResponses(len(validTxs), abci.CodeTypeOK)

--- a/state/execution.go
+++ b/state/execution.go
@@ -388,7 +388,7 @@ func (blockExec *BlockExecutor) Commit(
 	)
 
 	// Update mempool.
-	err = blockExec.mempool.Update(
+	blockExec.mempool.Update(
 		block.Height,
 		block.Txs,
 		abciResponse.TxResults,


### PR DESCRIPTION
Addresses TODO about redundant error return in mempool.Update

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments

