### PR TITLE
mempool: Add missing gauge constructor for `size_bytes` metric

### DIFF
--- a/mempool/metrics.go
+++ b/mempool/metrics.go
@@ -64,6 +64,13 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Help:      "Size of the mempool (number of uncommitted transactions).",
 		}, labels).With(labelsAndValues...),
 
+		SizeBytes: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "size_bytes",
+			Help:      "Total size of the mempool in bytes.",
+		}, labels).With(labelsAndValues...),
+
 		TxSizeBytes: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,


### PR DESCRIPTION
Running the nightlies on #1641 picked up a segmentation fault which I traced to the fact that we're not constructing a gauge related to the `size_bytes` metric (from #1568). In the v0.34 line, we need to manually construct these gauges.

Running the E2E nightlies manually on this branch to validate that this fixes the problem: https://github.com/cometbft/cometbft/actions/runs/6897189522

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

