### PR TITLE
mempool: Add metric size of pool in bytes

### DIFF
--- a/.changelog/unreleased/features/1512-metric-mempool-size-bytes.md
+++ b/.changelog/unreleased/features/1512-metric-mempool-size-bytes.md
@@ -1,0 +1,2 @@
+- `[metrics]` Add metric for mempool size in bytes `SizeBytes`.
+  ([\#1512](https://github.com/cometbft/cometbft/pull/1512))

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -314,7 +314,7 @@ func (mem *CListMempool) globalCb(req *abci.Request, res *abci.Response) {
 
 		// update metrics
 		mem.metrics.Size.Set(float64(mem.Size()))
-		mem.metrics.SizeBytes.Set(float64(mem.txsBytes))
+		mem.metrics.SizeBytes.Set(float64(mem.SizeBytes()))
 
 	default:
 		// ignore other messages
@@ -640,7 +640,7 @@ func (mem *CListMempool) Update(
 
 	// Update metrics
 	mem.metrics.Size.Set(float64(mem.Size()))
-	mem.metrics.SizeBytes.Set(float64(mem.txsBytes))
+	mem.metrics.SizeBytes.Set(float64(mem.SizeBytes()))
 
 	return nil
 }

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -314,6 +314,7 @@ func (mem *CListMempool) globalCb(req *abci.Request, res *abci.Response) {
 
 		// update metrics
 		mem.metrics.Size.Set(float64(mem.Size()))
+		mem.metrics.SizeBytes.Set(float64(mem.txsBytes))
 
 	default:
 		// ignore other messages
@@ -639,6 +640,7 @@ func (mem *CListMempool) Update(
 
 	// Update metrics
 	mem.metrics.Size.Set(float64(mem.Size()))
+	mem.metrics.SizeBytes.Set(float64(mem.txsBytes))
 
 	return nil
 }

--- a/mempool/metrics.gen.go
+++ b/mempool/metrics.gen.go
@@ -20,6 +20,12 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Name:      "size",
 			Help:      "Number of uncommitted transactions in the mempool.",
 		}, labels).With(labelsAndValues...),
+		SizeBytes: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "size_bytes",
+			Help:      "Total size of the mempool in bytes.",
+		}, labels).With(labelsAndValues...),
 		TxSizeBytes: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
@@ -58,6 +64,7 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 func NopMetrics() *Metrics {
 	return &Metrics{
 		Size:               discard.NewGauge(),
+		SizeBytes:          discard.NewGauge(),
 		TxSizeBytes:        discard.NewHistogram(),
 		FailedTxs:          discard.NewCounter(),
 		RejectedTxs:        discard.NewCounter(),

--- a/mempool/metrics.go
+++ b/mempool/metrics.go
@@ -18,6 +18,9 @@ type Metrics struct {
 	// Number of uncommitted transactions in the mempool.
 	Size metrics.Gauge
 
+	// Total size of the mempool in bytes.
+	SizeBytes metrics.Gauge
+
 	// Histogram of transaction sizes in bytes.
 	TxSizeBytes metrics.Histogram `metrics_buckettype:"exp" metrics_bucketsizes:"1,3,7"`
 


### PR DESCRIPTION
Relates to #1061.

This PR exposes a new metric `SizeBytes` for the total size of the mempool in bytes. We already keep track of this value internally, in the variable `txsBytes`. Currently there is the metric `Size` for the size of the mempool in number of transactions.

---

#### PR checklist

- [ ] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

