### PR TITLE
Bump p2p version following introduction of `HasProposalBlockPartMessage`

### DIFF
--- a/.changelog/unreleased/breaking-changes/1411-bump-p2p-version.md
+++ b/.changelog/unreleased/breaking-changes/1411-bump-p2p-version.md
@@ -1,0 +1,2 @@
+- `[version]` Bumped the P2P version from 8 to 9, as this release contains new P2P messages.
+   ([\#1411](https://github.com/cometbft/cometbft/pull/1411))

--- a/version/version.go
+++ b/version/version.go
@@ -9,7 +9,7 @@ const (
 	ABCIVersion = ABCISemVer
 	// P2PProtocol versions all p2p behavior and msgs.
 	// This includes proposer selection.
-	P2PProtocol uint64 = 8
+	P2PProtocol uint64 = 9
 
 	// BlockProtocol versions all block data structures and processing.
 	// This includes validity of blocks and state updates.


### PR DESCRIPTION
Related to #26

#904 introduced a new p2p message: `HasProposalBlockPartMessage`. This will require a coordinated upgrade (not a big deal, this has been the norm from `v0.34.x` to `v0.37.x`, and from `v0.37.x` to `v0.38.x`).
In addition, for safety (to avoid misunderstandings during node handshake), we need to bump the p2p version.
This is usually done as part of the [release process](https://github.com/cometbft/cometbft/blob/86c07f20f/RELEASES.md?plain=1#L205), but, as suggested [here](https://github.com/cometbft/cometbft/pull/904#issuecomment-1738812069), let's do it now to make sure we don't forget.

---

#### PR checklist

- [ ] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

