### PR TITLE
ci: Fix v0.34 nightly build

### DIFF
--- a/.github/workflows/e2e-nightly-34x.yml
+++ b/.github/workflows/e2e-nightly-34x.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.18'
+          go-version: '1.20'
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The v0.34.x nightly build has been failing for a few days now, and it seems like it's because we're using the wrong version of Go to build it.

The workflow on the `main` branch is the one that's executed nightly.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

