### PR TITLE
Update changelog on `main` with new releases

### DIFF
--- a/.changelog/v0.34.30/build/1351-bump-go-120.md
+++ b/.changelog/v0.34.30/build/1351-bump-go-120.md
@@ -1,0 +1,2 @@
+- Bump Go version used to v1.20 since v1.19 has reached EOL
+  ([\#1351](https://github.com/cometbft/cometbft/pull/1351))

--- a/.changelog/v0.34.30/features/1512-metric-mempool-size-bytes.md
+++ b/.changelog/v0.34.30/features/1512-metric-mempool-size-bytes.md
@@ -1,0 +1,2 @@
+- `[metrics]` Add metric for mempool size in bytes `SizeBytes`.
+  ([\#1512](https://github.com/cometbft/cometbft/pull/1512))

--- a/.changelog/v0.34.30/improvements/1210-close-evidence-db.md
+++ b/.changelog/v0.34.30/improvements/1210-close-evidence-db.md
@@ -1,0 +1,1 @@
+- `[node]` Close evidence.db OnStop ([cometbft/cometbft\#1210](https://github.com/cometbft/cometbft/pull/1210): @chillyvee)

--- a/.changelog/v0.34.30/improvements/1558-experimental-gossip-limiting.md
+++ b/.changelog/v0.34.30/improvements/1558-experimental-gossip-limiting.md
@@ -1,0 +1,9 @@
+- `[mempool]` Add experimental feature to limit the number of persistent peers and non-persistent
+  peers to which the node gossip transactions (only for "v0" mempool).
+  ([\#1558](https://github.com/cometbft/cometbft/pull/1558),
+  ([\#1584](https://github.com/cometbft/cometbft/pull/1584))
+- `[config]` Add mempool parameters `experimental_max_gossip_connections_to_persistent_peers` and
+  `experimental_max_gossip_connections_to_non_persistent_peers` for limiting the number of peers to
+  which the node gossip transactions. 
+  ([\#1558](https://github.com/cometbft/cometbft/pull/1558))
+  ([\#1584](https://github.com/cometbft/cometbft/pull/1584))

--- a/.changelog/v0.34.30/improvements/857-make-handshake-cancelable.md
+++ b/.changelog/v0.34.30/improvements/857-make-handshake-cancelable.md
@@ -1,0 +1,1 @@
+- `[node]` Make handshake cancelable ([cometbft/cometbft\#857](https://github.com/cometbft/cometbft/pull/857))

--- a/.changelog/v0.34.30/summary.md
+++ b/.changelog/v0.34.30/summary.md
@@ -1,0 +1,5 @@
+*November 17, 2023*
+
+This release contains, among other things, an opt-in, experimental feature to
+help reduce the bandwidth consumption associated with the mempool's transaction
+gossip.

--- a/.changelog/v0.37.3/breaking-changes/1113-rm-upnp.md
+++ b/.changelog/v0.37.3/breaking-changes/1113-rm-upnp.md
@@ -1,0 +1,2 @@
+- `[p2p]` Remove unused UPnP functionality
+  ([\#1113](https://github.com/cometbft/cometbft/issues/1113))

--- a/.changelog/v0.37.3/bug-fixes/1529-indexer-respect-height-params-on-query.md
+++ b/.changelog/v0.37.3/bug-fixes/1529-indexer-respect-height-params-on-query.md
@@ -1,0 +1,2 @@
+- `[state/indexer]` Respect both height params while querying for events
+   ([\#1529](https://github.com/cometbft/cometbft/pull/1529))

--- a/.changelog/v0.37.3/features/1057-bootstrap-state-api.md
+++ b/.changelog/v0.37.3/features/1057-bootstrap-state-api.md
@@ -1,0 +1,2 @@
+- `[node/state]` Add Go API to bootstrap block store and state store to a height
+  ([\#1057](https://github.com/tendermint/tendermint/pull/#1057)) (@yihuang)

--- a/.changelog/v0.37.3/features/1512-metric-mempool-size-bytes.md
+++ b/.changelog/v0.37.3/features/1512-metric-mempool-size-bytes.md
@@ -1,0 +1,2 @@
+- `[metrics]` Add metric for mempool size in bytes `SizeBytes`.
+  ([\#1512](https://github.com/cometbft/cometbft/pull/1512))

--- a/.changelog/v0.37.3/improvements/1210-close-evidence-db.md
+++ b/.changelog/v0.37.3/improvements/1210-close-evidence-db.md
@@ -1,0 +1,1 @@
+- `[node]` Close evidence.db OnStop ([cometbft/cometbft\#1210](https://github.com/cometbft/cometbft/pull/1210): @chillyvee)

--- a/.changelog/v0.37.3/improvements/1558-experimental-gossip-limiting.md
+++ b/.changelog/v0.37.3/improvements/1558-experimental-gossip-limiting.md
@@ -1,0 +1,9 @@
+- `[mempool]` Add experimental feature to limit the number of persistent peers and non-persistent
+  peers to which the node gossip transactions (only for "v0" mempool).
+  ([\#1558](https://github.com/cometbft/cometbft/pull/1558))
+  ([\#1584](https://github.com/cometbft/cometbft/pull/1584))
+- `[config]` Add mempool parameters `experimental_max_gossip_connections_to_persistent_peers` and
+  `experimental_max_gossip_connections_to_non_persistent_peers` for limiting the number of peers to
+  which the node gossip transactions. 
+  ([\#1558](https://github.com/cometbft/cometbft/pull/1558))
+  ([\#1584](https://github.com/cometbft/cometbft/pull/1584))

--- a/.changelog/v0.37.3/improvements/475-upgrade-go-schnorrkel.md
+++ b/.changelog/v0.37.3/improvements/475-upgrade-go-schnorrkel.md
@@ -1,0 +1,1 @@
+- `[crypto/sr25519]` Upgrade to go-schnorrkel@v1.0.0 ([\#475](https://github.com/cometbft/cometbft/issues/475))

--- a/.changelog/v0.37.3/improvements/857-make-handshake-cancelable.md
+++ b/.changelog/v0.37.3/improvements/857-make-handshake-cancelable.md
@@ -1,0 +1,1 @@
+- `[node]` Make handshake cancelable ([cometbft/cometbft\#857](https://github.com/cometbft/cometbft/pull/857))

--- a/.changelog/v0.37.3/summary.md
+++ b/.changelog/v0.37.3/summary.md
@@ -1,0 +1,5 @@
+*November 17, 2023*
+
+This release contains, among other things, an opt-in, experimental feature to
+help reduce the bandwidth consumption associated with the mempool's transaction
+gossip.

--- a/.changelog/v0.38.1/bug-fixes/1529-indexer-respect-height-params-on-query.md
+++ b/.changelog/v0.38.1/bug-fixes/1529-indexer-respect-height-params-on-query.md
@@ -1,0 +1,2 @@
+- `[state/indexer]` Respect both height params while querying for events
+   ([\#1529](https://github.com/cometbft/cometbft/pull/1529))

--- a/.changelog/v0.38.1/features/1512-metric-mempool-size-bytes.md
+++ b/.changelog/v0.38.1/features/1512-metric-mempool-size-bytes.md
@@ -1,0 +1,2 @@
+- `[metrics]` Add metric for mempool size in bytes `SizeBytes`.
+  ([\#1512](https://github.com/cometbft/cometbft/pull/1512))

--- a/.changelog/v0.38.1/improvements/1558-experimental-gossip-limiting.md
+++ b/.changelog/v0.38.1/improvements/1558-experimental-gossip-limiting.md
@@ -1,0 +1,9 @@
+- `[mempool]` Add experimental feature to limit the number of persistent peers and non-persistent
+  peers to which the node gossip transactions.
+  ([\#1558](https://github.com/cometbft/cometbft/pull/1558))
+  ([\#1584](https://github.com/cometbft/cometbft/pull/1584))
+- `[config]` Add mempool parameters `experimental_max_gossip_connections_to_persistent_peers` and
+  `experimental_max_gossip_connections_to_non_persistent_peers` for limiting the number of peers to
+  which the node gossip transactions. 
+  ([\#1558](https://github.com/cometbft/cometbft/pull/1558))
+  ([\#1584](https://github.com/cometbft/cometbft/pull/1584))

--- a/.changelog/v0.38.1/summary.md
+++ b/.changelog/v0.38.1/summary.md
@@ -1,0 +1,5 @@
+*November 17, 2023*
+
+This release contains, among other things, an opt-in, experimental feature to
+help reduce the bandwidth consumption associated with the mempool's transaction
+gossip.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,66 +1,34 @@
 # CHANGELOG
 
-## Unreleased
+## v0.38.1
 
-### BREAKING CHANGES
+*November 17, 2023*
 
-- `[crypto/merkle]` The public `Proof.ComputeRootHash` function has been deleted.
-   ([\#558](https://github.com/cometbft/cometbft/issues/558))
-- `[rpc/grpc]` Remove the deprecated gRPC broadcast API
-  ([\#650](https://github.com/cometbft/cometbft/issues/650))
-- `[consensus]` `Handshaker.Handshake` now requires `context.Context` ([cometbft/cometbft\#857](https://github.com/cometbft/cometbft/pull/857))
-- `[node]` `NewNode` now requires `context.Context` as the first parameter ([cometbft/cometbft\#857](https://github.com/cometbft/cometbft/pull/857))
-`[mempool]` Change the signature of `CheckTx` in the `Mempool` interface to
-`CheckTx(tx types.Tx) (*abcicli.ReqRes, error)`. Also, add new method
-`SetTxRemovedCallback`.
-([\#1010](https://github.com/cometbft/cometbft/issues/1010))
-- `[mempool]` Remove `mempoolIDs` for internally storing peer ids as `p2p.ID`
-  instead of `uint16`.
-  ([\#1146](https://github.com/cometbft/cometbft/pull/1146))
-- `[cmd]` Remove `replay` and `replay-console` subcommands
-  and corresponding consensus file replay code, such as
-  `consensus.RunReplayFile`, and `consensus.State.ReplayFile`
-  ([\#1170](https://github.com/cometbft/cometbft/pull/1170))
-- `[node]` Change the signature of `GenesisDocProvider` to
-  return the checksum of JSON content alongside the parsed genesis data
-  ([\#1287](https://github.com/cometbft/cometbft/issues/1287)).
+This release contains, among other things, an opt-in, experimental feature to
+help reduce the bandwidth consumption associated with the mempool's transaction
+gossip.
 
 ### BUG FIXES
 
-- `[consensus]` \#1203 consensus now prevotes `nil` when the proposed value
-  does not match the value the local validator has locked on
-  ([\#1203](https://github.com/cometbft/cometbft/pull/1203))
-- `[consensus]` \#1175 remove logic to unlock block on +2/3 prevote for nil
-  ([\#1175](https://github.com/cometbft/cometbft/pull/1175): @BrendanChou)
+- `[state/indexer]` Respect both height params while querying for events
+   ([\#1529](https://github.com/cometbft/cometbft/pull/1529))
+
+### FEATURES
+
+- `[metrics]` Add metric for mempool size in bytes `SizeBytes`.
+  ([\#1512](https://github.com/cometbft/cometbft/pull/1512))
 
 ### IMPROVEMENTS
 
-- `[mempool]` Add a metric (a counter) to measure whether a tx was received more than once.
-  ([\#634](https://github.com/cometbft/cometbft/pull/634))
-- `[consensus]` New metrics (counters) to track duplicate votes and block parts.
-  ([\#896](https://github.com/cometbft/cometbft/pull/896))
-- `[consensus]` Optimize vote and block part gossip with new message `HasProposalBlockPartMessage`,
-  which is similar to `HasVoteMessage`; and random sleep in the loop broadcasting those messages.
-  The sleep can be configured with new config `peer_gossip_intraloop_sleep_duration`, which is set to 0
-  by default as this is experimental.
-  Our scale tests show substantial bandwidth improvement with a value of 50 ms.
-  ([\#904](https://github.com/cometbft/cometbft/pull/904))
-- Update Apalache type annotations in the light client spec ([#955](https://github.com/cometbft/cometbft/pull/955))
-- `[node]` Remove genesis persistence in state db, replaced by a hash
-  ([cometbft/cometbft\#1017](https://github.com/cometbft/cometbft/pull/1017),
-  [cometbft/cometbft\#1295](https://github.com/cometbft/cometbft/pull/1295))
-- `[consensus]` Log vote validation failures at info level
-  ([\#1022](https://github.com/cometbft/cometbft/pull/1022))
-- `[consensus]` When prevoting, avoid calling PropocessProposal when we know the
-  proposal was already validated by correct nodes.
-  ([\#1230](https://github.com/cometbft/cometbft/pull/1230))
-- `[node]` On upgrade, after [\#1296](https://github.com/cometbft/cometbft/pull/1296), delete the genesis file existing in the DB.
-  ([cometbft/cometbft\#1297](https://github.com/cometbft/cometbft/pull/1297)
-
-### MINIMUM GO VERSION
-
-- Bump minimum Go version to v1.21
-  ([\#1244](https://github.com/cometbft/cometbft/pull/1244))
+- `[mempool]` Add experimental feature to limit the number of persistent peers and non-persistent
+  peers to which the node gossip transactions.
+  ([\#1558](https://github.com/cometbft/cometbft/pull/1558))
+  ([\#1584](https://github.com/cometbft/cometbft/pull/1584))
+- `[config]` Add mempool parameters `experimental_max_gossip_connections_to_persistent_peers` and
+  `experimental_max_gossip_connections_to_non_persistent_peers` for limiting the number of peers to
+  which the node gossip transactions. 
+  ([\#1558](https://github.com/cometbft/cometbft/pull/1558))
+  ([\#1584](https://github.com/cometbft/cometbft/pull/1584))
 
 ## v0.38.0
 
@@ -94,10 +62,10 @@ for people who forked CometBFT and interact directly with the indexers kvstore.
 - `[rpc]` Removed `begin_block_events` and `end_block_events` from `BlockResultsResponse`.
   The events are merged into one field called `finalize_block_events`.
   ([\#9427](https://github.com/tendermint/tendermint/issues/9427))
-- `[pubsub]` Added support for big integers and big floats in the pubsub event query system.
+- `[kvindexer]` Added support for big integers and big floats in the kvindexer.
   Breaking changes: function `Number` in package `libs/pubsub/query/syntax` changed its return value.
   ([\#797](https://github.com/cometbft/cometbft/pull/797))
-- `[kvindexer]` Added support for big integers and big floats in the kvindexer.
+- `[pubsub]` Added support for big integers and big floats in the pubsub event query system.
   Breaking changes: function `Number` in package `libs/pubsub/query/syntax` changed its return value.
   ([\#797](https://github.com/cometbft/cometbft/pull/797))
 - `[mempool]` Application can now set `ConsensusParams.Block.MaxBytes` to -1
@@ -220,6 +188,46 @@ for people who forked CometBFT and interact directly with the indexers kvstore.
 - `[pubsub]` Performance improvements for the event query API
   ([\#7319](https://github.com/tendermint/tendermint/pull/7319))
 
+## v0.37.3
+
+*November 17, 2023*
+
+This release contains, among other things, an opt-in, experimental feature to
+help reduce the bandwidth consumption associated with the mempool's transaction
+gossip.
+
+### BREAKING CHANGES
+
+- `[p2p]` Remove unused UPnP functionality
+  ([\#1113](https://github.com/cometbft/cometbft/issues/1113))
+
+### BUG FIXES
+
+- `[state/indexer]` Respect both height params while querying for events
+   ([\#1529](https://github.com/cometbft/cometbft/pull/1529))
+
+### FEATURES
+
+- `[node/state]` Add Go API to bootstrap block store and state store to a height
+  ([\#1057](https://github.com/tendermint/tendermint/pull/#1057)) (@yihuang)
+- `[metrics]` Add metric for mempool size in bytes `SizeBytes`.
+  ([\#1512](https://github.com/cometbft/cometbft/pull/1512))
+
+### IMPROVEMENTS
+
+- `[crypto/sr25519]` Upgrade to go-schnorrkel@v1.0.0 ([\#475](https://github.com/cometbft/cometbft/issues/475))
+- `[node]` Make handshake cancelable ([cometbft/cometbft\#857](https://github.com/cometbft/cometbft/pull/857))
+- `[node]` Close evidence.db OnStop ([cometbft/cometbft\#1210](https://github.com/cometbft/cometbft/pull/1210): @chillyvee)
+- `[mempool]` Add experimental feature to limit the number of persistent peers and non-persistent
+  peers to which the node gossip transactions (only for "v0" mempool).
+  ([\#1558](https://github.com/cometbft/cometbft/pull/1558))
+  ([\#1584](https://github.com/cometbft/cometbft/pull/1584))
+- `[config]` Add mempool parameters `experimental_max_gossip_connections_to_persistent_peers` and
+  `experimental_max_gossip_connections_to_non_persistent_peers` for limiting the number of peers to
+  which the node gossip transactions. 
+  ([\#1558](https://github.com/cometbft/cometbft/pull/1558))
+  ([\#1584](https://github.com/cometbft/cometbft/pull/1584))
+
 ## v0.37.2
 
 *June 14, 2023*
@@ -229,14 +237,14 @@ security issues.
 
 ### BUG FIXES
 
-- `[state/kvindex]` Querying event attributes that are bigger than int64 is now
-  enabled. We are not supporting reading floats from the db into the indexer
-  nor parsing them into BigFloats to not introduce breaking changes in minor
-  releases. ([\#771](https://github.com/cometbft/cometbft/pull/771))
 - `[pubsub]` Pubsub queries are now able to parse big integers (larger than
   int64). Very big floats are also properly parsed into very big integers
   instead of being truncated to int64.
   ([\#771](https://github.com/cometbft/cometbft/pull/771))
+- `[state/kvindex]` Querying event attributes that are bigger than int64 is now
+  enabled. We are not supporting reading floats from the db into the indexer
+  nor parsing them into BigFloats to not introduce breaking changes in minor
+  releases. ([\#771](https://github.com/cometbft/cometbft/pull/771))
 
 ### IMPROVEMENTS
 
@@ -430,6 +438,38 @@ See below for more details.
 - `[consensus]` Save peer LastCommit correctly to achieve 50% reduction in gossiped precommits.
   ([\#9760](https://github.com/tendermint/tendermint/pull/9760))
 
+## v0.34.30
+
+*November 17, 2023*
+
+This release contains, among other things, an opt-in, experimental feature to
+help reduce the bandwidth consumption associated with the mempool's transaction
+gossip.
+
+### BUILD
+
+- Bump Go version used to v1.20 since v1.19 has reached EOL
+  ([\#1351](https://github.com/cometbft/cometbft/pull/1351))
+
+### FEATURES
+
+- `[metrics]` Add metric for mempool size in bytes `SizeBytes`.
+  ([\#1512](https://github.com/cometbft/cometbft/pull/1512))
+
+### IMPROVEMENTS
+
+- `[node]` Make handshake cancelable ([cometbft/cometbft\#857](https://github.com/cometbft/cometbft/pull/857))
+- `[node]` Close evidence.db OnStop ([cometbft/cometbft\#1210](https://github.com/cometbft/cometbft/pull/1210): @chillyvee)
+- `[mempool]` Add experimental feature to limit the number of persistent peers and non-persistent
+  peers to which the node gossip transactions (only for "v0" mempool).
+  ([\#1558](https://github.com/cometbft/cometbft/pull/1558),
+  ([\#1584](https://github.com/cometbft/cometbft/pull/1584))
+- `[config]` Add mempool parameters `experimental_max_gossip_connections_to_persistent_peers` and
+  `experimental_max_gossip_connections_to_non_persistent_peers` for limiting the number of peers to
+  which the node gossip transactions. 
+  ([\#1558](https://github.com/cometbft/cometbft/pull/1558))
+  ([\#1584](https://github.com/cometbft/cometbft/pull/1584))
+
 ## v0.34.29
 
 *June 14, 2023*
@@ -439,12 +479,12 @@ security issues.
 
 ### BUG FIXES
 
-- `[state/kvindex]` Querying event attributes that are bigger than int64 is now
-  enabled. ([\#771](https://github.com/cometbft/cometbft/pull/771))
 - `[pubsub]` Pubsub queries are now able to parse big integers (larger than
   int64). Very big floats are also properly parsed into very big integers
   instead of being truncated to int64.
   ([\#771](https://github.com/cometbft/cometbft/pull/771))
+- `[state/kvindex]` Querying event attributes that are bigger than int64 is now
+  enabled. ([\#771](https://github.com/cometbft/cometbft/pull/771))
 
 ### IMPROVEMENTS
 


### PR DESCRIPTION
Pulls the changelog entries into `main` from #1639, #1640 and #1641.

[Rendered](https://github.com/cometbft/cometbft/blob/thane/update-changelog/CHANGELOG.md)

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

