### PR TITLE
fix(consensus): return last saved BeginBlock, not a empty one

### DIFF
--- a/consensus/replay_stubs.go
+++ b/consensus/replay_stubs.go
@@ -77,6 +77,10 @@ type mockProxyApp struct {
 	abciResponses *cmtstate.ABCIResponses
 }
 
+func (mock *mockProxyApp) BeginBlock(req abci.RequestBeginBlock) abci.ResponseBeginBlock {
+	return *mock.abciResponses.BeginBlock
+}
+
 func (mock *mockProxyApp) DeliverTx(req abci.RequestDeliverTx) abci.ResponseDeliverTx {
 	r := mock.abciResponses.DeliverTxs[mock.txCount]
 	mock.txCount++


### PR DESCRIPTION
Otherwise, the events from app's BeginBlock won't be fired.

Closes #1468

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

