### PR TITLE
Make BuildLastCommitInfo and BuildExtendedCommitInfo public

### DIFF
--- a/state/execution.go
+++ b/state/execution.go
@@ -174,9 +174,9 @@ func (blockExec *BlockExecutor) ProcessProposal(
 	block *types.Block,
 	state State,
 ) (bool, error) {
-	lastValSet, err := blockExec.store.LoadValidators(block.LastCommit.Height)
+	lastValSet, err := blockExec.store.LoadValidators(block.Height - 1)
 	if err != nil {
-		return false, fmt.Errorf("failed to load validator set at height %d, initial height %d: %w", block.LastCommit.Height, state.InitialHeight, err)
+		return false, fmt.Errorf("failed to load validator set at height %d, initial height %d: %w", block.Height-1, state.InitialHeight, err)
 	}
 	resp, err := blockExec.proxyApp.ProcessProposal(context.TODO(), &abci.RequestProcessProposal{
 		Hash:               block.Header.Hash(),
@@ -223,9 +223,9 @@ func (blockExec *BlockExecutor) ApplyBlock(
 		return state, ErrInvalidBlock(err)
 	}
 
-	lastValSet, err := blockExec.store.LoadValidators(block.LastCommit.Height)
+	lastValSet, err := blockExec.store.LoadValidators(block.Height - 1)
 	if err != nil {
-		panic(fmt.Errorf("failed to load validator set at height %d, initial height %d: %w", block.LastCommit.Height, state.InitialHeight, err))
+		panic(fmt.Errorf("failed to load validator set at height %d, initial height %d: %w", block.Height-1, state.InitialHeight, err))
 	}
 
 	commitInfo := BuildLastCommitInfo(block, lastValSet, state.InitialHeight)
@@ -343,9 +343,9 @@ func (blockExec *BlockExecutor) ExtendVote(
 		panic(fmt.Sprintf("vote's and block's heights do not match %d!=%d", block.Height, vote.Height))
 	}
 
-	lastValSet, err := blockExec.store.LoadValidators(block.LastCommit.Height)
+	lastValSet, err := blockExec.store.LoadValidators(block.Height - 1)
 	if err != nil {
-		panic(fmt.Errorf("failed to load validator set at height %d, initial height %d: %w", block.LastCommit.Height, state.InitialHeight, err))
+		panic(fmt.Errorf("failed to load validator set at height %d, initial height %d: %w", block.Height-1, state.InitialHeight, err))
 	}
 	req := abci.RequestExtendVote{
 		Hash:               vote.BlockID.Hash,
@@ -712,9 +712,9 @@ func ExecCommitBlock(
 	store Store,
 	initialHeight int64,
 ) ([]byte, error) {
-	lastValSet, err := store.LoadValidators(block.LastCommit.Height)
+	lastValSet, err := store.LoadValidators(block.Height - 1)
 	if err != nil {
-		panic(fmt.Errorf("failed to load validator set at height %d, initial height %d: %w", block.LastCommit.Height, initialHeight, err))
+		panic(fmt.Errorf("failed to load validator set at height %d, initial height %d: %w", block.Height-1, initialHeight, err))
 	}
 	commitInfo := BuildLastCommitInfo(block, lastValSet, initialHeight)
 

--- a/state/execution.go
+++ b/state/execution.go
@@ -437,7 +437,9 @@ func buildLastCommitInfoFromStore(block *types.Block, store Store, initialHeight
 	return BuildLastCommitInfo(block, lastValSet, initialHeight)
 }
 
-// Like
+// BuildLastCommitInfo builds a CommitInfo from the given block and validator set.
+// If you want to load the validator set from the store instead of providing it,
+// use buildLastCommitInfoFromStore.
 func BuildLastCommitInfo(block *types.Block, lastValSet *types.ValidatorSet, initialHeight int64) abci.CommitInfo {
 	if block.Height == initialHeight {
 		// there is no last commit for the initial height.
@@ -497,6 +499,9 @@ func buildExtendedCommitInfoFromStore(ec *types.ExtendedCommit, store Store, ini
 	return BuildExtendedCommitInfo(ec, valSet, initialHeight, ap)
 }
 
+// BuildExtendedCommitInfo builds an ExtendedCommitInfo from the given block and validator set.
+// If you want to load the validator set from the store instead of providing it,
+// use buildExtendedCommitInfoFromStore.
 func BuildExtendedCommitInfo(ec *types.ExtendedCommit, valSet *types.ValidatorSet, initialHeight int64, ap types.ABCIParams) abci.ExtendedCommitInfo {
 	if ec.Height < initialHeight {
 		// There are no extended commits for heights below the initial height.

--- a/state/execution.go
+++ b/state/execution.go
@@ -474,7 +474,7 @@ func BuildLastCommitInfo(block *types.Block, lastValSet *types.ValidatorSet, ini
 	}
 }
 
-// BuildExtendedCommitInfo populates an ABCI extended commit from the
+// buildExtendedCommitInfoFromStore populates an ABCI extended commit from the
 // corresponding CometBFT extended commit ec, using the stored validator set
 // from ec.  It requires ec to include the original precommit votes along with
 // the vote extensions from the last commit.

--- a/state/execution.go
+++ b/state/execution.go
@@ -174,12 +174,16 @@ func (blockExec *BlockExecutor) ProcessProposal(
 	block *types.Block,
 	state State,
 ) (bool, error) {
+	lastValSet, err := blockExec.store.LoadValidators(block.LastCommit.Height)
+	if err != nil {
+		return false, fmt.Errorf("failed to load validator set at height %d, initial height %d: %w", block.LastCommit.Height, state.InitialHeight, err)
+	}
 	resp, err := blockExec.proxyApp.ProcessProposal(context.TODO(), &abci.RequestProcessProposal{
 		Hash:               block.Header.Hash(),
 		Height:             block.Header.Height,
 		Time:               block.Header.Time,
 		Txs:                block.Data.Txs.ToSliceOfBytes(),
-		ProposedLastCommit: buildLastCommitInfo(block, blockExec.store, state.InitialHeight),
+		ProposedLastCommit: BuildLastCommitInfo(block, lastValSet, state.InitialHeight),
 		Misbehavior:        block.Evidence.Evidence.ToABCI(),
 		ProposerAddress:    block.ProposerAddress,
 		NextValidatorsHash: block.NextValidatorsHash,
@@ -219,7 +223,12 @@ func (blockExec *BlockExecutor) ApplyBlock(
 		return state, ErrInvalidBlock(err)
 	}
 
-	commitInfo := buildLastCommitInfo(block, blockExec.store, state.InitialHeight)
+	lastValSet, err := blockExec.store.LoadValidators(block.LastCommit.Height)
+	if err != nil {
+		panic(fmt.Errorf("failed to load validator set at height %d, initial height %d: %w", block.LastCommit.Height, state.InitialHeight, err))
+	}
+
+	commitInfo := BuildLastCommitInfo(block, lastValSet, state.InitialHeight)
 
 	startTime := time.Now().UnixNano()
 	abciResponse, err := blockExec.proxyApp.FinalizeBlock(context.TODO(), &abci.RequestFinalizeBlock{
@@ -333,12 +342,17 @@ func (blockExec *BlockExecutor) ExtendVote(
 	if vote.Height != block.Height {
 		panic(fmt.Sprintf("vote's and block's heights do not match %d!=%d", block.Height, vote.Height))
 	}
+
+	lastValSet, err := blockExec.store.LoadValidators(block.LastCommit.Height)
+	if err != nil {
+		panic(fmt.Errorf("failed to load validator set at height %d, initial height %d: %w", block.LastCommit.Height, state.InitialHeight, err))
+	}
 	req := abci.RequestExtendVote{
 		Hash:               vote.BlockID.Hash,
 		Height:             vote.Height,
 		Time:               block.Time,
 		Txs:                block.Txs.ToSliceOfBytes(),
-		ProposedLastCommit: buildLastCommitInfo(block, blockExec.store, state.InitialHeight),
+		ProposedLastCommit: BuildLastCommitInfo(block, lastValSet, state.InitialHeight),
 		Misbehavior:        block.Evidence.Evidence.ToABCI(),
 		NextValidatorsHash: block.NextValidatorsHash,
 		ProposerAddress:    block.ProposerAddress,
@@ -427,16 +441,11 @@ func (blockExec *BlockExecutor) Commit(
 //---------------------------------------------------------
 // Helper functions for executing blocks and updating state
 
-func buildLastCommitInfo(block *types.Block, store Store, initialHeight int64) abci.CommitInfo {
+func BuildLastCommitInfo(block *types.Block, lastValSet *types.ValidatorSet, initialHeight int64) abci.CommitInfo {
 	if block.Height == initialHeight {
 		// there is no last commit for the initial height.
 		// return an empty value.
 		return abci.CommitInfo{}
-	}
-
-	lastValSet, err := store.LoadValidators(block.Height - 1)
-	if err != nil {
-		panic(fmt.Errorf("failed to load validator set at height %d: %w", block.Height-1, err))
 	}
 
 	var (
@@ -703,7 +712,11 @@ func ExecCommitBlock(
 	store Store,
 	initialHeight int64,
 ) ([]byte, error) {
-	commitInfo := buildLastCommitInfo(block, store, initialHeight)
+	lastValSet, err := store.LoadValidators(block.LastCommit.Height)
+	if err != nil {
+		panic(fmt.Errorf("failed to load validator set at height %d, initial height %d: %w", block.LastCommit.Height, initialHeight, err))
+	}
+	commitInfo := BuildLastCommitInfo(block, lastValSet, initialHeight)
 
 	resp, err := appConnConsensus.FinalizeBlock(context.TODO(), &abci.RequestFinalizeBlock{
 		Hash:               block.Hash(),

--- a/state/state.go
+++ b/state/state.go
@@ -81,7 +81,6 @@ type State struct {
 
 // Copy makes a copy of the State for mutating.
 func (state State) Copy() State {
-
 	return State{
 		Version:       state.Version,
 		ChainID:       state.ChainID,
@@ -238,7 +237,6 @@ func (state State) MakeBlock(
 	evidence []types.Evidence,
 	proposerAddress []byte,
 ) *types.Block {
-
 	// Build base block with block data.
 	block := types.MakeBlock(height, txs, lastCommit, evidence)
 

--- a/state/state.go
+++ b/state/state.go
@@ -81,6 +81,7 @@ type State struct {
 
 // Copy makes a copy of the State for mutating.
 func (state State) Copy() State {
+
 	return State{
 		Version:       state.Version,
 		ChainID:       state.ChainID,
@@ -237,6 +238,7 @@ func (state State) MakeBlock(
 	evidence []types.Evidence,
 	proposerAddress []byte,
 ) *types.Block {
+
 	// Build base block with block data.
 	block := types.MakeBlock(height, txs, lastCommit, evidence)
 


### PR DESCRIPTION
Makes the BuildExtendedCommitInfo and BuildLastCommitInfo functions public,
and makes them take a validator set instead of the store as an input.

These functions are useful to also call from outside of CometBFT if one has a need to obtain the CommitInfo structs,
in particular I am using them in a mock for cometbft.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

