### PR TITLE
Add metric for redundant tx bytes sent/received and duplicate blockparts/votes

### DIFF
--- a/consensus/metrics.go
+++ b/consensus/metrics.go
@@ -65,6 +65,12 @@ type Metrics struct {
 	// Number of blockparts transmitted by peer.
 	BlockParts metrics.Counter
 
+	// Number of times we received a duplicate block part
+	DuplicateBlockPart metrics.Counter
+
+	// Number of times we received a duplicate vote
+	DuplicateVote metrics.Counter
+
 	// Histogram of step duration.
 	StepDuration metrics.Histogram
 	stepStart    time.Time

--- a/consensus/metrics.go
+++ b/consensus/metrics.go
@@ -219,6 +219,18 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Name:      "block_parts",
 			Help:      "Number of blockparts transmitted by peer.",
 		}, append(labels, "peer_id")).With(labelsAndValues...),
+		DuplicateBlockPart: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "duplicate_block_part",
+			Help:      "Number of times we received a duplicate block part",
+		}, labels).With(labelsAndValues...),
+		DuplicateVote: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "duplicate_vote",
+			Help:      "Number of times we received a duplicate vote",
+		}, labels).With(labelsAndValues...),
 		BlockGossipPartsReceived: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
@@ -278,6 +290,8 @@ func NopMetrics() *Metrics {
 		FastSyncing:               discard.NewGauge(),
 		StateSyncing:              discard.NewGauge(),
 		BlockParts:                discard.NewCounter(),
+		DuplicateBlockPart:        discard.NewCounter(),
+		DuplicateVote:             discard.NewCounter(),
 		BlockGossipPartsReceived:  discard.NewCounter(),
 		QuorumPrevoteMessageDelay: discard.NewGauge(),
 		FullPrevoteMessageDelay:   discard.NewGauge(),

--- a/consensus/metrics.go
+++ b/consensus/metrics.go
@@ -71,12 +71,6 @@ type Metrics struct {
 	// Number of times we received a duplicate vote
 	DuplicateVote metrics.Counter
 
-	// Amount of redundant tx byte sent
-	RedundantTxBytesSent metrics.Counter
-
-	// Amount of redundant tx byte received
-	RedundantTxBytesReceived metrics.Counter
-
 	// Histogram of step duration.
 	StepDuration metrics.Histogram
 	stepStart    time.Time
@@ -236,18 +230,6 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Subsystem: MetricsSubsystem,
 			Name:      "duplicate_vote",
 			Help:      "Number of times we received a duplicate vote",
-		}, labels).With(labelsAndValues...),
-		RedundantTxBytesSent: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: MetricsSubsystem,
-			Name:      "redundant_tx_bytes_sent",
-			Help:      "",
-		}, labels).With(labelsAndValues...),
-		RedundantTxBytesReceived: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: MetricsSubsystem,
-			Name:      "redundant_tx_bytes_received",
-			Help:      "",
 		}, labels).With(labelsAndValues...),
 		BlockGossipPartsReceived: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,

--- a/consensus/metrics.go
+++ b/consensus/metrics.go
@@ -71,6 +71,12 @@ type Metrics struct {
 	// Number of times we received a duplicate vote
 	DuplicateVote metrics.Counter
 
+	// Amount of redundant tx byte sent
+	RedundantTxBytesSent metrics.Counter
+
+	// Amount of redundant tx byte received
+	RedundantTxBytesReceived metrics.Counter
+
 	// Histogram of step duration.
 	StepDuration metrics.Histogram
 	stepStart    time.Time
@@ -230,6 +236,18 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Subsystem: MetricsSubsystem,
 			Name:      "duplicate_vote",
 			Help:      "Number of times we received a duplicate vote",
+		}, labels).With(labelsAndValues...),
+		RedundantTxBytesSent: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "redundant_tx_bytes_sent",
+			Help:      "",
+		}, labels).With(labelsAndValues...),
+		RedundantTxBytesReceived: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "redundant_tx_bytes_received",
+			Help:      "",
 		}, labels).With(labelsAndValues...),
 		BlockGossipPartsReceived: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,

--- a/mempool/metrics.go
+++ b/mempool/metrics.go
@@ -39,6 +39,12 @@ type Metrics struct {
 
 	// Number of times transactions are rechecked in the mempool.
 	RecheckTimes metrics.Counter
+
+	// Amount of redundant tx byte sent
+	RedundantTxBytesSent metrics.Counter
+
+	// Amount of redundant tx byte received
+	RedundantTxBytesReceived metrics.Counter
 }
 
 // PrometheusMetrics returns Metrics build using Prometheus client library.
@@ -63,6 +69,20 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Name:      "tx_size_bytes",
 			Help:      "Transaction sizes in bytes.",
 			Buckets:   stdprometheus.ExponentialBuckets(1, 3, 17),
+		}, labels).With(labelsAndValues...),
+
+		RedundantTxBytesSent: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "redundant_tx_bytes_sent",
+			Help:      "",
+		}, labels).With(labelsAndValues...),
+
+		RedundantTxBytesReceived: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "redundant_tx_bytes_received",
+			Help:      "",
 		}, labels).With(labelsAndValues...),
 
 		FailedTxs: prometheus.NewCounterFrom(stdprometheus.CounterOpts{

--- a/mempool/metrics.go
+++ b/mempool/metrics.go
@@ -118,11 +118,13 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 // NopMetrics returns no-op Metrics.
 func NopMetrics() *Metrics {
 	return &Metrics{
-		Size:         discard.NewGauge(),
-		TxSizeBytes:  discard.NewHistogram(),
-		FailedTxs:    discard.NewCounter(),
-		RejectedTxs:  discard.NewCounter(),
-		EvictedTxs:   discard.NewCounter(),
-		RecheckTimes: discard.NewCounter(),
+		Size:                     discard.NewGauge(),
+		TxSizeBytes:              discard.NewHistogram(),
+		FailedTxs:                discard.NewCounter(),
+		RejectedTxs:              discard.NewCounter(),
+		EvictedTxs:               discard.NewCounter(),
+		RecheckTimes:             discard.NewCounter(),
+		RedundantTxBytesSent:     discard.NewCounter(),
+		RedundantTxBytesReceived: discard.NewCounter(),
 	}
 }

--- a/mempool/v0/clist_mempool.go
+++ b/mempool/v0/clist_mempool.go
@@ -393,6 +393,7 @@ func (mem *CListMempool) resCbFirstTime(
 
 			// Check transaction not already in the mempool
 			if e, ok := mem.txsMap.Load(types.Tx(tx).Key()); ok {
+				mem.metrics.RedundantTxBytesReceived.Add(float64(len(tx)))
 				memTx := e.(*clist.CElement).Value.(*mempoolTx)
 				memTx.senders.LoadOrStore(peerID, true)
 				mem.logger.Debug(

--- a/mempool/v0/clist_mempool.go
+++ b/mempool/v0/clist_mempool.go
@@ -242,6 +242,7 @@ func (mem *CListMempool) CheckTx(
 		// (eg. after committing a block, txs are removed from mempool but not cache),
 		// so we only record the sender for txs still in the mempool.
 		if e, ok := mem.txsMap.Load(tx.Key()); ok {
+			mem.metrics.RedundantTxBytesReceived.Add(float64(len(tx)))
 			memTx := e.(*clist.CElement).Value.(*mempoolTx)
 			memTx.senders.LoadOrStore(txInfo.SenderID, true)
 			// TODO: consider punishing peer for dups,
@@ -685,6 +686,8 @@ type mempoolTx struct {
 	// ids of peers who've sent us this tx (as a map for quick lookups).
 	// senders: PeerID -> bool
 	senders sync.Map
+
+	sentToPeers sync.Map
 }
 
 // Height returns the height for this transaction

--- a/mempool/v0/reactor.go
+++ b/mempool/v0/reactor.go
@@ -268,6 +268,15 @@ func (memR *Reactor) broadcastTxRoutine(peer p2p.Peer) {
 			if !success {
 				time.Sleep(mempool.PeerCatchupSleepIntervalMS * time.Millisecond)
 				continue
+			} else {
+				// check if this message has been sent to the peer
+				if _, ok := memTx.sentToPeers.Load(peerID); ok {
+					memR.mempool.metrics.RedundantTxBytesSent.Add(float64(len(memTx.tx)))
+				} else {
+					// marked already sent to this peer
+					memTx.sentToPeers.Store(peerID, true)
+				}
+
 			}
 		}
 

--- a/mempool/v1/mempool.go
+++ b/mempool/v1/mempool.go
@@ -206,6 +206,7 @@ func (txmp *TxMempool) CheckTx(tx types.Tx, cb func(*abci.Response), txInfo memp
 		if !txmp.cache.Push(tx) {
 			// If the cached transaction is also in the pool, record its sender.
 			if elt, ok := txmp.txByKey[txKey]; ok {
+				txmp.metrics.RedundantTxBytesReceived.Add(float64(len(tx)))
 				w := elt.Value.(*WrappedTx)
 				w.SetPeer(txInfo.SenderID)
 			}

--- a/mempool/v1/reactor.go
+++ b/mempool/v1/reactor.go
@@ -269,6 +269,12 @@ func (memR *Reactor) broadcastTxRoutine(peer p2p.Peer) {
 			if !success {
 				time.Sleep(mempool.PeerCatchupSleepIntervalMS * time.Millisecond)
 				continue
+			} else {
+				if memTx.HasSentToPeer(peerID) {
+					memR.mempool.metrics.RedundantTxBytesSent.Add(float64(len(memTx.tx)))
+				} else {
+					memTx.SetAlreadSentToPeers(peerID)
+				}
 			}
 		}
 


### PR DESCRIPTION
<!--


Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

This PR add metric for redundant tx bytes sent/received and duplicate blockparts/votes to the cometbft used by gaia

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

