### PR TITLE
`VerifyCommitLight` and `VerifyCommitLightTrusting` _never_ check all signatures

### DIFF
--- a/internal/evidence/pool.go
+++ b/internal/evidence/pool.go
@@ -133,11 +133,11 @@ func (evpool *Pool) Update(state sm.State, ev types.EvidenceList) {
 
 // AddEvidence checks the evidence is valid and adds it to the pool.
 func (evpool *Pool) AddEvidence(ev types.Evidence) error {
-	evpool.logger.Debug("Attempting to add evidence", "ev", ev)
+	evpool.logger.Info("Attempting to add evidence", "ev", ev)
 
 	// We have already verified this piece of evidence - no need to do it again
 	if evpool.isPending(ev) {
-		evpool.logger.Debug("Evidence already pending, ignoring this one", "ev", ev)
+		evpool.logger.Info("Evidence already pending, ignoring this one", "ev", ev)
 		return nil
 	}
 
@@ -145,7 +145,7 @@ func (evpool *Pool) AddEvidence(ev types.Evidence) error {
 	if evpool.isCommitted(ev) {
 		// this can happen if the peer that sent us the evidence is behind so we shouldn't
 		// punish the peer.
-		evpool.logger.Debug("Evidence was already committed, ignoring this one", "ev", ev)
+		evpool.logger.Info("Evidence was already committed, ignoring this one", "ev", ev)
 		return nil
 	}
 
@@ -514,13 +514,13 @@ func (evpool *Pool) processConsensusBuffer(state sm.State) {
 
 		// check if we already have this evidence
 		if evpool.isPending(dve) {
-			evpool.logger.Debug("evidence already pending; ignoring", "evidence", dve)
+			evpool.logger.Info("evidence already pending; ignoring", "evidence", dve)
 			continue
 		}
 
 		// check that the evidence is not already committed on chain
 		if evpool.isCommitted(dve) {
-			evpool.logger.Debug("evidence already committed; ignoring", "evidence", dve)
+			evpool.logger.Info("evidence already committed; ignoring", "evidence", dve)
 			continue
 		}
 

--- a/test/e2e/app/app.go
+++ b/test/e2e/app/app.go
@@ -237,6 +237,16 @@ func (app *Application) FinalizeBlock(_ context.Context, req *abci.FinalizeBlock
 		txs[i] = &abci.ExecTxResult{Code: kvstore.CodeTypeOK}
 	}
 
+	for _, ev := range req.Misbehavior {
+		app.logger.Info("Misbehavior. Slashing validator",
+			"validator_address", ev.GetValidator().Address,
+			"type", ev.GetType(),
+			"height", ev.GetHeight(),
+			"time", ev.GetTime(),
+			"total_voting_power", ev.GetTotalVotingPower(),
+		)
+	}
+
 	valUpdates, err := app.validatorUpdates(uint64(req.Height))
 	if err != nil {
 		panic(err)

--- a/test/e2e/runner/evidence.go
+++ b/test/e2e/runner/evidence.go
@@ -24,7 +24,7 @@ import (
 // 1 in 4 evidence is light client evidence, the rest is duplicate vote evidence
 const lightClientEvidenceRatio = 4
 
-// InjectEvidence takes a running testnet and generates an amount of valid
+// InjectEvidence takes a running testnet and generates an amount of valid/invalid
 // evidence and broadcasts it to a random node through the rpc endpoint `/broadcast_evidence`.
 // Evidence is random and can be a mixture of LightClientAttackEvidence and
 // DuplicateVoteEvidence.
@@ -87,10 +87,12 @@ func InjectEvidence(ctx context.Context, r *rand.Rand, testnet *e2e.Testnet, amo
 	}
 
 	var ev types.Evidence
-	for i := 1; i <= amount; i++ {
+	for i := 0; i < amount; i++ {
+		validEv := true
 		if i%lightClientEvidenceRatio == 0 {
+			validEv = i%(lightClientEvidenceRatio*2) != 0 // Alternate valid and invalid evidence
 			ev, err = generateLightClientAttackEvidence(
-				ctx, privVals, evidenceHeight, valSet, testnet.Name, blockRes.Block.Time,
+				ctx, privVals, evidenceHeight, valSet, testnet.Name, blockRes.Block.Time, validEv,
 			)
 		} else {
 			var dve *types.DuplicateVoteEvidence
@@ -110,7 +112,15 @@ func InjectEvidence(ctx context.Context, r *rand.Rand, testnet *e2e.Testnet, amo
 		}
 
 		_, err := client.BroadcastEvidence(ctx, ev)
-		if err != nil {
+		if !validEv {
+			// The tests will count committed evidences later on,
+			// and only valid evidences will make it
+			amount++
+		}
+		if validEv != (err == nil) {
+			if err == nil {
+				return errors.New("submitting invalid evidence didn't return an error")
+			}
 			return err
 		}
 	}
@@ -155,6 +165,7 @@ func generateLightClientAttackEvidence(
 	vals *types.ValidatorSet,
 	chainID string,
 	evTime time.Time,
+	validEvidence bool,
 ) (*types.LightClientAttackEvidence, error) {
 	// forge a random header
 	forgedHeight := height + 2
@@ -164,7 +175,7 @@ func generateLightClientAttackEvidence(
 
 	// add a new bogus validator and remove an existing one to
 	// vary the validator set slightly
-	pv, conflictingVals, err := mutateValidatorSet(ctx, privVals, vals)
+	pv, conflictingVals, err := mutateValidatorSet(ctx, privVals, vals, !validEvidence)
 	if err != nil {
 		return nil, err
 	}
@@ -177,6 +188,10 @@ func generateLightClientAttackEvidence(
 	commit, err := test.MakeCommitFromVoteSet(blockID, voteSet, pv, forgedTime)
 	if err != nil {
 		return nil, err
+	}
+
+	if !validEvidence {
+		commit.Signatures[len(commit.Signatures)-1].Signature[0]++
 	}
 
 	ev := &types.LightClientAttackEvidence{
@@ -292,7 +307,11 @@ func makeBlockID(hash []byte, partSetSize uint32, partSetHash []byte) types.Bloc
 	}
 }
 
-func mutateValidatorSet(ctx context.Context, privVals []types.MockPV, vals *types.ValidatorSet,
+func mutateValidatorSet(
+	ctx context.Context,
+	privVals []types.MockPV,
+	vals *types.ValidatorSet,
+	nop bool,
 ) ([]types.PrivValidator, *types.ValidatorSet, error) {
 	newVal, newPrivVal, err := test.Validator(ctx, 10)
 	if err != nil {
@@ -300,10 +319,14 @@ func mutateValidatorSet(ctx context.Context, privVals []types.MockPV, vals *type
 	}
 
 	var newVals *types.ValidatorSet
-	if vals.Size() > 2 {
-		newVals = types.NewValidatorSet(append(vals.Copy().Validators[:vals.Size()-1], newVal))
+	if nop {
+		newVals = types.NewValidatorSet(vals.Copy().Validators)
 	} else {
-		newVals = types.NewValidatorSet(append(vals.Copy().Validators, newVal))
+		if vals.Size() > 2 {
+			newVals = types.NewValidatorSet(append(vals.Copy().Validators[:vals.Size()-1], newVal))
+		} else {
+			newVals = types.NewValidatorSet(append(vals.Copy().Validators, newVal))
+		}
 	}
 
 	// we need to sort the priv validators with the same index as the validator set


### PR DESCRIPTION
Closes #1749

Please see the description of #1749 for a thorough description of the problem.

This PR consists of two commits (initially):

* The first commit are changes in our `e2e` tests that allow for a controlled end-to-end reproduction of the problem, and extra logic in the `e2e` logic to properly catch it as test failure. Check the little ❌ next to the `e2e` CI run on this commit to see the error.
* The second commit is the fix on production code. Although the initially proposed fix was to set parameter `countAllSignatures` to true in _all_ calls to `verifyCommitBatch` and `verifyCommitSingle`, it would actually be overkill
  * the light client algorithm does not need to verify all signatures, as it doesn't produce or check any evidence
  * so the proposed fix is rather setting that parameter to true whenever a light client attack evidence is being checked, but to false when it is being used by the light client.
  * I also adapt some of the UTs testing this functionality to also check that VerifyCommitLight` and `VerifyCommitLightTrusting` are also working as expected when called with `countAllSignatures` set to to true
  * Check the little ✅ next to the `e2e` CI run on this commit to see that the error is now gone (i.e., malformed evidences are rejected, and correctly constructed evidences are accepted)


---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

