### PR TITLE
Add test/e2e/data to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ test/e2e/build
 test/e2e/data/
 test/e2e/networks/*/
 test/logs
+test/p2p/data/
 vendor
 test/fuzz/**/corpus
 test/fuzz/**/crashers

--- a/.gitignore
+++ b/.gitignore
@@ -40,9 +40,9 @@ terraform.tfstate.d
 test/app/grpc_client
 test/loadtime/build
 test/e2e/build
+test/e2e/data/
 test/e2e/networks/*/
 test/logs
-test/p2p/data/
 vendor
 test/fuzz/**/corpus
 test/fuzz/**/crashers


### PR DESCRIPTION
~~`.gitignore` includes `test/p2p/data` but this directory is never created.~~ What is needed is an entry for `test/e2e/data` which  occurs when running e2e networks.

The line for `test/p2p/data` [was added](https://github.com/tendermint/tendermint/pull/5918) with the fuzz tests. I run the fuzz tests and they don't create this directory.
