### PR TITLE
proto: make comment in README more Markdowny

### DIFF
--- a/proto/README.md
+++ b/proto/README.md
@@ -1,6 +1,9 @@
-<!-- NB: Ensure that all hyperlinks in this doc are absolute URLs, not relative
-ones, as this doc gets published to the Buf registry and relative URLs will fail
-to resolve. -->
+[NB]: # (
+  Ensure that all hyperlinks in this doc are absolute URLs, not relative ones,
+  as this doc gets published to the Buf registry and relative URLs will fail
+  to resolve.
+)
+
 # CometBFT Protocol Buffers Definitions
 
 This is the set of [Protobuf][protobuf] definitions of types used by various


### PR DESCRIPTION
Clean up for #1733

The Markdown processor used on the Buf Schema Registry is more
strict than GitHub Flavored Markdown and renders HTML comments
visible as text.
Use the link label syntax to hide comment text.
