### PR TITLE
Make BuildExtendedCommitInfo and BuildLastCommitInfo public and change their signature slightly

### DIFF
--- a/state/execution.go
+++ b/state/execution.go
@@ -166,9 +166,9 @@ func (blockExec *BlockExecutor) ProcessProposal(
 	block *types.Block,
 	state State,
 ) (bool, error) {
-	lastValSet, err := blockExec.store.LoadValidators(block.LastCommit.Height)
+	lastValSet, err := blockExec.store.LoadValidators(block.Height)
 	if err != nil {
-		return false, fmt.Errorf("failed to load validator set at height %d, initial height %d: %w", block.LastCommit.Height, state.InitialHeight, err)
+		return false, fmt.Errorf("failed to load validator set at height %d, initial height %d: %w", block.Height, state.InitialHeight, err)
 	}
 	resp, err := blockExec.proxyApp.ProcessProposal(context.TODO(), &abci.RequestProcessProposal{
 		Hash:               block.Header.Hash(),
@@ -215,9 +215,9 @@ func (blockExec *BlockExecutor) ApplyBlock(
 		return state, ErrInvalidBlock(err)
 	}
 
-	lastValSet, err := blockExec.store.LoadValidators(block.LastCommit.Height)
+	lastValSet, err := blockExec.store.LoadValidators(block.Height)
 	if err != nil {
-		panic(fmt.Errorf("failed to load validator set at height %d, initial height %d: %w", block.LastCommit.Height, state.InitialHeight, err))
+		panic(fmt.Errorf("failed to load validator set at height %d, initial height %d: %w", block.Height, state.InitialHeight, err))
 	}
 
 	commitInfo := BuildLastCommitInfo(block, lastValSet, state.InitialHeight)
@@ -337,9 +337,9 @@ func (blockExec *BlockExecutor) ExtendVote(
 		panic(fmt.Sprintf("vote's and block's heights do not match %d!=%d", block.Height, vote.Height))
 	}
 
-	lastValSet, err := blockExec.store.LoadValidators(block.LastCommit.Height)
+	lastValSet, err := blockExec.store.LoadValidators(block.Height)
 	if err != nil {
-		panic(fmt.Errorf("failed to load validator set at height %d, initial height %d: %w", block.LastCommit.Height, state.InitialHeight, err))
+		panic(fmt.Errorf("failed to load validator set at height %d, initial height %d: %w", block.Height, state.InitialHeight, err))
 	}
 	req := abci.RequestExtendVote{
 		Hash:               vote.BlockID.Hash,
@@ -706,9 +706,9 @@ func ExecCommitBlock(
 	store Store,
 	initialHeight int64,
 ) ([]byte, error) {
-	lastValSet, err := store.LoadValidators(block.LastCommit.Height)
+	lastValSet, err := store.LoadValidators(block.Height)
 	if err != nil {
-		panic(fmt.Errorf("failed to load validator set at height %d, initial height %d: %w", block.LastCommit.Height, initialHeight, err))
+		panic(fmt.Errorf("failed to load validator set at height %d, initial height %d: %w", block.Height, initialHeight, err))
 	}
 	commitInfo := BuildLastCommitInfo(block, lastValSet, initialHeight)
 

--- a/state/state.go
+++ b/state/state.go
@@ -81,7 +81,6 @@ type State struct {
 
 // Copy makes a copy of the State for mutating.
 func (state State) Copy() State {
-
 	return State{
 		Version:       state.Version,
 		ChainID:       state.ChainID,
@@ -238,7 +237,6 @@ func (state State) MakeBlock(
 	evidence []types.Evidence,
 	proposerAddress []byte,
 ) *types.Block {
-
 	// Build base block with block data.
 	block := types.MakeBlock(height, txs, lastCommit, evidence)
 


### PR DESCRIPTION
Related: https://github.com/cometbft/cometbft/discussions/1406#discussioncomment-7254221

Makes the BuildExtendedCommitInfo and BuildLastCommitInfo functions public,
and makes them take a validator set instead of the store as an input.

These functions  are useful to also call from outside of CometBFT if one has a need to obtain the CommitInfo structs,
in particular I am using them in a mock for cometbft.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

