### PR TITLE
backport to v1.x: types: validate Validator#Address field (#1715)

### DIFF
--- a/.changelog/unreleased/improvements/1715-validate-validator-address
+++ b/.changelog/unreleased/improvements/1715-validate-validator-address
@@ -1,0 +1,1 @@
+- `[types]` Validate `Validator#Address` in `ValidateBasic` ([\#1715](https://github.com/cometbft/cometbft/pull/1715))

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -18,9 +18,7 @@ import (
 
 	abci "github.com/cometbft/cometbft/abci/types"
 	cmtstate "github.com/cometbft/cometbft/api/cometbft/state/v1"
-	"github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/crypto/ed25519"
-	cmtrand "github.com/cometbft/cometbft/internal/rand"
 	sm "github.com/cometbft/cometbft/internal/state"
 	"github.com/cometbft/cometbft/internal/store"
 	"github.com/cometbft/cometbft/internal/test"
@@ -135,7 +133,7 @@ func TestPruneStates(t *testing.T) {
 
 			// Generate a bunch of state data. Validators change for heights ending with 3, and
 			// parameters when ending with 5.
-			validator := &types.Validator{Address: cmtrand.Bytes(crypto.AddressSize), VotingPower: 100, PubKey: pk}
+			validator := &types.Validator{Address: pk.Address(), VotingPower: 100, PubKey: pk}
 			validatorSet := &types.ValidatorSet{
 				Validators: []*types.Validator{validator},
 				Proposer:   validator,

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -608,7 +608,7 @@ func TestPruningService(t *testing.T) {
 	// Generate a bunch of state data.
 	// This is needed because the pruning is expecting to load the state from the database thus
 	// We have to have acceptable values for all fields of the state
-	validator := &types.Validator{Address: cmtrand.Bytes(crypto.AddressSize), VotingPower: 100, PubKey: pk}
+	validator := &types.Validator{Address: pk.Address(), VotingPower: 100, PubKey: pk}
 	validatorSet := &types.ValidatorSet{
 		Validators: []*types.Validator{validator},
 		Proposer:   validator,

--- a/types/validator.go
+++ b/types/validator.go
@@ -46,8 +46,9 @@ func (v *Validator) ValidateBasic() error {
 		return errors.New("validator has negative voting power")
 	}
 
-	if len(v.Address) != crypto.AddressSize {
-		return fmt.Errorf("validator address is the wrong size: %v", v.Address)
+	addr := v.PubKey.Address()
+	if !bytes.Equal(v.Address, addr) {
+		return fmt.Errorf("validator address is incorrectly derived from pubkey. Exp: %v, got %v", addr, v.Address)
 	}
 
 	return nil

--- a/types/validator_set_test.go
+++ b/types/validator_set_test.go
@@ -299,18 +299,22 @@ func TestProposerSelection2(t *testing.T) {
 }
 
 func TestProposerSelection3(t *testing.T) {
-	vset := NewValidatorSet([]*Validator{
+	vals := []*Validator{
 		newValidator([]byte("avalidator_address12"), 1),
 		newValidator([]byte("bvalidator_address12"), 1),
 		newValidator([]byte("cvalidator_address12"), 1),
 		newValidator([]byte("dvalidator_address12"), 1),
-	})
+	}
 
+	for i := 0; i < 4; i++ {
+		pk := ed25519.GenPrivKey().PubKey()
+		vals[i].PubKey = pk
+		vals[i].Address = pk.Address()
+	}
+	sort.Sort(ValidatorsByAddress(vals))
+	vset := NewValidatorSet(vals)
 	proposerOrder := make([]*Validator, 4)
 	for i := 0; i < 4; i++ {
-		// need to give all validators to have keys
-		pk := ed25519.GenPrivKey().PubKey()
-		vset.Validators[i].PubKey = pk
 		proposerOrder[i] = vset.GetProposer()
 		vset.IncrementProposerPriority(1)
 	}

--- a/types/validator_test.go
+++ b/types/validator_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -74,7 +75,7 @@ func TestValidatorValidateBasic(t *testing.T) {
 				Address: nil,
 			},
 			err: true,
-			msg: "validator address is the wrong size: ",
+			msg: fmt.Sprintf("validator address is incorrectly derived from pubkey. Exp: %v, got ", pubKey.Address()),
 		},
 		{
 			val: &Validator{
@@ -82,7 +83,7 @@ func TestValidatorValidateBasic(t *testing.T) {
 				Address: []byte{'a'},
 			},
 			err: true,
-			msg: "validator address is the wrong size: 61",
+			msg: fmt.Sprintf("validator address is incorrectly derived from pubkey. Exp: %v, got 61", pubKey.Address()),
 		},
 	}
 


### PR DESCRIPTION
Manual backport of #1715 to `v1.x`, since I forgot to add the Mergify config until #1724.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

