### PR TITLE
doc: improve documentation of BlockParams.MaxBytes

### DIFF
--- a/spec/abci/abci++_app_requirements.md
+++ b/spec/abci/abci++_app_requirements.md
@@ -622,6 +622,11 @@ If the Application sets value -1, consensus will:
 
 Must have `MaxBytes == -1` OR `0 < MaxBytes <= 100 MB`.
 
+> Bear in mind that the default value for the `BlockParams.MaxBytes` consensus
+> parameter considers that blocks of size up to 21 MB are valid.
+> If the Application's use case does not need blocks of that size, it is
+> strongly recommended to wind down this default value.
+
 ##### BlockParams.MaxGas
 
 The maximum of the sum of `GasWanted` that will be allowed in a proposed block.

--- a/spec/abci/abci++_app_requirements.md
+++ b/spec/abci/abci++_app_requirements.md
@@ -598,15 +598,15 @@ These are the current consensus parameters (as of v0.37.x):
 The maximum size of a complete Protobuf encoded block.
 This is enforced by the consensus algorithm.
 
+This implies a maximum transaction size that is this `MaxBytes`, less the expected size of
+the header, the validator set, and any included evidence in the block.
+
 The Application should be aware that honest validators _may_ produce and
 broadcast blocks with up the configured `MaxBytes` size.
 As a result, the consensus
 [timeout parameters](../../docs/core/configuration.md#consensus-timeouts-explained)
 adopted by nodes should be configured so that to account for the worst-case
 latency for the delivery of a full block with `MaxBytes` size to all validators.
-
-This implies a maximum transaction size that is this `MaxBytes`, less the expected size of
-the header, the validator set, and any included evidence in the block.
 
 If the Application wants full control over the size of blocks,
 it can do so by enforcing a byte limit set up at the Application level.

--- a/spec/abci/abci++_app_requirements.md
+++ b/spec/abci/abci++_app_requirements.md
@@ -623,7 +623,7 @@ If the Application sets value -1, consensus will:
 Must have `MaxBytes == -1` OR `0 < MaxBytes <= 100 MB`.
 
 > Bear in mind that the default value for the `BlockParams.MaxBytes` consensus
-> parameter considers as valid blocks with size up to 21 MB.
+> parameter accepts as valid blocks with size up to 21 MB.
 > If the Application's use case does not need blocks of that size,
 > or if the impact (specially on bandwidth consumption and block latency)
 > of propagating blocks of that size was not evaluated,

--- a/spec/abci/abci++_app_requirements.md
+++ b/spec/abci/abci++_app_requirements.md
@@ -598,6 +598,13 @@ These are the current consensus parameters (as of v0.37.x):
 The maximum size of a complete Protobuf encoded block.
 This is enforced by the consensus algorithm.
 
+The Application should be aware that honest validators _may_ produce and
+broadcast blocks with up the configured `MaxBytes` size.
+As a result, the consensus
+[timeout parameters](../../docs/core/configuration#consensus-timeouts-explained)
+adopted by nodes should be configured so that to account for the worst-case
+latency for the delivery of a full block with `MaxBytes` size to all validators.
+
 This implies a maximum transaction size that is this `MaxBytes`, less the expected size of
 the header, the validator set, and any included evidence in the block.
 

--- a/spec/abci/abci++_app_requirements.md
+++ b/spec/abci/abci++_app_requirements.md
@@ -625,8 +625,8 @@ Must have `MaxBytes == -1` OR `0 < MaxBytes <= 100 MB`.
 > Bear in mind that the default value for the `BlockParams.MaxBytes` consensus
 > parameter considers that blocks of size up to 21 MB are valid.
 > If the Application's use case does not need blocks of that size,
-> or if the impact (specially bandwidth consumption and block propagation
-> latency) of propagating blocks of that size was not evaluated,
+> or if the impact (specially on bandwidth consumption and block latency)
+> of propagating blocks of that size was not evaluated,
 > it is strongly recommended to wind down this default value.
 
 ##### BlockParams.MaxGas

--- a/spec/abci/abci++_app_requirements.md
+++ b/spec/abci/abci++_app_requirements.md
@@ -624,8 +624,10 @@ Must have `MaxBytes == -1` OR `0 < MaxBytes <= 100 MB`.
 
 > Bear in mind that the default value for the `BlockParams.MaxBytes` consensus
 > parameter considers that blocks of size up to 21 MB are valid.
-> If the Application's use case does not need blocks of that size, it is
-> strongly recommended to wind down this default value.
+> If the Application's use case does not need blocks of that size,
+> or if the impact (specially bandwidth consumption and block propagation
+> latency) of propagating blocks of that size was not evaluated,
+> it is strongly recommended to wind down this default value.
 
 ##### BlockParams.MaxGas
 

--- a/spec/abci/abci++_app_requirements.md
+++ b/spec/abci/abci++_app_requirements.md
@@ -601,7 +601,7 @@ This is enforced by the consensus algorithm.
 The Application should be aware that honest validators _may_ produce and
 broadcast blocks with up the configured `MaxBytes` size.
 As a result, the consensus
-[timeout parameters](../../docs/core/configuration#consensus-timeouts-explained)
+[timeout parameters](../../docs/core/configuration.md#consensus-timeouts-explained)
 adopted by nodes should be configured so that to account for the worst-case
 latency for the delivery of a full block with `MaxBytes` size to all validators.
 

--- a/spec/abci/abci++_app_requirements.md
+++ b/spec/abci/abci++_app_requirements.md
@@ -602,7 +602,7 @@ This implies a maximum transaction size that is this `MaxBytes`, less the expect
 the header, the validator set, and any included evidence in the block.
 
 The Application should be aware that honest validators _may_ produce and
-broadcast blocks with up the configured `MaxBytes` size.
+broadcast blocks with up to the configured `MaxBytes` size.
 As a result, the consensus
 [timeout parameters](../../docs/core/configuration.md#consensus-timeouts-explained)
 adopted by nodes should be configured so as to account for the worst-case

--- a/spec/abci/abci++_app_requirements.md
+++ b/spec/abci/abci++_app_requirements.md
@@ -605,7 +605,7 @@ The Application should be aware that honest validators _may_ produce and
 broadcast blocks with up the configured `MaxBytes` size.
 As a result, the consensus
 [timeout parameters](../../docs/core/configuration.md#consensus-timeouts-explained)
-adopted by nodes should be configured so that to account for the worst-case
+adopted by nodes should be configured so as to account for the worst-case
 latency for the delivery of a full block with `MaxBytes` size to all validators.
 
 If the Application wants full control over the size of blocks,

--- a/spec/abci/abci++_app_requirements.md
+++ b/spec/abci/abci++_app_requirements.md
@@ -623,7 +623,7 @@ If the Application sets value -1, consensus will:
 Must have `MaxBytes == -1` OR `0 < MaxBytes <= 100 MB`.
 
 > Bear in mind that the default value for the `BlockParams.MaxBytes` consensus
-> parameter considers that blocks of size up to 21 MB are valid.
+> parameter considers as valid blocks with size up to 21 MB.
 > If the Application's use case does not need blocks of that size,
 > or if the impact (specially on bandwidth consumption and block latency)
 > of propagating blocks of that size was not evaluated,


### PR DESCRIPTION
Additions to the description of the `BlockParams.MaxBytes` consensus parameter on the ABCI documentation.

Rendered: https://github.com/cometbft/cometbft/blob/cason/doc-maxbytes-param/spec/abci/abci%2B%2B_app_requirements.md

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments

