### PR TITLE
doc: improve documentation of BlockParams.MaxBytes (backport of #1405)

### DIFF
--- a/spec/abci/apps.md
+++ b/spec/abci/apps.md
@@ -302,7 +302,7 @@ This implies a maximum transaction size that is this `MaxBytes`, less the expect
 the header, the validator set, and any included evidence in the block.
 
 The Application should be aware that honest validators _may_ produce and
-broadcast blocks with up the configured `MaxBytes` size.
+broadcast blocks with up to the configured `MaxBytes` size.
 As a result, the consensus
 [timeout parameters](../../docs/core/configuration.md#consensus-timeouts-explained)
 adopted by nodes should be configured so as to account for the worst-case

--- a/spec/abci/apps.md
+++ b/spec/abci/apps.md
@@ -298,7 +298,7 @@ evidence. They can be set in InitChain and updated in EndBlock.
 The maximum size of a complete Protobuf encoded block.
 This is enforced by the consensus algorithm.
 
-This implies a maximum transaction size that is this `MaxBytes`, less the expected size of
+This implies a maximum transaction size that is `MaxBytes`, less the expected size of
 the header, the validator set, and any included evidence in the block.
 
 The Application should be aware that honest validators _may_ produce and

--- a/spec/abci/apps.md
+++ b/spec/abci/apps.md
@@ -296,12 +296,26 @@ evidence. They can be set in InitChain and updated in EndBlock.
 ### BlockParams.MaxBytes
 
 The maximum size of a complete Protobuf encoded block.
-This is enforced by CometBFT consensus.
+This is enforced by the consensus algorithm.
 
-This implies a maximum transaction size that is this MaxBytes, less the expected size of
+This implies a maximum transaction size that is this `MaxBytes`, less the expected size of
 the header, the validator set, and any included evidence in the block.
 
-Must have `0 < MaxBytes < 100 MB`.
+The Application should be aware that honest validators _may_ produce and
+broadcast blocks with up the configured `MaxBytes` size.
+As a result, the consensus
+[timeout parameters](../../docs/core/configuration.md#consensus-timeouts-explained)
+adopted by nodes should be configured so as to account for the worst-case
+latency for the delivery of a full block with `MaxBytes` size to all validators.
+
+Must have `0 < MaxBytes <= 100 MB`.
+
+> Bear in mind that the default value for the `BlockParams.MaxBytes` consensus
+> parameter accepts as valid blocks with size up to 21 MB.
+> If the Application's use case does not need blocks of that size,
+> or if the impact (specially on bandwidth consumption and block latency)
+> of propagating blocks of that size was not evaluated,
+> it is strongly recommended to wind down this default value.
 
 ### BlockParams.MaxGas
 


### PR DESCRIPTION
This is a manual backport #1405.

Rendered: https://github.com/cometbft/cometbft/blob/cason/doc-maxbytes-param-v0.34.x/spec/abci/apps.md

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments

