### PR TITLE
perf(store): Batch save `Block`

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -324,7 +324,7 @@ func (bs *BlockStore) PruneBlocks(height int64, state sm.State) (uint64, int64, 
 		bs.mtx.Lock()
 		bs.base = base
 		bs.mtx.Unlock()
-		bs.saveState()
+		bs.saveState(batch)
 
 		err := batch.WriteSync()
 		if err != nil {
@@ -403,12 +403,26 @@ func (bs *BlockStore) SaveBlock(block *types.Block, blockParts *types.PartSet, s
 	if block == nil {
 		panic("BlockStore can only save a non-nil block")
 	}
-	if err := bs.saveBlockToBatch(block, blockParts, seenCommit); err != nil {
+
+	batch := bs.db.NewBatch()
+	defer func(batch dbm.Batch) {
+		err := batch.Close()
+		if err != nil {
+			panic(err)
+		}
+	}(batch)
+
+	if err := bs.saveBlockToBatch(block, blockParts, seenCommit, batch); err != nil {
 		panic(err)
 	}
 
 	// Save new BlockStoreState descriptor. This also flushes the database.
-	bs.saveState()
+	bs.saveState(batch)
+
+	err := batch.WriteSync()
+	if err != nil {
+		panic(err)
+	}
 }
 
 // SaveBlockWithExtendedCommit persists the given block, blockParts, and
@@ -423,22 +437,36 @@ func (bs *BlockStore) SaveBlockWithExtendedCommit(block *types.Block, blockParts
 	if err := seenExtendedCommit.EnsureExtensions(true); err != nil {
 		panic(fmt.Errorf("problems saving block with extensions: %w", err))
 	}
-	if err := bs.saveBlockToBatch(block, blockParts, seenExtendedCommit.ToCommit()); err != nil {
+
+	batch := bs.db.NewBatch()
+	defer func(batch dbm.Batch) {
+		err := batch.Close()
+		if err != nil {
+			panic(err)
+		}
+	}(batch)
+
+	if err := bs.saveBlockToBatch(block, blockParts, seenExtendedCommit.ToCommit(), batch); err != nil {
 		panic(err)
 	}
 	height := block.Height
 
 	pbec := seenExtendedCommit.ToProto()
 	extCommitBytes := mustEncode(pbec)
-	if err := bs.db.Set(calcExtCommitKey(height), extCommitBytes); err != nil {
+	if err := batch.Set(calcExtCommitKey(height), extCommitBytes); err != nil {
 		panic(err)
 	}
 
 	// Save new BlockStoreState descriptor. This also flushes the database.
-	bs.saveState()
+	bs.saveState(batch)
+
+	err := batch.WriteSync()
+	if err != nil {
+		panic(err)
+	}
 }
 
-func (bs *BlockStore) saveBlockToBatch(block *types.Block, blockParts *types.PartSet, seenCommit *types.Commit) error {
+func (bs *BlockStore) saveBlockToBatch(block *types.Block, blockParts *types.PartSet, seenCommit *types.Commit, batch dbm.Batch) error {
 	if block == nil {
 		panic("BlockStore can only save a non-nil block")
 	}
@@ -462,7 +490,7 @@ func (bs *BlockStore) saveBlockToBatch(block *types.Block, blockParts *types.Par
 	// complete as soon as the block meta is written.
 	for i := 0; i < int(blockParts.Total()); i++ {
 		part := blockParts.GetPart(i)
-		bs.saveBlockPart(height, i, part)
+		bs.saveBlockPart(height, i, part, batch)
 	}
 
 	// Save block meta
@@ -472,17 +500,17 @@ func (bs *BlockStore) saveBlockToBatch(block *types.Block, blockParts *types.Par
 		return errors.New("nil blockmeta")
 	}
 	metaBytes := mustEncode(pbm)
-	if err := bs.db.Set(calcBlockMetaKey(height), metaBytes); err != nil {
+	if err := batch.Set(calcBlockMetaKey(height), metaBytes); err != nil {
 		return err
 	}
-	if err := bs.db.Set(calcBlockHashKey(hash), []byte(fmt.Sprintf("%d", height))); err != nil {
+	if err := batch.Set(calcBlockHashKey(hash), []byte(fmt.Sprintf("%d", height))); err != nil {
 		return err
 	}
 
 	// Save block commit (duplicate and separate from the Block)
 	pbc := block.LastCommit.ToProto()
 	blockCommitBytes := mustEncode(pbc)
-	if err := bs.db.Set(calcBlockCommitKey(height-1), blockCommitBytes); err != nil {
+	if err := batch.Set(calcBlockCommitKey(height-1), blockCommitBytes); err != nil {
 		return err
 	}
 
@@ -490,7 +518,7 @@ func (bs *BlockStore) saveBlockToBatch(block *types.Block, blockParts *types.Par
 	// NOTE: we can delete this at a later height
 	pbsc := seenCommit.ToProto()
 	seenCommitBytes := mustEncode(pbsc)
-	if err := bs.db.Set(calcSeenCommitKey(height), seenCommitBytes); err != nil {
+	if err := batch.Set(calcSeenCommitKey(height), seenCommitBytes); err != nil {
 		return err
 	}
 
@@ -505,25 +533,25 @@ func (bs *BlockStore) saveBlockToBatch(block *types.Block, blockParts *types.Par
 	return nil
 }
 
-func (bs *BlockStore) saveBlockPart(height int64, index int, part *types.Part) {
+func (bs *BlockStore) saveBlockPart(height int64, index int, part *types.Part, batch dbm.Batch) {
 	pbp, err := part.ToProto()
 	if err != nil {
 		panic(cmterrors.ErrMsgToProto{MessageName: "Part", Err: err})
 	}
 	partBytes := mustEncode(pbp)
-	if err := bs.db.Set(calcBlockPartKey(height, index), partBytes); err != nil {
+	if err := batch.Set(calcBlockPartKey(height, index), partBytes); err != nil {
 		panic(err)
 	}
 }
 
-func (bs *BlockStore) saveState() {
+func (bs *BlockStore) saveState(batch dbm.Batch) {
 	bs.mtx.RLock()
 	bss := cmtstore.BlockStoreState{
 		Base:   bs.base,
 		Height: bs.height,
 	}
 	bs.mtx.RUnlock()
-	SaveBlockStoreState(&bss, bs.db)
+	SaveBlockStoreState(&bss, batch)
 }
 
 // SaveSeenCommit saves a seen commit, used by e.g. the state sync reactor when bootstrapping node.
@@ -571,12 +599,12 @@ func calcBlockHashKey(hash []byte) []byte {
 var blockStoreKey = []byte("blockStore")
 
 // SaveBlockStoreState persists the blockStore state to the database.
-func SaveBlockStoreState(bsj *cmtstore.BlockStoreState, db dbm.DB) {
+func SaveBlockStoreState(bsj *cmtstore.BlockStoreState, batch dbm.Batch) {
 	bytes, err := proto.Marshal(bsj)
 	if err != nil {
 		panic(fmt.Sprintf("Could not marshal state bytes: %v", err))
 	}
-	if err := db.SetSync(blockStoreKey, bytes); err != nil {
+	if err := batch.Set(blockStoreKey, bytes); err != nil {
 		panic(err)
 	}
 }
@@ -655,7 +683,7 @@ func (bs *BlockStore) DeleteLatestBlock() error {
 	bs.mtx.Lock()
 	bs.height = targetHeight - 1
 	bs.mtx.Unlock()
-	bs.saveState()
+	bs.saveState(batch)
 
 	err := batch.WriteSync()
 	if err != nil {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -92,9 +92,14 @@ func TestLoadBlockStoreState(t *testing.T) {
 
 	for _, tc := range testCases {
 		db := dbm.NewMemDB()
-		SaveBlockStoreState(tc.bss, db)
+		batch := db.NewBatch()
+		SaveBlockStoreState(tc.bss, batch)
+		err := batch.WriteSync()
+		require.NoError(t, err)
 		retrBSJ := LoadBlockStoreState(db)
 		assert.Equal(t, tc.want, retrBSJ, "expected the retrieved DBs to match: %s", tc.testName)
+		err = batch.Close()
+		require.NoError(t, err)
 	}
 }
 


### PR DESCRIPTION
Refs https://github.com/cometbft/cometbft/issues/1040

LSMs don't handle big batches very well ([1](https://github.com/cosmos/iavl/issues/619)). The ideal for `goleveldb` is ~ 100KB ([2](https://github.com/ethereum/go-ethereum/pull/15115)), which is more or less equal to our block part size (64kB).

Here are the results from running the Anton's benchmark on my local PC:

<details>

<summary>Benchmark</summary>

```
func BenchmarkBlockStore_SaveBlockWithExtendedCommit(b *testing.B) {
	dbTypes := []dbm.BackendType{
		dbm.GoLevelDBBackend,
	}
	NTXs := int64(1024)

	for _, dbType := range dbTypes {
		state, bs, cleanup := makeStateAndBlockStoreSpecificBackend(dbType)
		b.Run(fmt.Sprintf("DBType:%s;NTxs:%d", dbType, NTXs),
			func(b *testing.B) {
				for i := 0; i < b.N; i++ {
					height := bs.Height() + 1
					block := state.MakeBlock(height, test.MakeNTxs(height, NTXs), new(types.Commit), nil, state.Validators.GetProposer().Address)
					validPartSet, err := block.MakePartSet(types.BlockPartSizeBytes)
					if err != nil {
						b.Error(err)
					}
					seenCommit := makeTestExtCommit(block.Header.Height, cmttime.Now())

					bs.SaveBlockWithExtendedCommit(block, validPartSet, seenCommit)
				}
			})

		cleanup()
	}

}

type cleanupFunc func()

func makeStateAndBlockStoreSpecificBackend(backendType dbm.BackendType) (sm.State, *BlockStore, cleanupFunc) {
	config := test.ResetTestRoot("blockchain_reactor_test")
	blockDB, err := dbm.NewDB("block", backendType, config.DBDir())
	if err != nil {
		panic(fmt.Errorf("error creating %s: %w", backendType, err))
	}
	stateDB, err := dbm.NewDB("state", backendType, config.DBDir())
	if err != nil {
		panic(fmt.Errorf("error creating %s: %w", backendType, err))
	}
	stateStore := sm.NewStore(stateDB, sm.StoreOptions{
		DiscardABCIResponses: false,
	})
	state, err := stateStore.LoadFromDBOrGenesisFile(config.GenesisFile())
	if err != nil {
		panic(fmt.Errorf("error constructing state from genesis file: %w", err))
	}
	return state, NewBlockStore(blockDB), func() { os.RemoveAll(config.RootDir) }
}
```

</details>

```
## batching / 1 MB block / goleveldb
155921071 ns/op
## NO batching / 1 MB block / goleveldb
134169606 ns/op
## batching / 10 MB block / goleveldb
1135896143 ns/op
## NO batching / 10 MB block / goleveldb
1096632817 ns/op
```

If we want to support blocks bigger than 100kB on average, we should not batch single blocks. This becomes more important for big blocks (>1MB). The current max size is 4MB. This implies that CometBFT must handle such a scenario efficiently, which won't be the case w/ a single batch.

Now, the current block size of Cosmos Hub is 64kB, with peaks ranging from 200kB to 700kB. For Osmosis, it's 74kB. If we want to target the current customers, then creating a single batch makes sense.

The solution presented here is to batch save the whole block only if it's within 640kB (10 block parts * 64kB each). Otherwise, save each block part individually. All the commits are still saved as part of the batch.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

