### PR TITLE
grpc: backport Add `Close` method to gRPC client (#1251) to v0.38.x-experimental

### DIFF
--- a/test/e2e/tests/grpc_test.go
+++ b/test/e2e/tests/grpc_test.go
@@ -19,6 +19,7 @@ func TestGRPC_Version(t *testing.T) {
 		defer ctxCancel()
 		client, err := node.GRPCClient(ctx)
 		require.NoError(t, err)
+		defer client.Close()
 
 		res, err := client.GetVersion(ctx)
 		require.NoError(t, err)
@@ -63,6 +64,7 @@ func TestGRPC_Block_GetByHeight(t *testing.T) {
 		defer ctxCancel()
 		gRPCClient, err := node.GRPCClient(ctx)
 		require.NoError(t, err)
+		defer gRPCClient.Close()
 
 		for _, block := range blocks {
 			if block.Header.Height < first {
@@ -102,6 +104,7 @@ func TestGRPC_Block_GetLatest(t *testing.T) {
 
 		gclient, err := node.GRPCClient(ctx)
 		require.NoError(t, err)
+		defer gclient.Close()
 
 		resultCh, err := gclient.GetLatestHeight(ctx)
 		require.NoError(t, err)
@@ -132,6 +135,7 @@ func TestGRPC_Block_GetLatestHeight(t *testing.T) {
 
 		gclient, err := node.GRPCClient(ctx)
 		require.NoError(t, err)
+		defer gclient.Close()
 
 		resultCh, err := gclient.GetLatestHeight(ctx)
 		require.NoError(t, err)
@@ -163,6 +167,7 @@ func TestGRPC_GetBlockResults(t *testing.T) {
 		defer ctxCancel()
 		gRPCClient, err := node.GRPCClient(ctx)
 		require.NoError(t, err)
+		defer gRPCClient.Close()
 
 		// GetLatestBlockResults
 		latestBlockResults, err := gRPCClient.GetLatestBlockResults(ctx)
@@ -208,6 +213,7 @@ func TestGRPC_BlockRetainHeight(t *testing.T) {
 		defer ctxCancel()
 		grpcClient, err := node.GRPCPrivilegedClient(ctx)
 		require.NoError(t, err)
+		defer grpcClient.Close()
 
 		client, err := node.Client()
 		require.NoError(t, err)
@@ -232,19 +238,21 @@ func TestGRPC_BlockResultsRetainHeight(t *testing.T) {
 
 		ctx, ctxCancel := context.WithTimeout(context.Background(), time.Minute)
 		defer ctxCancel()
+
 		grpcClient, err := node.GRPCPrivilegedClient(ctx)
 		require.NoError(t, err)
+		defer grpcClient.Close()
+
 		client, err := node.Client()
 		require.NoError(t, err)
+
 		status, err := client.Status(ctx)
 		require.NoError(t, err)
 
 		err = grpcClient.SetBlockResultsRetainHeight(ctx, uint64(status.SyncInfo.LatestBlockHeight)-1)
-
 		require.NoError(t, err, "Unexpected error for SetBlockResultsRetainHeight")
 
 		height, err := grpcClient.GetBlockResultsRetainHeight(ctx)
-
 		require.NoError(t, err, "Unexpected error for GetBlockRetainHeight")
 		require.Equal(t, height, uint64(status.SyncInfo.LatestBlockHeight)-1)
 	})


### PR DESCRIPTION
Partially addresses #1419:

   - [ ] Close method for gRPC client https://github.com/cometbft/cometbft/commit/3479642e2f45c76311d12ec43c6339f132587af8

Should not conflict with #1473, so they can be merged in any order.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

