### PR TITLE
genesis:revert removing the genesis file out of the DB

### DIFF
--- a/.changelog/unreleased/bug-fixes/1017-remove-genesis-persistence-in-state-db.md
+++ b/.changelog/unreleased/bug-fixes/1017-remove-genesis-persistence-in-state-db.md
@@ -1,1 +1,0 @@
-- `[node]` Remove genesis persistence in state db ([cometbft/cometbft\#1017](https://github.com/cometbft/cometbft/pull/1017))

--- a/blocksync/reactor_test.go
+++ b/blocksync/reactor_test.go
@@ -77,9 +77,13 @@ func newReactor(
 	}
 
 	blockDB := dbm.NewMemDB()
+	stateDB := dbm.NewMemDB()
+	stateStore := sm.NewStore(stateDB, sm.StoreOptions{
+		DiscardABCIResponses: false,
+	})
 	blockStore := store.NewBlockStore(blockDB)
 
-	state, err := sm.MakeGenesisState(genDoc)
+	state, err := stateStore.LoadFromDBOrGenesisDoc(genDoc)
 	if err != nil {
 		panic(fmt.Errorf("error constructing state from genesis file: %w", err))
 	}
@@ -101,7 +105,7 @@ func newReactor(
 	// pool.height is determined from the store.
 	fastSync := true
 	db := dbm.NewMemDB()
-	stateStore := sm.NewStore(db, sm.StoreOptions{
+	stateStore = sm.NewStore(db, sm.StoreOptions{
 		DiscardABCIResponses: false,
 	})
 	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyApp.Consensus(),

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -55,15 +55,13 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 		stateStore := sm.NewStore(stateDB, sm.StoreOptions{
 			DiscardABCIResponses: false,
 		})
-		state, err := sm.MakeGenesisState(genDoc)
-		require.NoError(t, err)
-		require.NoError(t, stateStore.Save(state))
+		state, _ := stateStore.LoadFromDBOrGenesisDoc(genDoc)
 		thisConfig := ResetConfig(fmt.Sprintf("%s_%d", testName, i))
 		defer os.RemoveAll(thisConfig.RootDir)
 		ensureDir(path.Dir(thisConfig.Consensus.WalFile()), 0o700) // dir for wal
 		app := appFunc()
 		vals := types.TM2PB.ValidatorUpdates(state.Validators)
-		_, err = app.InitChain(context.Background(), &abci.RequestInitChain{Validators: vals})
+		_, err := app.InitChain(context.Background(), &abci.RequestInitChain{Validators: vals})
 		require.NoError(t, err)
 
 		blockDB := dbm.NewMemDB()

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -771,7 +771,10 @@ func randConsensusNet(t *testing.T, nValidators int, testName string, tickerFunc
 	configRootDirs := make([]string, 0, nValidators)
 	for i := 0; i < nValidators; i++ {
 		stateDB := dbm.NewMemDB() // each state needs its own db
-		state, _ := sm.MakeGenesisState(genDoc)
+		stateStore := sm.NewStore(stateDB, sm.StoreOptions{
+			DiscardABCIResponses: false,
+		})
+		state, _ := stateStore.LoadFromDBOrGenesisDoc(genDoc)
 		thisConfig := ResetConfig(fmt.Sprintf("%s_%d", testName, i))
 		configRootDirs = append(configRootDirs, thisConfig.RootDir)
 		for _, opt := range configOpts {
@@ -815,7 +818,7 @@ func randConsensusNetWithPeers(
 			DiscardABCIResponses: false,
 		})
 		t.Cleanup(func() { _ = stateStore.Close() })
-		state, _ := sm.MakeGenesisState(genDoc)
+		state, _ := stateStore.LoadFromDBOrGenesisDoc(genDoc)
 		thisConfig := ResetConfig(fmt.Sprintf("%s_%d", testName, i))
 		configRootDirs = append(configRootDirs, thisConfig.RootDir)
 		ensureDir(filepath.Dir(thisConfig.Consensus.WalFile()), 0o700) // dir for wal

--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -140,14 +140,13 @@ func TestReactorWithEvidence(t *testing.T) {
 		stateStore := sm.NewStore(stateDB, sm.StoreOptions{
 			DiscardABCIResponses: false,
 		})
-		state, err := sm.MakeGenesisState(genDoc)
-		require.NoError(t, err)
+		state, _ := stateStore.LoadFromDBOrGenesisDoc(genDoc)
 		thisConfig := ResetConfig(fmt.Sprintf("%s_%d", testName, i))
 		defer os.RemoveAll(thisConfig.RootDir)
 		ensureDir(path.Dir(thisConfig.Consensus.WalFile()), 0o700) // dir for wal
 		app := appFunc()
 		vals := types.TM2PB.ValidatorUpdates(state.Validators)
-		_, err = app.InitChain(context.Background(), &abci.RequestInitChain{Validators: vals})
+		_, err := app.InitChain(context.Background(), &abci.RequestInitChain{Validators: vals})
 		require.NoError(t, err)
 
 		pv := privVals[i]

--- a/node/node.go
+++ b/node/node.go
@@ -155,17 +155,7 @@ func NewNode(ctx context.Context,
 		DiscardABCIResponses: config.Storage.DiscardABCIResponses,
 	})
 
-	genDoc, err := genesisDocProvider()
-	if err != nil {
-		return nil, err
-	}
-
-	err = genDoc.ValidateAndComplete()
-	if err != nil {
-		return nil, fmt.Errorf("error in genesis doc: %w", err)
-	}
-
-	state, err := loadStateFromDBOrGenesisDoc(stateStore, stateDB, genDoc)
+	state, genDoc, err := LoadStateFromDBOrGenesisDocProvider(stateDB, genesisDocProvider)
 	if err != nil {
 		return nil, err
 	}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -18,12 +18,9 @@ import (
 	"github.com/cometbft/cometbft/abci/example/kvstore"
 	cfg "github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/crypto/ed25519"
-	"github.com/cometbft/cometbft/crypto/tmhash"
 	"github.com/cometbft/cometbft/evidence"
 	"github.com/cometbft/cometbft/internal/test"
-	cmtjson "github.com/cometbft/cometbft/libs/json"
 	"github.com/cometbft/cometbft/libs/log"
-	cmtos "github.com/cometbft/cometbft/libs/os"
 	cmtrand "github.com/cometbft/cometbft/libs/rand"
 	mempl "github.com/cometbft/cometbft/mempool"
 	"github.com/cometbft/cometbft/p2p"
@@ -466,73 +463,6 @@ func TestNodeNewNodeCustomReactors(t *testing.T) {
 	channels := n.NodeInfo().(p2p.DefaultNodeInfo).Channels
 	assert.Contains(t, channels, mempl.MempoolChannel)
 	assert.Contains(t, channels, cr.Channels[0].ID)
-}
-
-func TestNodeNewNodeGenesisHashMismatch(t *testing.T) {
-	config := test.ResetTestRoot("node_new_node_genesis_hash")
-	defer os.RemoveAll(config.RootDir)
-
-	// Use goleveldb so we can reuse the same db for the second NewNode()
-	config.DBBackend = string(dbm.GoLevelDBBackend)
-
-	nodeKey, err := p2p.LoadOrGenNodeKey(config.NodeKeyFile())
-	require.NoError(t, err)
-
-	n, err := NewNode(
-		context.Background(),
-		config,
-		privval.LoadOrGenFilePV(config.PrivValidatorKeyFile(), config.PrivValidatorStateFile()),
-		nodeKey,
-		proxy.DefaultClientCreator(config.ProxyApp, config.ABCI, config.DBDir()),
-		DefaultGenesisDocProviderFunc(config),
-		cfg.DefaultDBProvider,
-		DefaultMetricsProvider(config.Instrumentation),
-		log.TestingLogger(),
-	)
-	require.NoError(t, err)
-
-	// Start and stop to close the db for later reading
-	err = n.Start()
-	require.NoError(t, err)
-
-	err = n.Stop()
-	require.NoError(t, err)
-
-	// Ensure the genesis doc hash is saved to db
-	stateDB, err := cfg.DefaultDBProvider(&cfg.DBContext{ID: "state", Config: config})
-	require.NoError(t, err)
-
-	genDocHash, err := stateDB.Get(genesisDocHashKey)
-	require.NoError(t, err)
-	require.NotNil(t, genDocHash, "genesis doc hash should be saved in db")
-	require.Len(t, genDocHash, tmhash.Size)
-
-	err = stateDB.Close()
-	require.NoError(t, err)
-
-	// Modify the genesis file chain ID to get a different hash
-	genBytes := cmtos.MustReadFile(config.GenesisFile())
-	var genesisDoc types.GenesisDoc
-	err = cmtjson.Unmarshal(genBytes, &genesisDoc)
-	require.NoError(t, err)
-
-	genesisDoc.ChainID = "different-chain-id"
-	err = genesisDoc.SaveAs(config.GenesisFile())
-	require.NoError(t, err)
-
-	_, err = NewNode(
-		context.Background(),
-		config,
-		privval.LoadOrGenFilePV(config.PrivValidatorKeyFile(), config.PrivValidatorStateFile()),
-		nodeKey,
-		proxy.DefaultClientCreator(config.ProxyApp, config.ABCI, config.DBDir()),
-		DefaultGenesisDocProviderFunc(config),
-		cfg.DefaultDBProvider,
-		DefaultMetricsProvider(config.Instrumentation),
-		log.TestingLogger(),
-	)
-	require.Error(t, err, "NewNode should error when genesisDoc is changed")
-	require.Equal(t, "genesis doc hash in db does not match loaded genesis doc", err.Error())
 }
 
 func state(nVals int, height int64) (sm.State, dbm.DB, []types.PrivValidator) {

--- a/node/setup.go
+++ b/node/setup.go
@@ -3,6 +3,7 @@ package node
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -17,7 +18,6 @@ import (
 	cfg "github.com/cometbft/cometbft/config"
 	cs "github.com/cometbft/cometbft/consensus"
 	"github.com/cometbft/cometbft/crypto"
-	"github.com/cometbft/cometbft/crypto/tmhash"
 	"github.com/cometbft/cometbft/evidence"
 	"github.com/cometbft/cometbft/statesync"
 
@@ -529,60 +529,67 @@ func startStateSync(
 
 //------------------------------------------------------------------------------
 
-var genesisDocHashKey = []byte("genesisDocHash")
+var genesisDocKey = []byte("genesisDoc")
 
-// loadStateFromDBOrGenesisDoc attempts to load the state from the
+// LoadStateFromDBOrGenesisDocProvider attempts to load the state from the
 // database, or creates one using the given genesisDocProvider. On success this also
 // returns the genesis doc loaded through the given provider.
-func loadStateFromDBOrGenesisDoc(
-	stateStore sm.Store,
+func LoadStateFromDBOrGenesisDocProvider(
 	stateDB dbm.DB,
-	genDoc *types.GenesisDoc,
-) (sm.State, error) {
-	// 1. Verify genesisDoc hash in db if exists
-	genDocHash, err := stateDB.Get(genesisDocHashKey)
+	genesisDocProvider GenesisDocProvider,
+) (sm.State, *types.GenesisDoc, error) {
+	// Get genesis doc
+	genDoc, err := loadGenesisDoc(stateDB)
 	if err != nil {
-		return sm.State{}, err
-	}
-
-	genDocBytes, err := cmtjson.Marshal(genDoc)
-	if err != nil {
-		return sm.State{}, fmt.Errorf("failed to save genesis doc hash due to marshaling error: %w", err)
-	}
-
-	incomingGenDocHash := tmhash.Sum(genDocBytes)
-	if len(genDocHash) != 0 && !bytes.Equal(genDocHash, incomingGenDocHash) {
-		return sm.State{}, fmt.Errorf("genesis doc hash in db does not match loaded genesis doc")
-	}
-
-	// 2. Attempt to load state form the database
-	state, err := stateStore.Load()
-	if err != nil {
-		return sm.State{}, err
-	}
-
-	if state.IsEmpty() {
-		// 3. If it's not there, derive it from the genesis doc
-		state, err = sm.MakeGenesisState(genDoc)
+		genDoc, err = genesisDocProvider()
 		if err != nil {
-			return sm.State{}, err
+			return sm.State{}, nil, err
 		}
 
-		// 4. save the gensis document to the state store so
-		// its fetchable by other callers.
-		if err := stateStore.Save(state); err != nil {
-			return sm.State{}, err
+		err = genDoc.ValidateAndComplete()
+		if err != nil {
+			return sm.State{}, nil, fmt.Errorf("error in genesis doc: %w", err)
 		}
-
-		// 5. Save the genDoc hash in the store if it doesn't already exist for future verification
-		if len(genDocHash) == 0 {
-			if err := stateDB.SetSync(genesisDocHashKey, incomingGenDocHash); err != nil {
-				return sm.State{}, fmt.Errorf("failed to save genesis doc hash to db: %w", err)
-			}
+		// save genesis doc to prevent a certain class of user errors (e.g. when it
+		// was changed, accidentally or not). Also good for audit trail.
+		if err := saveGenesisDoc(stateDB, genDoc); err != nil {
+			return sm.State{}, nil, err
 		}
 	}
+	stateStore := sm.NewStore(stateDB, sm.StoreOptions{
+		DiscardABCIResponses: false,
+	})
+	state, err := stateStore.LoadFromDBOrGenesisDoc(genDoc)
+	if err != nil {
+		return sm.State{}, nil, err
+	}
+	return state, genDoc, nil
+}
 
-	return state, nil
+// panics if failed to unmarshal bytes
+func loadGenesisDoc(db dbm.DB) (*types.GenesisDoc, error) {
+	b, err := db.Get(genesisDocKey)
+	if err != nil {
+		panic(err)
+	}
+	if len(b) == 0 {
+		return nil, errors.New("genesis doc not found")
+	}
+	var genDoc *types.GenesisDoc
+	err = cmtjson.Unmarshal(b, &genDoc)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to load genesis doc due to unmarshaling error: %v (bytes: %X)", err, b))
+	}
+	return genDoc, nil
+}
+
+// panics if failed to marshal the given genesis document
+func saveGenesisDoc(db dbm.DB, genDoc *types.GenesisDoc) error {
+	b, err := cmtjson.Marshal(genDoc)
+	if err != nil {
+		return fmt.Errorf("failed to save genesis doc due to marshaling error: %w", err)
+	}
+	return db.SetSync(genesisDocKey, b)
 }
 
 func createAndStartPrivValidatorSocketClient(

--- a/state/mocks/store.go
+++ b/state/mocks/store.go
@@ -118,6 +118,54 @@ func (_m *Store) LoadFinalizeBlockResponse(_a0 int64) (*abcitypes.ResponseFinali
 	return r0, r1
 }
 
+// LoadFromDBOrGenesisDoc provides a mock function with given fields: _a0
+func (_m *Store) LoadFromDBOrGenesisDoc(_a0 *types.GenesisDoc) (state.State, error) {
+	ret := _m.Called(_a0)
+
+	var r0 state.State
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*types.GenesisDoc) (state.State, error)); ok {
+		return rf(_a0)
+	}
+	if rf, ok := ret.Get(0).(func(*types.GenesisDoc) state.State); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(state.State)
+	}
+
+	if rf, ok := ret.Get(1).(func(*types.GenesisDoc) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// LoadFromDBOrGenesisFile provides a mock function with given fields: _a0
+func (_m *Store) LoadFromDBOrGenesisFile(_a0 string) (state.State, error) {
+	ret := _m.Called(_a0)
+
+	var r0 state.State
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (state.State, error)); ok {
+		return rf(_a0)
+	}
+	if rf, ok := ret.Get(0).(func(string) state.State); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(state.State)
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // LoadLastFinalizeBlockResponse provides a mock function with given fields: _a0
 func (_m *Store) LoadLastFinalizeBlockResponse(_a0 int64) (*abcitypes.ResponseFinalizeBlock, error) {
 	ret := _m.Called(_a0)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -31,7 +31,7 @@ func setupTestCase(t *testing.T) (func(t *testing.T), dbm.DB, sm.State) {
 		DiscardABCIResponses: false,
 	})
 	require.NoError(t, err)
-	state, err := sm.MakeGenesisStateFromFile(config.GenesisFile())
+	state, err := stateStore.LoadFromDBOrGenesisFile(config.GenesisFile())
 	assert.NoError(t, err, "expected no error on LoadStateFromDBOrGenesisFile")
 	err = stateStore.Save(state)
 	require.NoError(t, err)

--- a/state/store.go
+++ b/state/store.go
@@ -49,6 +49,12 @@ var lastABCIResponseKey = []byte("lastABCIResponseKey")
 // It is used to retrieve current state and save and load ABCI responses,
 // validators and consensus parameters
 type Store interface {
+	// LoadFromDBOrGenesisFile loads the most recent state.
+	// If the chain is new it will use the genesis file from the provided genesis file path as the current state.
+	LoadFromDBOrGenesisFile(string) (State, error)
+	// LoadFromDBOrGenesisDoc loads the most recent state.
+	// If the chain is new it will use the genesis doc as the current state.
+	LoadFromDBOrGenesisDoc(*types.GenesisDoc) (State, error)
 	// Load loads the current state of the blockchain
 	Load() (State, error)
 	// LoadValidators loads the validator set at a given height

--- a/state/store_test.go
+++ b/state/store_test.go
@@ -58,7 +58,7 @@ func BenchmarkLoadValidators(b *testing.B) {
 	stateStore := sm.NewStore(stateDB, sm.StoreOptions{
 		DiscardABCIResponses: false,
 	})
-	state, err := sm.MakeGenesisStateFromFile(config.GenesisFile())
+	state, err := stateStore.LoadFromDBOrGenesisFile(config.GenesisFile())
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/state/tx_filter_test.go
+++ b/state/tx_filter_test.go
@@ -1,10 +1,13 @@
 package state_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	dbm "github.com/cometbft/cometbft-db"
 
 	cmtrand "github.com/cometbft/cometbft/libs/rand"
 	sm "github.com/cometbft/cometbft/state"
@@ -28,7 +31,12 @@ func TestTxFilter(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		state, err := sm.MakeGenesisState(genDoc)
+		stateDB, err := dbm.NewDB("state", "memdb", os.TempDir())
+		require.NoError(t, err)
+		stateStore := sm.NewStore(stateDB, sm.StoreOptions{
+			DiscardABCIResponses: false,
+		})
+		state, err := stateStore.LoadFromDBOrGenesisDoc(genDoc)
 		require.NoError(t, err)
 
 		f := sm.TxPreCheck(state)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -56,7 +56,11 @@ func makeStateAndBlockStore() (sm.State, *BlockStore, cleanupFunc) {
 	// blockDB := dbm.NewDebugDB("blockDB", dbm.NewMemDB())
 	// stateDB := dbm.NewDebugDB("stateDB", dbm.NewMemDB())
 	blockDB := dbm.NewMemDB()
-	state, err := sm.MakeGenesisStateFromFile(config.GenesisFile())
+	stateDB := dbm.NewMemDB()
+	stateStore := sm.NewStore(stateDB, sm.StoreOptions{
+		DiscardABCIResponses: false,
+	})
+	state, err := stateStore.LoadFromDBOrGenesisFile(config.GenesisFile())
 	if err != nil {
 		panic(fmt.Errorf("error constructing state from genesis file: %w", err))
 	}
@@ -450,7 +454,10 @@ func TestLoadBlockExtendedCommit(t *testing.T) {
 func TestLoadBaseMeta(t *testing.T) {
 	config := test.ResetTestRoot("blockchain_reactor_test")
 	defer os.RemoveAll(config.RootDir)
-	state, err := sm.MakeGenesisStateFromFile(config.GenesisFile())
+	stateStore := sm.NewStore(dbm.NewMemDB(), sm.StoreOptions{
+		DiscardABCIResponses: false,
+	})
+	state, err := stateStore.LoadFromDBOrGenesisFile(config.GenesisFile())
 	require.NoError(t, err)
 	bs := NewBlockStore(dbm.NewMemDB())
 
@@ -519,7 +526,10 @@ func TestLoadBlockPart(t *testing.T) {
 func TestPruneBlocks(t *testing.T) {
 	config := test.ResetTestRoot("blockchain_reactor_test")
 	defer os.RemoveAll(config.RootDir)
-	state, err := sm.MakeGenesisStateFromFile(config.GenesisFile())
+	stateStore := sm.NewStore(dbm.NewMemDB(), sm.StoreOptions{
+		DiscardABCIResponses: false,
+	})
+	state, err := stateStore.LoadFromDBOrGenesisFile(config.GenesisFile())
 	require.NoError(t, err)
 	db := dbm.NewMemDB()
 	bs := NewBlockStore(db)
@@ -658,7 +668,10 @@ func TestLoadBlockMeta(t *testing.T) {
 func TestLoadBlockMetaByHash(t *testing.T) {
 	config := test.ResetTestRoot("blockchain_reactor_test")
 	defer os.RemoveAll(config.RootDir)
-	state, err := sm.MakeGenesisStateFromFile(config.GenesisFile())
+	stateStore := sm.NewStore(dbm.NewMemDB(), sm.StoreOptions{
+		DiscardABCIResponses: false,
+	})
+	state, err := stateStore.LoadFromDBOrGenesisFile(config.GenesisFile())
 	require.NoError(t, err)
 	bs := NewBlockStore(dbm.NewMemDB())
 


### PR DESCRIPTION
PR #1017  was failing our e2e tests. The fix was not trivial hence reverting this PR. A fix will follow this revert.

This reverts commit ae9826ed75ee411c0d809797ce209ee770c15c4f.

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

