### PR TITLE
Bump Go version used in `v0.34.x` to v1.20

### DIFF
--- a/.changelog/unreleased/build/1351-bump-go-120.md
+++ b/.changelog/unreleased/build/1351-bump-go-120.md
@@ -1,0 +1,2 @@
+- Bump Go version used to v1.20 since v1.19 has reached EOL
+  ([\#1351](https://github.com/cometbft/cometbft/pull/1351))

--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.19"
+          go-version: "1.20"
 
       - uses: actions/checkout@v4
 
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: '1.20'
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.19"
+          go-version: "1.20"
       - uses: actions/checkout@v4
       - uses: technote-space/get-diff-action@v6
         with:
@@ -67,7 +67,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.19"
+          go-version: "1.20"
       - uses: actions/checkout@v4
       - uses: technote-space/get-diff-action@v6
         with:

--- a/.github/workflows/e2e-manual.yml
+++ b/.github/workflows/e2e-manual.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: '1.20'
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/e2e-nightly-34x.yml
+++ b/.github/workflows/e2e-nightly-34x.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: '1.20'
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: '1.20'
       - uses: actions/checkout@v4
       - uses: technote-space/get-diff-action@v6
         with:

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: '1.20'
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.19"
+          go-version: "1.20"
           check-latest: true
       - uses: actions/checkout@v4
       - uses: technote-space/get-diff-action@v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
           # Required: the version of golangci-lint is required and
           # must be specified without patch version: we always use the
           # latest patch version.
-          version: v1.50.1
+          version: latest
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}
         if: env.GIT_DIFF

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: '1.20'
       - uses: technote-space/get-diff-action@v6
         with:
           PATTERNS: |

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: '1.20'
 
       # Similar check to ./release-version.yml, but enforces this when pushing
       # tags. The ./release-version.yml check can be bypassed and is mainly

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: '1.20'
 
       - name: Check version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: '1.20'
 
       # Similar check to ./release-version.yml, but enforces this when pushing
       # tags. The ./release-version.yml check can be bypassed and is mainly

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.19"
+          go-version: "1.20"
       - uses: actions/checkout@v4
       - uses: technote-space/get-diff-action@v6
         with:
@@ -56,7 +56,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.19"
+          go-version: "1.20"
       - uses: actions/checkout@v4
       - uses: technote-space/get-diff-action@v6
         with:
@@ -88,7 +88,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.19"
+          go-version: "1.20"
       - uses: actions/checkout@v4
       - uses: technote-space/get-diff-action@v6
         with:
@@ -119,7 +119,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.19"
+          go-version: "1.20"
       - uses: actions/checkout@v4
       - uses: technote-space/get-diff-action@v6
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,7 @@
+run:
+  skip-files:
+    - "libs/pubsub/query/query.peg.go"
+
 linters:
   enable:
     - asciicheck
@@ -10,13 +14,13 @@ linters:
     - goconst
     - gofmt
     - goimports
-    - revive
+    #- revive
     - gosec
     - gosimple
     - govet
     - ineffassign
     - misspell
-    - nakedret
+    #- nakedret
     - nolintlint
     - prealloc
     - staticcheck
@@ -31,6 +35,13 @@ issues:
     - path: _test\.go
       linters:
         - gosec
+        - staticcheck
+        - nolintlint
+    - path: test/fuzz/
+      linters:
+        - gosec
+        - nolintlint
+        - staticcheck
   max-same-issues: 50
 
 linters-settings:
@@ -40,7 +51,67 @@ linters-settings:
     min-confidence: 0
   maligned:
     suggest-new: true
-
-run:
-  skip-files:
-    - libs/pubsub/query/query.peg.go
+  depguard:
+    rules:
+      main:
+        files:
+          - $all
+          - "!$test"
+        allow:
+          - $gostd
+          - github.com/tendermint
+          - github.com/cometbft
+          - github.com/cosmos
+          - github.com/gogo
+          - github.com/Workiva/go-datastructures
+          - github.com/ChainSafe/go-schnorrkel
+          - github.com/creachadair/taskgroup
+          - github.com/gtank/merlin
+          - github.com/btcsuite/btcd/btcec/v2
+          - github.com/BurntSushi/toml
+          - github.com/go-git/go-git/v5
+          - github.com/go-kit
+          - github.com/go-logfmt/logfmt
+          - github.com/gofrs/uuid
+          - github.com/google
+          - github.com/gorilla/websocket
+          - github.com/informalsystems/tm-load-test/pkg/loadtest
+          - github.com/lib/pq
+          - github.com/libp2p/go-buffer-pool
+          - github.com/Masterminds/semver/v3
+          - github.com/minio/highwayhash
+          - github.com/oasisprotocol/curve25519-voi
+          - github.com/pkg/errors
+          - github.com/prometheus
+          - github.com/rcrowley/go-metrics
+          - github.com/rs/cors
+          - github.com/snikch/goodman
+          - github.com/spf13
+          - github.com/stretchr/testify/require
+          - github.com/syndtr/goleveldb
+      test:
+        files:
+          - "$test"
+        allow:
+          - $gostd
+          - github.com/cosmos
+          - github.com/tendermint
+          - github.com/cometbft
+          - github.com/gogo
+          - github.com/Workiva/go-datastructures
+          - github.com/ChainSafe/go-schnorrkel
+          - github.com/creachadair/taskgroup
+          - github.com/gtank/merlin
+          - github.com/adlio/schema
+          - github.com/btcsuite/btcd
+          - github.com/fortytw2/leaktest
+          - github.com/go-kit
+          - github.com/google/uuid
+          - github.com/gorilla/websocket
+          - github.com/lib/pq
+          - github.com/oasisprotocol/curve25519-voi/primitives/merlin
+          - github.com/ory/dockertest
+          - github.com/pkg/errors
+          - github.com/prometheus/client_golang/prometheus/promhttp
+          - github.com/spf13
+          - github.com/stretchr/testify

--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -1,6 +1,6 @@
 # Use a build arg to ensure that both stages use the same,
 # hopefully current, go version.
-ARG GOLANG_BASE_IMAGE=golang:1.19-alpine
+ARG GOLANG_BASE_IMAGE=golang:1.20-alpine
 
 # stage 1 Generate CometBFT Binary
 FROM --platform=$BUILDPLATFORM $GOLANG_BASE_IMAGE as builder

--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,7 @@ format:
 
 lint:
 	@echo "--> Running linter"
-	@go run github.com/golangci/golangci-lint/cmd/golangci-lint run
+	@go run github.com/golangci/golangci-lint/cmd/golangci-lint@latest run
 .PHONY: lint
 
 vulncheck:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ more details about [versioning](#versioning).
 
 In any case, if you intend to run CometBFT in production, we're happy to help.
 
-To contact us, you can also 
+To contact us, you can also
 [join the chat](https://discord.com/channels/669268347736686612/669283915743232011).
 
 More on how releases are conducted can be found [here](./RELEASES.md).
@@ -60,7 +60,7 @@ looking for, see [our security policy](SECURITY.md).
 
 | Requirement | Notes             |
 |-------------|-------------------|
-| Go version  | Go 1.19 or higher |
+| Go version  | Go 1.20 or higher |
 
 ### Install
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,11 @@
 
 This guide provides instructions for upgrading to specific versions of CometBFT.
 
+## v0.34.29
+
+It is recommended that CometBFT be built with Go v1.20+ since v1.19 is no longer
+supported.
+
 ## v0.34.28
 
 For users explicitly making use of the Go APIs provided in the `crypto/merkle`

--- a/docs/guides/upgrading-from-tm.md
+++ b/docs/guides/upgrading-from-tm.md
@@ -39,8 +39,7 @@ subsequent major release of CometBFT.
 ## Building CometBFT
 
 If you are building CometBFT from scratch, please note that it must be compiled
-using Go 1.19 or higher. The use of Go 1.18 is not supported, since this version
-has reached end-of-life with the release of Go 1.20.
+using Go 1.20 or higher.
 
 [v03424]: https://github.com/tendermint/tendermint/releases/tag/v0.34.24
 [v03425]: https://github.com/informalsystems/tendermint/releases/tag/v0.34.25

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tendermint/tendermint
 
-go 1.19
+go 1.20
 
 require (
 	github.com/BurntSushi/toml v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,6 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
 github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d h1:nalkkPQcITbvhmL4+C4cKA87NW0tfm3Kl9VXRoPywFg=
-github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
 github.com/ChainSafe/go-schnorrkel v1.0.0 h1:3aDA67lAykLaG1y3AOjs88dMxC88PgUuHRrLeDnvGIM=
 github.com/ChainSafe/go-schnorrkel v1.0.0/go.mod h1:dpzHYVxLZcp8pjlV+O+UR8K0Hp/z7vcchBSbMBEhCw4=
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=

--- a/p2p/conn/connection.go
+++ b/p2p/conn/connection.go
@@ -707,12 +707,13 @@ func (c *MConnection) Status() ConnectionStatus {
 	status.RecvMonitor = c.recvMonitor.Status()
 	status.Channels = make([]ChannelStatus, len(c.channels))
 	for i, channel := range c.channels {
+		channel := channel
 		status.Channels[i] = ChannelStatus{
 			ID:                channel.desc.ID,
 			SendQueueCapacity: cap(channel.sendQueue),
-			SendQueueSize:     int(atomic.LoadInt32(&channel.sendQueueSize)), //nolint:gosec
+			SendQueueSize:     int(atomic.LoadInt32(&channel.sendQueueSize)),
 			Priority:          channel.desc.Priority,
-			RecentlySent:      atomic.LoadInt64(&channel.recentlySent), //nolint:gosec
+			RecentlySent:      atomic.LoadInt64(&channel.recentlySent),
 		}
 	}
 	return status

--- a/p2p/conn/connection.go
+++ b/p2p/conn/connection.go
@@ -47,8 +47,10 @@ const (
 	defaultPongTimeout         = 45 * time.Second
 )
 
-type receiveCbFunc func(chID byte, msgBytes []byte)
-type errorCbFunc func(interface{})
+type (
+	receiveCbFunc func(chID byte, msgBytes []byte)
+	errorCbFunc   func(interface{})
+)
 
 /*
 Each peer has one `MConnection` (multiplex connection) instance.
@@ -190,8 +192,8 @@ func NewMConnectionWithConfig(
 	}
 
 	// Create channels
-	var channelsIdx = map[byte]*Channel{}
-	var channels = []*Channel{}
+	channelsIdx := map[byte]*Channel{}
+	channels := []*Channel{}
 
 	for _, desc := range chDescs {
 		channel := newChannel(mconn, *desc)
@@ -708,9 +710,9 @@ func (c *MConnection) Status() ConnectionStatus {
 		status.Channels[i] = ChannelStatus{
 			ID:                channel.desc.ID,
 			SendQueueCapacity: cap(channel.sendQueue),
-			SendQueueSize:     int(atomic.LoadInt32(&channel.sendQueueSize)),
+			SendQueueSize:     int(atomic.LoadInt32(&channel.sendQueueSize)), //nolint:gosec
 			Priority:          channel.desc.Priority,
-			RecentlySent:      atomic.LoadInt64(&channel.recentlySent),
+			RecentlySent:      atomic.LoadInt64(&channel.recentlySent), //nolint:gosec
 		}
 	}
 	return status
@@ -856,7 +858,7 @@ func (ch *Channel) writePacketMsgTo(w io.Writer) (n int, err error) {
 // Not goroutine-safe
 func (ch *Channel) recvPacketMsg(packet tmp2p.PacketMsg) ([]byte, error) {
 	ch.Logger.Debug("Read PacketMsg", "conn", ch.conn, "packet", packet)
-	var recvCap, recvReceived = ch.desc.RecvMessageCapacity, len(ch.recving) + len(packet.Data)
+	recvCap, recvReceived := ch.desc.RecvMessageCapacity, len(ch.recving)+len(packet.Data)
 	if recvCap < recvReceived {
 		return nil, fmt.Errorf("received message exceeds available capacity: %v < %v", recvCap, recvReceived)
 	}

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19
+FROM golang:1.20
 
 # Grab deps (jq, hexdump, xxd, killall)
 RUN apt-get update && \

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -1,7 +1,7 @@
 # We need to build in a Linux environment to support C libraries, e.g. RocksDB.
 # We use Debian instead of Alpine, so that we can use binary database packages
 # instead of spending time compiling them.
-FROM golang:1.19-bullseye
+FROM golang:1.20-bullseye
 
 RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
 RUN apt-get -qq install -y libleveldb-dev librocksdb-dev >/dev/null


### PR DESCRIPTION
Follows from the govulncheck failure in #1342, since Go v1.19 has reached EOL.

---

#### PR checklist

- [ ] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments

