### PR TITLE
Update proto file references to follow renaming/versioning

### DIFF
--- a/proto/tendermint/services/block/v1/block.proto
+++ b/proto/tendermint/services/block/v1/block.proto
@@ -4,8 +4,6 @@ package tendermint.services.block.v1;
 import "tendermint/types/block.proto";
 import "tendermint/types/types.proto";
 
-option go_package = "github.com/cometbft/cometbft/proto/tendermint/services/block/v1";
-
 message GetByHeightRequest {
   // The height of the block requested. If set to 0, the latest height will be returned.
   int64 height = 1;

--- a/proto/tendermint/services/block/v1/block_service.proto
+++ b/proto/tendermint/services/block/v1/block_service.proto
@@ -1,8 +1,6 @@
 syntax = "proto3";
 package tendermint.services.block.v1;
 
-option go_package = "github.com/cometbft/cometbft/proto/tendermint/services/block/v1";
-
 import "tendermint/services/block/v1/block.proto";
 
 // BlockService provides information about blocks

--- a/proto/tendermint/services/block_results/v1/block_results.proto
+++ b/proto/tendermint/services/block_results/v1/block_results.proto
@@ -4,8 +4,6 @@ package tendermint.services.block_results.v1;
 import "tendermint/abci/types.proto";
 import "tendermint/types/params.proto";
 
-option go_package = "github.com/cometbft/cometbft/proto/tendermint/services/block_results/v1";
-
 message GetBlockResultsRequest {
   int64 height = 1;
 }

--- a/proto/tendermint/services/block_results/v1/block_results_service.proto
+++ b/proto/tendermint/services/block_results/v1/block_results_service.proto
@@ -1,8 +1,6 @@
 syntax = "proto3";
 package tendermint.services.block_results.v1;
 
-option go_package = "github.com/cometbft/cometbft/proto/tendermint/services/block_results/v1";
-
 import "tendermint/services/block_results/v1/block_results.proto";
 
 /*

--- a/proto/tendermint/services/version/v1/version.proto
+++ b/proto/tendermint/services/version/v1/version.proto
@@ -1,8 +1,6 @@
 syntax = "proto3";
 package tendermint.services.version.v1;
 
-option go_package = "github.com/cometbft/cometbft/proto/tendermint/services/version/v1";
-
 message GetVersionRequest {}
 
 message GetVersionResponse {

--- a/proto/tendermint/services/version/v1/version_service.proto
+++ b/proto/tendermint/services/version/v1/version_service.proto
@@ -1,8 +1,6 @@
 syntax = "proto3";
 package tendermint.services.version.v1;
 
-option go_package = "github.com/cometbft/cometbft/proto/tendermint/services/version/v1";
-
 import "tendermint/services/version/v1/version.proto";
 
 // VersionService simply provides version information about the node and the

--- a/spec/abci/README.md
+++ b/spec/abci/README.md
@@ -17,7 +17,7 @@ message type.
 
 The methods are always initiated by CometBFT. The Application implements its logic
 for handling all ABCI++ methods.
-Thus, CometBFT always sends the `Request*` messages and receives the `Response*` messages
+Thus, CometBFT always sends the `*Request` messages and receives the `*Response` messages
 in return.
 
 All ABCI++ messages and methods are defined in [protocol buffers](https://github.com/cometbft/cometbft/blob/main/proto/cometbft/abci/v1beta4/types.proto).

--- a/spec/abci/README.md
+++ b/spec/abci/README.md
@@ -20,7 +20,7 @@ for handling all ABCI++ methods.
 Thus, CometBFT always sends the `Request*` messages and receives the `Response*` messages
 in return.
 
-All ABCI++ messages and methods are defined in [protocol buffers](https://github.com/cometbft/cometbft/blob/main/proto/tendermint/abci/types.proto).
+All ABCI++ messages and methods are defined in [protocol buffers](https://github.com/cometbft/cometbft/blob/main/proto/cometbft/abci/v1beta4/types.proto).
 This allows CometBFT to run with applications written in many programming languages.
 
 This specification is split as follows:

--- a/spec/abci/abci++_basic_concepts.md
+++ b/spec/abci/abci++_basic_concepts.md
@@ -278,14 +278,14 @@ Note that some methods (`Query`, `FinalizeBlock`) return non-deterministic data 
 of `Info` and `Log` fields. The `Log` is intended for the literal output from the Application's
 logger, while the `Info` is any additional info that should be returned. These are the only fields
 that are not included in block header computations, so we don't need agreement
-on them. All other fields in the `Response*` must be strictly deterministic.
+on them. All other fields in the `*Response` must be strictly deterministic.
 
 ## Events
 
 [&#8593; Back to Outline](#outline)
 
 Method `FinalizeBlock` includes an `events` field at the top level in its
-`Response*`, and one `events` field per transaction included in the block.
+`FinalizeBlockResponse`, and one `events` field per transaction included in the block.
 Applications may respond to this ABCI 2.0 method with an event list for each executed
 transaction, and a general event list for the block itself.
 Events allow applications to associate metadata with transactions and blocks.
@@ -298,7 +298,8 @@ execution. `Event` values can be used to index transactions and blocks according
 happened during their execution.
 
 Each event has a `type` which is meant to categorize the event for a particular
-`Response*` or `Tx`. A `Response*` or `Tx` may contain multiple events with duplicate
+`FinalizeBlockResponse` or `Tx`. A `FinalizeBlockResponse` or `Tx` may contain
+multiple events with duplicate
 `type` values, where each distinct entry is meant to categorize attributes for a
 particular event. Every key and value in an event's attributes must be UTF-8
 encoded strings along with the event type itself.
@@ -387,7 +388,7 @@ enum EvidenceType {
 
 [&#8593; Back to Outline](#outline)
 
-The `Query` and `CheckTx` methods include a `Code` field in their `Response*`.
+The `Query` and `CheckTx` methods include a `Code` field in their `*Response`.
 Field `Code` is meant to contain an application-specific response code.
 A response code of `0` indicates no error.  Any other response code
 indicates to CometBFT that an error occurred.

--- a/spec/abci/abci++_client_server.md
+++ b/spec/abci/abci++_client_server.md
@@ -17,7 +17,7 @@ You are expected to have read all previous sections of ABCI++ specification, nam
 ## Message Protocol and Synchrony
 
 The message protocol consists of pairs of requests and responses defined in the
-[protobuf file](https://github.com/cometbft/cometbft/blob/main/proto/tendermint/abci/types.proto).
+[protobuf file](https://github.com/cometbft/cometbft/blob/main/proto/cometbft/abci/v1beta4/types.proto).
 
 Some messages have no fields, while others may include byte-arrays, strings, integers,
 or custom protobuf types.

--- a/spec/abci/abci++_comet_expected_behavior.md
+++ b/spec/abci/abci++_comet_expected_behavior.md
@@ -17,10 +17,10 @@ what will happen during a block height _h_ in these frequent, benign conditions:
 * Consensus will decide in round 0, for height _h_;
 * `PrepareProposal` will be called exactly once at the proposer process of round 0, height _h_;
 * `ProcessProposal` will be called exactly once at all processes, and
-  will return _accept_ in its `Response*`;
+  will return _accept_ in its `ProcessProposalResponse`;
 * `ExtendVote` will be called exactly once at all processes;
 * `VerifyVoteExtension` will be called exactly _n-1_ times at each validator process, where _n_ is
-  the number of validators, and will always return _accept_ in its `Response*`;
+  the number of validators, and will always return _accept_ in its `VerifyVoteExtensionResponse`;
 * `FinalizeBlock` will be called exactly once at all processes, conveying the same prepared
   block that all calls to `PrepareProposal` and `ProcessProposal` had previously reported for
   height _h_; and


### PR DESCRIPTION
Documentation and proto file fix ups for #1330:

* Change the URL to the ABCI proto file on GitHub in documentation
  to point to the latest versioned package.
* Remove the `go_package` directives from the legacy `tendermint.*` proto files.