### PR TITLE
refactor: Export func MakeHTTPDialer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
 ## Unreleased
+- `[rpc/jsonrpc]` Export `func MakeHTTPDialer` for doing http over tcp or unix feature can be conveniently used by external projects to reuse and do more customizations.
+  ([\#1594](https://github.com/cometbft/cometbft/pull/1594))
 
 ### BREAKING CHANGES
 

--- a/rpc/jsonrpc/client/http_json_client.go
+++ b/rpc/jsonrpc/client/http_json_client.go
@@ -376,7 +376,8 @@ func (b *RequestBatch) Call(
 
 //-------------------------------------------------------------
 
-func makeHTTPDialer(remoteAddr string) (func(string, string) (net.Conn, error), error) {
+// MakeHTTPDialer overwrite the http.Client.Dial so we can do http over tcp or unix.
+func MakeHTTPDialer(remoteAddr string) (func(string, string) (net.Conn, error), error) {
 	u, err := newParsedURL(remoteAddr)
 	if err != nil {
 		return nil, err
@@ -402,7 +403,7 @@ func makeHTTPDialer(remoteAddr string) (func(string, string) (net.Conn, error), 
 // remoteAddr should be fully featured (eg. with tcp:// or unix://).
 // An error will be returned in case of invalid remoteAddr.
 func DefaultHTTPClient(remoteAddr string) (*http.Client, error) {
-	dialFn, err := makeHTTPDialer(remoteAddr)
+	dialFn, err := MakeHTTPDialer(remoteAddr)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/jsonrpc/client/http_json_client_test.go
+++ b/rpc/jsonrpc/client/http_json_client_test.go
@@ -26,7 +26,7 @@ func TestHTTPClientMakeHTTPDialer(t *testing.T) {
 	for _, testURL := range []string{ts.URL, tsTLS.URL} {
 		u, err := newParsedURL(testURL)
 		require.NoError(t, err)
-		dialFn, err := makeHTTPDialer(testURL)
+		dialFn, err := MakeHTTPDialer(testURL)
 		require.Nil(t, err)
 
 		addr, err := dialFn(u.Scheme, u.GetHostWithPath())

--- a/rpc/jsonrpc/client/ws_client.go
+++ b/rpc/jsonrpc/client/ws_client.go
@@ -96,7 +96,7 @@ func NewWS(remoteAddr, endpoint string, options ...func(*WSClient)) (*WSClient, 
 		parsedURL.Scheme = protoWS
 	}
 
-	dialFn, err := makeHTTPDialer(remoteAddr)
+	dialFn, err := MakeHTTPDialer(remoteAddr)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Export func `func makeHTTPDialer(remoteAddr string)` for doing http over tcp or unix feature can be conveniently used by external projects to reuse and do more customizations. 

For example, I wanna make some more customizations to http client used by [`type Client struct{}`](https://github.com/cometbft/cometbft/blob/main/rpc/jsonrpc/client/http_json_client.go#L124), but also reuse the feature (doing http over tcp or unix), without exported `func makeHTTPDialer`, I need to re-implement it myself.

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments

