### PR TITLE
fix spelling of bandwidth

### DIFF
--- a/.changelog/unreleased/improvements/904-gossip-sleep-had-block-part.md
+++ b/.changelog/unreleased/improvements/904-gossip-sleep-had-block-part.md
@@ -2,5 +2,5 @@
   which is similar to `HasVoteMessage`; and random sleep in the loop broadcasting those messages.
   The sleep can be configured with new config `peer_gossip_intraloop_sleep_duration`, which is set to 0
   by default as this is experimental.
-  Our scale tests show substantial bandwith improvement with a value of 50 ms.
+  Our scale tests show substantial bandwidth improvement with a value of 50 ms.
   ([\#904](https://github.com/cometbft/cometbft/pull/904))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
   which is similar to `HasVoteMessage`; and random sleep in the loop broadcasting those messages.
   The sleep can be configured with new config `peer_gossip_intraloop_sleep_duration`, which is set to 0
   by default as this is experimental.
-  Our scale tests show substantial bandwith improvement with a value of 50 ms.
+  Our scale tests show substantial bandwidth improvement with a value of 50 ms.
   ([\#904](https://github.com/cometbft/cometbft/pull/904))
 - Update Apalache type annotations in the light client spec ([#955](https://github.com/cometbft/cometbft/pull/955))
 - `[node]` Remove genesis persistence in state db, replaced by a hash

--- a/docs/rfc/tendermint-core/rfc-017-abci++-vote-extension-propag.md
+++ b/docs/rfc/tendermint-core/rfc-017-abci++-vote-extension-propag.md
@@ -525,7 +525,7 @@ The changes to the blocksync reactor are more substantial:
 The two main drawbacks of this base implementation are:
 
 - the increased size taken by the block store, in particular with big extensions
-- the increased bandwith taken by the new format of `BlockResponse`
+- the increased bandwidth taken by the new format of `BlockResponse`
 
 #### Possible Optimization: Pruning the Extended Commit History
 


### PR DESCRIPTION
It's currently written "bandwith" in 3 places

#### PR checklist

Guessing this doesn't need a changelog entry?


