### PR TITLE
e2e-v0.38-experimental: Fix flakiness in grpc tests due to pruning (#1492)

### DIFF
--- a/test/e2e/tests/grpc_test.go
+++ b/test/e2e/tests/grpc_test.go
@@ -49,18 +49,18 @@ func TestLegacyGRPC_Ping(t *testing.T) {
 
 func TestGRPC_Block_GetByHeight(t *testing.T) {
 	testFullNodesOrValidators(t, 0, func(t *testing.T, node e2e.Node) {
-		blocks := fetchBlockChain(t)
 
 		client, err := node.Client()
 		require.NoError(t, err)
 		status, err := client.Status(ctx)
 		require.NoError(t, err)
 
-		first := status.SyncInfo.EarliestBlockHeight
+		// We are not testing getting the first block in these
+		// tests to prevent race conditions with the pruning mechanism
+		// that might make the tests fail. Just testing the last block
+		// is enough to validate the fact that we can fetch a block using
+		// the gRPC endpoint
 		last := status.SyncInfo.LatestBlockHeight
-		if node.RetainBlocks > 0 {
-			first++ // avoid race conditions with block pruning
-		}
 
 		ctx, ctxCancel := context.WithTimeout(context.Background(), time.Minute)
 		defer ctxCancel()
@@ -68,30 +68,14 @@ func TestGRPC_Block_GetByHeight(t *testing.T) {
 		require.NoError(t, err)
 		defer gRPCClient.Close()
 
-		for _, block := range blocks {
-			if block.Header.Height < first {
-				continue
-			}
-			if block.Header.Height > last {
-				break
-			}
+		// Get last block and fetch it using the gRPC endpoint
+		lastBlock, err := gRPCClient.GetBlockByHeight(ctx, last)
 
-			// Get first block
-			firstBlock, err := gRPCClient.GetBlockByHeight(ctx, first)
+		// Last block tests
+		require.NoError(t, err)
+		require.NotNil(t, lastBlock.BlockID)
+		require.Equal(t, lastBlock.Block.Height, last)
 
-			// First block tests
-			require.NoError(t, err)
-			require.NotNil(t, firstBlock.BlockID)
-			require.Equal(t, firstBlock.Block.Height, first)
-
-			// Get last block
-			lastBlock, err := gRPCClient.GetBlockByHeight(ctx, last)
-
-			// Last block tests
-			require.NoError(t, err)
-			require.NotNil(t, lastBlock.BlockID)
-			require.Equal(t, lastBlock.Block.Height, last)
-		}
 	})
 }
 


### PR DESCRIPTION

 Manual backport of #1492

* Initial attempt to decrease the flakiness

* Remove loop over blocks from archive nodes

* Removed needless loop through blocks

* removed the first block test (#1492)

---------

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

