### PR TITLE
Update link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Currently supported versions include:
 - [Terra](https://www.terra.money/)
 - [Celestia](https://celestia.org/)
 - [Anoma](https://anoma.network/)
-- [Vocdoni](https://docs.vocdoni.io/)
+- [Vocdoni](https://developer.vocdoni.io/)
 
 ### Research
 


### PR DESCRIPTION
On the old, existing link it says the following:
" The information provided on this website is no longer up-to-date. For the latest documentation, please visit developer.vocdoni.io"

This PR changes the link to that one, so it doesn't reference the not-up-to-date website.