### PR TITLE
Fix race condition in `gossipVotesRoutine`

### DIFF
--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -796,7 +796,11 @@ OUTER_LOOP:
 			if veEnabled {
 				ec = conR.conS.blockStore.LoadBlockExtendedCommit(prs.Height)
 			} else {
-				ec = conR.conS.blockStore.LoadBlockCommit(prs.Height).WrappedExtendedCommit()
+				c := conR.conS.blockStore.LoadBlockCommit(prs.Height)
+				if c == nil {
+					continue
+				}
+				ec = c.WrappedExtendedCommit()
 			}
 			if ec == nil {
 				continue


### PR DESCRIPTION
Fixes #1322

There is a race condition in `gossipVotesRoutine`.

The condition in the regular catch-up logic requires `prs.Height >= blockStoreBase`, otherwise it doesn't run (as it does not have the required history in its block store).
However, as no lock is kept, by the time we access the blockStore further down (with disabled vote extensions) the base height may have advanced as a result of (concurrent) pruning.
Therefore we need to check for `nil` when reading from the block store.

This affects `main` and `v0.38.x`

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

