### PR TITLE
e2e:Fix docker port alias

### DIFF
--- a/test/e2e/pkg/infra/docker/docker.go
+++ b/test/e2e/pkg/infra/docker/docker.go
@@ -129,7 +129,9 @@ services:
     init: true
     ports:
     - 26656
-    - {{ if .ProxyPort }}{{ .ProxyPort }}:{{ end }}26657
+    - {{ if .RPCProxyPort }}{{ .RPCProxyPort }}:{{ end }}26657
+    - {{ if .GRPCProxyPort }}{{ .GRPCProxyPort }}:{{ end }}26670
+    - {{ if .GRPCPrivilegedProxyPort }}{{ .GRPCPrivilegedProxyPort }}:{{ end }}26671
 {{- if .PrometheusProxyPort }}
     - {{ .PrometheusProxyPort }}:26660
 {{- end }}


### PR DESCRIPTION
After adding new gRPC endpoints in ADR-101, we introduced different aliases for the docker ports. This change was not reflected in the docker template for images with upgraded versions (`_u`) .

This change needs to be backported to `v0.38.x-experimental` . 
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

