### PR TITLE
Fixes assertion in failing test

### DIFF
--- a/light/provider/http/http_test.go
+++ b/light/provider/http/http_test.go
@@ -61,7 +61,6 @@ func TestProvider(t *testing.T) {
 		lb, err := p.LightBlock(context.Background(), 0)
 		require.NoError(t, err)
 		require.NotNil(t, lb)
-		assert.True(t, lb.Height < 1000)
 		assert.True(t, lb.Height >= 10)
 
 		// let's check this is valid somehow
@@ -80,7 +79,7 @@ func TestProvider(t *testing.T) {
 		lb, err = p.LightBlock(context.Background(), 0)
 		require.NoError(t, err)
 		require.NotNil(t, lb)
-		lb, err = p.LightBlock(context.Background(), lb.Height+1000)
+		lb, err = p.LightBlock(context.Background(), lb.Height+100000)
 		require.Error(t, err)
 		require.Nil(t, lb)
 		assert.Equal(t, provider.ErrHeightTooHigh, err)


### PR DESCRIPTION
Closes: #1582 

This PR removes the wrong assertion and decreases likelihood of a block expected to be from the future to have actually been already created and causing another assertion to fail.

---

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

