### PR TITLE
chore: ADR 109: go mod tidy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/cometbft/cometbft
 
 go 1.21.3
 
+toolchain go1.21.4
+
 require (
 	github.com/BurntSushi/toml v1.3.2 // indirect
 	github.com/adlio/schema v1.3.4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cometbft/cometbft
 
-go 1.21.3
+go 1.21
 
 toolchain go1.21.4
 

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/cometbft/cometbft
 
 go 1.21
 
-toolchain go1.21.4
-
 require (
 	github.com/BurntSushi/toml v1.3.2 // indirect
 	github.com/adlio/schema v1.3.4

--- a/test/e2e/app/go.mod
+++ b/test/e2e/app/go.mod
@@ -2,6 +2,8 @@ module github.com/cometbft/cometbft/test/e2e/app
 
 go 1.21.3
 
+toolchain go1.21.4
+
 require (
 	github.com/cometbft/cometbft v0.38.0
 	github.com/cosmos/gogoproto v1.4.11

--- a/test/e2e/app/go.mod
+++ b/test/e2e/app/go.mod
@@ -1,6 +1,6 @@
 module github.com/cometbft/cometbft/test/e2e/app
 
-go 1.21.3
+go 1.21
 
 toolchain go1.21.4
 

--- a/test/e2e/app/go.mod
+++ b/test/e2e/app/go.mod
@@ -2,8 +2,6 @@ module github.com/cometbft/cometbft/test/e2e/app
 
 go 1.21
 
-toolchain go1.21.4
-
 require (
 	github.com/cometbft/cometbft v0.38.0
 	github.com/cosmos/gogoproto v1.4.11

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -2,8 +2,6 @@ module github.com/cometbft/cometbft/test/e2e
 
 go 1.21
 
-toolchain go1.21.4
-
 require (
 	github.com/BurntSushi/toml v1.3.2
 	github.com/Masterminds/semver/v3 v3.2.1

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/cometbft/cometbft/test/e2e
 
-go 1.21.3
+go 1.21
 
 toolchain go1.21.4
 

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -2,6 +2,8 @@ module github.com/cometbft/cometbft/test/e2e
 
 go 1.21.3
 
+toolchain go1.21.4
+
 require (
 	github.com/BurntSushi/toml v1.3.2
 	github.com/Masterminds/semver/v3 v3.2.1

--- a/test/loadtime/go.mod
+++ b/test/loadtime/go.mod
@@ -1,6 +1,6 @@
 module github.com/cometbft/cometbft/test/loadtime
 
-go 1.21.3
+go 1.21
 
 toolchain go1.21.4
 

--- a/test/loadtime/go.mod
+++ b/test/loadtime/go.mod
@@ -2,6 +2,8 @@ module github.com/cometbft/cometbft/test/loadtime
 
 go 1.21.3
 
+toolchain go1.21.4
+
 require (
 	github.com/cometbft/cometbft v0.38.0
 	github.com/cometbft/cometbft-db v0.7.0

--- a/test/loadtime/go.mod
+++ b/test/loadtime/go.mod
@@ -2,8 +2,6 @@ module github.com/cometbft/cometbft/test/loadtime
 
 go 1.21
 
-toolchain go1.21.4
-
 require (
 	github.com/cometbft/cometbft v0.38.0
 	github.com/cometbft/cometbft-db v0.7.0


### PR DESCRIPTION
CodeQL seems to be complaining about some recent changes that `go mod tidy` produces.

Seems to be fixed after removing the patch version numbers in the go.mod files: https://github.com/cometbft/cometbft/actions/runs/6852623623/job/18631585336

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

