### PR TITLE
fix: docs: default db provider moved from node to config

### DIFF
--- a/docs/guides/go-built-in.md
+++ b/docs/guides/go-built-in.md
@@ -586,7 +586,7 @@ func main() {
         nodeKey,
         proxy.NewLocalClientCreator(app),
         nm.DefaultGenesisDocProviderFunc(config),
-        nm.DefaultDBProvider,
+        cfg.DefaultDBProvider,
         nm.DefaultMetricsProvider(config.Instrumentation),
         logger
     )

--- a/docs/guides/go-built-in.md
+++ b/docs/guides/go-built-in.md
@@ -475,17 +475,17 @@ In the following code, the application simply returns the unmodified group of tr
 
      return &abcitypes.ResponsePrepareProposal{Txs: proposal.Txs}, nil
  }
- ```
+```
 
- This code snippet iterates through the proposed transactions and calculates the `total bytes`. If the `total bytes` exceeds the `MaxTxBytes` specified in the `RequestPrepareProposal` struct, the loop breaks and the transactions processed so far are returned.
+This code snippet iterates through the proposed transactions and calculates the `total bytes`. If the `total bytes` exceeds the `MaxTxBytes` specified in the `RequestPrepareProposal` struct, the loop breaks and the transactions processed so far are returned.
 
- Note: It is the responsibility of the application to ensure that the `total bytes` of transactions returned does not exceed the `RequestPrepareProposal.max_tx_bytes` limit.
+Note: It is the responsibility of the application to ensure that the `total bytes` of transactions returned does not exceed the `RequestPrepareProposal.max_tx_bytes` limit.
 
- Once a proposed block is received by a node, the proposal is passed to the application to give
- its blessing before voting to accept the proposal.
+Once a proposed block is received by a node, the proposal is passed to the application to give
+its blessing before voting to accept the proposal.
 
- This mechanism may be used for different reasons, for example to deal with blocks manipulated
- by malicious nodes, in which case the block should not be considered valid.
+This mechanism may be used for different reasons, for example to deal with blocks manipulated
+by malicious nodes, in which case the block should not be considered valid.
 
 The following code simply accepts all proposals:
 
@@ -676,7 +676,7 @@ node, err := nm.NewNode(
     nodeKey,
     proxy.NewLocalClientCreator(app),
     nm.DefaultGenesisDocProviderFunc(config),
-    nm.DefaultDBProvider,
+    cfg.DefaultDBProvider,
     nm.DefaultMetricsProvider(config.Instrumentation),
 logger)
 
@@ -747,7 +747,7 @@ I[2023-04-25|09:08:50.085] service start                                module=a
 ...
 ```
 
-More importantly, the application using CometBFT is producing blocks  🎉🎉 and you can see this reflected in the log output in lines like this:
+More importantly, the application using CometBFT is producing blocks 🎉🎉 and you can see this reflected in the log output in lines like this:
 
 ```bash
 I[2023-04-25|09:08:52.147] received proposal                            module=consensus proposal="Proposal{2/0 (F518444C0E348270436A73FD0F0B9DFEA758286BEB29482F1E3BEA75330E825C:1:C73D3D1273F2, -1) AD19AE292A45 @ 2023-04-25T12:08:52.143393Z}"


### PR DESCRIPTION
Small correction of the guide to setup a built-in cometbft application. Current example code gave me an error (DefaultDBProvider does not exist in nm/node), I believe this should be cfg/config instead. The code bellow is working for me.

I did not add anything to the changelog as that seems kinda unnecessary for such a small change to just the docs.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

