### PR TITLE
buf improvements prior to publishing on BSR

### DIFF
--- a/proto/buf.lock
+++ b/proto/buf.lock
@@ -4,4 +4,5 @@ deps:
   - remote: buf.build
     owner: cosmos
     repository: gogo-proto
-    commit: 6652e3443c3b4504bb3bf82e73a7e409
+    commit: 5e5b9fdd01804356895f8f79a6f1ddc1
+    digest: shake256:0b85da49e2e5f9ebc4806eae058e2f56096ff3b1c59d1fb7c190413dd15f45dd456f0b69ced9059341c80795d2b6c943de15b120a9e0308b499e43e4b5fc2952

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -4,6 +4,9 @@ deps:
 breaking:
   use:
     - FILE
+build:
+  excludes:
+    - tendermint
 lint:
   use:
     - DEFAULT
@@ -11,8 +14,6 @@ lint:
     - FILE_LOWER_SNAKE_CASE
   except:
     - COMMENT_FIELD
-  ignore:
-    - tendermint
   ignore_only:
     ENUM_VALUE_PREFIX:
       - cometbft/abci/v1beta1


### PR DESCRIPTION
Update buf configuration files to:

- Update the gogo-proto dependency to the latest revision;
- Exclude the `tendermint` files from any consideration by buf.