### PR TITLE
crypto: export errors

### DIFF
--- a/crypto/armor/armor.go
+++ b/crypto/armor/armor.go
@@ -8,28 +8,32 @@ import (
 	"golang.org/x/crypto/openpgp/armor" //nolint: staticcheck
 )
 
-// EncodeError represents an error from calling [EncodeArmor].
-type EncodeError struct{ Err error }
+// ErrEncode represents an error from calling [EncodeArmor].
+type ErrEncode struct {
+	Err error
+}
 
-func (e *EncodeError) Error() string {
+func (e *ErrEncode) Error() string {
 	return fmt.Sprintf("armor: could not encode ASCII armor: %v", e.Err)
 }
 
-func (e *EncodeError) Unwrap() error { return e.Err }
+func (e *ErrEncode) Unwrap() error {
+	return e.Err
+}
 
 func EncodeArmor(blockType string, headers map[string]string, data []byte) (string, error) {
 	buf := new(bytes.Buffer)
 	w, err := armor.Encode(buf, blockType, headers)
 	if err != nil {
-		return "", &EncodeError{Err: err}
+		return "", &ErrEncode{Err: err}
 	}
 	_, err = w.Write(data)
 	if err != nil {
-		return "", &EncodeError{Err: err}
+		return "", &ErrEncode{Err: err}
 	}
 	err = w.Close()
 	if err != nil {
-		return "", &EncodeError{Err: err}
+		return "", &ErrEncode{Err: err}
 	}
 	return buf.String(), nil
 }

--- a/crypto/armor/armor.go
+++ b/crypto/armor/armor.go
@@ -13,11 +13,11 @@ type ErrEncode struct {
 	Err error
 }
 
-func (e *ErrEncode) Error() string {
+func (e ErrEncode) Error() string {
 	return fmt.Sprintf("armor: could not encode ASCII armor: %v", e.Err)
 }
 
-func (e *ErrEncode) Unwrap() error {
+func (e ErrEncode) Unwrap() error {
 	return e.Err
 }
 
@@ -25,15 +25,15 @@ func EncodeArmor(blockType string, headers map[string]string, data []byte) (stri
 	buf := new(bytes.Buffer)
 	w, err := armor.Encode(buf, blockType, headers)
 	if err != nil {
-		return "", &ErrEncode{Err: err}
+		return "", ErrEncode{Err: err}
 	}
 	_, err = w.Write(data)
 	if err != nil {
-		return "", &ErrEncode{Err: err}
+		return "", ErrEncode{Err: err}
 	}
 	err = w.Close()
 	if err != nil {
-		return "", &ErrEncode{Err: err}
+		return "", ErrEncode{Err: err}
 	}
 	return buf.String(), nil
 }

--- a/crypto/armor/armor.go
+++ b/crypto/armor/armor.go
@@ -8,21 +8,30 @@ import (
 	"golang.org/x/crypto/openpgp/armor" //nolint: staticcheck
 )
 
-func EncodeArmor(blockType string, headers map[string]string, data []byte) string {
+// EncodeError represents an error from calling [EncodeArmor].
+type EncodeError struct{ Err error }
+
+func (e *EncodeError) Error() string {
+	return fmt.Sprintf("armor: could not encode ASCII armor: %v", e.Err)
+}
+
+func (e *EncodeError) Unwrap() error { return e.Err }
+
+func EncodeArmor(blockType string, headers map[string]string, data []byte) (string, error) {
 	buf := new(bytes.Buffer)
 	w, err := armor.Encode(buf, blockType, headers)
 	if err != nil {
-		panic(fmt.Errorf("could not encode ascii armor: %s", err))
+		return "", &EncodeError{Err: err}
 	}
 	_, err = w.Write(data)
 	if err != nil {
-		panic(fmt.Errorf("could not encode ascii armor: %s", err))
+		return "", &EncodeError{Err: err}
 	}
 	err = w.Close()
 	if err != nil {
-		panic(fmt.Errorf("could not encode ascii armor: %s", err))
+		return "", &EncodeError{Err: err}
 	}
-	return buf.String()
+	return buf.String(), nil
 }
 
 func DecodeArmor(armorStr string) (blockType string, headers map[string]string, data []byte, err error) {

--- a/crypto/armor/armor_test.go
+++ b/crypto/armor/armor_test.go
@@ -10,7 +10,8 @@ import (
 func TestArmor(t *testing.T) {
 	blockType := "MINT TEST"
 	data := []byte("somedata")
-	armorStr := EncodeArmor(blockType, nil, data)
+	armorStr, err := EncodeArmor(blockType, nil, data)
+	require.Nil(t, err, "%+v", err)
 
 	// Decode armorStr and test for equivalence.
 	blockType2, _, data2, err := DecodeArmor(armorStr)

--- a/crypto/ed25519/ed25519.go
+++ b/crypto/ed25519/ed25519.go
@@ -15,7 +15,18 @@ import (
 	cmtjson "github.com/cometbft/cometbft/libs/json"
 )
 
-//-------------------------------------
+var (
+	ErrNotEd25519Key    = errors.New("ed25519: pubkey is not Ed25519")
+	ErrInvalidSignature = errors.New("ed25519: invalid signature")
+)
+
+// InvalidKeyLenError describes an error resulting from an passing in a
+// key with an invalid key in the call to [BatchVerifier.Add].
+type InvalidKeyLenError struct{ got, want int }
+
+func (e *InvalidKeyLenError) Error() string {
+	return fmt.Sprintf("ed25519: invalid key length: got %d, want %d", e.got, e.want)
+}
 
 var (
 	_ crypto.PrivKey       = PrivKey{}
@@ -204,18 +215,18 @@ func NewBatchVerifier() crypto.BatchVerifier {
 func (b *BatchVerifier) Add(key crypto.PubKey, msg, signature []byte) error {
 	pkEd, ok := key.(PubKey)
 	if !ok {
-		return fmt.Errorf("pubkey is not Ed25519")
+		return ErrNotEd25519Key
 	}
 
 	pkBytes := pkEd.Bytes()
 
 	if l := len(pkBytes); l != PubKeySize {
-		return fmt.Errorf("pubkey size is incorrect; expected: %d, got %d", PubKeySize, l)
+		return &InvalidKeyLenError{got: l, want: PubKeySize}
 	}
 
 	// check that the signature is the correct length
 	if len(signature) != SignatureSize {
-		return errors.New("invalid signature")
+		return ErrInvalidSignature
 	}
 
 	cachingVerifier.AddWithOptions(b.BatchVerifier, ed25519.PublicKey(pkBytes), msg, signature, verifyOptions)

--- a/crypto/ed25519/ed25519.go
+++ b/crypto/ed25519/ed25519.go
@@ -20,12 +20,14 @@ var (
 	ErrInvalidSignature = errors.New("ed25519: invalid signature")
 )
 
-// InvalidKeyLenError describes an error resulting from an passing in a
+// ErrInvalidKeyLen describes an error resulting from an passing in a
 // key with an invalid key in the call to [BatchVerifier.Add].
-type InvalidKeyLenError struct{ got, want int }
+type ErrInvalidKeyLen struct {
+	Got, Want int
+}
 
-func (e *InvalidKeyLenError) Error() string {
-	return fmt.Sprintf("ed25519: invalid key length: got %d, want %d", e.got, e.want)
+func (e *ErrInvalidKeyLen) Error() string {
+	return fmt.Sprintf("ed25519: invalid key length: got %d, want %d", e.Got, e.Want)
 }
 
 var (
@@ -221,7 +223,7 @@ func (b *BatchVerifier) Add(key crypto.PubKey, msg, signature []byte) error {
 	pkBytes := pkEd.Bytes()
 
 	if l := len(pkBytes); l != PubKeySize {
-		return &InvalidKeyLenError{got: l, want: PubKeySize}
+		return &ErrInvalidKeyLen{Got: l, Want: PubKeySize}
 	}
 
 	// check that the signature is the correct length

--- a/crypto/ed25519/ed25519.go
+++ b/crypto/ed25519/ed25519.go
@@ -26,7 +26,7 @@ type ErrInvalidKeyLen struct {
 	Got, Want int
 }
 
-func (e *ErrInvalidKeyLen) Error() string {
+func (e ErrInvalidKeyLen) Error() string {
 	return fmt.Sprintf("ed25519: invalid key length: got %d, want %d", e.Got, e.Want)
 }
 
@@ -223,7 +223,7 @@ func (b *BatchVerifier) Add(key crypto.PubKey, msg, signature []byte) error {
 	pkBytes := pkEd.Bytes()
 
 	if l := len(pkBytes); l != PubKeySize {
-		return &ErrInvalidKeyLen{Got: l, Want: PubKeySize}
+		return ErrInvalidKeyLen{Got: l, Want: PubKeySize}
 	}
 
 	// check that the signature is the correct length

--- a/crypto/encoding/codec.go
+++ b/crypto/encoding/codec.go
@@ -16,7 +16,7 @@ type ErrUnsupportedKey struct {
 	Key any
 }
 
-func (e *ErrUnsupportedKey) Error() string {
+func (e ErrUnsupportedKey) Error() string {
 	return fmt.Sprintf("encoding: unsupported key %v", e.Key)
 }
 
@@ -27,7 +27,7 @@ type ErrInvalidKeyLen struct {
 	Got, Want int
 }
 
-func (e *ErrInvalidKeyLen) Error() string {
+func (e ErrInvalidKeyLen) Error() string {
 	return fmt.Sprintf("encoding: invalid key length for %v, got %d, want %d", e.Key, e.Got, e.Want)
 }
 
@@ -54,7 +54,7 @@ func PubKeyToProto(k crypto.PubKey) (pc.PublicKey, error) {
 			},
 		}
 	default:
-		return kp, &ErrUnsupportedKey{Key: k}
+		return kp, ErrUnsupportedKey{Key: k}
 	}
 	return kp, nil
 }
@@ -64,7 +64,7 @@ func PubKeyFromProto(k pc.PublicKey) (crypto.PubKey, error) {
 	switch k := k.Sum.(type) {
 	case *pc.PublicKey_Ed25519:
 		if len(k.Ed25519) != ed25519.PubKeySize {
-			return nil, &ErrInvalidKeyLen{
+			return nil, ErrInvalidKeyLen{
 				Key:  k,
 				Got:  len(k.Ed25519),
 				Want: ed25519.PubKeySize,
@@ -75,7 +75,7 @@ func PubKeyFromProto(k pc.PublicKey) (crypto.PubKey, error) {
 		return pk, nil
 	case *pc.PublicKey_Secp256K1:
 		if len(k.Secp256K1) != secp256k1.PubKeySize {
-			return nil, &ErrInvalidKeyLen{
+			return nil, ErrInvalidKeyLen{
 				Key:  k,
 				Got:  len(k.Secp256K1),
 				Want: secp256k1.PubKeySize,
@@ -85,6 +85,6 @@ func PubKeyFromProto(k pc.PublicKey) (crypto.PubKey, error) {
 		copy(pk, k.Secp256K1)
 		return pk, nil
 	default:
-		return nil, &ErrUnsupportedKey{Key: k}
+		return nil, ErrUnsupportedKey{Key: k}
 	}
 }

--- a/crypto/merkle/proof.go
+++ b/crypto/merkle/proof.go
@@ -22,11 +22,11 @@ type ErrInvalidHash struct {
 	Err error
 }
 
-func (e *ErrInvalidHash) Error() string {
+func (e ErrInvalidHash) Error() string {
 	return fmt.Sprintf("merkle: invalid hash: %s", e.Err)
 }
 
-func (e *ErrInvalidHash) Unwrap() error {
+func (e ErrInvalidHash) Unwrap() error {
 	return e.Err
 }
 
@@ -34,11 +34,11 @@ type ErrInvalidProof struct {
 	Err error
 }
 
-func (e *ErrInvalidProof) Error() string {
+func (e ErrInvalidProof) Error() string {
 	return fmt.Sprintf("merkle: invalid proof: %s", e.Err)
 }
 
-func (e *ErrInvalidProof) Unwrap() error {
+func (e ErrInvalidProof) Unwrap() error {
 	return e.Err
 }
 
@@ -77,34 +77,34 @@ func ProofsFromByteSlices(items [][]byte) (rootHash []byte, proofs []*Proof) {
 // Check sp.Index/sp.Total manually if needed
 func (sp *Proof) Verify(rootHash []byte, leaf []byte) error {
 	if rootHash == nil {
-		return &ErrInvalidHash{
+		return ErrInvalidHash{
 			Err: errors.New("nil root"),
 		}
 	}
 	if sp.Total < 0 {
-		return &ErrInvalidProof{
+		return ErrInvalidProof{
 			Err: errors.New("negative proof total"),
 		}
 	}
 	if sp.Index < 0 {
-		return &ErrInvalidProof{
+		return ErrInvalidProof{
 			Err: errors.New("negative proof index"),
 		}
 	}
 	leafHash := leafHash(leaf)
 	if !bytes.Equal(sp.LeafHash, leafHash) {
-		return &ErrInvalidHash{
+		return ErrInvalidHash{
 			Err: fmt.Errorf("leaf %x, want %x", sp.LeafHash, leafHash),
 		}
 	}
 	computedHash, err := sp.computeRootHash()
 	if err != nil {
-		return &ErrInvalidHash{
+		return ErrInvalidHash{
 			Err: fmt.Errorf("compute root hash: %w", err),
 		}
 	}
 	if !bytes.Equal(computedHash, rootHash) {
-		return &ErrInvalidHash{
+		return ErrInvalidHash{
 			Err: fmt.Errorf("root %x, want %x", computedHash, rootHash),
 		}
 	}
@@ -141,17 +141,17 @@ func (sp *Proof) StringIndented(indent string) string {
 // and it expects at most MaxAunts elements in Aunts.
 func (sp *Proof) ValidateBasic() error {
 	if sp.Total < 0 {
-		return &ErrInvalidProof{
+		return ErrInvalidProof{
 			Err: errors.New("negative proof total"),
 		}
 	}
 	if sp.Index < 0 {
-		return &ErrInvalidProof{
+		return ErrInvalidProof{
 			Err: errors.New("negative proof index"),
 		}
 	}
 	if len(sp.LeafHash) != tmhash.Size {
-		return &ErrInvalidHash{
+		return ErrInvalidHash{
 			Err: fmt.Errorf("leaf length %d, want %d", len(sp.LeafHash), tmhash.Size),
 		}
 	}
@@ -160,7 +160,7 @@ func (sp *Proof) ValidateBasic() error {
 	}
 	for i, auntHash := range sp.Aunts {
 		if len(auntHash) != tmhash.Size {
-			return &ErrInvalidHash{
+			return ErrInvalidHash{
 				Err: fmt.Errorf("aunt#%d hash length %d, want %d", i, len(auntHash), tmhash.Size),
 			}
 		}
@@ -184,7 +184,7 @@ func (sp *Proof) ToProto() *cmtcrypto.Proof {
 
 func ProofFromProto(pb *cmtcrypto.Proof) (*Proof, error) {
 	if pb == nil {
-		return nil, &ErrInvalidProof{Err: errors.New("nil proof")}
+		return nil, ErrInvalidProof{Err: errors.New("nil proof")}
 	}
 
 	sp := new(Proof)

--- a/crypto/merkle/proof_key_path.go
+++ b/crypto/merkle/proof_key_path.go
@@ -86,7 +86,7 @@ type ErrInvalidKey struct {
 	Err error
 }
 
-func (e *ErrInvalidKey) Error() string {
+func (e ErrInvalidKey) Error() string {
 	return fmt.Sprintf("merkle: invalid key error: %v", e.Err)
 }
 
@@ -94,7 +94,7 @@ func (e *ErrInvalidKey) Error() string {
 // Each key must use a known encoding.
 func KeyPathToKeys(path string) (keys [][]byte, err error) {
 	if path == "" || path[0] != '/' {
-		return nil, &ErrInvalidKey{
+		return nil, ErrInvalidKey{
 			Err: errors.New("key path string must start with a forward slash '/'"),
 		}
 	}
@@ -105,7 +105,7 @@ func KeyPathToKeys(path string) (keys [][]byte, err error) {
 			hexPart := part[2:]
 			key, err := hex.DecodeString(hexPart)
 			if err != nil {
-				return nil, &ErrInvalidKey{
+				return nil, ErrInvalidKey{
 					Err: fmt.Errorf("decoding hex-encoded part #%d: /%s: %w", i, part, err),
 				}
 			}
@@ -113,7 +113,7 @@ func KeyPathToKeys(path string) (keys [][]byte, err error) {
 		} else {
 			key, err := url.PathUnescape(part)
 			if err != nil {
-				return nil, &ErrInvalidKey{
+				return nil, ErrInvalidKey{
 					Err: fmt.Errorf("decoding url-encoded part #%d: /%s: %w", i, part, err),
 				}
 			}

--- a/crypto/merkle/proof_key_path.go
+++ b/crypto/merkle/proof_key_path.go
@@ -82,11 +82,19 @@ func (pth KeyPath) String() string {
 	return res
 }
 
+type InvalidKeyError struct{ Err error }
+
+func (e *InvalidKeyError) Error() string {
+	return fmt.Sprintf("merkle: invalid key error: %v", e.Err)
+}
+
 // Decode a path to a list of keys. Path must begin with `/`.
 // Each key must use a known encoding.
 func KeyPathToKeys(path string) (keys [][]byte, err error) {
 	if path == "" || path[0] != '/' {
-		return nil, errors.New("key path string must start with a forward slash '/'")
+		return nil, &InvalidKeyError{
+			Err: errors.New("key path string must start with a forward slash '/'"),
+		}
 	}
 	parts := strings.Split(path[1:], "/")
 	keys = make([][]byte, len(parts))
@@ -95,13 +103,17 @@ func KeyPathToKeys(path string) (keys [][]byte, err error) {
 			hexPart := part[2:]
 			key, err := hex.DecodeString(hexPart)
 			if err != nil {
-				return nil, fmt.Errorf("decoding hex-encoded part #%d: /%s: %w", i, part, err)
+				return nil, &InvalidKeyError{
+					Err: fmt.Errorf("decoding hex-encoded part #%d: /%s: %w", i, part, err),
+				}
 			}
 			keys[i] = key
 		} else {
 			key, err := url.PathUnescape(part)
 			if err != nil {
-				return nil, fmt.Errorf("decoding url-encoded part #%d: /%s: %w", i, part, err)
+				return nil, &InvalidKeyError{
+					Err: fmt.Errorf("decoding url-encoded part #%d: /%s: %w", i, part, err),
+				}
 			}
 			keys[i] = []byte(key) // TODO Test this with random bytes, I'm not sure that it works for arbitrary bytes...
 		}

--- a/crypto/merkle/proof_key_path.go
+++ b/crypto/merkle/proof_key_path.go
@@ -82,9 +82,11 @@ func (pth KeyPath) String() string {
 	return res
 }
 
-type InvalidKeyError struct{ Err error }
+type ErrInvalidKey struct {
+	Err error
+}
 
-func (e *InvalidKeyError) Error() string {
+func (e *ErrInvalidKey) Error() string {
 	return fmt.Sprintf("merkle: invalid key error: %v", e.Err)
 }
 
@@ -92,7 +94,7 @@ func (e *InvalidKeyError) Error() string {
 // Each key must use a known encoding.
 func KeyPathToKeys(path string) (keys [][]byte, err error) {
 	if path == "" || path[0] != '/' {
-		return nil, &InvalidKeyError{
+		return nil, &ErrInvalidKey{
 			Err: errors.New("key path string must start with a forward slash '/'"),
 		}
 	}
@@ -103,7 +105,7 @@ func KeyPathToKeys(path string) (keys [][]byte, err error) {
 			hexPart := part[2:]
 			key, err := hex.DecodeString(hexPart)
 			if err != nil {
-				return nil, &InvalidKeyError{
+				return nil, &ErrInvalidKey{
 					Err: fmt.Errorf("decoding hex-encoded part #%d: /%s: %w", i, part, err),
 				}
 			}
@@ -111,7 +113,7 @@ func KeyPathToKeys(path string) (keys [][]byte, err error) {
 		} else {
 			key, err := url.PathUnescape(part)
 			if err != nil {
-				return nil, &InvalidKeyError{
+				return nil, &ErrInvalidKey{
 					Err: fmt.Errorf("decoding url-encoded part #%d: /%s: %w", i, part, err),
 				}
 			}

--- a/crypto/merkle/proof_op.go
+++ b/crypto/merkle/proof_op.go
@@ -38,10 +38,10 @@ func (poz ProofOperators) VerifyValue(root []byte, keypath string, value []byte)
 	return poz.Verify(root, keypath, [][]byte{value})
 }
 
-func (poz ProofOperators) Verify(root []byte, keypath string, args [][]byte) (err error) {
+func (poz ProofOperators) Verify(root []byte, keypath string, args [][]byte) error {
 	keys, err := KeyPathToKeys(keypath)
 	if err != nil {
-		return
+		return err
 	}
 
 	for i, op := range poz {
@@ -62,7 +62,7 @@ func (poz ProofOperators) Verify(root []byte, keypath string, args [][]byte) (er
 		}
 		args, err = op.Run(args)
 		if err != nil {
-			return
+			return err
 		}
 	}
 	if !bytes.Equal(root, args[0]) {

--- a/crypto/merkle/proof_op.go
+++ b/crypto/merkle/proof_op.go
@@ -8,6 +8,8 @@ import (
 	cmtcrypto "github.com/cometbft/cometbft/proto/tendermint/crypto"
 )
 
+var ErrKeyPathNotConsumed = errors.New("merkle: keypath not consumed")
+
 //----------------------------------------
 // ProofOp gets converted to an instance of ProofOperator:
 
@@ -46,11 +48,15 @@ func (poz ProofOperators) Verify(root []byte, keypath string, args [][]byte) (er
 		key := op.GetKey()
 		if len(key) != 0 {
 			if len(keys) == 0 {
-				return fmt.Errorf("key path has insufficient # of parts: expected no more keys but got %+v", string(key))
+				return &InvalidKeyError{
+					Err: fmt.Errorf("key path has insufficient # of parts: expected no more keys but got %+v", string(key)),
+				}
 			}
 			lastKey := keys[len(keys)-1]
 			if !bytes.Equal(lastKey, key) {
-				return fmt.Errorf("key mismatch on operation #%d: expected %+v but got %+v", i, string(lastKey), string(key))
+				return &InvalidKeyError{
+					Err: fmt.Errorf("key mismatch on operation #%d: expected %+v but got %+v", i, string(lastKey), string(key)),
+				}
 			}
 			keys = keys[:len(keys)-1]
 		}
@@ -60,10 +66,12 @@ func (poz ProofOperators) Verify(root []byte, keypath string, args [][]byte) (er
 		}
 	}
 	if !bytes.Equal(root, args[0]) {
-		return fmt.Errorf("calculated root hash is invalid: expected %X but got %X", root, args[0])
+		return &InvalidHashError{
+			Err: fmt.Errorf("root %x, want %x", args[0], root),
+		}
 	}
 	if len(keys) != 0 {
-		return errors.New("keypath not consumed all")
+		return ErrKeyPathNotConsumed
 	}
 	return nil
 }
@@ -94,7 +102,9 @@ func (prt *ProofRuntime) RegisterOpDecoder(typ string, dec OpDecoder) {
 func (prt *ProofRuntime) Decode(pop cmtcrypto.ProofOp) (ProofOperator, error) {
 	decoder := prt.decoders[pop.Type]
 	if decoder == nil {
-		return nil, fmt.Errorf("unrecognized proof type %v", pop.Type)
+		return nil, &InvalidProofError{
+			Err: fmt.Errorf("unrecognized proof type %v", pop.Type),
+		}
 	}
 	return decoder(pop)
 }
@@ -104,7 +114,9 @@ func (prt *ProofRuntime) DecodeProof(proof *cmtcrypto.ProofOps) (ProofOperators,
 	for _, pop := range proof.Ops {
 		operator, err := prt.Decode(pop)
 		if err != nil {
-			return nil, fmt.Errorf("decoding a proof operator: %w", err)
+			return nil, &InvalidProofError{
+				Err: fmt.Errorf("decoding a proof operator: %w", err),
+			}
 		}
 		poz = append(poz, operator)
 	}
@@ -124,7 +136,9 @@ func (prt *ProofRuntime) VerifyAbsence(proof *cmtcrypto.ProofOps, root []byte, k
 func (prt *ProofRuntime) Verify(proof *cmtcrypto.ProofOps, root []byte, keypath string, args [][]byte) (err error) {
 	poz, err := prt.DecodeProof(proof)
 	if err != nil {
-		return fmt.Errorf("decoding proof: %w", err)
+		return &InvalidProofError{
+			Err: fmt.Errorf("decoding proof: %w", err),
+		}
 	}
 	return poz.Verify(root, keypath, args)
 }

--- a/crypto/merkle/proof_op.go
+++ b/crypto/merkle/proof_op.go
@@ -48,13 +48,13 @@ func (poz ProofOperators) Verify(root []byte, keypath string, args [][]byte) (er
 		key := op.GetKey()
 		if len(key) != 0 {
 			if len(keys) == 0 {
-				return &InvalidKeyError{
+				return &ErrInvalidKey{
 					Err: fmt.Errorf("key path has insufficient # of parts: expected no more keys but got %+v", string(key)),
 				}
 			}
 			lastKey := keys[len(keys)-1]
 			if !bytes.Equal(lastKey, key) {
-				return &InvalidKeyError{
+				return &ErrInvalidKey{
 					Err: fmt.Errorf("key mismatch on operation #%d: expected %+v but got %+v", i, string(lastKey), string(key)),
 				}
 			}
@@ -66,7 +66,7 @@ func (poz ProofOperators) Verify(root []byte, keypath string, args [][]byte) (er
 		}
 	}
 	if !bytes.Equal(root, args[0]) {
-		return &InvalidHashError{
+		return &ErrInvalidHash{
 			Err: fmt.Errorf("root %x, want %x", args[0], root),
 		}
 	}
@@ -102,7 +102,7 @@ func (prt *ProofRuntime) RegisterOpDecoder(typ string, dec OpDecoder) {
 func (prt *ProofRuntime) Decode(pop cmtcrypto.ProofOp) (ProofOperator, error) {
 	decoder := prt.decoders[pop.Type]
 	if decoder == nil {
-		return nil, &InvalidProofError{
+		return nil, &ErrInvalidProof{
 			Err: fmt.Errorf("unrecognized proof type %v", pop.Type),
 		}
 	}
@@ -114,7 +114,7 @@ func (prt *ProofRuntime) DecodeProof(proof *cmtcrypto.ProofOps) (ProofOperators,
 	for _, pop := range proof.Ops {
 		operator, err := prt.Decode(pop)
 		if err != nil {
-			return nil, &InvalidProofError{
+			return nil, &ErrInvalidProof{
 				Err: fmt.Errorf("decoding a proof operator: %w", err),
 			}
 		}
@@ -136,7 +136,7 @@ func (prt *ProofRuntime) VerifyAbsence(proof *cmtcrypto.ProofOps, root []byte, k
 func (prt *ProofRuntime) Verify(proof *cmtcrypto.ProofOps, root []byte, keypath string, args [][]byte) (err error) {
 	poz, err := prt.DecodeProof(proof)
 	if err != nil {
-		return &InvalidProofError{
+		return &ErrInvalidProof{
 			Err: fmt.Errorf("decoding proof: %w", err),
 		}
 	}

--- a/crypto/merkle/proof_op.go
+++ b/crypto/merkle/proof_op.go
@@ -48,13 +48,13 @@ func (poz ProofOperators) Verify(root []byte, keypath string, args [][]byte) err
 		key := op.GetKey()
 		if len(key) != 0 {
 			if len(keys) == 0 {
-				return &ErrInvalidKey{
+				return ErrInvalidKey{
 					Err: fmt.Errorf("key path has insufficient # of parts: expected no more keys but got %+v", string(key)),
 				}
 			}
 			lastKey := keys[len(keys)-1]
 			if !bytes.Equal(lastKey, key) {
-				return &ErrInvalidKey{
+				return ErrInvalidKey{
 					Err: fmt.Errorf("key mismatch on operation #%d: expected %+v but got %+v", i, string(lastKey), string(key)),
 				}
 			}
@@ -66,7 +66,7 @@ func (poz ProofOperators) Verify(root []byte, keypath string, args [][]byte) err
 		}
 	}
 	if !bytes.Equal(root, args[0]) {
-		return &ErrInvalidHash{
+		return ErrInvalidHash{
 			Err: fmt.Errorf("root %x, want %x", args[0], root),
 		}
 	}
@@ -102,7 +102,7 @@ func (prt *ProofRuntime) RegisterOpDecoder(typ string, dec OpDecoder) {
 func (prt *ProofRuntime) Decode(pop cmtcrypto.ProofOp) (ProofOperator, error) {
 	decoder := prt.decoders[pop.Type]
 	if decoder == nil {
-		return nil, &ErrInvalidProof{
+		return nil, ErrInvalidProof{
 			Err: fmt.Errorf("unrecognized proof type %v", pop.Type),
 		}
 	}
@@ -114,7 +114,7 @@ func (prt *ProofRuntime) DecodeProof(proof *cmtcrypto.ProofOps) (ProofOperators,
 	for _, pop := range proof.Ops {
 		operator, err := prt.Decode(pop)
 		if err != nil {
-			return nil, &ErrInvalidProof{
+			return nil, ErrInvalidProof{
 				Err: fmt.Errorf("decoding a proof operator: %w", err),
 			}
 		}
@@ -136,7 +136,7 @@ func (prt *ProofRuntime) VerifyAbsence(proof *cmtcrypto.ProofOps, root []byte, k
 func (prt *ProofRuntime) Verify(proof *cmtcrypto.ProofOps, root []byte, keypath string, args [][]byte) (err error) {
 	poz, err := prt.DecodeProof(proof)
 	if err != nil {
-		return &ErrInvalidProof{
+		return ErrInvalidProof{
 			Err: fmt.Errorf("decoding proof: %w", err),
 		}
 	}

--- a/crypto/merkle/proof_test.go
+++ b/crypto/merkle/proof_test.go
@@ -146,14 +146,20 @@ func TestProofValidateBasic(t *testing.T) {
 		errStr        string
 	}{
 		{"Good", func(sp *Proof) {}, ""},
-		{"Negative Total", func(sp *Proof) { sp.Total = -1 }, "negative Total"},
-		{"Negative Index", func(sp *Proof) { sp.Index = -1 }, "negative Index"},
-		{"Invalid LeafHash", func(sp *Proof) { sp.LeafHash = make([]byte, 10) },
-			"expected LeafHash size to be 32, got 10"},
-		{"Too many Aunts", func(sp *Proof) { sp.Aunts = make([][]byte, MaxAunts+1) },
-			"expected no more than 100 aunts, got 101"},
-		{"Invalid Aunt", func(sp *Proof) { sp.Aunts[0] = make([]byte, 10) },
-			"expected Aunts#0 size to be 32, got 10"},
+		{"Negative Total", func(sp *Proof) { sp.Total = -1 }, "negative proof total"},
+		{"Negative Index", func(sp *Proof) { sp.Index = -1 }, "negative proof index"},
+		{
+			"Invalid LeafHash", func(sp *Proof) { sp.LeafHash = make([]byte, 10) },
+			"leaf length 10, want 32",
+		},
+		{
+			"Too many Aunts", func(sp *Proof) { sp.Aunts = make([][]byte, MaxAunts+1) },
+			"maximum aunts length, 100, exceeded",
+		},
+		{
+			"Invalid Aunt", func(sp *Proof) { sp.Aunts[0] = make([]byte, 10) },
+			"aunt#0 hash length 10, want 32",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -172,6 +178,7 @@ func TestProofValidateBasic(t *testing.T) {
 		})
 	}
 }
+
 func TestVoteProtobuf(t *testing.T) {
 	_, proofs := ProofsFromByteSlices([][]byte{
 		[]byte("apple"),

--- a/crypto/merkle/proof_value.go
+++ b/crypto/merkle/proof_value.go
@@ -40,14 +40,14 @@ func NewValueOp(key []byte, proof *Proof) ValueOp {
 
 func ValueOpDecoder(pop cmtcrypto.ProofOp) (ProofOperator, error) {
 	if pop.Type != ProofOpValue {
-		return nil, &InvalidProofError{
+		return nil, &ErrInvalidProof{
 			Err: fmt.Errorf("unexpected ProofOp.Type; got %v, want %v", pop.Type, ProofOpValue),
 		}
 	}
 	var pbop cmtcrypto.ValueOp // a bit strange as we'll discard this, but it works.
 	err := pbop.Unmarshal(pop.Data)
 	if err != nil {
-		return nil, &InvalidProofError{
+		return nil, &ErrInvalidProof{
 			Err: fmt.Errorf("decoding ProofOp.Data into ValueOp: %w", err),
 		}
 	}
@@ -99,7 +99,7 @@ func (op ValueOp) Run(args [][]byte) ([][]byte, error) {
 	kvhash := leafHash(bz.Bytes())
 
 	if !bytes.Equal(kvhash, op.Proof.LeafHash) {
-		return nil, &InvalidHashError{
+		return nil, &ErrInvalidHash{
 			Err: fmt.Errorf("leaf %x, want %x", kvhash, op.Proof.LeafHash),
 		}
 	}

--- a/crypto/merkle/proof_value.go
+++ b/crypto/merkle/proof_value.go
@@ -40,14 +40,14 @@ func NewValueOp(key []byte, proof *Proof) ValueOp {
 
 func ValueOpDecoder(pop cmtcrypto.ProofOp) (ProofOperator, error) {
 	if pop.Type != ProofOpValue {
-		return nil, &ErrInvalidProof{
+		return nil, ErrInvalidProof{
 			Err: fmt.Errorf("unexpected ProofOp.Type; got %v, want %v", pop.Type, ProofOpValue),
 		}
 	}
 	var pbop cmtcrypto.ValueOp // a bit strange as we'll discard this, but it works.
 	err := pbop.Unmarshal(pop.Data)
 	if err != nil {
-		return nil, &ErrInvalidProof{
+		return nil, ErrInvalidProof{
 			Err: fmt.Errorf("decoding ProofOp.Data into ValueOp: %w", err),
 		}
 	}
@@ -99,7 +99,7 @@ func (op ValueOp) Run(args [][]byte) ([][]byte, error) {
 	kvhash := leafHash(bz.Bytes())
 
 	if !bytes.Equal(kvhash, op.Proof.LeafHash) {
-		return nil, &ErrInvalidHash{
+		return nil, ErrInvalidHash{
 			Err: fmt.Errorf("leaf %x, want %x", kvhash, op.Proof.LeafHash),
 		}
 	}

--- a/crypto/merkle/proof_value.go
+++ b/crypto/merkle/proof_value.go
@@ -2,6 +2,7 @@ package merkle
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 
 	"github.com/cometbft/cometbft/crypto/tmhash"
@@ -39,12 +40,16 @@ func NewValueOp(key []byte, proof *Proof) ValueOp {
 
 func ValueOpDecoder(pop cmtcrypto.ProofOp) (ProofOperator, error) {
 	if pop.Type != ProofOpValue {
-		return nil, fmt.Errorf("unexpected ProofOp.Type; got %v, want %v", pop.Type, ProofOpValue)
+		return nil, &InvalidProofError{
+			Err: fmt.Errorf("unexpected ProofOp.Type; got %v, want %v", pop.Type, ProofOpValue),
+		}
 	}
 	var pbop cmtcrypto.ValueOp // a bit strange as we'll discard this, but it works.
 	err := pbop.Unmarshal(pop.Data)
 	if err != nil {
-		return nil, fmt.Errorf("decoding ProofOp.Data into ValueOp: %w", err)
+		return nil, &InvalidProofError{
+			Err: fmt.Errorf("decoding ProofOp.Data into ValueOp: %w", err),
+		}
 	}
 
 	sp, err := ProofFromProto(pbop.Proof)
@@ -74,9 +79,13 @@ func (op ValueOp) String() string {
 	return fmt.Sprintf("ValueOp{%v}", op.GetKey())
 }
 
+// ErrTooManyArgs is returned when the input to [ValueOp.Run] has length
+// exceeding 1.
+var ErrTooManyArgs = errors.New("merkle: len(args) != 1")
+
 func (op ValueOp) Run(args [][]byte) ([][]byte, error) {
 	if len(args) != 1 {
-		return nil, fmt.Errorf("expected 1 arg, got %v", len(args))
+		return nil, ErrTooManyArgs
 	}
 	value := args[0]
 	hasher := tmhash.New()
@@ -90,7 +99,9 @@ func (op ValueOp) Run(args [][]byte) ([][]byte, error) {
 	kvhash := leafHash(bz.Bytes())
 
 	if !bytes.Equal(kvhash, op.Proof.LeafHash) {
-		return nil, fmt.Errorf("leaf hash mismatch: want %X got %X", op.Proof.LeafHash, kvhash)
+		return nil, &InvalidHashError{
+			Err: fmt.Errorf("leaf %x, want %x", kvhash, op.Proof.LeafHash),
+		}
 	}
 
 	rootHash, err := op.Proof.computeRootHash()

--- a/crypto/sr25519/batch.go
+++ b/crypto/sr25519/batch.go
@@ -1,6 +1,7 @@
 package sr25519
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/oasisprotocol/curve25519-voi/primitives/sr25519"
@@ -9,6 +10,28 @@ import (
 )
 
 var _ crypto.BatchVerifier = &BatchVerifier{}
+
+// InvalidKeyError represents an error that could occur as a result of
+// using an invalid private or public key. It wraps errors that could
+// arise due to failures in serialization or the use of an incorrect
+// key, i.e., uninitialised or not sr25519.
+type InvalidKeyError struct{ Err error }
+
+func (e *InvalidKeyError) Error() string {
+	return fmt.Sprintf("sr25519: invalid public key: %v", e.Err)
+}
+
+func (e *InvalidKeyError) Unwrap() error { return e.Err }
+
+// InvalidSignatureError wraps an error that could occur as a result of
+// generating an invalid signature.
+type InvalidSignatureError struct{ Err error }
+
+func (e *InvalidSignatureError) Error() string {
+	return fmt.Sprintf("sr25519: invalid signature: %v", e.Err)
+}
+
+func (e *InvalidSignatureError) Unwrap() error { return e.Err }
 
 // BatchVerifier implements batch verification for sr25519.
 type BatchVerifier struct {
@@ -22,17 +45,17 @@ func NewBatchVerifier() crypto.BatchVerifier {
 func (b *BatchVerifier) Add(key crypto.PubKey, msg, signature []byte) error {
 	pk, ok := key.(PubKey)
 	if !ok {
-		return fmt.Errorf("sr25519: pubkey is not sr25519")
+		return &InvalidKeyError{Err: errors.New("sr25519: pubkey is not sr25519")}
 	}
 
 	var srpk sr25519.PublicKey
 	if err := srpk.UnmarshalBinary(pk); err != nil {
-		return fmt.Errorf("sr25519: invalid public key: %w", err)
+		return &InvalidKeyError{Err: err}
 	}
 
 	var sig sr25519.Signature
 	if err := sig.UnmarshalBinary(signature); err != nil {
-		return fmt.Errorf("sr25519: unable to decode signature: %w", err)
+		return &InvalidSignatureError{Err: err}
 	}
 
 	st := signingCtx.NewTranscriptBytes(msg)

--- a/crypto/sr25519/batch.go
+++ b/crypto/sr25519/batch.go
@@ -11,27 +11,33 @@ import (
 
 var _ crypto.BatchVerifier = &BatchVerifier{}
 
-// InvalidKeyError represents an error that could occur as a result of
+// ErrInvalidKey represents an error that could occur as a result of
 // using an invalid private or public key. It wraps errors that could
 // arise due to failures in serialization or the use of an incorrect
 // key, i.e., uninitialised or not sr25519.
-type InvalidKeyError struct{ Err error }
+type ErrInvalidKey struct {
+	Err error
+}
 
-func (e *InvalidKeyError) Error() string {
+func (e *ErrInvalidKey) Error() string {
 	return fmt.Sprintf("sr25519: invalid public key: %v", e.Err)
 }
 
-func (e *InvalidKeyError) Unwrap() error { return e.Err }
+func (e *ErrInvalidKey) Unwrap() error {
+	return e.Err
+}
 
-// InvalidSignatureError wraps an error that could occur as a result of
+// ErrInvalidSignature wraps an error that could occur as a result of
 // generating an invalid signature.
-type InvalidSignatureError struct{ Err error }
+type ErrInvalidSignature struct {
+	Err error
+}
 
-func (e *InvalidSignatureError) Error() string {
+func (e *ErrInvalidSignature) Error() string {
 	return fmt.Sprintf("sr25519: invalid signature: %v", e.Err)
 }
 
-func (e *InvalidSignatureError) Unwrap() error { return e.Err }
+func (e *ErrInvalidSignature) Unwrap() error { return e.Err }
 
 // BatchVerifier implements batch verification for sr25519.
 type BatchVerifier struct {
@@ -45,17 +51,17 @@ func NewBatchVerifier() crypto.BatchVerifier {
 func (b *BatchVerifier) Add(key crypto.PubKey, msg, signature []byte) error {
 	pk, ok := key.(PubKey)
 	if !ok {
-		return &InvalidKeyError{Err: errors.New("sr25519: pubkey is not sr25519")}
+		return &ErrInvalidKey{Err: errors.New("sr25519: pubkey is not sr25519")}
 	}
 
 	var srpk sr25519.PublicKey
 	if err := srpk.UnmarshalBinary(pk); err != nil {
-		return &InvalidKeyError{Err: err}
+		return &ErrInvalidKey{Err: err}
 	}
 
 	var sig sr25519.Signature
 	if err := sig.UnmarshalBinary(signature); err != nil {
-		return &InvalidSignatureError{Err: err}
+		return &ErrInvalidSignature{Err: err}
 	}
 
 	st := signingCtx.NewTranscriptBytes(msg)

--- a/crypto/sr25519/batch.go
+++ b/crypto/sr25519/batch.go
@@ -19,11 +19,11 @@ type ErrInvalidKey struct {
 	Err error
 }
 
-func (e *ErrInvalidKey) Error() string {
+func (e ErrInvalidKey) Error() string {
 	return fmt.Sprintf("sr25519: invalid public key: %v", e.Err)
 }
 
-func (e *ErrInvalidKey) Unwrap() error {
+func (e ErrInvalidKey) Unwrap() error {
 	return e.Err
 }
 
@@ -33,11 +33,13 @@ type ErrInvalidSignature struct {
 	Err error
 }
 
-func (e *ErrInvalidSignature) Error() string {
+func (e ErrInvalidSignature) Error() string {
 	return fmt.Sprintf("sr25519: invalid signature: %v", e.Err)
 }
 
-func (e *ErrInvalidSignature) Unwrap() error { return e.Err }
+func (e ErrInvalidSignature) Unwrap() error {
+	return e.Err
+}
 
 // BatchVerifier implements batch verification for sr25519.
 type BatchVerifier struct {
@@ -51,17 +53,17 @@ func NewBatchVerifier() crypto.BatchVerifier {
 func (b *BatchVerifier) Add(key crypto.PubKey, msg, signature []byte) error {
 	pk, ok := key.(PubKey)
 	if !ok {
-		return &ErrInvalidKey{Err: errors.New("sr25519: pubkey is not sr25519")}
+		return ErrInvalidKey{Err: errors.New("sr25519: pubkey is not sr25519")}
 	}
 
 	var srpk sr25519.PublicKey
 	if err := srpk.UnmarshalBinary(pk); err != nil {
-		return &ErrInvalidKey{Err: err}
+		return ErrInvalidKey{Err: err}
 	}
 
 	var sig sr25519.Signature
 	if err := sig.UnmarshalBinary(signature); err != nil {
-		return &ErrInvalidSignature{Err: err}
+		return ErrInvalidSignature{Err: err}
 	}
 
 	st := signingCtx.NewTranscriptBytes(msg)

--- a/crypto/sr25519/privkey.go
+++ b/crypto/sr25519/privkey.go
@@ -40,7 +40,7 @@ func (privKey PrivKey) Bytes() []byte {
 // Sign produces a signature on the provided message.
 func (privKey PrivKey) Sign(msg []byte) ([]byte, error) {
 	if privKey.kp == nil {
-		return nil, &InvalidKeyError{
+		return nil, &ErrInvalidKey{
 			Err: fmt.Errorf("sr25519: uninitialized private key"),
 		}
 	}
@@ -49,14 +49,14 @@ func (privKey PrivKey) Sign(msg []byte) ([]byte, error) {
 
 	sig, err := privKey.kp.Sign(crypto.CReader(), st)
 	if err != nil {
-		return nil, &InvalidSignatureError{
+		return nil, &ErrInvalidSignature{
 			Err: fmt.Errorf("sr25519: failed to sign message: %w", err),
 		}
 	}
 
 	sigBytes, err := sig.MarshalBinary()
 	if err != nil {
-		return nil, &InvalidSignatureError{
+		return nil, &ErrInvalidSignature{
 			Err: fmt.Errorf("sr25519: failed to serialize signature: %w", err),
 		}
 	}
@@ -110,7 +110,7 @@ func (privKey *PrivKey) UnmarshalJSON(data []byte) error {
 
 	var b []byte
 	if err := json.Unmarshal(data, &b); err != nil {
-		return &InvalidKeyError{
+		return &ErrInvalidKey{
 			Err: fmt.Errorf("sr25519: failed to deserialize JSON: %w", err),
 		}
 	}

--- a/crypto/sr25519/privkey.go
+++ b/crypto/sr25519/privkey.go
@@ -40,7 +40,7 @@ func (privKey PrivKey) Bytes() []byte {
 // Sign produces a signature on the provided message.
 func (privKey PrivKey) Sign(msg []byte) ([]byte, error) {
 	if privKey.kp == nil {
-		return nil, &ErrInvalidKey{
+		return nil, ErrInvalidKey{
 			Err: fmt.Errorf("sr25519: uninitialized private key"),
 		}
 	}
@@ -49,14 +49,14 @@ func (privKey PrivKey) Sign(msg []byte) ([]byte, error) {
 
 	sig, err := privKey.kp.Sign(crypto.CReader(), st)
 	if err != nil {
-		return nil, &ErrInvalidSignature{
+		return nil, ErrInvalidSignature{
 			Err: fmt.Errorf("sr25519: failed to sign message: %w", err),
 		}
 	}
 
 	sigBytes, err := sig.MarshalBinary()
 	if err != nil {
-		return nil, &ErrInvalidSignature{
+		return nil, ErrInvalidSignature{
 			Err: fmt.Errorf("sr25519: failed to serialize signature: %w", err),
 		}
 	}
@@ -110,7 +110,7 @@ func (privKey *PrivKey) UnmarshalJSON(data []byte) error {
 
 	var b []byte
 	if err := json.Unmarshal(data, &b); err != nil {
-		return &ErrInvalidKey{
+		return ErrInvalidKey{
 			Err: fmt.Errorf("sr25519: failed to deserialize JSON: %w", err),
 		}
 	}

--- a/crypto/sr25519/privkey.go
+++ b/crypto/sr25519/privkey.go
@@ -40,19 +40,25 @@ func (privKey PrivKey) Bytes() []byte {
 // Sign produces a signature on the provided message.
 func (privKey PrivKey) Sign(msg []byte) ([]byte, error) {
 	if privKey.kp == nil {
-		return nil, fmt.Errorf("sr25519: uninitialized private key")
+		return nil, &InvalidKeyError{
+			Err: fmt.Errorf("sr25519: uninitialized private key"),
+		}
 	}
 
 	st := signingCtx.NewTranscriptBytes(msg)
 
 	sig, err := privKey.kp.Sign(crypto.CReader(), st)
 	if err != nil {
-		return nil, fmt.Errorf("sr25519: failed to sign message: %w", err)
+		return nil, &InvalidSignatureError{
+			Err: fmt.Errorf("sr25519: failed to sign message: %w", err),
+		}
 	}
 
 	sigBytes, err := sig.MarshalBinary()
 	if err != nil {
-		return nil, fmt.Errorf("sr25519: failed to serialize signature: %w", err)
+		return nil, &InvalidSignatureError{
+			Err: fmt.Errorf("sr25519: failed to serialize signature: %w", err),
+		}
 	}
 
 	return sigBytes, nil
@@ -104,7 +110,9 @@ func (privKey *PrivKey) UnmarshalJSON(data []byte) error {
 
 	var b []byte
 	if err := json.Unmarshal(data, &b); err != nil {
-		return fmt.Errorf("sr25519: failed to deserialize JSON: %w", err)
+		return &InvalidKeyError{
+			Err: fmt.Errorf("sr25519: failed to deserialize JSON: %w", err),
+		}
 	}
 	if len(b) == 0 {
 		return nil

--- a/crypto/xchacha20poly1305/xchachapoly.go
+++ b/crypto/xchacha20poly1305/xchachapoly.go
@@ -6,7 +6,6 @@ import (
 	"crypto/cipher"
 	"encoding/binary"
 	"errors"
-	"fmt"
 
 	"golang.org/x/crypto/chacha20poly1305"
 )
@@ -37,10 +36,16 @@ const (
 	sigma3 = uint32(0x6b206574)
 )
 
+var (
+	ErrInvalidKeyLen        = errors.New("xchacha20poly1305: bad key length")
+	ErrInvalidNonceLen      = errors.New("xchacha20poly1305: bad nonce length")
+	ErrInvalidCipherTextLen = errors.New("xchacha20poly1305: ciphertext too large")
+)
+
 // New returns a new xchachapoly1305 AEAD
 func New(key []byte) (cipher.AEAD, error) {
 	if len(key) != KeySize {
-		return nil, errors.New("xchacha20poly1305: bad key length")
+		return nil, ErrInvalidKeyLen
 	}
 	ret := new(xchacha20poly1305)
 	copy(ret.key[:], key)
@@ -81,10 +86,10 @@ func (c *xchacha20poly1305) Seal(dst, nonce, plaintext, additionalData []byte) [
 
 func (c *xchacha20poly1305) Open(dst, nonce, ciphertext, additionalData []byte) ([]byte, error) {
 	if len(nonce) != NonceSize {
-		return nil, fmt.Errorf("xchacha20poly1305: bad nonce length passed to Open")
+		return nil, ErrInvalidNonceLen
 	}
 	if uint64(len(ciphertext)) > MaxCiphertextSize {
-		return nil, fmt.Errorf("xchacha20poly1305: ciphertext too large")
+		return nil, ErrInvalidCipherTextLen
 	}
 	var subKey [KeySize]byte
 	var hNonce [16]byte

--- a/p2p/conn/secret_connection_test.go
+++ b/p2p/conn/secret_connection_test.go
@@ -269,7 +269,7 @@ func TestNilPubkey(t *testing.T) {
 
 	_, err := MakeSecretConnection(barConn, barPrvKey)
 	require.Error(t, err)
-	assert.Equal(t, "toproto: key type <nil> is not supported", err.Error())
+	assert.Equal(t, "encoding: unsupported key <nil>", err.Error())
 }
 
 func TestNonEd25519Pubkey(t *testing.T) {
@@ -283,7 +283,7 @@ func TestNonEd25519Pubkey(t *testing.T) {
 
 	_, err := MakeSecretConnection(barConn, barPrvKey)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "is not supported")
+	assert.Contains(t, err.Error(), "unsupported key")
 }
 
 func writeLots(t *testing.T, wg *sync.WaitGroup, conn io.Writer, txt string, n int) {


### PR DESCRIPTION
Exports errors from the `crypto` module per #1140 for the following submodules:

- [x] `armor`
- [x] `ed25519`
- [x] `encoding`
- [x] `merkle`
- [x] `sr25519`
- [x] `xchacha20poly1305`
- [x] `xsalsa20symmetric`

On an unrelated note: I noticed that the following `break` statement is [ineffectual if the intention is to break out of the outer loop](https://go.dev/ref/spec#Break_statements). I am not sure if this posses a problem.

https://github.com/cometbft/cometbft/blob/77fa8a00c524474a055d95bd5d522491c3bdbea3/crypto/merkle/proof.go#L207-L217

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments

