### PR TITLE
Use semaphore to limit concurrency

### DIFF
--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -1,9 +1,9 @@
 package mempool
 
 import (
+	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -15,6 +15,7 @@ import (
 	"github.com/cometbft/cometbft/p2p"
 	protomem "github.com/cometbft/cometbft/proto/tendermint/mempool"
 	"github.com/cometbft/cometbft/types"
+	"golang.org/x/sync/semaphore"
 )
 
 // Reactor handles mempool tx broadcasting amongst peers.
@@ -35,8 +36,7 @@ type Reactor struct {
 	txSenders    map[types.TxKey]map[p2p.ID]bool
 	txSendersMtx cmtsync.Mutex
 
-	mtx            sync.Mutex
-	numActivePeers int
+	sem *semaphore.Weighted
 }
 
 // NewReactor returns a new Reactor with the given config and mempool.
@@ -53,6 +53,8 @@ func NewReactor(config *cfg.MempoolConfig, mempool *CListMempool, waitSync bool)
 		memR.waitSyncCh = make(chan struct{})
 	}
 	memR.mempool.SetTxRemovedCallback(func(txKey types.TxKey) { memR.removeSenders(txKey) })
+	memR.sem = semaphore.NewWeighted(int64(memR.config.MaxPeers))
+
 	return memR
 }
 
@@ -170,36 +172,18 @@ type PeerState interface {
 	GetHeight() int64
 }
 
-func (memR *Reactor) CheckActivatePeer() bool {
-	maxPeers := memR.config.MaxPeers
-
-	memR.mtx.Lock()
-	defer memR.mtx.Unlock()
-
-	if memR.numActivePeers < maxPeers {
-		memR.numActivePeers += 1
-		return true
-	}
-	return false
-}
-
-func (memR *Reactor) DeactivePeer() {
-	memR.mtx.Lock()
-	defer memR.mtx.Unlock()
-	memR.numActivePeers -= 1
-}
-
 // Send new mempool txs to peer.
 func (memR *Reactor) broadcastTxRoutine(peer p2p.Peer) {
 	var next *clist.CElement
 
-	var active bool
+	if memR.config.MaxPeers > 0 {
 
-	defer func() {
-		if active {
-			memR.DeactivePeer()
+		if err := memR.sem.Acquire(context.TODO(), 1); err != nil {
+			memR.Logger.Error("Failed to acquire semaphore: %v", err)
+			return
 		}
-	}()
+		defer memR.sem.Release(1)
+	}
 
 	// If the node is catching up, don't start this routine immediately.
 	if memR.WaitSync() {
@@ -215,16 +199,6 @@ func (memR *Reactor) broadcastTxRoutine(peer p2p.Peer) {
 		// In case of both next.NextWaitChan() and peer.Quit() are variable at the same time
 		if !memR.IsRunning() || !peer.IsRunning() {
 			return
-		}
-
-		if !active {
-			// check if we should activate the peer
-			if memR.CheckActivatePeer() {
-				active = true
-			} else {
-				time.Sleep(time.Second)
-				continue
-			}
 		}
 
 		// This happens because the CElement we were looking at got garbage

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -53,7 +53,7 @@ func NewReactor(config *cfg.MempoolConfig, mempool *CListMempool, waitSync bool)
 		memR.waitSyncCh = make(chan struct{})
 	}
 	memR.mempool.SetTxRemovedCallback(func(txKey types.TxKey) { memR.removeSenders(txKey) })
-	memR.sem = semaphore.NewWeighted(int64(memR.config.MaxPeers))
+	memR.sem = semaphore.NewWeighted(int64(memR.config.MaxOutboundPeers))
 
 	return memR
 }
@@ -175,7 +175,7 @@ type PeerState interface {
 func (memR *Reactor) broadcastTxRoutine(peer p2p.Peer) {
 	var next *clist.CElement
 
-	if memR.config.MaxPeers > 0 {
+	if memR.config.MaxOutboundPeers > 0 {
 
 		if err := memR.sem.Acquire(context.TODO(), 1); err != nil {
 			memR.Logger.Error("Failed to acquire semaphore: %v", err)

--- a/test/e2e/pkg/manifest.go
+++ b/test/e2e/pkg/manifest.go
@@ -98,6 +98,9 @@ type Manifest struct {
 
 	// Upper bound of sleep duration then gossipping votes and block parts
 	PeerGossipIntraloopSleepDuration time.Duration `toml:"peer_gossip_intraloop_sleep_duration"`
+
+	// Only broadcast txs to up to this many peers.
+	MempoolMaxOutboundPeers int `toml:"mempool_max_outbound_peers"`
 }
 
 // ManifestNode represents a node in a testnet manifest.
@@ -178,6 +181,10 @@ type ManifestNode struct {
 	// It defaults to false so unless the configured, the node will
 	// receive load.
 	SendNoLoad bool `toml:"send_no_load"`
+
+	// Only broadcast txs to up to this many peers.
+	// If this configuration is set at the network level, this value will be ignored.
+	MempoolMaxOutboundPeers int `toml:"mempool_max_outbound_peers"`
 }
 
 // Save saves the testnet manifest to a file.

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -93,6 +93,7 @@ type Testnet struct {
 	VoteExtensionsEnableHeight       int64
 	VoteExtensionSize                uint
 	PeerGossipIntraloopSleepDuration time.Duration
+	MempoolMaxOutboundPeers          int
 }
 
 // Node represents a CometBFT node in a testnet.
@@ -124,6 +125,7 @@ type Node struct {
 	SendNoLoad              bool
 	Prometheus              bool
 	PrometheusProxyPort     uint32
+	MempoolMaxOutboundPeers int
 }
 
 // LoadTestnet loads a testnet from a manifest file, using the filename to
@@ -176,6 +178,7 @@ func NewTestnetFromManifest(manifest Manifest, file string, ifd InfrastructureDa
 		VoteExtensionsEnableHeight:       manifest.VoteExtensionsEnableHeight,
 		VoteExtensionSize:                manifest.VoteExtensionSize,
 		PeerGossipIntraloopSleepDuration: manifest.PeerGossipIntraloopSleepDuration,
+		MempoolMaxOutboundPeers:          manifest.MempoolMaxOutboundPeers,
 	}
 	if len(manifest.KeyType) != 0 {
 		testnet.KeyType = manifest.KeyType
@@ -266,6 +269,11 @@ func NewTestnetFromManifest(manifest Manifest, file string, ifd InfrastructureDa
 		}
 		for _, p := range nodeManifest.Perturb {
 			node.Perturbations = append(node.Perturbations, Perturbation(p))
+		}
+		if manifest.MempoolMaxOutboundPeers > 0 {
+			node.MempoolMaxOutboundPeers = manifest.MempoolMaxOutboundPeers
+		} else if nodeManifest.MempoolMaxOutboundPeers > 0 {
+			node.MempoolMaxOutboundPeers = nodeManifest.MempoolMaxOutboundPeers
 		}
 		testnet.Nodes = append(testnet.Nodes, node)
 	}

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -271,6 +271,10 @@ func MakeConfig(node *e2e.Node) (*config.Config, error) {
 		cfg.Instrumentation.Prometheus = true
 	}
 
+	if node.MempoolMaxOutboundPeers > 0 {
+		cfg.Mempool.MaxOutboundPeers = node.MempoolMaxOutboundPeers
+	}
+
 	return cfg, nil
 }
 


### PR DESCRIPTION
use semaphores to simplify the code
---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

