### PR TITLE
use assert.Greater instead of Equal for better failure reporting

### DIFF
--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -432,8 +432,8 @@ func TestReactorRecordsVotesAndBlockParts(t *testing.T) {
 	// Get peer state
 	ps := peer.Get(types.PeerStateKey).(*PeerState)
 
-	assert.Equal(t, true, ps.VotesSent() > 0, "number of votes sent should have increased")
-	assert.Equal(t, true, ps.BlockPartsSent() > 0, "number of votes sent should have increased")
+	assert.Greater(t, ps.VotesSent(), 0, "number of votes sent should have increased")
+	assert.Greater(t, ps.BlockPartsSent(), 0, "number of votes sent should have increased")
 }
 
 //-------------------------------------------------------------


### PR DESCRIPTION
Simple test improvement. Failure reporting prints the numbers.

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments

