### PR TITLE
feature/proto-upgrade: Last-minute fixes

### DIFF
--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -6,8 +6,6 @@
 name: Check generated code
 on:
   pull_request:
-    branches:
-      - main
   merge_group:
 
 permissions:

--- a/Makefile
+++ b/Makefile
@@ -126,14 +126,14 @@ endif
 
 proto-gen: check-proto-deps
 	@echo "Generating Protobuf files"
-	@go run github.com/bufbuild/buf/cmd/buf generate --path proto/cometbft
+	@go run github.com/bufbuild/buf/cmd/buf@latest generate --path proto/cometbft
 .PHONY: proto-gen
 
 # These targets are provided for convenience and are intended for local
 # execution only.
 proto-lint: check-proto-deps
 	@echo "Linting Protobuf files"
-	@go run github.com/bufbuild/buf/cmd/buf lint
+	@go run github.com/bufbuild/buf/cmd/buf@latest lint
 .PHONY: proto-lint
 
 proto-format: check-proto-format-deps
@@ -146,11 +146,11 @@ proto-check-breaking: check-proto-deps
 	@echo "Note: This is only useful if your changes have not yet been committed."
 	@echo "      Otherwise read up on buf's \"breaking\" command usage:"
 	@echo "      https://docs.buf.build/breaking/usage"
-	@go run github.com/bufbuild/buf/cmd/buf breaking --against ".git"
+	@go run github.com/bufbuild/buf/cmd/buf@latest breaking --against ".git"
 .PHONY: proto-check-breaking
 
 proto-check-breaking-ci:
-	@go run github.com/bufbuild/buf/cmd/buf breaking --against $(HTTPS_GIT)#branch=v0.34.x
+	@go run github.com/bufbuild/buf/cmd/buf@latest breaking --against $(HTTPS_GIT)#branch=v0.34.x
 .PHONY: proto-check-breaking-ci
 
 ###############################################################################

--- a/api/cometbft/abci/v1/service.pb.go
+++ b/api/cometbft/abci/v1/service.pb.go
@@ -75,21 +75,37 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type ABCIServiceClient interface {
+	// Echo returns back the same message it is sent.
 	Echo(ctx context.Context, in *EchoRequest, opts ...grpc.CallOption) (*EchoResponse, error)
+	// Flush flushes the write buffer.
 	Flush(ctx context.Context, in *FlushRequest, opts ...grpc.CallOption) (*FlushResponse, error)
+	// Info returns information about the application state.
 	Info(ctx context.Context, in *InfoRequest, opts ...grpc.CallOption) (*InfoResponse, error)
+	// CheckTx validates a transaction.
 	CheckTx(ctx context.Context, in *CheckTxRequest, opts ...grpc.CallOption) (*CheckTxResponse, error)
+	// Query queries the application state.
 	Query(ctx context.Context, in *QueryRequest, opts ...grpc.CallOption) (*QueryResponse, error)
+	// Commit commits a block of transactions.
 	Commit(ctx context.Context, in *CommitRequest, opts ...grpc.CallOption) (*CommitResponse, error)
+	// InitChain initializes the blockchain.
 	InitChain(ctx context.Context, in *InitChainRequest, opts ...grpc.CallOption) (*InitChainResponse, error)
+	// ListSnapshots lists all the available snapshots.
 	ListSnapshots(ctx context.Context, in *ListSnapshotsRequest, opts ...grpc.CallOption) (*ListSnapshotsResponse, error)
+	// OfferSnapshot sends a snapshot offer.
 	OfferSnapshot(ctx context.Context, in *OfferSnapshotRequest, opts ...grpc.CallOption) (*OfferSnapshotResponse, error)
+	// LoadSnapshotChunk returns a chunk of snapshot.
 	LoadSnapshotChunk(ctx context.Context, in *LoadSnapshotChunkRequest, opts ...grpc.CallOption) (*LoadSnapshotChunkResponse, error)
+	// ApplySnapshotChunk applies a chunk of snapshot.
 	ApplySnapshotChunk(ctx context.Context, in *ApplySnapshotChunkRequest, opts ...grpc.CallOption) (*ApplySnapshotChunkResponse, error)
+	// PrepareProposal returns a proposal for the next block.
 	PrepareProposal(ctx context.Context, in *PrepareProposalRequest, opts ...grpc.CallOption) (*PrepareProposalResponse, error)
+	// ProcessProposal validates a proposal.
 	ProcessProposal(ctx context.Context, in *ProcessProposalRequest, opts ...grpc.CallOption) (*ProcessProposalResponse, error)
+	// ExtendVote extends a vote with application-injected data (vote extentions).
 	ExtendVote(ctx context.Context, in *ExtendVoteRequest, opts ...grpc.CallOption) (*ExtendVoteResponse, error)
+	// VerifyVoteExtension verifies a vote extension.
 	VerifyVoteExtension(ctx context.Context, in *VerifyVoteExtensionRequest, opts ...grpc.CallOption) (*VerifyVoteExtensionResponse, error)
+	// FinalizeBlock finalizes a block.
 	FinalizeBlock(ctx context.Context, in *FinalizeBlockRequest, opts ...grpc.CallOption) (*FinalizeBlockResponse, error)
 }
 
@@ -247,21 +263,37 @@ func (c *aBCIServiceClient) FinalizeBlock(ctx context.Context, in *FinalizeBlock
 
 // ABCIServiceServer is the server API for ABCIService service.
 type ABCIServiceServer interface {
+	// Echo returns back the same message it is sent.
 	Echo(context.Context, *EchoRequest) (*EchoResponse, error)
+	// Flush flushes the write buffer.
 	Flush(context.Context, *FlushRequest) (*FlushResponse, error)
+	// Info returns information about the application state.
 	Info(context.Context, *InfoRequest) (*InfoResponse, error)
+	// CheckTx validates a transaction.
 	CheckTx(context.Context, *CheckTxRequest) (*CheckTxResponse, error)
+	// Query queries the application state.
 	Query(context.Context, *QueryRequest) (*QueryResponse, error)
+	// Commit commits a block of transactions.
 	Commit(context.Context, *CommitRequest) (*CommitResponse, error)
+	// InitChain initializes the blockchain.
 	InitChain(context.Context, *InitChainRequest) (*InitChainResponse, error)
+	// ListSnapshots lists all the available snapshots.
 	ListSnapshots(context.Context, *ListSnapshotsRequest) (*ListSnapshotsResponse, error)
+	// OfferSnapshot sends a snapshot offer.
 	OfferSnapshot(context.Context, *OfferSnapshotRequest) (*OfferSnapshotResponse, error)
+	// LoadSnapshotChunk returns a chunk of snapshot.
 	LoadSnapshotChunk(context.Context, *LoadSnapshotChunkRequest) (*LoadSnapshotChunkResponse, error)
+	// ApplySnapshotChunk applies a chunk of snapshot.
 	ApplySnapshotChunk(context.Context, *ApplySnapshotChunkRequest) (*ApplySnapshotChunkResponse, error)
+	// PrepareProposal returns a proposal for the next block.
 	PrepareProposal(context.Context, *PrepareProposalRequest) (*PrepareProposalResponse, error)
+	// ProcessProposal validates a proposal.
 	ProcessProposal(context.Context, *ProcessProposalRequest) (*ProcessProposalResponse, error)
+	// ExtendVote extends a vote with application-injected data (vote extentions).
 	ExtendVote(context.Context, *ExtendVoteRequest) (*ExtendVoteResponse, error)
+	// VerifyVoteExtension verifies a vote extension.
 	VerifyVoteExtension(context.Context, *VerifyVoteExtensionRequest) (*VerifyVoteExtensionResponse, error)
+	// FinalizeBlock finalizes a block.
 	FinalizeBlock(context.Context, *FinalizeBlockRequest) (*FinalizeBlockResponse, error)
 }
 

--- a/api/cometbft/abci/v1/types.pb.go
+++ b/api/cometbft/abci/v1/types.pb.go
@@ -37,9 +37,12 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 type CheckTxType int32
 
 const (
+	// Unknown
 	CHECK_TX_TYPE_UNKNOWN CheckTxType = 0
+	// Recheck (2nd, 3rd, etc.)
 	CHECK_TX_TYPE_RECHECK CheckTxType = 1
-	CHECK_TX_TYPE_CHECK   CheckTxType = 2
+	// Check (1st time)
+	CHECK_TX_TYPE_CHECK CheckTxType = 2
 )
 
 var CheckTxType_name = map[int32]string{
@@ -62,14 +65,21 @@ func (CheckTxType) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_95dd8f7b670b96e3, []int{0}
 }
 
+// The result of offering a snapshot.
 type OfferSnapshotResult int32
 
 const (
-	OFFER_SNAPSHOT_RESULT_UNKNOWN       OfferSnapshotResult = 0
-	OFFER_SNAPSHOT_RESULT_ACCEPT        OfferSnapshotResult = 1
-	OFFER_SNAPSHOT_RESULT_ABORT         OfferSnapshotResult = 2
-	OFFER_SNAPSHOT_RESULT_REJECT        OfferSnapshotResult = 3
+	// Unknown result, abort all snapshot restoration
+	OFFER_SNAPSHOT_RESULT_UNKNOWN OfferSnapshotResult = 0
+	// Snapshot accepted, apply chunks
+	OFFER_SNAPSHOT_RESULT_ACCEPT OfferSnapshotResult = 1
+	// Abort all snapshot restoration
+	OFFER_SNAPSHOT_RESULT_ABORT OfferSnapshotResult = 2
+	// Reject this specific snapshot, try others
+	OFFER_SNAPSHOT_RESULT_REJECT OfferSnapshotResult = 3
+	// Reject all snapshots of this format, try others
 	OFFER_SNAPSHOT_RESULT_REJECT_FORMAT OfferSnapshotResult = 4
+	// Reject all snapshots from the sender(s), try others
 	OFFER_SNAPSHOT_RESULT_REJECT_SENDER OfferSnapshotResult = 5
 )
 
@@ -99,14 +109,21 @@ func (OfferSnapshotResult) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_95dd8f7b670b96e3, []int{1}
 }
 
+// The result of applying a snapshot chunk.
 type ApplySnapshotChunkResult int32
 
 const (
-	APPLY_SNAPSHOT_CHUNK_RESULT_UNKNOWN         ApplySnapshotChunkResult = 0
-	APPLY_SNAPSHOT_CHUNK_RESULT_ACCEPT          ApplySnapshotChunkResult = 1
-	APPLY_SNAPSHOT_CHUNK_RESULT_ABORT           ApplySnapshotChunkResult = 2
-	APPLY_SNAPSHOT_CHUNK_RESULT_RETRY           ApplySnapshotChunkResult = 3
-	APPLY_SNAPSHOT_CHUNK_RESULT_RETRY_SNAPSHOT  ApplySnapshotChunkResult = 4
+	// Unknown result, abort all snapshot restoration
+	APPLY_SNAPSHOT_CHUNK_RESULT_UNKNOWN ApplySnapshotChunkResult = 0
+	// Chunk successfully accepted
+	APPLY_SNAPSHOT_CHUNK_RESULT_ACCEPT ApplySnapshotChunkResult = 1
+	// Abort all snapshot restoration
+	APPLY_SNAPSHOT_CHUNK_RESULT_ABORT ApplySnapshotChunkResult = 2
+	// Retry chunk (combine with refetch and reject)
+	APPLY_SNAPSHOT_CHUNK_RESULT_RETRY ApplySnapshotChunkResult = 3
+	// Retry snapshot (combine with refetch and reject)
+	APPLY_SNAPSHOT_CHUNK_RESULT_RETRY_SNAPSHOT ApplySnapshotChunkResult = 4
+	// Reject this snapshot, try others
 	APPLY_SNAPSHOT_CHUNK_RESULT_REJECT_SNAPSHOT ApplySnapshotChunkResult = 5
 )
 
@@ -136,12 +153,16 @@ func (ApplySnapshotChunkResult) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_95dd8f7b670b96e3, []int{2}
 }
 
+// ProcessProposalStatus is the status of the proposal processing.
 type ProcessProposalStatus int32
 
 const (
+	// Unknown
 	PROCESS_PROPOSAL_STATUS_UNKNOWN ProcessProposalStatus = 0
-	PROCESS_PROPOSAL_STATUS_ACCEPT  ProcessProposalStatus = 1
-	PROCESS_PROPOSAL_STATUS_REJECT  ProcessProposalStatus = 2
+	// Accepted
+	PROCESS_PROPOSAL_STATUS_ACCEPT ProcessProposalStatus = 1
+	// Rejected
+	PROCESS_PROPOSAL_STATUS_REJECT ProcessProposalStatus = 2
 )
 
 var ProcessProposalStatus_name = map[int32]string{
@@ -164,11 +185,14 @@ func (ProcessProposalStatus) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_95dd8f7b670b96e3, []int{3}
 }
 
+// VerifyVoteExtensionStatus is the status of the vote extension verification.
 type VerifyVoteExtensionStatus int32
 
 const (
+	// Unknown
 	VERIFY_VOTE_EXTENSION_STATUS_UNKNOWN VerifyVoteExtensionStatus = 0
-	VERIFY_VOTE_EXTENSION_STATUS_ACCEPT  VerifyVoteExtensionStatus = 1
+	// Accepted
+	VERIFY_VOTE_EXTENSION_STATUS_ACCEPT VerifyVoteExtensionStatus = 1
 	// Rejecting the vote extension will reject the entire precommit by the sender.
 	// Incorrectly implementing this thus has liveness implications as it may affect
 	// CometBFT's ability to receive 2/3+ valid votes to finalize the block.
@@ -196,11 +220,15 @@ func (VerifyVoteExtensionStatus) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_95dd8f7b670b96e3, []int{4}
 }
 
+// The type of misbehavior committed by a validator.
 type MisbehaviorType int32
 
 const (
-	MISBEHAVIOR_TYPE_UNKNOWN             MisbehaviorType = 0
-	MISBEHAVIOR_TYPE_DUPLICATE_VOTE      MisbehaviorType = 1
+	// Unknown
+	MISBEHAVIOR_TYPE_UNKNOWN MisbehaviorType = 0
+	// Duplicate vote
+	MISBEHAVIOR_TYPE_DUPLICATE_VOTE MisbehaviorType = 1
+	// Light client attack
 	MISBEHAVIOR_TYPE_LIGHT_CLIENT_ATTACK MisbehaviorType = 2
 )
 
@@ -224,7 +252,10 @@ func (MisbehaviorType) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_95dd8f7b670b96e3, []int{5}
 }
 
+// Request represents a request to the ABCI application.
 type Request struct {
+	// Sum of all possible messages.
+	//
 	// Types that are valid to be assigned to Value:
 	//	*Request_Echo
 	//	*Request_Flush
@@ -491,6 +522,7 @@ func (*Request) XXX_OneofWrappers() []interface{} {
 	}
 }
 
+// EchoRequest is a request to "echo" the given string.
 type EchoRequest struct {
 	Message string `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
 }
@@ -535,6 +567,7 @@ func (m *EchoRequest) GetMessage() string {
 	return ""
 }
 
+// FlushRequest is a request to flush the write buffer.
 type FlushRequest struct {
 }
 
@@ -571,6 +604,7 @@ func (m *FlushRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_FlushRequest proto.InternalMessageInfo
 
+// InfoRequest is a request for the ABCI application version.
 type InfoRequest struct {
 	Version      string `protobuf:"bytes,1,opt,name=version,proto3" json:"version,omitempty"`
 	BlockVersion uint64 `protobuf:"varint,2,opt,name=block_version,json=blockVersion,proto3" json:"block_version,omitempty"`
@@ -639,6 +673,7 @@ func (m *InfoRequest) GetAbciVersion() string {
 	return ""
 }
 
+// InitChainRequest is a request to initialize the blockchain.
 type InitChainRequest struct {
 	Time            time.Time           `protobuf:"bytes,1,opt,name=time,proto3,stdtime" json:"time"`
 	ChainId         string              `protobuf:"bytes,2,opt,name=chain_id,json=chainId,proto3" json:"chain_id,omitempty"`
@@ -723,6 +758,7 @@ func (m *InitChainRequest) GetInitialHeight() int64 {
 	return 0
 }
 
+// QueryRequest is a request to query the application state.
 type QueryRequest struct {
 	Data   []byte `protobuf:"bytes,1,opt,name=data,proto3" json:"data,omitempty"`
 	Path   string `protobuf:"bytes,2,opt,name=path,proto3" json:"path,omitempty"`
@@ -791,6 +827,7 @@ func (m *QueryRequest) GetProve() bool {
 	return false
 }
 
+// CheckTxRequest is a request to check that the transaction is valid.
 type CheckTxRequest struct {
 	Tx   []byte      `protobuf:"bytes,1,opt,name=tx,proto3" json:"tx,omitempty"`
 	Type CheckTxType `protobuf:"varint,3,opt,name=type,proto3,enum=cometbft.abci.v1.CheckTxType" json:"type,omitempty"`
@@ -843,6 +880,7 @@ func (m *CheckTxRequest) GetType() CheckTxType {
 	return CHECK_TX_TYPE_UNKNOWN
 }
 
+// CommitRequest is a request to commit the pending application state.
 type CommitRequest struct {
 }
 
@@ -879,7 +917,7 @@ func (m *CommitRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_CommitRequest proto.InternalMessageInfo
 
-// Request to list available snapshots
+// Request to list available snapshots.
 type ListSnapshotsRequest struct {
 }
 
@@ -916,7 +954,7 @@ func (m *ListSnapshotsRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_ListSnapshotsRequest proto.InternalMessageInfo
 
-// Request offering a snapshot to the application
+// Request offering a snapshot to the application.
 type OfferSnapshotRequest struct {
 	Snapshot *Snapshot `protobuf:"bytes,1,opt,name=snapshot,proto3" json:"snapshot,omitempty"`
 	AppHash  []byte    `protobuf:"bytes,2,opt,name=app_hash,json=appHash,proto3" json:"app_hash,omitempty"`
@@ -969,7 +1007,7 @@ func (m *OfferSnapshotRequest) GetAppHash() []byte {
 	return nil
 }
 
-// Request to load a snapshot chunk
+// Request to load a snapshot chunk.
 type LoadSnapshotChunkRequest struct {
 	Height uint64 `protobuf:"varint,1,opt,name=height,proto3" json:"height,omitempty"`
 	Format uint32 `protobuf:"varint,2,opt,name=format,proto3" json:"format,omitempty"`
@@ -1030,7 +1068,7 @@ func (m *LoadSnapshotChunkRequest) GetChunk() uint32 {
 	return 0
 }
 
-// Request to apply a snapshot chunk
+// Request to apply a snapshot chunk.
 type ApplySnapshotChunkRequest struct {
 	Index  uint32 `protobuf:"varint,1,opt,name=index,proto3" json:"index,omitempty"`
 	Chunk  []byte `protobuf:"bytes,2,opt,name=chunk,proto3" json:"chunk,omitempty"`
@@ -1091,6 +1129,8 @@ func (m *ApplySnapshotChunkRequest) GetSender() string {
 	return ""
 }
 
+// PrepareProposalRequest is a request for the ABCI application to prepare a new
+// block proposal.
 type PrepareProposalRequest struct {
 	// the modified transactions cannot exceed this size.
 	MaxTxBytes int64 `protobuf:"varint,1,opt,name=max_tx_bytes,json=maxTxBytes,proto3" json:"max_tx_bytes,omitempty"`
@@ -1195,6 +1235,8 @@ func (m *PrepareProposalRequest) GetProposerAddress() []byte {
 	return nil
 }
 
+// ProcessProposalRequest is a request for the ABCI application to process a proposal
+// received from another validator.
 type ProcessProposalRequest struct {
 	Txs                [][]byte      `protobuf:"bytes,1,rep,name=txs,proto3" json:"txs,omitempty"`
 	ProposedLastCommit CommitInfo    `protobuf:"bytes,2,opt,name=proposed_last_commit,json=proposedLastCommit,proto3" json:"proposed_last_commit"`
@@ -1297,7 +1339,7 @@ func (m *ProcessProposalRequest) GetProposerAddress() []byte {
 	return nil
 }
 
-// Extends a vote with application-injected data
+// ExtendVoteRequest extends a precommit vote with application-injected data.
 type ExtendVoteRequest struct {
 	// the hash of the block that this vote may be referring to
 	Hash []byte `protobuf:"bytes,1,opt,name=hash,proto3" json:"hash,omitempty"`
@@ -1402,7 +1444,8 @@ func (m *ExtendVoteRequest) GetProposerAddress() []byte {
 	return nil
 }
 
-// Request to verify a vote extension
+// VerifyVoteExtensionRequest is a request for the application to verify a vote extension
+// produced by a different validator.
 type VerifyVoteExtensionRequest struct {
 	// the hash of the block that this received vote corresponds to
 	Hash []byte `protobuf:"bytes,1,opt,name=hash,proto3" json:"hash,omitempty"`
@@ -1473,6 +1516,7 @@ func (m *VerifyVoteExtensionRequest) GetVoteExtension() []byte {
 	return nil
 }
 
+// FinalizeBlockRequest is a request to finalize the block.
 type FinalizeBlockRequest struct {
 	Txs               [][]byte      `protobuf:"bytes,1,rep,name=txs,proto3" json:"txs,omitempty"`
 	DecidedLastCommit CommitInfo    `protobuf:"bytes,2,opt,name=decided_last_commit,json=decidedLastCommit,proto3" json:"decided_last_commit"`
@@ -1575,7 +1619,10 @@ func (m *FinalizeBlockRequest) GetProposerAddress() []byte {
 	return nil
 }
 
+// Response represents a response from the ABCI application.
 type Response struct {
+	// Sum of all possible messages.
+	//
 	// Types that are valid to be assigned to Value:
 	//
 	//	*Response_Exception
@@ -1901,6 +1948,7 @@ func (m *ExceptionResponse) GetError() string {
 	return ""
 }
 
+// EchoResponse indicates that the connection is still alive.
 type EchoResponse struct {
 	Message string `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
 }
@@ -1945,6 +1993,7 @@ func (m *EchoResponse) GetMessage() string {
 	return ""
 }
 
+// FlushResponse indicates that the write buffer was flushed.
 type FlushResponse struct {
 }
 
@@ -1981,6 +2030,7 @@ func (m *FlushResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_FlushResponse proto.InternalMessageInfo
 
+// InfoResponse contains the ABCI application version information.
 type InfoResponse struct {
 	Data             string `protobuf:"bytes,1,opt,name=data,proto3" json:"data,omitempty"`
 	Version          string `protobuf:"bytes,2,opt,name=version,proto3" json:"version,omitempty"`
@@ -2057,6 +2107,8 @@ func (m *InfoResponse) GetLastBlockAppHash() []byte {
 	return nil
 }
 
+// InitChainResponse contains the ABCI application's hash and updates to the
+// validator set and/or the consensus params, if any.
 type InitChainResponse struct {
 	ConsensusParams *v1.ConsensusParams `protobuf:"bytes,1,opt,name=consensus_params,json=consensusParams,proto3" json:"consensus_params,omitempty"`
 	Validators      []ValidatorUpdate   `protobuf:"bytes,2,rep,name=validators,proto3" json:"validators"`
@@ -2117,6 +2169,7 @@ func (m *InitChainResponse) GetAppHash() []byte {
 	return nil
 }
 
+// QueryResponse contains the ABCI application data along with a proof.
 type QueryResponse struct {
 	Code uint32 `protobuf:"varint,1,opt,name=code,proto3" json:"code,omitempty"`
 	// bytes data = 2; // use "value" instead.
@@ -2226,6 +2279,8 @@ func (m *QueryResponse) GetCodespace() string {
 	return ""
 }
 
+// CheckTxResponse shows if the transaction was deemed valid by the ABCI
+// application.
 type CheckTxResponse struct {
 	Code      uint32  `protobuf:"varint,1,opt,name=code,proto3" json:"code,omitempty"`
 	Data      []byte  `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`
@@ -2326,6 +2381,7 @@ func (m *CheckTxResponse) GetCodespace() string {
 	return ""
 }
 
+// CommitResponse indicates how much blocks should CometBFT retain.
 type CommitResponse struct {
 	RetainHeight int64 `protobuf:"varint,3,opt,name=retain_height,json=retainHeight,proto3" json:"retain_height,omitempty"`
 }
@@ -2370,6 +2426,7 @@ func (m *CommitResponse) GetRetainHeight() int64 {
 	return 0
 }
 
+// ListSnapshotsResponse contains the list of snapshots.
 type ListSnapshotsResponse struct {
 	Snapshots []*Snapshot `protobuf:"bytes,1,rep,name=snapshots,proto3" json:"snapshots,omitempty"`
 }
@@ -2414,6 +2471,8 @@ func (m *ListSnapshotsResponse) GetSnapshots() []*Snapshot {
 	return nil
 }
 
+// OfferSnapshotResponse indicates the ABCI application decision whenever to
+// provide a snapshot to the requester or not.
 type OfferSnapshotResponse struct {
 	Result OfferSnapshotResult `protobuf:"varint,1,opt,name=result,proto3,enum=cometbft.abci.v1.OfferSnapshotResult" json:"result,omitempty"`
 }
@@ -2458,6 +2517,7 @@ func (m *OfferSnapshotResponse) GetResult() OfferSnapshotResult {
 	return OFFER_SNAPSHOT_RESULT_UNKNOWN
 }
 
+// LoadSnapshotChunkResponse returns a snapshot's chunk.
 type LoadSnapshotChunkResponse struct {
 	Chunk []byte `protobuf:"bytes,1,opt,name=chunk,proto3" json:"chunk,omitempty"`
 }
@@ -2502,6 +2562,7 @@ func (m *LoadSnapshotChunkResponse) GetChunk() []byte {
 	return nil
 }
 
+// ApplySnapshotChunkResponse returns a result of applying the specified chunk.
 type ApplySnapshotChunkResponse struct {
 	Result        ApplySnapshotChunkResult `protobuf:"varint,1,opt,name=result,proto3,enum=cometbft.abci.v1.ApplySnapshotChunkResult" json:"result,omitempty"`
 	RefetchChunks []uint32                 `protobuf:"varint,2,rep,packed,name=refetch_chunks,json=refetchChunks,proto3" json:"refetch_chunks,omitempty"`
@@ -2562,6 +2623,7 @@ func (m *ApplySnapshotChunkResponse) GetRejectSenders() []string {
 	return nil
 }
 
+// PrepareProposalResponse contains a list of transactions, which will form a block.
 type PrepareProposalResponse struct {
 	Txs [][]byte `protobuf:"bytes,1,rep,name=txs,proto3" json:"txs,omitempty"`
 }
@@ -2606,6 +2668,8 @@ func (m *PrepareProposalResponse) GetTxs() [][]byte {
 	return nil
 }
 
+// ProcessProposalResponse indicates the ABCI application's decision whenever
+// the given proposal should be accepted or not.
 type ProcessProposalResponse struct {
 	Status ProcessProposalStatus `protobuf:"varint,1,opt,name=status,proto3,enum=cometbft.abci.v1.ProcessProposalStatus" json:"status,omitempty"`
 }
@@ -2650,6 +2714,8 @@ func (m *ProcessProposalResponse) GetStatus() ProcessProposalStatus {
 	return PROCESS_PROPOSAL_STATUS_UNKNOWN
 }
 
+// ExtendVoteResponse contains the vote extension that the application would like to
+// attach to its next precommit vote.
 type ExtendVoteResponse struct {
 	VoteExtension []byte `protobuf:"bytes,1,opt,name=vote_extension,json=voteExtension,proto3" json:"vote_extension,omitempty"`
 }
@@ -2694,6 +2760,8 @@ func (m *ExtendVoteResponse) GetVoteExtension() []byte {
 	return nil
 }
 
+// VerifyVoteExtensionResponse indicates the ABCI application's decision
+// whenever the vote extension should be accepted or not.
 type VerifyVoteExtensionResponse struct {
 	Status VerifyVoteExtensionStatus `protobuf:"varint,1,opt,name=status,proto3,enum=cometbft.abci.v1.VerifyVoteExtensionStatus" json:"status,omitempty"`
 }
@@ -2738,6 +2806,7 @@ func (m *VerifyVoteExtensionResponse) GetStatus() VerifyVoteExtensionStatus {
 	return VERIFY_VOTE_EXTENSION_STATUS_UNKNOWN
 }
 
+// FinalizeBlockResponse contains the result of executing the block.
 type FinalizeBlockResponse struct {
 	// set of block events emmitted as part of executing the block
 	Events []Event `protobuf:"bytes,1,rep,name=events,proto3" json:"events,omitempty"`
@@ -2823,6 +2892,7 @@ func (m *FinalizeBlockResponse) GetAppHash() []byte {
 	return nil
 }
 
+// CommitInfo contains votes for the particular round.
 type CommitInfo struct {
 	Round int32      `protobuf:"varint,1,opt,name=round,proto3" json:"round,omitempty"`
 	Votes []VoteInfo `protobuf:"bytes,2,rep,name=votes,proto3" json:"votes"`
@@ -3225,6 +3295,7 @@ func (m *TxResult) GetResult() ExecTxResult {
 	return ExecTxResult{}
 }
 
+// Validator in the validator set.
 type Validator struct {
 	Address []byte `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
 	// PubKey pub_key = 2 [(gogoproto.nullable)=false];
@@ -3278,6 +3349,7 @@ func (m *Validator) GetPower() int64 {
 	return 0
 }
 
+// ValidatorUpdate is a singular update to a validator set.
 type ValidatorUpdate struct {
 	PubKey v11.PublicKey `protobuf:"bytes,1,opt,name=pub_key,json=pubKey,proto3" json:"pub_key"`
 	Power  int64         `protobuf:"varint,2,opt,name=power,proto3" json:"power,omitempty"`
@@ -3330,6 +3402,7 @@ func (m *ValidatorUpdate) GetPower() int64 {
 	return 0
 }
 
+// VoteInfo contains the information about the vote.
 type VoteInfo struct {
 	Validator   Validator      `protobuf:"bytes,1,opt,name=validator,proto3" json:"validator"`
 	BlockIdFlag v1.BlockIDFlag `protobuf:"varint,3,opt,name=block_id_flag,json=blockIdFlag,proto3,enum=cometbft.types.v1.BlockIDFlag" json:"block_id_flag,omitempty"`
@@ -3382,6 +3455,7 @@ func (m *VoteInfo) GetBlockIdFlag() v1.BlockIDFlag {
 	return v1.BlockIDFlagUnknown
 }
 
+// ExtendedVoteInfo extends VoteInfo with the vote extentions (non-deterministic).
 type ExtendedVoteInfo struct {
 	// The validator that sent the vote.
 	Validator Validator `protobuf:"bytes,1,opt,name=validator,proto3" json:"validator"`
@@ -3454,6 +3528,7 @@ func (m *ExtendedVoteInfo) GetBlockIdFlag() v1.BlockIDFlag {
 	return v1.BlockIDFlagUnknown
 }
 
+// Misbehavior is a type of misbehavior committed by a validator.
 type Misbehavior struct {
 	Type MisbehaviorType `protobuf:"varint,1,opt,name=type,proto3,enum=cometbft.abci.v1.MisbehaviorType" json:"type,omitempty"`
 	// The offending validator
@@ -3536,6 +3611,7 @@ func (m *Misbehavior) GetTotalVotingPower() int64 {
 	return 0
 }
 
+// Snapshot of the ABCI application state.
 type Snapshot struct {
 	Height   uint64 `protobuf:"varint,1,opt,name=height,proto3" json:"height,omitempty"`
 	Format   uint32 `protobuf:"varint,2,opt,name=format,proto3" json:"format,omitempty"`

--- a/api/cometbft/abci/v1beta1/types.pb.go
+++ b/api/cometbft/abci/v1beta1/types.pb.go
@@ -34,10 +34,13 @@ var _ = time.Kitchen
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// Type of the transaction check request.
 type CheckTxType int32
 
 const (
-	CheckTxType_New     CheckTxType = 0
+	// New
+	CheckTxType_New CheckTxType = 0
+	// Recheck (2nd, 3rd, etc.)
 	CheckTxType_Recheck CheckTxType = 1
 )
 
@@ -59,11 +62,15 @@ func (CheckTxType) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_916eac2194a40aed, []int{0}
 }
 
+// The type of evidence.
 type EvidenceType int32
 
 const (
-	EvidenceType_UNKNOWN             EvidenceType = 0
-	EvidenceType_DUPLICATE_VOTE      EvidenceType = 1
+	// Unknown
+	EvidenceType_UNKNOWN EvidenceType = 0
+	// Duplicate vote
+	EvidenceType_DUPLICATE_VOTE EvidenceType = 1
+	// Light client attack
 	EvidenceType_LIGHT_CLIENT_ATTACK EvidenceType = 2
 )
 
@@ -87,14 +94,21 @@ func (EvidenceType) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_916eac2194a40aed, []int{1}
 }
 
+// The status code.
 type ResponseOfferSnapshot_Result int32
 
 const (
-	ResponseOfferSnapshot_UNKNOWN       ResponseOfferSnapshot_Result = 0
-	ResponseOfferSnapshot_ACCEPT        ResponseOfferSnapshot_Result = 1
-	ResponseOfferSnapshot_ABORT         ResponseOfferSnapshot_Result = 2
-	ResponseOfferSnapshot_REJECT        ResponseOfferSnapshot_Result = 3
+	// Unknown result, abort all snapshot restoration
+	ResponseOfferSnapshot_UNKNOWN ResponseOfferSnapshot_Result = 0
+	// Snapshot accepted, apply chunks
+	ResponseOfferSnapshot_ACCEPT ResponseOfferSnapshot_Result = 1
+	// Abort all snapshot restoration
+	ResponseOfferSnapshot_ABORT ResponseOfferSnapshot_Result = 2
+	// Reject this specific snapshot, try others
+	ResponseOfferSnapshot_REJECT ResponseOfferSnapshot_Result = 3
+	// Reject all snapshots of this format, try others
 	ResponseOfferSnapshot_REJECT_FORMAT ResponseOfferSnapshot_Result = 4
+	// Reject all snapshots from the sender(s), try others
 	ResponseOfferSnapshot_REJECT_SENDER ResponseOfferSnapshot_Result = 5
 )
 
@@ -124,14 +138,21 @@ func (ResponseOfferSnapshot_Result) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_916eac2194a40aed, []int{30, 0}
 }
 
+// The status code.
 type ResponseApplySnapshotChunk_Result int32
 
 const (
-	ResponseApplySnapshotChunk_UNKNOWN         ResponseApplySnapshotChunk_Result = 0
-	ResponseApplySnapshotChunk_ACCEPT          ResponseApplySnapshotChunk_Result = 1
-	ResponseApplySnapshotChunk_ABORT           ResponseApplySnapshotChunk_Result = 2
-	ResponseApplySnapshotChunk_RETRY           ResponseApplySnapshotChunk_Result = 3
-	ResponseApplySnapshotChunk_RETRY_SNAPSHOT  ResponseApplySnapshotChunk_Result = 4
+	// Unknown result, abort all snapshot restoration
+	ResponseApplySnapshotChunk_UNKNOWN ResponseApplySnapshotChunk_Result = 0
+	// Chunk successfully accepted
+	ResponseApplySnapshotChunk_ACCEPT ResponseApplySnapshotChunk_Result = 1
+	// Abort all snapshot restoration
+	ResponseApplySnapshotChunk_ABORT ResponseApplySnapshotChunk_Result = 2
+	// Retry chunk (combine with refetch and reject)
+	ResponseApplySnapshotChunk_RETRY ResponseApplySnapshotChunk_Result = 3
+	// Retry snapshot (combine with refetch and reject)
+	ResponseApplySnapshotChunk_RETRY_SNAPSHOT ResponseApplySnapshotChunk_Result = 4
+	// Reject this snapshot, try others
 	ResponseApplySnapshotChunk_REJECT_SNAPSHOT ResponseApplySnapshotChunk_Result = 5
 )
 
@@ -161,7 +182,10 @@ func (ResponseApplySnapshotChunk_Result) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_916eac2194a40aed, []int{32, 0}
 }
 
+// Request represents a request to the ABCI application.
 type Request struct {
+	// Sum of all possible messages.
+	//
 	// Types that are valid to be assigned to Value:
 	//	*Request_Echo
 	//	*Request_Flush
@@ -415,6 +439,7 @@ func (*Request) XXX_OneofWrappers() []interface{} {
 	}
 }
 
+// RequestEcho is a request to "echo" the given string.
 type RequestEcho struct {
 	Message string `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
 }
@@ -459,6 +484,7 @@ func (m *RequestEcho) GetMessage() string {
 	return ""
 }
 
+// RequestFlush is a request to flush the write buffer.
 type RequestFlush struct {
 }
 
@@ -495,6 +521,7 @@ func (m *RequestFlush) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_RequestFlush proto.InternalMessageInfo
 
+// RequestInfo is a request for the ABCI application version.
 type RequestInfo struct {
 	Version      string `protobuf:"bytes,1,opt,name=version,proto3" json:"version,omitempty"`
 	BlockVersion uint64 `protobuf:"varint,2,opt,name=block_version,json=blockVersion,proto3" json:"block_version,omitempty"`
@@ -608,6 +635,7 @@ func (m *RequestSetOption) GetValue() string {
 	return ""
 }
 
+// RequestInitChain is a request to initialize the blockchain.
 type RequestInitChain struct {
 	Time            time.Time         `protobuf:"bytes,1,opt,name=time,proto3,stdtime" json:"time"`
 	ChainId         string            `protobuf:"bytes,2,opt,name=chain_id,json=chainId,proto3" json:"chain_id,omitempty"`
@@ -692,6 +720,7 @@ func (m *RequestInitChain) GetInitialHeight() int64 {
 	return 0
 }
 
+// RequestQuery is a request to query the application state.
 type RequestQuery struct {
 	Data   []byte `protobuf:"bytes,1,opt,name=data,proto3" json:"data,omitempty"`
 	Path   string `protobuf:"bytes,2,opt,name=path,proto3" json:"path,omitempty"`
@@ -760,6 +789,7 @@ func (m *RequestQuery) GetProve() bool {
 	return false
 }
 
+// RequestBeginBlock indicates the beginning of commiting the block.
 type RequestBeginBlock struct {
 	Hash                []byte         `protobuf:"bytes,1,opt,name=hash,proto3" json:"hash,omitempty"`
 	Header              v1beta1.Header `protobuf:"bytes,2,opt,name=header,proto3" json:"header"`
@@ -828,6 +858,7 @@ func (m *RequestBeginBlock) GetByzantineValidators() []Evidence {
 	return nil
 }
 
+// RequestCheckTx is a request to check the transaction.
 type RequestCheckTx struct {
 	Tx   []byte      `protobuf:"bytes,1,opt,name=tx,proto3" json:"tx,omitempty"`
 	Type CheckTxType `protobuf:"varint,2,opt,name=type,proto3,enum=cometbft.abci.v1beta1.CheckTxType" json:"type,omitempty"`
@@ -880,6 +911,7 @@ func (m *RequestCheckTx) GetType() CheckTxType {
 	return CheckTxType_New
 }
 
+// RequestDeliverTx is a request to apply the transaction.
 type RequestDeliverTx struct {
 	Tx []byte `protobuf:"bytes,1,opt,name=tx,proto3" json:"tx,omitempty"`
 }
@@ -924,6 +956,7 @@ func (m *RequestDeliverTx) GetTx() []byte {
 	return nil
 }
 
+// RequestEndBlock indicates the end of committing the block.
 type RequestEndBlock struct {
 	Height int64 `protobuf:"varint,1,opt,name=height,proto3" json:"height,omitempty"`
 }
@@ -968,6 +1001,7 @@ func (m *RequestEndBlock) GetHeight() int64 {
 	return 0
 }
 
+// RequestCommit is a request to commit the pending application state.
 type RequestCommit struct {
 }
 
@@ -1216,7 +1250,10 @@ func (m *RequestApplySnapshotChunk) GetSender() string {
 	return ""
 }
 
+// Response represents a response from the ABCI application.
 type Response struct {
+	// Sum of all possible messages.
+	//
 	// Types that are valid to be assigned to Value:
 	//
 	//	*Response_Exception
@@ -1529,6 +1566,7 @@ func (m *ResponseException) GetError() string {
 	return ""
 }
 
+// ResponseEcho indicates that the connection is still alive.
 type ResponseEcho struct {
 	Message string `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
 }
@@ -1573,6 +1611,7 @@ func (m *ResponseEcho) GetMessage() string {
 	return ""
 }
 
+// ResponseFlush indicates that the ABCI application state was flushed?
 type ResponseFlush struct {
 }
 
@@ -1609,6 +1648,7 @@ func (m *ResponseFlush) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_ResponseFlush proto.InternalMessageInfo
 
+// ResponseInfo contains the ABCI application version information.
 type ResponseInfo struct {
 	Data             string `protobuf:"bytes,1,opt,name=data,proto3" json:"data,omitempty"`
 	Version          string `protobuf:"bytes,2,opt,name=version,proto3" json:"version,omitempty"`
@@ -1747,6 +1787,8 @@ func (m *ResponseSetOption) GetInfo() string {
 	return ""
 }
 
+// ResponseInitChain contains the ABCI application's hash and updates to the
+// validator set and/or the consensus params, if any.
 type ResponseInitChain struct {
 	ConsensusParams *ConsensusParams  `protobuf:"bytes,1,opt,name=consensus_params,json=consensusParams,proto3" json:"consensus_params,omitempty"`
 	Validators      []ValidatorUpdate `protobuf:"bytes,2,rep,name=validators,proto3" json:"validators"`
@@ -1807,6 +1849,7 @@ func (m *ResponseInitChain) GetAppHash() []byte {
 	return nil
 }
 
+// ResponseQuery contains the ABCI application data along with a proof.
 type ResponseQuery struct {
 	Code uint32 `protobuf:"varint,1,opt,name=code,proto3" json:"code,omitempty"`
 	// bytes data = 2; // use "value" instead.
@@ -1916,6 +1959,7 @@ func (m *ResponseQuery) GetCodespace() string {
 	return ""
 }
 
+// ResponseBeginBlock contains a list of block-level events.
 type ResponseBeginBlock struct {
 	Events []Event `protobuf:"bytes,1,rep,name=events,proto3" json:"events,omitempty"`
 }
@@ -1960,6 +2004,8 @@ func (m *ResponseBeginBlock) GetEvents() []Event {
 	return nil
 }
 
+// ResponseCheckTx shows if the transaction was deemed valid by the ABCI
+// application.
 type ResponseCheckTx struct {
 	Code      uint32  `protobuf:"varint,1,opt,name=code,proto3" json:"code,omitempty"`
 	Data      []byte  `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`
@@ -2086,6 +2132,8 @@ func (m *ResponseCheckTx) GetMempoolError() string {
 	return ""
 }
 
+// ResponseDeliverTx contains a result of committing the given transaction and a
+// list of events.
 type ResponseDeliverTx struct {
 	Code      uint32  `protobuf:"varint,1,opt,name=code,proto3" json:"code,omitempty"`
 	Data      []byte  `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`
@@ -2186,6 +2234,7 @@ func (m *ResponseDeliverTx) GetCodespace() string {
 	return ""
 }
 
+// ResponseEndBlock contains updates to consensus params and/or validator set changes, if any.
 type ResponseEndBlock struct {
 	ValidatorUpdates      []ValidatorUpdate `protobuf:"bytes,1,rep,name=validator_updates,json=validatorUpdates,proto3" json:"validator_updates"`
 	ConsensusParamUpdates *ConsensusParams  `protobuf:"bytes,2,opt,name=consensus_param_updates,json=consensusParamUpdates,proto3" json:"consensus_param_updates,omitempty"`
@@ -2246,6 +2295,7 @@ func (m *ResponseEndBlock) GetEvents() []Event {
 	return nil
 }
 
+// ResponseCommit indicates how much blocks should CometBFT retain.
 type ResponseCommit struct {
 	// reserve 1
 	Data         []byte `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`
@@ -2299,6 +2349,7 @@ func (m *ResponseCommit) GetRetainHeight() int64 {
 	return 0
 }
 
+// ResponseListSnapshots contains the list of snapshots.
 type ResponseListSnapshots struct {
 	Snapshots []*Snapshot `protobuf:"bytes,1,rep,name=snapshots,proto3" json:"snapshots,omitempty"`
 }
@@ -2343,6 +2394,8 @@ func (m *ResponseListSnapshots) GetSnapshots() []*Snapshot {
 	return nil
 }
 
+// ResponseOfferSnapshot indicates the ABCI application decision whenever to
+// provide a snapshot to the requester or not.
 type ResponseOfferSnapshot struct {
 	Result ResponseOfferSnapshot_Result `protobuf:"varint,1,opt,name=result,proto3,enum=cometbft.abci.v1beta1.ResponseOfferSnapshot_Result" json:"result,omitempty"`
 }
@@ -2387,6 +2440,7 @@ func (m *ResponseOfferSnapshot) GetResult() ResponseOfferSnapshot_Result {
 	return ResponseOfferSnapshot_UNKNOWN
 }
 
+// ResponseLoadSnapshotChunk returns a snapshot's chunk.
 type ResponseLoadSnapshotChunk struct {
 	Chunk []byte `protobuf:"bytes,1,opt,name=chunk,proto3" json:"chunk,omitempty"`
 }
@@ -2431,6 +2485,7 @@ func (m *ResponseLoadSnapshotChunk) GetChunk() []byte {
 	return nil
 }
 
+// ResponseApplySnapshotChunk returns a result of applying the specified chunk.
 type ResponseApplySnapshotChunk struct {
 	Result        ResponseApplySnapshotChunk_Result `protobuf:"varint,1,opt,name=result,proto3,enum=cometbft.abci.v1beta1.ResponseApplySnapshotChunk_Result" json:"result,omitempty"`
 	RefetchChunks []uint32                          `protobuf:"varint,2,rep,packed,name=refetch_chunks,json=refetchChunks,proto3" json:"refetch_chunks,omitempty"`
@@ -2616,6 +2671,7 @@ func (m *BlockParams) GetMaxGas() int64 {
 	return 0
 }
 
+// LastCommitInfo contains votes for the particular round.
 type LastCommitInfo struct {
 	Round int32      `protobuf:"varint,1,opt,name=round,proto3" json:"round,omitempty"`
 	Votes []VoteInfo `protobuf:"bytes,2,rep,name=votes,proto3" json:"votes"`
@@ -2855,6 +2911,7 @@ func (m *TxResult) GetResult() ResponseDeliverTx {
 	return ResponseDeliverTx{}
 }
 
+// Validator in the validator set.
 type Validator struct {
 	Address []byte `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
 	// PubKey pub_key = 2 [(gogoproto.nullable)=false];
@@ -2908,6 +2965,7 @@ func (m *Validator) GetPower() int64 {
 	return 0
 }
 
+// ValidatorUpdate is a singular update to a validator set.
 type ValidatorUpdate struct {
 	PubKey v1.PublicKey `protobuf:"bytes,1,opt,name=pub_key,json=pubKey,proto3" json:"pub_key"`
 	Power  int64        `protobuf:"varint,2,opt,name=power,proto3" json:"power,omitempty"`
@@ -2960,6 +3018,7 @@ func (m *ValidatorUpdate) GetPower() int64 {
 	return 0
 }
 
+// VoteInfo contains the information about the vote.
 type VoteInfo struct {
 	Validator       Validator `protobuf:"bytes,1,opt,name=validator,proto3" json:"validator"`
 	SignedLastBlock bool      `protobuf:"varint,2,opt,name=signed_last_block,json=signedLastBlock,proto3" json:"signed_last_block,omitempty"`
@@ -3012,6 +3071,7 @@ func (m *VoteInfo) GetSignedLastBlock() bool {
 	return false
 }
 
+// Evidence of a misbehavior committed by a validator.
 type Evidence struct {
 	Type EvidenceType `protobuf:"varint,1,opt,name=type,proto3,enum=cometbft.abci.v1beta1.EvidenceType" json:"type,omitempty"`
 	// The offending validator
@@ -3094,6 +3154,7 @@ func (m *Evidence) GetTotalVotingPower() int64 {
 	return 0
 }
 
+// Snapshot of the ABCI application state.
 type Snapshot struct {
 	Height   uint64 `protobuf:"varint,1,opt,name=height,proto3" json:"height,omitempty"`
 	Format   uint32 `protobuf:"varint,2,opt,name=format,proto3" json:"format,omitempty"`
@@ -3416,20 +3477,35 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type ABCIApplicationClient interface {
+	// Echo returns back the same message it is sent.
 	Echo(ctx context.Context, in *RequestEcho, opts ...grpc.CallOption) (*ResponseEcho, error)
+	// Flush flushes the write buffer.
 	Flush(ctx context.Context, in *RequestFlush, opts ...grpc.CallOption) (*ResponseFlush, error)
+	// Info returns information about the application state.
 	Info(ctx context.Context, in *RequestInfo, opts ...grpc.CallOption) (*ResponseInfo, error)
+	// SetOption sets a parameter in the application.
 	SetOption(ctx context.Context, in *RequestSetOption, opts ...grpc.CallOption) (*ResponseSetOption, error)
+	// DeliverTx applies a transaction.
 	DeliverTx(ctx context.Context, in *RequestDeliverTx, opts ...grpc.CallOption) (*ResponseDeliverTx, error)
+	// CheckTx validates a transaction.
 	CheckTx(ctx context.Context, in *RequestCheckTx, opts ...grpc.CallOption) (*ResponseCheckTx, error)
+	// Query queries the application state.
 	Query(ctx context.Context, in *RequestQuery, opts ...grpc.CallOption) (*ResponseQuery, error)
+	// Commit commits a block of transactions.
 	Commit(ctx context.Context, in *RequestCommit, opts ...grpc.CallOption) (*ResponseCommit, error)
+	// InitChain initializes the blockchain.
 	InitChain(ctx context.Context, in *RequestInitChain, opts ...grpc.CallOption) (*ResponseInitChain, error)
+	// BeginBlock signals the beginning of a block.
 	BeginBlock(ctx context.Context, in *RequestBeginBlock, opts ...grpc.CallOption) (*ResponseBeginBlock, error)
+	// EndBlock signals the end of a block, returns changes to the validator set.
 	EndBlock(ctx context.Context, in *RequestEndBlock, opts ...grpc.CallOption) (*ResponseEndBlock, error)
+	// ListSnapshots lists all the available snapshots.
 	ListSnapshots(ctx context.Context, in *RequestListSnapshots, opts ...grpc.CallOption) (*ResponseListSnapshots, error)
+	// OfferSnapshot sends a snapshot offer.
 	OfferSnapshot(ctx context.Context, in *RequestOfferSnapshot, opts ...grpc.CallOption) (*ResponseOfferSnapshot, error)
+	// LoadSnapshotChunk returns a chunk of snapshot.
 	LoadSnapshotChunk(ctx context.Context, in *RequestLoadSnapshotChunk, opts ...grpc.CallOption) (*ResponseLoadSnapshotChunk, error)
+	// ApplySnapshotChunk applies a chunk of snapshot.
 	ApplySnapshotChunk(ctx context.Context, in *RequestApplySnapshotChunk, opts ...grpc.CallOption) (*ResponseApplySnapshotChunk, error)
 }
 
@@ -3578,20 +3654,35 @@ func (c *aBCIApplicationClient) ApplySnapshotChunk(ctx context.Context, in *Requ
 
 // ABCIApplicationServer is the server API for ABCIApplication service.
 type ABCIApplicationServer interface {
+	// Echo returns back the same message it is sent.
 	Echo(context.Context, *RequestEcho) (*ResponseEcho, error)
+	// Flush flushes the write buffer.
 	Flush(context.Context, *RequestFlush) (*ResponseFlush, error)
+	// Info returns information about the application state.
 	Info(context.Context, *RequestInfo) (*ResponseInfo, error)
+	// SetOption sets a parameter in the application.
 	SetOption(context.Context, *RequestSetOption) (*ResponseSetOption, error)
+	// DeliverTx applies a transaction.
 	DeliverTx(context.Context, *RequestDeliverTx) (*ResponseDeliverTx, error)
+	// CheckTx validates a transaction.
 	CheckTx(context.Context, *RequestCheckTx) (*ResponseCheckTx, error)
+	// Query queries the application state.
 	Query(context.Context, *RequestQuery) (*ResponseQuery, error)
+	// Commit commits a block of transactions.
 	Commit(context.Context, *RequestCommit) (*ResponseCommit, error)
+	// InitChain initializes the blockchain.
 	InitChain(context.Context, *RequestInitChain) (*ResponseInitChain, error)
+	// BeginBlock signals the beginning of a block.
 	BeginBlock(context.Context, *RequestBeginBlock) (*ResponseBeginBlock, error)
+	// EndBlock signals the end of a block, returns changes to the validator set.
 	EndBlock(context.Context, *RequestEndBlock) (*ResponseEndBlock, error)
+	// ListSnapshots lists all the available snapshots.
 	ListSnapshots(context.Context, *RequestListSnapshots) (*ResponseListSnapshots, error)
+	// OfferSnapshot sends a snapshot offer.
 	OfferSnapshot(context.Context, *RequestOfferSnapshot) (*ResponseOfferSnapshot, error)
+	// LoadSnapshotChunk returns a chunk of snapshot.
 	LoadSnapshotChunk(context.Context, *RequestLoadSnapshotChunk) (*ResponseLoadSnapshotChunk, error)
+	// ApplySnapshotChunk applies a chunk of snapshot.
 	ApplySnapshotChunk(context.Context, *RequestApplySnapshotChunk) (*ResponseApplySnapshotChunk, error)
 }
 

--- a/api/cometbft/abci/v1beta2/types.pb.go
+++ b/api/cometbft/abci/v1beta2/types.pb.go
@@ -35,11 +35,15 @@ var _ = time.Kitchen
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// The type of misbehavior committed by a validator.
 type MisbehaviorType int32
 
 const (
-	MisbehaviorType_UNKNOWN             MisbehaviorType = 0
-	MisbehaviorType_DUPLICATE_VOTE      MisbehaviorType = 1
+	// Unknown
+	MisbehaviorType_UNKNOWN MisbehaviorType = 0
+	// Duplicate vote
+	MisbehaviorType_DUPLICATE_VOTE MisbehaviorType = 1
+	// Light client attack
 	MisbehaviorType_LIGHT_CLIENT_ATTACK MisbehaviorType = 2
 )
 
@@ -63,12 +67,16 @@ func (MisbehaviorType) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_84748304b8d8ccc3, []int{0}
 }
 
+// The status.
 type ResponseProcessProposal_ProposalStatus int32
 
 const (
+	// Unknown
 	ResponseProcessProposal_UNKNOWN ResponseProcessProposal_ProposalStatus = 0
-	ResponseProcessProposal_ACCEPT  ResponseProcessProposal_ProposalStatus = 1
-	ResponseProcessProposal_REJECT  ResponseProcessProposal_ProposalStatus = 2
+	// Accepted
+	ResponseProcessProposal_ACCEPT ResponseProcessProposal_ProposalStatus = 1
+	// Rejected
+	ResponseProcessProposal_REJECT ResponseProcessProposal_ProposalStatus = 2
 )
 
 var ResponseProcessProposal_ProposalStatus_name = map[int32]string{
@@ -91,7 +99,10 @@ func (ResponseProcessProposal_ProposalStatus) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_84748304b8d8ccc3, []int{13, 0}
 }
 
+// Request represents a request to the ABCI application.
 type Request struct {
+	// Sum of all possible messages.
+	//
 	// Types that are valid to be assigned to Value:
 	//	*Request_Echo
 	//	*Request_Flush
@@ -358,6 +369,7 @@ func (*Request) XXX_OneofWrappers() []interface{} {
 	}
 }
 
+// RequestInfo is a request for the ABCI application version.
 type RequestInfo struct {
 	Version      string `protobuf:"bytes,1,opt,name=version,proto3" json:"version,omitempty"`
 	BlockVersion uint64 `protobuf:"varint,2,opt,name=block_version,json=blockVersion,proto3" json:"block_version,omitempty"`
@@ -426,6 +438,7 @@ func (m *RequestInfo) GetAbciVersion() string {
 	return ""
 }
 
+// RequestInitChain is a request to initialize the blockchain.
 type RequestInitChain struct {
 	Time            time.Time                 `protobuf:"bytes,1,opt,name=time,proto3,stdtime" json:"time"`
 	ChainId         string                    `protobuf:"bytes,2,opt,name=chain_id,json=chainId,proto3" json:"chain_id,omitempty"`
@@ -510,6 +523,7 @@ func (m *RequestInitChain) GetInitialHeight() int64 {
 	return 0
 }
 
+// RequestBeginBlock indicates the beginning of commiting the block.
 type RequestBeginBlock struct {
 	Hash                []byte          `protobuf:"bytes,1,opt,name=hash,proto3" json:"hash,omitempty"`
 	Header              v1beta11.Header `protobuf:"bytes,2,opt,name=header,proto3" json:"header"`
@@ -578,6 +592,8 @@ func (m *RequestBeginBlock) GetByzantineValidators() []Misbehavior {
 	return nil
 }
 
+// RequestPrepareProposal is a request for the ABCI application to prepare a new
+// block proposal.
 type RequestPrepareProposal struct {
 	// the modified transactions cannot exceed this size.
 	MaxTxBytes int64 `protobuf:"varint,1,opt,name=max_tx_bytes,json=maxTxBytes,proto3" json:"max_tx_bytes,omitempty"`
@@ -682,6 +698,7 @@ func (m *RequestPrepareProposal) GetProposerAddress() []byte {
 	return nil
 }
 
+// RequestProcessProposal is a request for the ABCI application to process proposal.
 type RequestProcessProposal struct {
 	Txs                [][]byte      `protobuf:"bytes,1,rep,name=txs,proto3" json:"txs,omitempty"`
 	ProposedLastCommit CommitInfo    `protobuf:"bytes,2,opt,name=proposed_last_commit,json=proposedLastCommit,proto3" json:"proposed_last_commit"`
@@ -784,7 +801,10 @@ func (m *RequestProcessProposal) GetProposerAddress() []byte {
 	return nil
 }
 
+// Response represents a response from the ABCI application.
 type Response struct {
+	// Sum of all possible messages.
+	//
 	// Types that are valid to be assigned to Value:
 	//	*Response_Exception
 	//	*Response_Echo
@@ -1064,6 +1084,8 @@ func (*Response) XXX_OneofWrappers() []interface{} {
 	}
 }
 
+// ResponseInitChain contains the ABCI application's hash and updates to the
+// validator set and/or the consensus params, if any.
 type ResponseInitChain struct {
 	ConsensusParams *v1beta2.ConsensusParams  `protobuf:"bytes,1,opt,name=consensus_params,json=consensusParams,proto3" json:"consensus_params,omitempty"`
 	Validators      []v1beta1.ValidatorUpdate `protobuf:"bytes,2,rep,name=validators,proto3" json:"validators"`
@@ -1124,6 +1146,7 @@ func (m *ResponseInitChain) GetAppHash() []byte {
 	return nil
 }
 
+// ResponseBeginBlock contains a list of block-level events.
 type ResponseBeginBlock struct {
 	Events []Event `protobuf:"bytes,1,rep,name=events,proto3" json:"events,omitempty"`
 }
@@ -1168,6 +1191,8 @@ func (m *ResponseBeginBlock) GetEvents() []Event {
 	return nil
 }
 
+// ResponseCheckTx shows if the transaction was deemed valid by the ABCI
+// application.
 type ResponseCheckTx struct {
 	Code      uint32  `protobuf:"varint,1,opt,name=code,proto3" json:"code,omitempty"`
 	Data      []byte  `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`
@@ -1294,6 +1319,8 @@ func (m *ResponseCheckTx) GetMempoolError() string {
 	return ""
 }
 
+// ResponseDeliverTx contains a result of committing the given transaction and a
+// list of events.
 type ResponseDeliverTx struct {
 	Code      uint32  `protobuf:"varint,1,opt,name=code,proto3" json:"code,omitempty"`
 	Data      []byte  `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`
@@ -1394,6 +1421,7 @@ func (m *ResponseDeliverTx) GetCodespace() string {
 	return ""
 }
 
+// ResponseEndBlock contains updates to consensus params and/or validator set changes, if any.
 type ResponseEndBlock struct {
 	ValidatorUpdates      []v1beta1.ValidatorUpdate `protobuf:"bytes,1,rep,name=validator_updates,json=validatorUpdates,proto3" json:"validator_updates"`
 	ConsensusParamUpdates *v1beta2.ConsensusParams  `protobuf:"bytes,2,opt,name=consensus_param_updates,json=consensusParamUpdates,proto3" json:"consensus_param_updates,omitempty"`
@@ -1454,6 +1482,7 @@ func (m *ResponseEndBlock) GetEvents() []Event {
 	return nil
 }
 
+// ResponsePrepareProposal contains the list of transactions that will be included in the proposal.
 type ResponsePrepareProposal struct {
 	Txs [][]byte `protobuf:"bytes,1,rep,name=txs,proto3" json:"txs,omitempty"`
 }
@@ -1498,6 +1527,7 @@ func (m *ResponsePrepareProposal) GetTxs() [][]byte {
 	return nil
 }
 
+// ResponseProcessProposal contains the result of processing a proposal.
 type ResponseProcessProposal struct {
 	Status ResponseProcessProposal_ProposalStatus `protobuf:"varint,1,opt,name=status,proto3,enum=cometbft.abci.v1beta2.ResponseProcessProposal_ProposalStatus" json:"status,omitempty"`
 }
@@ -1542,6 +1572,7 @@ func (m *ResponseProcessProposal) GetStatus() ResponseProcessProposal_ProposalSt
 	return ResponseProcessProposal_UNKNOWN
 }
 
+// CommitInfo contains votes for the particular round.
 type CommitInfo struct {
 	Round int32              `protobuf:"varint,1,opt,name=round,proto3" json:"round,omitempty"`
 	Votes []v1beta1.VoteInfo `protobuf:"bytes,2,rep,name=votes,proto3" json:"votes"`
@@ -1770,6 +1801,7 @@ func (m *EventAttribute) GetIndex() bool {
 	return false
 }
 
+// ExtendedVoteInfo extends VoteInfo with the vote extentions (non-deterministic).
 type ExtendedVoteInfo struct {
 	// The validator that sent the vote.
 	Validator v1beta1.Validator `protobuf:"bytes,1,opt,name=validator,proto3" json:"validator"`
@@ -1833,6 +1865,7 @@ func (m *ExtendedVoteInfo) GetVoteExtension() []byte {
 	return nil
 }
 
+// Misbehavior is a type of misbehavior committed by a validator.
 type Misbehavior struct {
 	Type MisbehaviorType `protobuf:"varint,1,opt,name=type,proto3,enum=cometbft.abci.v1beta2.MisbehaviorType" json:"type,omitempty"`
 	// The offending validator
@@ -2100,21 +2133,37 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type ABCIApplicationClient interface {
+	// Echo returns back the same message it is sent.
 	Echo(ctx context.Context, in *v1beta1.RequestEcho, opts ...grpc.CallOption) (*v1beta1.ResponseEcho, error)
+	// Flush flushes the write buffer.
 	Flush(ctx context.Context, in *v1beta1.RequestFlush, opts ...grpc.CallOption) (*v1beta1.ResponseFlush, error)
+	// Info returns information about the application state.
 	Info(ctx context.Context, in *RequestInfo, opts ...grpc.CallOption) (*v1beta1.ResponseInfo, error)
+	// DeliverTx applies a transaction.
 	DeliverTx(ctx context.Context, in *v1beta1.RequestDeliverTx, opts ...grpc.CallOption) (*ResponseDeliverTx, error)
+	// CheckTx validates a transaction.
 	CheckTx(ctx context.Context, in *v1beta1.RequestCheckTx, opts ...grpc.CallOption) (*ResponseCheckTx, error)
+	// Query queries the application state.
 	Query(ctx context.Context, in *v1beta1.RequestQuery, opts ...grpc.CallOption) (*v1beta1.ResponseQuery, error)
+	// Commit commits a block of transactions.
 	Commit(ctx context.Context, in *v1beta1.RequestCommit, opts ...grpc.CallOption) (*v1beta1.ResponseCommit, error)
+	// InitChain initializes the blockchain.
 	InitChain(ctx context.Context, in *RequestInitChain, opts ...grpc.CallOption) (*ResponseInitChain, error)
+	// BeginBlock signals the beginning of a block.
 	BeginBlock(ctx context.Context, in *RequestBeginBlock, opts ...grpc.CallOption) (*ResponseBeginBlock, error)
+	// EndBlock signals the end of a block, returns changes to the validator set.
 	EndBlock(ctx context.Context, in *v1beta1.RequestEndBlock, opts ...grpc.CallOption) (*ResponseEndBlock, error)
+	// ListSnapshots lists all the available snapshots.
 	ListSnapshots(ctx context.Context, in *v1beta1.RequestListSnapshots, opts ...grpc.CallOption) (*v1beta1.ResponseListSnapshots, error)
+	// OfferSnapshot sends a snapshot offer.
 	OfferSnapshot(ctx context.Context, in *v1beta1.RequestOfferSnapshot, opts ...grpc.CallOption) (*v1beta1.ResponseOfferSnapshot, error)
+	// LoadSnapshotChunk returns a chunk of snapshot.
 	LoadSnapshotChunk(ctx context.Context, in *v1beta1.RequestLoadSnapshotChunk, opts ...grpc.CallOption) (*v1beta1.ResponseLoadSnapshotChunk, error)
+	// ApplySnapshotChunk applies a chunk of snapshot.
 	ApplySnapshotChunk(ctx context.Context, in *v1beta1.RequestApplySnapshotChunk, opts ...grpc.CallOption) (*v1beta1.ResponseApplySnapshotChunk, error)
+	// PrepareProposal returns a proposal for the next block.
 	PrepareProposal(ctx context.Context, in *RequestPrepareProposal, opts ...grpc.CallOption) (*ResponsePrepareProposal, error)
+	// ProcessProposal validates a proposal.
 	ProcessProposal(ctx context.Context, in *RequestProcessProposal, opts ...grpc.CallOption) (*ResponseProcessProposal, error)
 }
 
@@ -2272,21 +2321,37 @@ func (c *aBCIApplicationClient) ProcessProposal(ctx context.Context, in *Request
 
 // ABCIApplicationServer is the server API for ABCIApplication service.
 type ABCIApplicationServer interface {
+	// Echo returns back the same message it is sent.
 	Echo(context.Context, *v1beta1.RequestEcho) (*v1beta1.ResponseEcho, error)
+	// Flush flushes the write buffer.
 	Flush(context.Context, *v1beta1.RequestFlush) (*v1beta1.ResponseFlush, error)
+	// Info returns information about the application state.
 	Info(context.Context, *RequestInfo) (*v1beta1.ResponseInfo, error)
+	// DeliverTx applies a transaction.
 	DeliverTx(context.Context, *v1beta1.RequestDeliverTx) (*ResponseDeliverTx, error)
+	// CheckTx validates a transaction.
 	CheckTx(context.Context, *v1beta1.RequestCheckTx) (*ResponseCheckTx, error)
+	// Query queries the application state.
 	Query(context.Context, *v1beta1.RequestQuery) (*v1beta1.ResponseQuery, error)
+	// Commit commits a block of transactions.
 	Commit(context.Context, *v1beta1.RequestCommit) (*v1beta1.ResponseCommit, error)
+	// InitChain initializes the blockchain.
 	InitChain(context.Context, *RequestInitChain) (*ResponseInitChain, error)
+	// BeginBlock signals the beginning of a block.
 	BeginBlock(context.Context, *RequestBeginBlock) (*ResponseBeginBlock, error)
+	// EndBlock signals the end of a block, returns changes to the validator set.
 	EndBlock(context.Context, *v1beta1.RequestEndBlock) (*ResponseEndBlock, error)
+	// ListSnapshots lists all the available snapshots.
 	ListSnapshots(context.Context, *v1beta1.RequestListSnapshots) (*v1beta1.ResponseListSnapshots, error)
+	// OfferSnapshot sends a snapshot offer.
 	OfferSnapshot(context.Context, *v1beta1.RequestOfferSnapshot) (*v1beta1.ResponseOfferSnapshot, error)
+	// LoadSnapshotChunk returns a chunk of snapshot.
 	LoadSnapshotChunk(context.Context, *v1beta1.RequestLoadSnapshotChunk) (*v1beta1.ResponseLoadSnapshotChunk, error)
+	// ApplySnapshotChunk applies a chunk of snapshot.
 	ApplySnapshotChunk(context.Context, *v1beta1.RequestApplySnapshotChunk) (*v1beta1.ResponseApplySnapshotChunk, error)
+	// PrepareProposal returns a proposal for the next block.
 	PrepareProposal(context.Context, *RequestPrepareProposal) (*ResponsePrepareProposal, error)
+	// ProcessProposal validates a proposal.
 	ProcessProposal(context.Context, *RequestProcessProposal) (*ResponseProcessProposal, error)
 }
 

--- a/api/cometbft/abci/v1beta3/types.pb.go
+++ b/api/cometbft/abci/v1beta3/types.pb.go
@@ -36,11 +36,14 @@ var _ = time.Kitchen
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// Verification status.
 type ResponseVerifyVoteExtension_VerifyStatus int32
 
 const (
+	// Unknown
 	ResponseVerifyVoteExtension_UNKNOWN ResponseVerifyVoteExtension_VerifyStatus = 0
-	ResponseVerifyVoteExtension_ACCEPT  ResponseVerifyVoteExtension_VerifyStatus = 1
+	// Accepted
+	ResponseVerifyVoteExtension_ACCEPT ResponseVerifyVoteExtension_VerifyStatus = 1
 	// Rejecting the vote extension will reject the entire precommit by the sender.
 	// Incorrectly implementing this thus has liveness implications as it may affect
 	// CometBFT's ability to receive 2/3+ valid votes to finalize the block.
@@ -68,7 +71,10 @@ func (ResponseVerifyVoteExtension_VerifyStatus) EnumDescriptor() ([]byte, []int)
 	return fileDescriptor_1cabe0dccee1dedf, []int{12, 0}
 }
 
+// Request represents a request to the ABCI application.
 type Request struct {
+	// Sum of all possible messages.
+	//
 	// Types that are valid to be assigned to Value:
 	//	*Request_Echo
 	//	*Request_Flush
@@ -335,6 +341,7 @@ func (*Request) XXX_OneofWrappers() []interface{} {
 	}
 }
 
+// RequestInitChain is a request to initialize the blockchain.
 type RequestInitChain struct {
 	Time            time.Time                 `protobuf:"bytes,1,opt,name=time,proto3,stdtime" json:"time"`
 	ChainId         string                    `protobuf:"bytes,2,opt,name=chain_id,json=chainId,proto3" json:"chain_id,omitempty"`
@@ -419,6 +426,8 @@ func (m *RequestInitChain) GetInitialHeight() int64 {
 	return 0
 }
 
+// RequestPrepareProposal is a request for the ABCI application to prepare a new
+// block proposal.
 type RequestPrepareProposal struct {
 	// the modified transactions cannot exceed this size.
 	MaxTxBytes int64 `protobuf:"varint,1,opt,name=max_tx_bytes,json=maxTxBytes,proto3" json:"max_tx_bytes,omitempty"`
@@ -523,6 +532,7 @@ func (m *RequestPrepareProposal) GetProposerAddress() []byte {
 	return nil
 }
 
+// RequestProcessProposal is a request for the ABCI application to process proposal.
 type RequestProcessProposal struct {
 	Txs                [][]byte              `protobuf:"bytes,1,rep,name=txs,proto3" json:"txs,omitempty"`
 	ProposedLastCommit CommitInfo            `protobuf:"bytes,2,opt,name=proposed_last_commit,json=proposedLastCommit,proto3" json:"proposed_last_commit"`
@@ -801,6 +811,7 @@ func (m *RequestVerifyVoteExtension) GetVoteExtension() []byte {
 	return nil
 }
 
+// RequestFinalizeBlock is a request to finalize the block.
 type RequestFinalizeBlock struct {
 	Txs               [][]byte              `protobuf:"bytes,1,rep,name=txs,proto3" json:"txs,omitempty"`
 	DecidedLastCommit CommitInfo            `protobuf:"bytes,2,opt,name=decided_last_commit,json=decidedLastCommit,proto3" json:"decided_last_commit"`
@@ -903,7 +914,10 @@ func (m *RequestFinalizeBlock) GetProposerAddress() []byte {
 	return nil
 }
 
+// Response represents a response from the ABCI application.
 type Response struct {
+	// Sum of all possible messages.
+	//
 	// Types that are valid to be assigned to Value:
 	//	*Response_Exception
 	//	*Response_Echo
@@ -1183,6 +1197,8 @@ func (*Response) XXX_OneofWrappers() []interface{} {
 	}
 }
 
+// ResponseInitChain contains the ABCI application's hash and updates to the
+// validator set and/or the consensus params, if any.
 type ResponseInitChain struct {
 	ConsensusParams *v1.ConsensusParams       `protobuf:"bytes,1,opt,name=consensus_params,json=consensusParams,proto3" json:"consensus_params,omitempty"`
 	Validators      []v1beta1.ValidatorUpdate `protobuf:"bytes,2,rep,name=validators,proto3" json:"validators"`
@@ -1243,6 +1259,8 @@ func (m *ResponseInitChain) GetAppHash() []byte {
 	return nil
 }
 
+// ResponseCheckTx shows if the transaction was deemed valid by the ABCI
+// application.
 type ResponseCheckTx struct {
 	Code      uint32          `protobuf:"varint,1,opt,name=code,proto3" json:"code,omitempty"`
 	Data      []byte          `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`
@@ -1343,6 +1361,7 @@ func (m *ResponseCheckTx) GetCodespace() string {
 	return ""
 }
 
+// ResponseCommit indicates how much blocks should CometBFT retain.
 type ResponseCommit struct {
 	RetainHeight int64 `protobuf:"varint,3,opt,name=retain_height,json=retainHeight,proto3" json:"retain_height,omitempty"`
 }
@@ -1387,6 +1406,7 @@ func (m *ResponseCommit) GetRetainHeight() int64 {
 	return 0
 }
 
+// ResponseExtendVote is the result of extending a vote with application-injected data.
 type ResponseExtendVote struct {
 	VoteExtension []byte `protobuf:"bytes,1,opt,name=vote_extension,json=voteExtension,proto3" json:"vote_extension,omitempty"`
 }
@@ -1431,6 +1451,7 @@ func (m *ResponseExtendVote) GetVoteExtension() []byte {
 	return nil
 }
 
+// ResponseVerifyVoteExtension is the result of verifying a vote extension.
 type ResponseVerifyVoteExtension struct {
 	Status ResponseVerifyVoteExtension_VerifyStatus `protobuf:"varint,1,opt,name=status,proto3,enum=cometbft.abci.v1beta3.ResponseVerifyVoteExtension_VerifyStatus" json:"status,omitempty"`
 }
@@ -1475,6 +1496,7 @@ func (m *ResponseVerifyVoteExtension) GetStatus() ResponseVerifyVoteExtension_Ve
 	return ResponseVerifyVoteExtension_UNKNOWN
 }
 
+// FinalizeBlockResponse contains the result of executing the block.
 type ResponseFinalizeBlock struct {
 	// set of block events emmitted as part of executing the block
 	Events []v1beta2.Event `protobuf:"bytes,1,rep,name=events,proto3" json:"events,omitempty"`
@@ -1560,6 +1582,7 @@ func (m *ResponseFinalizeBlock) GetAppHash() []byte {
 	return nil
 }
 
+// VoteInfo contains the information about the vote.
 type VoteInfo struct {
 	Validator   v1beta1.Validator    `protobuf:"bytes,1,opt,name=validator,proto3" json:"validator"`
 	BlockIdFlag v1beta11.BlockIDFlag `protobuf:"varint,3,opt,name=block_id_flag,json=blockIdFlag,proto3,enum=cometbft.types.v1beta1.BlockIDFlag" json:"block_id_flag,omitempty"`
@@ -1612,6 +1635,7 @@ func (m *VoteInfo) GetBlockIdFlag() v1beta11.BlockIDFlag {
 	return v1beta11.BlockIDFlagUnknown
 }
 
+// ExtendedVoteInfo extends VoteInfo with the vote extentions (non-deterministic).
 type ExtendedVoteInfo struct {
 	// The validator that sent the vote.
 	Validator v1beta1.Validator `protobuf:"bytes,1,opt,name=validator,proto3" json:"validator"`
@@ -1684,6 +1708,7 @@ func (m *ExtendedVoteInfo) GetBlockIdFlag() v1beta11.BlockIDFlag {
 	return v1beta11.BlockIDFlagUnknown
 }
 
+// CommitInfo contains votes for the particular round.
 type CommitInfo struct {
 	Round int32      `protobuf:"varint,1,opt,name=round,proto3" json:"round,omitempty"`
 	Votes []VoteInfo `protobuf:"bytes,2,rep,name=votes,proto3" json:"votes"`
@@ -2150,21 +2175,37 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type ABCIClient interface {
+	// Echo returns back the same message it is sent.
 	Echo(ctx context.Context, in *v1beta1.RequestEcho, opts ...grpc.CallOption) (*v1beta1.ResponseEcho, error)
+	// Flush flushes the write buffer.
 	Flush(ctx context.Context, in *v1beta1.RequestFlush, opts ...grpc.CallOption) (*v1beta1.ResponseFlush, error)
+	// Info returns information about the application state.
 	Info(ctx context.Context, in *v1beta2.RequestInfo, opts ...grpc.CallOption) (*v1beta1.ResponseInfo, error)
+	// CheckTx validates a transaction.
 	CheckTx(ctx context.Context, in *v1beta1.RequestCheckTx, opts ...grpc.CallOption) (*ResponseCheckTx, error)
+	// Query queries the application state.
 	Query(ctx context.Context, in *v1beta1.RequestQuery, opts ...grpc.CallOption) (*v1beta1.ResponseQuery, error)
+	// Commit commits a block of transactions.
 	Commit(ctx context.Context, in *v1beta1.RequestCommit, opts ...grpc.CallOption) (*ResponseCommit, error)
+	// InitChain initializes the blockchain.
 	InitChain(ctx context.Context, in *RequestInitChain, opts ...grpc.CallOption) (*ResponseInitChain, error)
+	// ListSnapshots lists all the available snapshots.
 	ListSnapshots(ctx context.Context, in *v1beta1.RequestListSnapshots, opts ...grpc.CallOption) (*v1beta1.ResponseListSnapshots, error)
+	// OfferSnapshot sends a snapshot offer.
 	OfferSnapshot(ctx context.Context, in *v1beta1.RequestOfferSnapshot, opts ...grpc.CallOption) (*v1beta1.ResponseOfferSnapshot, error)
+	// LoadSnapshotChunk returns a chunk of snapshot.
 	LoadSnapshotChunk(ctx context.Context, in *v1beta1.RequestLoadSnapshotChunk, opts ...grpc.CallOption) (*v1beta1.ResponseLoadSnapshotChunk, error)
+	// ApplySnapshotChunk applies a chunk of snapshot.
 	ApplySnapshotChunk(ctx context.Context, in *v1beta1.RequestApplySnapshotChunk, opts ...grpc.CallOption) (*v1beta1.ResponseApplySnapshotChunk, error)
+	// PrepareProposal returns a proposal for the next block.
 	PrepareProposal(ctx context.Context, in *RequestPrepareProposal, opts ...grpc.CallOption) (*v1beta2.ResponsePrepareProposal, error)
+	// ProcessProposal validates a proposal.
 	ProcessProposal(ctx context.Context, in *RequestProcessProposal, opts ...grpc.CallOption) (*v1beta2.ResponseProcessProposal, error)
+	// ExtendVote extends a vote with application-injected data (vote extentions).
 	ExtendVote(ctx context.Context, in *RequestExtendVote, opts ...grpc.CallOption) (*ResponseExtendVote, error)
+	// VerifyVoteExtension verifies a vote extension.
 	VerifyVoteExtension(ctx context.Context, in *RequestVerifyVoteExtension, opts ...grpc.CallOption) (*ResponseVerifyVoteExtension, error)
+	// FinalizeBlock finalizes a block.
 	FinalizeBlock(ctx context.Context, in *RequestFinalizeBlock, opts ...grpc.CallOption) (*ResponseFinalizeBlock, error)
 }
 
@@ -2322,21 +2363,37 @@ func (c *aBCIClient) FinalizeBlock(ctx context.Context, in *RequestFinalizeBlock
 
 // ABCIServer is the server API for ABCI service.
 type ABCIServer interface {
+	// Echo returns back the same message it is sent.
 	Echo(context.Context, *v1beta1.RequestEcho) (*v1beta1.ResponseEcho, error)
+	// Flush flushes the write buffer.
 	Flush(context.Context, *v1beta1.RequestFlush) (*v1beta1.ResponseFlush, error)
+	// Info returns information about the application state.
 	Info(context.Context, *v1beta2.RequestInfo) (*v1beta1.ResponseInfo, error)
+	// CheckTx validates a transaction.
 	CheckTx(context.Context, *v1beta1.RequestCheckTx) (*ResponseCheckTx, error)
+	// Query queries the application state.
 	Query(context.Context, *v1beta1.RequestQuery) (*v1beta1.ResponseQuery, error)
+	// Commit commits a block of transactions.
 	Commit(context.Context, *v1beta1.RequestCommit) (*ResponseCommit, error)
+	// InitChain initializes the blockchain.
 	InitChain(context.Context, *RequestInitChain) (*ResponseInitChain, error)
+	// ListSnapshots lists all the available snapshots.
 	ListSnapshots(context.Context, *v1beta1.RequestListSnapshots) (*v1beta1.ResponseListSnapshots, error)
+	// OfferSnapshot sends a snapshot offer.
 	OfferSnapshot(context.Context, *v1beta1.RequestOfferSnapshot) (*v1beta1.ResponseOfferSnapshot, error)
+	// LoadSnapshotChunk returns a chunk of snapshot.
 	LoadSnapshotChunk(context.Context, *v1beta1.RequestLoadSnapshotChunk) (*v1beta1.ResponseLoadSnapshotChunk, error)
+	// ApplySnapshotChunk applies a chunk of snapshot.
 	ApplySnapshotChunk(context.Context, *v1beta1.RequestApplySnapshotChunk) (*v1beta1.ResponseApplySnapshotChunk, error)
+	// PrepareProposal returns a proposal for the next block.
 	PrepareProposal(context.Context, *RequestPrepareProposal) (*v1beta2.ResponsePrepareProposal, error)
+	// ProcessProposal validates a proposal.
 	ProcessProposal(context.Context, *RequestProcessProposal) (*v1beta2.ResponseProcessProposal, error)
+	// ExtendVote extends a vote with application-injected data (vote extentions).
 	ExtendVote(context.Context, *RequestExtendVote) (*ResponseExtendVote, error)
+	// VerifyVoteExtension verifies a vote extension.
 	VerifyVoteExtension(context.Context, *RequestVerifyVoteExtension) (*ResponseVerifyVoteExtension, error)
+	// FinalizeBlock finalizes a block.
 	FinalizeBlock(context.Context, *RequestFinalizeBlock) (*ResponseFinalizeBlock, error)
 }
 

--- a/api/cometbft/blocksync/v1/types.pb.go
+++ b/api/cometbft/blocksync/v1/types.pb.go
@@ -256,7 +256,10 @@ func (m *BlockResponse) GetExtCommit() *v1.ExtendedCommit {
 	return nil
 }
 
+// Message is an abtract blocksync message.
 type Message struct {
+	// Sum of all possible messages.
+	//
 	// Types that are valid to be assigned to Sum:
 	//	*Message_BlockRequest
 	//	*Message_NoBlockResponse

--- a/api/cometbft/blocksync/v1beta1/types.pb.go
+++ b/api/cometbft/blocksync/v1beta1/types.pb.go
@@ -248,7 +248,10 @@ func (m *StatusResponse) GetBase() int64 {
 	return 0
 }
 
+// Message is an abtract blocksync message.
 type Message struct {
+	// Sum of all possible messages.
+	//
 	// Types that are valid to be assigned to Sum:
 	//	*Message_BlockRequest
 	//	*Message_NoBlockResponse

--- a/api/cometbft/consensus/v1/types.pb.go
+++ b/api/cometbft/consensus/v1/types.pb.go
@@ -670,7 +670,10 @@ func (m *HasProposalBlockPart) GetIndex() int32 {
 	return 0
 }
 
+// Message is an abstract consensus message.
 type Message struct {
+	// Sum of all possible messages.
+	//
 	// Types that are valid to be assigned to Sum:
 	//	*Message_NewRoundStep
 	//	*Message_NewValidBlock

--- a/api/cometbft/consensus/v1/wal.pb.go
+++ b/api/cometbft/consensus/v1/wal.pb.go
@@ -197,7 +197,10 @@ func (m *EndHeight) GetHeight() int64 {
 	return 0
 }
 
+// WALMessage describes a consensus WAL (Write Ahead Log) entry.
 type WALMessage struct {
+	// Sum of all possible messages.
+	//
 	// Types that are valid to be assigned to Sum:
 	//	*WALMessage_EventDataRoundState
 	//	*WALMessage_MsgInfo

--- a/api/cometbft/consensus/v1beta1/types.pb.go
+++ b/api/cometbft/consensus/v1beta1/types.pb.go
@@ -609,7 +609,10 @@ func (m *VoteSetBits) GetVotes() v1.BitArray {
 	return v1.BitArray{}
 }
 
+// Message is an abstract consensus message.
 type Message struct {
+	// Sum of all possible messages.
+	//
 	// Types that are valid to be assigned to Sum:
 	//	*Message_NewRoundStep
 	//	*Message_NewValidBlock

--- a/api/cometbft/consensus/v1beta1/wal.pb.go
+++ b/api/cometbft/consensus/v1beta1/wal.pb.go
@@ -197,7 +197,10 @@ func (m *EndHeight) GetHeight() int64 {
 	return 0
 }
 
+// WALMessage describes a consensus WAL (Write Ahead Log) entry.
 type WALMessage struct {
+	// Sum of all possible messages.
+	//
 	// Types that are valid to be assigned to Sum:
 	//	*WALMessage_EventDataRoundState
 	//	*WALMessage_MsgInfo

--- a/api/cometbft/crypto/v1/keys.pb.go
+++ b/api/cometbft/crypto/v1/keys.pb.go
@@ -24,8 +24,10 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
-// PublicKey defines the keys available for use with Validators
+// PublicKey is a ED25519 or a secp256k1 public key.
 type PublicKey struct {
+	// The type of key.
+	//
 	// Types that are valid to be assigned to Sum:
 	//
 	//	*PublicKey_Ed25519

--- a/api/cometbft/crypto/v1/proof.pb.go
+++ b/api/cometbft/crypto/v1/proof.pb.go
@@ -23,6 +23,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// Proof is a Merkle proof.
 type Proof struct {
 	Total    int64    `protobuf:"varint,1,opt,name=total,proto3" json:"total,omitempty"`
 	Index    int64    `protobuf:"varint,2,opt,name=index,proto3" json:"index,omitempty"`
@@ -91,6 +92,7 @@ func (m *Proof) GetAunts() [][]byte {
 	return nil
 }
 
+// ValueOp is a Merkle proof for a single key.
 type ValueOp struct {
 	// Encoded in ProofOp.Key.
 	Key []byte `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
@@ -145,6 +147,7 @@ func (m *ValueOp) GetProof() *Proof {
 	return nil
 }
 
+// DominoOp always returns the given output.
 type DominoOp struct {
 	Key    string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
 	Input  string `protobuf:"bytes,2,opt,name=input,proto3" json:"input,omitempty"`

--- a/api/cometbft/libs/bits/v1/types.pb.go
+++ b/api/cometbft/libs/bits/v1/types.pb.go
@@ -22,6 +22,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// BitArray is an array of bits.
 type BitArray struct {
 	Bits  int64    `protobuf:"varint,1,opt,name=bits,proto3" json:"bits,omitempty"`
 	Elems []uint64 `protobuf:"varint,2,rep,packed,name=elems,proto3" json:"elems,omitempty"`

--- a/api/cometbft/mempool/v1/types.pb.go
+++ b/api/cometbft/mempool/v1/types.pb.go
@@ -22,6 +22,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// Txs contains a list of transaction from the mempool.
 type Txs struct {
 	Txs [][]byte `protobuf:"bytes,1,rep,name=txs,proto3" json:"txs,omitempty"`
 }
@@ -66,7 +67,10 @@ func (m *Txs) GetTxs() [][]byte {
 	return nil
 }
 
+// Message is an abstract mempool message.
 type Message struct {
+	// Sum of all possible messages.
+	//
 	// Types that are valid to be assigned to Sum:
 	//
 	//	*Message_Txs

--- a/api/cometbft/p2p/v1/conn.pb.go
+++ b/api/cometbft/p2p/v1/conn.pb.go
@@ -24,6 +24,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// PacketPing is a request to confirm that the connection is alive.
 type PacketPing struct {
 }
 
@@ -60,6 +61,7 @@ func (m *PacketPing) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_PacketPing proto.InternalMessageInfo
 
+// PacketPong is a response to confirm that the connection is alive.
 type PacketPong struct {
 }
 
@@ -96,6 +98,8 @@ func (m *PacketPong) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_PacketPong proto.InternalMessageInfo
 
+// PacketMsg contains data for the specified channel ID. EOF means the message
+// is fully received.
 type PacketMsg struct {
 	ChannelID int32  `protobuf:"varint,1,opt,name=channel_id,json=channelId,proto3" json:"channel_id,omitempty"`
 	EOF       bool   `protobuf:"varint,2,opt,name=eof,proto3" json:"eof,omitempty"`
@@ -156,7 +160,10 @@ func (m *PacketMsg) GetData() []byte {
 	return nil
 }
 
+// Packet is an abstract p2p message.
 type Packet struct {
+	// Sum of all possible messages.
+	//
 	// Types that are valid to be assigned to Sum:
 	//
 	//	*Packet_PacketPing
@@ -255,6 +262,8 @@ func (*Packet) XXX_OneofWrappers() []interface{} {
 	}
 }
 
+// AuthSigMessage is sent during the authentication and contains our/remote's
+// signature along with the public key.
 type AuthSigMessage struct {
 	PubKey v1.PublicKey `protobuf:"bytes,1,opt,name=pub_key,json=pubKey,proto3" json:"pub_key"`
 	Sig    []byte       `protobuf:"bytes,2,opt,name=sig,proto3" json:"sig,omitempty"`

--- a/api/cometbft/p2p/v1/pex.pb.go
+++ b/api/cometbft/p2p/v1/pex.pb.go
@@ -23,6 +23,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// PexRequest is a request for peer addresses.
 type PexRequest struct {
 }
 
@@ -59,6 +60,7 @@ func (m *PexRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_PexRequest proto.InternalMessageInfo
 
+// PexAddrs is a response with peer addresses.
 type PexAddrs struct {
 	Addrs []NetAddress `protobuf:"bytes,1,rep,name=addrs,proto3" json:"addrs"`
 }
@@ -103,7 +105,10 @@ func (m *PexAddrs) GetAddrs() []NetAddress {
 	return nil
 }
 
+// Message is an abstract PEX message.
 type Message struct {
+	// Sum of all possible messages.
+	//
 	// Types that are valid to be assigned to Sum:
 	//	*Message_PexRequest
 	//	*Message_PexAddrs

--- a/api/cometbft/p2p/v1/types.pb.go
+++ b/api/cometbft/p2p/v1/types.pb.go
@@ -23,6 +23,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// NetAddress represents a peer's network address.
 type NetAddress struct {
 	ID   string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	IP   string `protobuf:"bytes,2,opt,name=ip,proto3" json:"ip,omitempty"`
@@ -83,6 +84,7 @@ func (m *NetAddress) GetPort() uint32 {
 	return 0
 }
 
+// ProtocolVersion represents the current p2p protocol version.
 type ProtocolVersion struct {
 	P2P   uint64 `protobuf:"varint,1,opt,name=p2p,proto3" json:"p2p,omitempty"`
 	Block uint64 `protobuf:"varint,2,opt,name=block,proto3" json:"block,omitempty"`
@@ -143,6 +145,8 @@ func (m *ProtocolVersion) GetApp() uint64 {
 	return 0
 }
 
+// DefaultNodeInfo is a basic node's information sent to other peers during the
+// p2p handshake.
 type DefaultNodeInfo struct {
 	ProtocolVersion ProtocolVersion      `protobuf:"bytes,1,opt,name=protocol_version,json=protocolVersion,proto3" json:"protocol_version"`
 	DefaultNodeID   string               `protobuf:"bytes,2,opt,name=default_node_id,json=defaultNodeId,proto3" json:"default_node_id,omitempty"`
@@ -243,6 +247,7 @@ func (m *DefaultNodeInfo) GetOther() DefaultNodeInfoOther {
 	return DefaultNodeInfoOther{}
 }
 
+// DefaultNodeInfoOther is the misc. application specific data.
 type DefaultNodeInfoOther struct {
 	TxIndex    string `protobuf:"bytes,1,opt,name=tx_index,json=txIndex,proto3" json:"tx_index,omitempty"`
 	RPCAddress string `protobuf:"bytes,2,opt,name=rpc_address,json=rpcAddress,proto3" json:"rpc_address,omitempty"`

--- a/api/cometbft/privval/v1/types.pb.go
+++ b/api/cometbft/privval/v1/types.pb.go
@@ -25,6 +25,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// remotesignererror is returned when the remote signer fails.
 type RemoteSignerError struct {
 	Code        int32  `protobuf:"varint,1,opt,name=code,proto3" json:"code,omitempty"`
 	Description string `protobuf:"bytes,2,opt,name=description,proto3" json:"description,omitempty"`
@@ -461,7 +462,10 @@ func (m *PingResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_PingResponse proto.InternalMessageInfo
 
+// Message is an abstract message to/from the remote signer.
 type Message struct {
+	// Sum of all possible messages.
+	//
 	// Types that are valid to be assigned to Sum:
 	//	*Message_PubKeyRequest
 	//	*Message_PubKeyResponse

--- a/api/cometbft/privval/v1beta1/types.pb.go
+++ b/api/cometbft/privval/v1beta1/types.pb.go
@@ -25,15 +25,22 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// Errors is a list of error codes that can be returned by the remote signer.
 type Errors int32
 
 const (
-	Errors_ERRORS_UNKNOWN             Errors = 0
+	// Unknown error
+	Errors_ERRORS_UNKNOWN Errors = 0
+	// Unexpected response
 	Errors_ERRORS_UNEXPECTED_RESPONSE Errors = 1
-	Errors_ERRORS_NO_CONNECTION       Errors = 2
-	Errors_ERRORS_CONNECTION_TIMEOUT  Errors = 3
-	Errors_ERRORS_READ_TIMEOUT        Errors = 4
-	Errors_ERRORS_WRITE_TIMEOUT       Errors = 5
+	// Connection lost
+	Errors_ERRORS_NO_CONNECTION Errors = 2
+	// Connection timeout
+	Errors_ERRORS_CONNECTION_TIMEOUT Errors = 3
+	// Read timeout
+	Errors_ERRORS_READ_TIMEOUT Errors = 4
+	// Write timeout
+	Errors_ERRORS_WRITE_TIMEOUT Errors = 5
 )
 
 var Errors_name = map[int32]string{
@@ -62,6 +69,7 @@ func (Errors) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_2e82066b29171f6d, []int{0}
 }
 
+// A service for broadcasting transactions.
 type RemoteSignerError struct {
 	Code        int32  `protobuf:"varint,1,opt,name=code,proto3" json:"code,omitempty"`
 	Description string `protobuf:"bytes,2,opt,name=description,proto3" json:"description,omitempty"`
@@ -498,7 +506,10 @@ func (m *PingResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_PingResponse proto.InternalMessageInfo
 
+// Message is an abstract message to/from the remote signer.
 type Message struct {
+	// Sum of all possible messages.
+	//
 	// Types that are valid to be assigned to Sum:
 	//	*Message_PubKeyRequest
 	//	*Message_PubKeyResponse

--- a/api/cometbft/rpc/grpc/v1beta1/types.pb.go
+++ b/api/cometbft/rpc/grpc/v1beta1/types.pb.go
@@ -28,6 +28,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// PingRequest is a request to confirm that the connection is alive.
 type RequestPing struct {
 }
 
@@ -64,6 +65,7 @@ func (m *RequestPing) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_RequestPing proto.InternalMessageInfo
 
+// RequestBroadcastTx is a request to broadcast the transaction.
 type RequestBroadcastTx struct {
 	Tx []byte `protobuf:"bytes,1,opt,name=tx,proto3" json:"tx,omitempty"`
 }
@@ -108,6 +110,7 @@ func (m *RequestBroadcastTx) GetTx() []byte {
 	return nil
 }
 
+// PingResponse is a response to confirm that the connection is alive.
 type ResponsePing struct {
 }
 
@@ -144,6 +147,7 @@ func (m *ResponsePing) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_ResponsePing proto.InternalMessageInfo
 
+// ResponseBroadcastTx is a response of broadcasting the transaction.
 type ResponseBroadcastTx struct {
 	CheckTx   *v1beta1.ResponseCheckTx   `protobuf:"bytes,1,opt,name=check_tx,json=checkTx,proto3" json:"check_tx,omitempty"`
 	DeliverTx *v1beta1.ResponseDeliverTx `protobuf:"bytes,2,opt,name=deliver_tx,json=deliverTx,proto3" json:"deliver_tx,omitempty"`
@@ -244,7 +248,9 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type BroadcastAPIClient interface {
+	// Ping the connection.
 	Ping(ctx context.Context, in *RequestPing, opts ...grpc.CallOption) (*ResponsePing, error)
+	// BroadcastTx broadcasts the transaction.
 	BroadcastTx(ctx context.Context, in *RequestBroadcastTx, opts ...grpc.CallOption) (*ResponseBroadcastTx, error)
 }
 
@@ -276,7 +282,9 @@ func (c *broadcastAPIClient) BroadcastTx(ctx context.Context, in *RequestBroadca
 
 // BroadcastAPIServer is the server API for BroadcastAPI service.
 type BroadcastAPIServer interface {
+	// Ping the connection.
 	Ping(context.Context, *RequestPing) (*ResponsePing, error)
+	// BroadcastTx broadcasts the transaction.
 	BroadcastTx(context.Context, *RequestBroadcastTx) (*ResponseBroadcastTx, error)
 }
 

--- a/api/cometbft/rpc/grpc/v1beta2/types.pb.go
+++ b/api/cometbft/rpc/grpc/v1beta2/types.pb.go
@@ -29,6 +29,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// ResponseBroadcastTx is a response of broadcasting the transaction.
 type ResponseBroadcastTx struct {
 	CheckTx   *v1beta2.ResponseCheckTx   `protobuf:"bytes,1,opt,name=check_tx,json=checkTx,proto3" json:"check_tx,omitempty"`
 	DeliverTx *v1beta2.ResponseDeliverTx `protobuf:"bytes,2,opt,name=deliver_tx,json=deliverTx,proto3" json:"deliver_tx,omitempty"`
@@ -124,7 +125,9 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type BroadcastAPIClient interface {
+	// Ping the connection.
 	Ping(ctx context.Context, in *v1beta1.RequestPing, opts ...grpc.CallOption) (*v1beta1.ResponsePing, error)
+	// BroadcastTx broadcasts the transaction.
 	BroadcastTx(ctx context.Context, in *v1beta1.RequestBroadcastTx, opts ...grpc.CallOption) (*ResponseBroadcastTx, error)
 }
 
@@ -156,7 +159,9 @@ func (c *broadcastAPIClient) BroadcastTx(ctx context.Context, in *v1beta1.Reques
 
 // BroadcastAPIServer is the server API for BroadcastAPI service.
 type BroadcastAPIServer interface {
+	// Ping the connection.
 	Ping(context.Context, *v1beta1.RequestPing) (*v1beta1.ResponsePing, error)
+	// BroadcastTx broadcasts the transaction.
 	BroadcastTx(context.Context, *v1beta1.RequestBroadcastTx) (*ResponseBroadcastTx, error)
 }
 

--- a/api/cometbft/rpc/grpc/v1beta3/types.pb.go
+++ b/api/cometbft/rpc/grpc/v1beta3/types.pb.go
@@ -29,6 +29,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// ResponseBroadcastTx is a response of broadcasting the transaction.
 type ResponseBroadcastTx struct {
 	CheckTx  *v1beta3.ResponseCheckTx `protobuf:"bytes,1,opt,name=check_tx,json=checkTx,proto3" json:"check_tx,omitempty"`
 	TxResult *v1beta3.ExecTxResult    `protobuf:"bytes,2,opt,name=tx_result,json=txResult,proto3" json:"tx_result,omitempty"`
@@ -125,7 +126,9 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type BroadcastAPIClient interface {
+	// Ping the connection.
 	Ping(ctx context.Context, in *v1beta1.RequestPing, opts ...grpc.CallOption) (*v1beta1.ResponsePing, error)
+	// BroadcastTx broadcasts a transaction.
 	BroadcastTx(ctx context.Context, in *v1beta1.RequestBroadcastTx, opts ...grpc.CallOption) (*ResponseBroadcastTx, error)
 }
 
@@ -157,7 +160,9 @@ func (c *broadcastAPIClient) BroadcastTx(ctx context.Context, in *v1beta1.Reques
 
 // BroadcastAPIServer is the server API for BroadcastAPI service.
 type BroadcastAPIServer interface {
+	// Ping the connection.
 	Ping(context.Context, *v1beta1.RequestPing) (*v1beta1.ResponsePing, error)
+	// BroadcastTx broadcasts a transaction.
 	BroadcastTx(context.Context, *v1beta1.RequestBroadcastTx) (*ResponseBroadcastTx, error)
 }
 

--- a/api/cometbft/services/block/v1/block.pb.go
+++ b/api/cometbft/services/block/v1/block.pb.go
@@ -23,6 +23,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// GetByHeightRequest is a request for a block at the specified height.
 type GetByHeightRequest struct {
 	// The height of the block requested. If set to 0, the latest height will be returned.
 	Height int64 `protobuf:"varint,1,opt,name=height,proto3" json:"height,omitempty"`
@@ -68,6 +69,7 @@ func (m *GetByHeightRequest) GetHeight() int64 {
 	return 0
 }
 
+// GetByHeightResponse contains the block ID and the block at the specified height.
 type GetByHeightResponse struct {
 	BlockId *v1.BlockID `protobuf:"bytes,1,opt,name=block_id,json=blockId,proto3" json:"block_id,omitempty"`
 	Block   *v1.Block   `protobuf:"bytes,2,opt,name=block,proto3" json:"block,omitempty"`
@@ -120,6 +122,7 @@ func (m *GetByHeightResponse) GetBlock() *v1.Block {
 	return nil
 }
 
+// GetLatestRequest is a request for the latest block.
 type GetLatestRequest struct {
 }
 
@@ -156,6 +159,7 @@ func (m *GetLatestRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_GetLatestRequest proto.InternalMessageInfo
 
+// GetLatestResponse contains the latest block ID and the latest block.
 type GetLatestResponse struct {
 	BlockId *v1.BlockID `protobuf:"bytes,1,opt,name=block_id,json=blockId,proto3" json:"block_id,omitempty"`
 	Block   *v1.Block   `protobuf:"bytes,2,opt,name=block,proto3" json:"block,omitempty"`

--- a/api/cometbft/services/block_results/v1/block_results.pb.go
+++ b/api/cometbft/services/block_results/v1/block_results.pb.go
@@ -24,6 +24,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// GetBlockResults is a request for the BlockResults of a given height.
 type GetBlockResultsRequest struct {
 	Height int64 `protobuf:"varint,1,opt,name=height,proto3" json:"height,omitempty"`
 }
@@ -68,6 +69,7 @@ func (m *GetBlockResultsRequest) GetHeight() int64 {
 	return 0
 }
 
+// GetLatestBlockResultsRequest is a request for the BlockResults of the latest block.
 type GetLatestBlockResultsRequest struct {
 }
 
@@ -104,6 +106,7 @@ func (m *GetLatestBlockResultsRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_GetLatestBlockResultsRequest proto.InternalMessageInfo
 
+// GetBlockResultsResponse contains the block results for the given height.
 type GetBlockResultsResponse struct {
 	Height                int64                 `protobuf:"varint,1,opt,name=height,proto3" json:"height,omitempty"`
 	TxResults             []*v1.ExecTxResult    `protobuf:"bytes,2,rep,name=tx_results,json=txResults,proto3" json:"tx_results,omitempty"`
@@ -188,6 +191,7 @@ func (m *GetBlockResultsResponse) GetAppHash() []byte {
 	return nil
 }
 
+// GetLatestBlockResultsResponse contains the block results for the latest block.
 type GetLatestBlockResultsResponse struct {
 	Height                int64                 `protobuf:"varint,1,opt,name=height,proto3" json:"height,omitempty"`
 	TxResults             []*v1.ExecTxResult    `protobuf:"bytes,2,rep,name=tx_results,json=txResults,proto3" json:"tx_results,omitempty"`

--- a/api/cometbft/services/pruning/v1/pruning.pb.go
+++ b/api/cometbft/services/pruning/v1/pruning.pb.go
@@ -22,6 +22,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// SetBlockRetainHeightRequest sets the retain height for blocks.
 type SetBlockRetainHeightRequest struct {
 	Height uint64 `protobuf:"varint,1,opt,name=height,proto3" json:"height,omitempty"`
 }
@@ -66,6 +67,7 @@ func (m *SetBlockRetainHeightRequest) GetHeight() uint64 {
 	return 0
 }
 
+// SetBlockRetainHeightResponse is empty.
 type SetBlockRetainHeightResponse struct {
 }
 
@@ -102,6 +104,7 @@ func (m *SetBlockRetainHeightResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_SetBlockRetainHeightResponse proto.InternalMessageInfo
 
+// GetBlockRetainHeightRequest is a request for the retain height.
 type GetBlockRetainHeightRequest struct {
 }
 
@@ -138,6 +141,7 @@ func (m *GetBlockRetainHeightRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_GetBlockRetainHeightRequest proto.InternalMessageInfo
 
+// GetBlockRetainHeightResponse returns the retain height for blocks.
 type GetBlockRetainHeightResponse struct {
 	// The retain height set by the application.
 	AppRetainHeight uint64 `protobuf:"varint,1,opt,name=app_retain_height,json=appRetainHeight,proto3" json:"app_retain_height,omitempty"`
@@ -193,6 +197,7 @@ func (m *GetBlockRetainHeightResponse) GetPruningServiceRetainHeight() uint64 {
 	return 0
 }
 
+// SetBlockResultsRetainHeightRequest sets the retain height for block results.
 type SetBlockResultsRetainHeightRequest struct {
 	Height uint64 `protobuf:"varint,1,opt,name=height,proto3" json:"height,omitempty"`
 }
@@ -237,6 +242,7 @@ func (m *SetBlockResultsRetainHeightRequest) GetHeight() uint64 {
 	return 0
 }
 
+// SetBlockResultsRetainHeightResponse is empty.
 type SetBlockResultsRetainHeightResponse struct {
 }
 
@@ -273,6 +279,7 @@ func (m *SetBlockResultsRetainHeightResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_SetBlockResultsRetainHeightResponse proto.InternalMessageInfo
 
+// GetBlockResultsRetainHeightRequest is a request for the retain height.
 type GetBlockResultsRetainHeightRequest struct {
 }
 
@@ -309,6 +316,7 @@ func (m *GetBlockResultsRetainHeightRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_GetBlockResultsRetainHeightRequest proto.InternalMessageInfo
 
+// GetBlockResultsRetainHeightResponse returns the retain height for block results.
 type GetBlockResultsRetainHeightResponse struct {
 	// The retain height set by the pruning service (e.g. by the data
 	// companion) specifically for block results.
@@ -355,6 +363,7 @@ func (m *GetBlockResultsRetainHeightResponse) GetPruningServiceRetainHeight() ui
 	return 0
 }
 
+// SetTxIndexerRetainHeightRequest sets the retain height for the tx indexer.
 type SetTxIndexerRetainHeightRequest struct {
 	Height uint64 `protobuf:"varint,1,opt,name=height,proto3" json:"height,omitempty"`
 }
@@ -399,6 +408,7 @@ func (m *SetTxIndexerRetainHeightRequest) GetHeight() uint64 {
 	return 0
 }
 
+// SetTxIndexerRetainHeightResponse is empty.
 type SetTxIndexerRetainHeightResponse struct {
 }
 
@@ -435,6 +445,7 @@ func (m *SetTxIndexerRetainHeightResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_SetTxIndexerRetainHeightResponse proto.InternalMessageInfo
 
+// GetTxIndexerRetainHeightRequest is a request for the retain height.
 type GetTxIndexerRetainHeightRequest struct {
 }
 
@@ -471,6 +482,7 @@ func (m *GetTxIndexerRetainHeightRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_GetTxIndexerRetainHeightRequest proto.InternalMessageInfo
 
+// GetTxIndexerRetainHeightResponse returns the retain height for the tx indexer.
 type GetTxIndexerRetainHeightResponse struct {
 	Height uint64 `protobuf:"varint,1,opt,name=height,proto3" json:"height,omitempty"`
 }
@@ -515,6 +527,7 @@ func (m *GetTxIndexerRetainHeightResponse) GetHeight() uint64 {
 	return 0
 }
 
+// SetBlockIndexerRetainHeightRequest sets the retain height for the block indexer.
 type SetBlockIndexerRetainHeightRequest struct {
 	Height uint64 `protobuf:"varint,1,opt,name=height,proto3" json:"height,omitempty"`
 }
@@ -559,6 +572,7 @@ func (m *SetBlockIndexerRetainHeightRequest) GetHeight() uint64 {
 	return 0
 }
 
+// SetBlockIndexerRetainHeightResponse is empty.
 type SetBlockIndexerRetainHeightResponse struct {
 }
 
@@ -595,6 +609,7 @@ func (m *SetBlockIndexerRetainHeightResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_SetBlockIndexerRetainHeightResponse proto.InternalMessageInfo
 
+// GetBlockIndexerRetainHeightRequest is a request for the retain height.
 type GetBlockIndexerRetainHeightRequest struct {
 }
 
@@ -631,6 +646,7 @@ func (m *GetBlockIndexerRetainHeightRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_GetBlockIndexerRetainHeightRequest proto.InternalMessageInfo
 
+// GetBlockIndexerRetainHeightResponse returns the retain height for the block indexer.
 type GetBlockIndexerRetainHeightResponse struct {
 	Height uint64 `protobuf:"varint,1,opt,name=height,proto3" json:"height,omitempty"`
 }

--- a/api/cometbft/services/version/v1/version.pb.go
+++ b/api/cometbft/services/version/v1/version.pb.go
@@ -22,6 +22,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// GetVersionRequest is the request for the ABCI version.
 type GetVersionRequest struct {
 }
 
@@ -58,6 +59,7 @@ func (m *GetVersionRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_GetVersionRequest proto.InternalMessageInfo
 
+// GetVersionResponse contains the ABCI application version info.
 type GetVersionResponse struct {
 	Node  string `protobuf:"bytes,1,opt,name=node,proto3" json:"node,omitempty"`
 	Abci  string `protobuf:"bytes,2,opt,name=abci,proto3" json:"abci,omitempty"`

--- a/api/cometbft/state/v1/types.pb.go
+++ b/api/cometbft/state/v1/types.pb.go
@@ -310,6 +310,7 @@ func (m *ConsensusParamsInfo) GetLastHeightChanged() int64 {
 	return 0
 }
 
+// ABCIResponsesInfo retains the responses of the ABCI calls during block processing.
 type ABCIResponsesInfo struct {
 	// Retains the responses of the legacy ABCI calls during block processing.
 	LegacyAbciResponses *LegacyABCIResponses      `protobuf:"bytes,1,opt,name=legacy_abci_responses,json=legacyAbciResponses,proto3" json:"legacy_abci_responses,omitempty"`
@@ -371,6 +372,7 @@ func (m *ABCIResponsesInfo) GetFinalizeBlock() *v1.FinalizeBlockResponse {
 	return nil
 }
 
+// Version is a message for storing versioning information.
 type Version struct {
 	Consensus v12.Consensus `protobuf:"bytes,1,opt,name=consensus,proto3" json:"consensus"`
 	Software  string        `protobuf:"bytes,2,opt,name=software,proto3" json:"software,omitempty"`
@@ -423,6 +425,7 @@ func (m *Version) GetSoftware() string {
 	return ""
 }
 
+// State represents the state of the blockchain.
 type State struct {
 	Version Version `protobuf:"bytes,1,opt,name=version,proto3" json:"version"`
 	// immutable

--- a/api/cometbft/state/v1beta1/types.pb.go
+++ b/api/cometbft/state/v1beta1/types.pb.go
@@ -199,6 +199,7 @@ func (m *ConsensusParamsInfo) GetLastHeightChanged() int64 {
 	return 0
 }
 
+// ABCIResponsesInfo retains the responses of the ABCI calls during block processing.
 type ABCIResponsesInfo struct {
 	AbciResponses *ABCIResponses `protobuf:"bytes,1,opt,name=abci_responses,json=abciResponses,proto3" json:"abci_responses,omitempty"`
 	Height        int64          `protobuf:"varint,2,opt,name=height,proto3" json:"height,omitempty"`
@@ -251,6 +252,7 @@ func (m *ABCIResponsesInfo) GetHeight() int64 {
 	return 0
 }
 
+// Version is a message for storing versioning information.
 type Version struct {
 	Consensus v1.Consensus `protobuf:"bytes,1,opt,name=consensus,proto3" json:"consensus"`
 	Software  string       `protobuf:"bytes,2,opt,name=software,proto3" json:"software,omitempty"`
@@ -303,6 +305,7 @@ func (m *Version) GetSoftware() string {
 	return ""
 }
 
+// State represents the state of the blockchain.
 type State struct {
 	Version Version `protobuf:"bytes,1,opt,name=version,proto3" json:"version"`
 	// immutable

--- a/api/cometbft/state/v1beta2/types.pb.go
+++ b/api/cometbft/state/v1beta2/types.pb.go
@@ -147,6 +147,7 @@ func (m *ConsensusParamsInfo) GetLastHeightChanged() int64 {
 	return 0
 }
 
+// ABCIResponsesInfo retains the responses of the ABCI calls during block processing.
 type ABCIResponsesInfo struct {
 	AbciResponses *ABCIResponses `protobuf:"bytes,1,opt,name=abci_responses,json=abciResponses,proto3" json:"abci_responses,omitempty"`
 	Height        int64          `protobuf:"varint,2,opt,name=height,proto3" json:"height,omitempty"`
@@ -199,6 +200,7 @@ func (m *ABCIResponsesInfo) GetHeight() int64 {
 	return 0
 }
 
+// State represents the state of the blockchain.
 type State struct {
 	Version v1beta1.Version `protobuf:"bytes,1,opt,name=version,proto3" json:"version"`
 	// immutable

--- a/api/cometbft/state/v1beta3/types.pb.go
+++ b/api/cometbft/state/v1beta3/types.pb.go
@@ -260,6 +260,7 @@ func (m *ConsensusParamsInfo) GetLastHeightChanged() int64 {
 	return 0
 }
 
+// ABCIResponsesInfo retains the responses of the ABCI calls during block processing.
 type ABCIResponsesInfo struct {
 	// Retains the responses of the legacy ABCI calls during block processing.
 	LegacyAbciResponses   *LegacyABCIResponses           `protobuf:"bytes,1,opt,name=legacy_abci_responses,json=legacyAbciResponses,proto3" json:"legacy_abci_responses,omitempty"`
@@ -321,6 +322,7 @@ func (m *ABCIResponsesInfo) GetResponseFinalizeBlock() *v1beta3.ResponseFinalize
 	return nil
 }
 
+// State represents the state of the blockchain.
 type State struct {
 	Version v1beta11.Version `protobuf:"bytes,1,opt,name=version,proto3" json:"version"`
 	// immutable

--- a/api/cometbft/statesync/v1/types.pb.go
+++ b/api/cometbft/statesync/v1/types.pb.go
@@ -22,7 +22,10 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// Message is the top-level message type for the statesync service.
 type Message struct {
+	// The message type.
+	//
 	// Types that are valid to be assigned to Sum:
 	//
 	//	*Message_SnapshotsRequest
@@ -134,6 +137,7 @@ func (*Message) XXX_OneofWrappers() []interface{} {
 	}
 }
 
+// SnapshotsRequest is sent to request a snapshot.
 type SnapshotsRequest struct {
 }
 
@@ -170,6 +174,7 @@ func (m *SnapshotsRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_SnapshotsRequest proto.InternalMessageInfo
 
+// SnapshotsResponse contains the snapshot metadata.
 type SnapshotsResponse struct {
 	Height   uint64 `protobuf:"varint,1,opt,name=height,proto3" json:"height,omitempty"`
 	Format   uint32 `protobuf:"varint,2,opt,name=format,proto3" json:"format,omitempty"`
@@ -246,6 +251,7 @@ func (m *SnapshotsResponse) GetMetadata() []byte {
 	return nil
 }
 
+// ChunkRequest is sent to request a chunk.
 type ChunkRequest struct {
 	Height uint64 `protobuf:"varint,1,opt,name=height,proto3" json:"height,omitempty"`
 	Format uint32 `protobuf:"varint,2,opt,name=format,proto3" json:"format,omitempty"`
@@ -306,6 +312,7 @@ func (m *ChunkRequest) GetIndex() uint32 {
 	return 0
 }
 
+// ChunkResponse contains a chunk of the snapshot.
 type ChunkResponse struct {
 	Height  uint64 `protobuf:"varint,1,opt,name=height,proto3" json:"height,omitempty"`
 	Format  uint32 `protobuf:"varint,2,opt,name=format,proto3" json:"format,omitempty"`

--- a/api/cometbft/store/v1/types.pb.go
+++ b/api/cometbft/store/v1/types.pb.go
@@ -22,6 +22,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// BlockStoreState represents the state of the block store.
 type BlockStoreState struct {
 	Base   int64 `protobuf:"varint,1,opt,name=base,proto3" json:"base,omitempty"`
 	Height int64 `protobuf:"varint,2,opt,name=height,proto3" json:"height,omitempty"`

--- a/api/cometbft/types/v1/block.pb.go
+++ b/api/cometbft/types/v1/block.pb.go
@@ -23,6 +23,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// Block defines the structure of a block in the CometBFT blockchain.
 type Block struct {
 	Header     Header       `protobuf:"bytes,1,opt,name=header,proto3" json:"header"`
 	Data       Data         `protobuf:"bytes,2,opt,name=data,proto3" json:"data"`

--- a/api/cometbft/types/v1/canonical.pb.go
+++ b/api/cometbft/types/v1/canonical.pb.go
@@ -28,6 +28,8 @@ var _ = time.Kitchen
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// CanonicalBlockID is a canonical representation of a BlockID, which gets
+// serialized and signed.
 type CanonicalBlockID struct {
 	Hash          []byte                 `protobuf:"bytes,1,opt,name=hash,proto3" json:"hash,omitempty"`
 	PartSetHeader CanonicalPartSetHeader `protobuf:"bytes,2,opt,name=part_set_header,json=partSetHeader,proto3" json:"part_set_header"`
@@ -80,6 +82,8 @@ func (m *CanonicalBlockID) GetPartSetHeader() CanonicalPartSetHeader {
 	return CanonicalPartSetHeader{}
 }
 
+// CanonicalPartSetHeader is a canonical representation of a PartSetHeader,
+// which gets serialized and signed.
 type CanonicalPartSetHeader struct {
 	Total uint32 `protobuf:"varint,1,opt,name=total,proto3" json:"total,omitempty"`
 	Hash  []byte `protobuf:"bytes,2,opt,name=hash,proto3" json:"hash,omitempty"`
@@ -132,6 +136,8 @@ func (m *CanonicalPartSetHeader) GetHash() []byte {
 	return nil
 }
 
+// CanonicalProposal is a canonical representation of a Proposal, which gets
+// serialized and signed.
 type CanonicalProposal struct {
 	Type      SignedMsgType     `protobuf:"varint,1,opt,name=type,proto3,enum=cometbft.types.v1.SignedMsgType" json:"type,omitempty"`
 	Height    int64             `protobuf:"fixed64,2,opt,name=height,proto3" json:"height,omitempty"`
@@ -224,6 +230,8 @@ func (m *CanonicalProposal) GetChainID() string {
 	return ""
 }
 
+// CanonicalVote is a canonical representation of a Vote, which gets
+// serialized and signed.
 type CanonicalVote struct {
 	Type      SignedMsgType     `protobuf:"varint,1,opt,name=type,proto3,enum=cometbft.types.v1.SignedMsgType" json:"type,omitempty"`
 	Height    int64             `protobuf:"fixed64,2,opt,name=height,proto3" json:"height,omitempty"`

--- a/api/cometbft/types/v1/events.pb.go
+++ b/api/cometbft/types/v1/events.pb.go
@@ -22,6 +22,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// EventDataRoundState is emmitted with each new round step.
 type EventDataRoundState struct {
 	Height int64  `protobuf:"varint,1,opt,name=height,proto3" json:"height,omitempty"`
 	Round  int32  `protobuf:"varint,2,opt,name=round,proto3" json:"round,omitempty"`

--- a/api/cometbft/types/v1/evidence.pb.go
+++ b/api/cometbft/types/v1/evidence.pb.go
@@ -27,7 +27,10 @@ var _ = time.Kitchen
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// Evidence is a generic type for wrapping evidence of misbehavior by a validator.
 type Evidence struct {
+	// The type of evidence.
+	//
 	// Types that are valid to be assigned to Sum:
 	//	*Evidence_DuplicateVoteEvidence
 	//	*Evidence_LightClientAttackEvidence
@@ -266,6 +269,7 @@ func (m *LightClientAttackEvidence) GetTimestamp() time.Time {
 	return time.Time{}
 }
 
+// EvidenceList is a list of evidence.
 type EvidenceList struct {
 	Evidence []Evidence `protobuf:"bytes,1,rep,name=evidence,proto3" json:"evidence"`
 }

--- a/api/cometbft/types/v1/types.pb.go
+++ b/api/cometbft/types/v1/types.pb.go
@@ -33,11 +33,13 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 type SignedMsgType int32
 
 const (
+	// Unknown
 	UnknownType SignedMsgType = 0
-	// Votes
-	PrevoteType   SignedMsgType = 1
+	// Prevote
+	PrevoteType SignedMsgType = 1
+	// Precommit
 	PrecommitType SignedMsgType = 2
-	// Proposals
+	// Proposal
 	ProposalType SignedMsgType = 32
 )
 
@@ -63,6 +65,7 @@ func (SignedMsgType) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_8ea20b664d765b5f, []int{0}
 }
 
+// Header of the parts set for a block.
 type PartSetHeader struct {
 	Total uint32 `protobuf:"varint,1,opt,name=total,proto3" json:"total,omitempty"`
 	Hash  []byte `protobuf:"bytes,2,opt,name=hash,proto3" json:"hash,omitempty"`
@@ -115,6 +118,7 @@ func (m *PartSetHeader) GetHash() []byte {
 	return nil
 }
 
+// Part of the block.
 type Part struct {
 	Index uint32   `protobuf:"varint,1,opt,name=index,proto3" json:"index,omitempty"`
 	Bytes []byte   `protobuf:"bytes,2,opt,name=bytes,proto3" json:"bytes,omitempty"`
@@ -175,6 +179,7 @@ func (m *Part) GetProof() v1.Proof {
 	return v1.Proof{}
 }
 
+// BlockID defines the unique ID of a block as its hash and its `PartSetHeader`.
 type BlockID struct {
 	Hash          []byte        `protobuf:"bytes,1,opt,name=hash,proto3" json:"hash,omitempty"`
 	PartSetHeader PartSetHeader `protobuf:"bytes,2,opt,name=part_set_header,json=partSetHeader,proto3" json:"part_set_header"`
@@ -692,6 +697,7 @@ func (m *CommitSig) GetSignature() []byte {
 	return nil
 }
 
+// ExtendedCommit is a Commit with ExtendedCommitSig.
 type ExtendedCommit struct {
 	Height             int64               `protobuf:"varint,1,opt,name=height,proto3" json:"height,omitempty"`
 	Round              int32               `protobuf:"varint,2,opt,name=round,proto3" json:"round,omitempty"`
@@ -849,6 +855,7 @@ func (m *ExtendedCommitSig) GetExtensionSignature() []byte {
 	return nil
 }
 
+// Block proposal.
 type Proposal struct {
 	Type      SignedMsgType `protobuf:"varint,1,opt,name=type,proto3,enum=cometbft.types.v1.SignedMsgType" json:"type,omitempty"`
 	Height    int64         `protobuf:"varint,2,opt,name=height,proto3" json:"height,omitempty"`
@@ -941,6 +948,7 @@ func (m *Proposal) GetSignature() []byte {
 	return nil
 }
 
+// SignedHeader contains a Header(H) and Commit(H+1) with signatures of validators who signed it.
 type SignedHeader struct {
 	Header *Header `protobuf:"bytes,1,opt,name=header,proto3" json:"header,omitempty"`
 	Commit *Commit `protobuf:"bytes,2,opt,name=commit,proto3" json:"commit,omitempty"`
@@ -993,6 +1001,7 @@ func (m *SignedHeader) GetCommit() *Commit {
 	return nil
 }
 
+// LightBlock is a combination of SignedHeader and ValidatorSet. It is used by light clients.
 type LightBlock struct {
 	SignedHeader *SignedHeader `protobuf:"bytes,1,opt,name=signed_header,json=signedHeader,proto3" json:"signed_header,omitempty"`
 	ValidatorSet *ValidatorSet `protobuf:"bytes,2,opt,name=validator_set,json=validatorSet,proto3" json:"validator_set,omitempty"`
@@ -1045,6 +1054,7 @@ func (m *LightBlock) GetValidatorSet() *ValidatorSet {
 	return nil
 }
 
+// BlockMeta contains meta information about a block.
 type BlockMeta struct {
 	BlockID   BlockID `protobuf:"bytes,1,opt,name=block_id,json=blockId,proto3" json:"block_id"`
 	BlockSize int64   `protobuf:"varint,2,opt,name=block_size,json=blockSize,proto3" json:"block_size,omitempty"`

--- a/api/cometbft/types/v1/validator.pb.go
+++ b/api/cometbft/types/v1/validator.pb.go
@@ -28,10 +28,14 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 type BlockIDFlag int32
 
 const (
+	// Indicates an error condition
 	BlockIDFlagUnknown BlockIDFlag = 0
-	BlockIDFlagAbsent  BlockIDFlag = 1
-	BlockIDFlagCommit  BlockIDFlag = 2
-	BlockIDFlagNil     BlockIDFlag = 3
+	// The vote was not received
+	BlockIDFlagAbsent BlockIDFlag = 1
+	// Voted for the block that received the majority
+	BlockIDFlagCommit BlockIDFlag = 2
+	// Voted for nil
+	BlockIDFlagNil BlockIDFlag = 3
 )
 
 var BlockIDFlag_name = map[int32]string{
@@ -56,6 +60,7 @@ func (BlockIDFlag) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_20d37f2fd54e559e, []int{0}
 }
 
+// ValidatorSet defines a set of validators.
 type ValidatorSet struct {
 	Validators       []*Validator `protobuf:"bytes,1,rep,name=validators,proto3" json:"validators,omitempty"`
 	Proposer         *Validator   `protobuf:"bytes,2,opt,name=proposer,proto3" json:"proposer,omitempty"`
@@ -116,6 +121,7 @@ func (m *ValidatorSet) GetTotalVotingPower() int64 {
 	return 0
 }
 
+// Validator represents a node participating in the consensus protocol.
 type Validator struct {
 	Address          []byte       `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
 	PubKey           v1.PublicKey `protobuf:"bytes,2,opt,name=pub_key,json=pubKey,proto3" json:"pub_key"`
@@ -184,6 +190,9 @@ func (m *Validator) GetProposerPriority() int64 {
 	return 0
 }
 
+// SimpleValidator is a Validator, which is serialized and hashed in consensus.
+// Address is removed because it's redundant with the pubkey.
+// Proposer priority is removed because it changes every round.
 type SimpleValidator struct {
 	PubKey      *v1.PublicKey `protobuf:"bytes,1,opt,name=pub_key,json=pubKey,proto3" json:"pub_key,omitempty"`
 	VotingPower int64         `protobuf:"varint,2,opt,name=voting_power,json=votingPower,proto3" json:"voting_power,omitempty"`

--- a/api/cometbft/types/v1beta1/block.pb.go
+++ b/api/cometbft/types/v1beta1/block.pb.go
@@ -23,6 +23,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// Block defines the structure of a block in the CometBFT blockchain.
 type Block struct {
 	Header     Header       `protobuf:"bytes,1,opt,name=header,proto3" json:"header"`
 	Data       Data         `protobuf:"bytes,2,opt,name=data,proto3" json:"data"`

--- a/api/cometbft/types/v1beta1/canonical.pb.go
+++ b/api/cometbft/types/v1beta1/canonical.pb.go
@@ -28,6 +28,8 @@ var _ = time.Kitchen
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// CanonicalBlockID is a canonical representation of a BlockID, which gets
+// serialized and signed.
 type CanonicalBlockID struct {
 	Hash          []byte                 `protobuf:"bytes,1,opt,name=hash,proto3" json:"hash,omitempty"`
 	PartSetHeader CanonicalPartSetHeader `protobuf:"bytes,2,opt,name=part_set_header,json=partSetHeader,proto3" json:"part_set_header"`
@@ -80,6 +82,8 @@ func (m *CanonicalBlockID) GetPartSetHeader() CanonicalPartSetHeader {
 	return CanonicalPartSetHeader{}
 }
 
+// CanonicalPartSetHeader is a canonical representation of a PartSetHeader,
+// which gets serialized and signed.
 type CanonicalPartSetHeader struct {
 	Total uint32 `protobuf:"varint,1,opt,name=total,proto3" json:"total,omitempty"`
 	Hash  []byte `protobuf:"bytes,2,opt,name=hash,proto3" json:"hash,omitempty"`
@@ -132,6 +136,8 @@ func (m *CanonicalPartSetHeader) GetHash() []byte {
 	return nil
 }
 
+// CanonicalProposal is a canonical representation of a Proposal, which gets
+// serialized and signed.
 type CanonicalProposal struct {
 	Type      SignedMsgType     `protobuf:"varint,1,opt,name=type,proto3,enum=cometbft.types.v1beta1.SignedMsgType" json:"type,omitempty"`
 	Height    int64             `protobuf:"fixed64,2,opt,name=height,proto3" json:"height,omitempty"`
@@ -224,6 +230,8 @@ func (m *CanonicalProposal) GetChainID() string {
 	return ""
 }
 
+// CanonicalVote is a canonical representation of a Vote, which gets
+// serialized and signed.
 type CanonicalVote struct {
 	Type      SignedMsgType     `protobuf:"varint,1,opt,name=type,proto3,enum=cometbft.types.v1beta1.SignedMsgType" json:"type,omitempty"`
 	Height    int64             `protobuf:"fixed64,2,opt,name=height,proto3" json:"height,omitempty"`

--- a/api/cometbft/types/v1beta1/events.pb.go
+++ b/api/cometbft/types/v1beta1/events.pb.go
@@ -22,6 +22,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// EventDataRoundState is emmitted with each new round step.
 type EventDataRoundState struct {
 	Height int64  `protobuf:"varint,1,opt,name=height,proto3" json:"height,omitempty"`
 	Round  int32  `protobuf:"varint,2,opt,name=round,proto3" json:"round,omitempty"`

--- a/api/cometbft/types/v1beta1/evidence.pb.go
+++ b/api/cometbft/types/v1beta1/evidence.pb.go
@@ -27,7 +27,10 @@ var _ = time.Kitchen
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// Evidence is a generic type for wrapping evidence of misbehavior by a validator.
 type Evidence struct {
+	// The type of evidence.
+	//
 	// Types that are valid to be assigned to Sum:
 	//	*Evidence_DuplicateVoteEvidence
 	//	*Evidence_LightClientAttackEvidence
@@ -266,6 +269,7 @@ func (m *LightClientAttackEvidence) GetTimestamp() time.Time {
 	return time.Time{}
 }
 
+// EvidenceList is a list of evidence.
 type EvidenceList struct {
 	Evidence []Evidence `protobuf:"bytes,1,rep,name=evidence,proto3" json:"evidence"`
 }

--- a/api/cometbft/types/v1beta1/types.pb.go
+++ b/api/cometbft/types/v1beta1/types.pb.go
@@ -33,11 +33,13 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 type SignedMsgType int32
 
 const (
+	// Unknown
 	UnknownType SignedMsgType = 0
-	// Votes
-	PrevoteType   SignedMsgType = 1
+	// Prevote
+	PrevoteType SignedMsgType = 1
+	// Precommit
 	PrecommitType SignedMsgType = 2
-	// Proposals
+	// Proposal
 	ProposalType SignedMsgType = 32
 )
 
@@ -63,7 +65,7 @@ func (SignedMsgType) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_af6831286a0350e0, []int{0}
 }
 
-// PartsetHeader
+// Header of the parts set for a block.
 type PartSetHeader struct {
 	Total uint32 `protobuf:"varint,1,opt,name=total,proto3" json:"total,omitempty"`
 	Hash  []byte `protobuf:"bytes,2,opt,name=hash,proto3" json:"hash,omitempty"`
@@ -116,6 +118,7 @@ func (m *PartSetHeader) GetHash() []byte {
 	return nil
 }
 
+// Part of the block.
 type Part struct {
 	Index uint32   `protobuf:"varint,1,opt,name=index,proto3" json:"index,omitempty"`
 	Bytes []byte   `protobuf:"bytes,2,opt,name=bytes,proto3" json:"bytes,omitempty"`
@@ -176,7 +179,7 @@ func (m *Part) GetProof() v1.Proof {
 	return v1.Proof{}
 }
 
-// BlockID
+// BlockID defines the unique ID of a block as its hash and its `PartSetHeader`.
 type BlockID struct {
 	Hash          []byte        `protobuf:"bytes,1,opt,name=hash,proto3" json:"hash,omitempty"`
 	PartSetHeader PartSetHeader `protobuf:"bytes,2,opt,name=part_set_header,json=partSetHeader,proto3" json:"part_set_header"`
@@ -671,6 +674,7 @@ func (m *CommitSig) GetSignature() []byte {
 	return nil
 }
 
+// Block proposal.
 type Proposal struct {
 	Type      SignedMsgType `protobuf:"varint,1,opt,name=type,proto3,enum=cometbft.types.v1beta1.SignedMsgType" json:"type,omitempty"`
 	Height    int64         `protobuf:"varint,2,opt,name=height,proto3" json:"height,omitempty"`
@@ -763,6 +767,7 @@ func (m *Proposal) GetSignature() []byte {
 	return nil
 }
 
+// SignedHeader contains a Header(H) and Commit(H+1) with signatures of validators who signed it.
 type SignedHeader struct {
 	Header *Header `protobuf:"bytes,1,opt,name=header,proto3" json:"header,omitempty"`
 	Commit *Commit `protobuf:"bytes,2,opt,name=commit,proto3" json:"commit,omitempty"`
@@ -815,6 +820,7 @@ func (m *SignedHeader) GetCommit() *Commit {
 	return nil
 }
 
+// LightBlock is a combination of SignedHeader and ValidatorSet. It is used by light clients.
 type LightBlock struct {
 	SignedHeader *SignedHeader `protobuf:"bytes,1,opt,name=signed_header,json=signedHeader,proto3" json:"signed_header,omitempty"`
 	ValidatorSet *ValidatorSet `protobuf:"bytes,2,opt,name=validator_set,json=validatorSet,proto3" json:"validator_set,omitempty"`
@@ -867,6 +873,7 @@ func (m *LightBlock) GetValidatorSet() *ValidatorSet {
 	return nil
 }
 
+// BlockMeta contains meta information about a block.
 type BlockMeta struct {
 	BlockID   BlockID `protobuf:"bytes,1,opt,name=block_id,json=blockId,proto3" json:"block_id"`
 	BlockSize int64   `protobuf:"varint,2,opt,name=block_size,json=blockSize,proto3" json:"block_size,omitempty"`

--- a/api/cometbft/types/v1beta1/validator.pb.go
+++ b/api/cometbft/types/v1beta1/validator.pb.go
@@ -28,10 +28,14 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 type BlockIDFlag int32
 
 const (
+	// Indicates an error condition
 	BlockIDFlagUnknown BlockIDFlag = 0
-	BlockIDFlagAbsent  BlockIDFlag = 1
-	BlockIDFlagCommit  BlockIDFlag = 2
-	BlockIDFlagNil     BlockIDFlag = 3
+	// The vote was not received
+	BlockIDFlagAbsent BlockIDFlag = 1
+	// Voted for the block that received the majority
+	BlockIDFlagCommit BlockIDFlag = 2
+	// Voted for nil
+	BlockIDFlagNil BlockIDFlag = 3
 )
 
 var BlockIDFlag_name = map[int32]string{
@@ -56,6 +60,7 @@ func (BlockIDFlag) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_2e1661b4f555b138, []int{0}
 }
 
+// ValidatorSet defines a set of validators.
 type ValidatorSet struct {
 	Validators       []*Validator `protobuf:"bytes,1,rep,name=validators,proto3" json:"validators,omitempty"`
 	Proposer         *Validator   `protobuf:"bytes,2,opt,name=proposer,proto3" json:"proposer,omitempty"`
@@ -116,6 +121,7 @@ func (m *ValidatorSet) GetTotalVotingPower() int64 {
 	return 0
 }
 
+// Validator represents a node participating in the consensus protocol.
 type Validator struct {
 	Address          []byte       `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
 	PubKey           v1.PublicKey `protobuf:"bytes,2,opt,name=pub_key,json=pubKey,proto3" json:"pub_key"`
@@ -184,6 +190,9 @@ func (m *Validator) GetProposerPriority() int64 {
 	return 0
 }
 
+// SimpleValidator is a Validator, which is serialized and hashed in consensus.
+// Address is removed because it's redundant with the pubkey.
+// Proposer priority is removed because it changes every round.
 type SimpleValidator struct {
 	PubKey      *v1.PublicKey `protobuf:"bytes,1,opt,name=pub_key,json=pubKey,proto3" json:"pub_key,omitempty"`
 	VotingPower int64         `protobuf:"varint,2,opt,name=voting_power,json=votingPower,proto3" json:"voting_power,omitempty"`


### PR DESCRIPTION
In reviewing #1672 I picked up on a few minor things:

1. If we don't include the `Makefile` change, Go will simply use whichever version of the Buf CLI is currently installed locally, which may not match the version used in CI (which is always the latest version).
2. CI should always check that the code generation has happened correctly.
3. I ran `make proto-gen` to update the generated code.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

