### PR TITLE
proto: give our buf module a name

### DIFF
--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -1,4 +1,5 @@
 version: v1
+name: buf.build/cometbft/cometbft
 deps:
   - buf.build/cosmos/gogo-proto
 breaking:


### PR DESCRIPTION
Almost forgot, this is needed so #1733 can be completed.