### PR TITLE
Introduce `countAllSignatures` in `VerifyCommitLight` & `VerifyCommitLightTrusting`

### DIFF
--- a/blocksync/reactor.go
+++ b/blocksync/reactor.go
@@ -368,7 +368,7 @@ FOR_LOOP:
 			// NOTE: we can probably make this more efficient, but note that calling
 			// first.Hash() doesn't verify the tx contents, so MakePartSet() is
 			// currently necessary.
-			err = state.Validators.VerifyCommitLight(
+			err = state.Validators.VerifyCommitLightAllSignatures(
 				chainID, firstID, first.Height, second.LastCommit)
 
 			if err == nil {

--- a/evidence/pool.go
+++ b/evidence/pool.go
@@ -132,11 +132,11 @@ func (evpool *Pool) Update(state sm.State, ev types.EvidenceList) {
 
 // AddEvidence checks the evidence is valid and adds it to the pool.
 func (evpool *Pool) AddEvidence(ev types.Evidence) error {
-	evpool.logger.Debug("Attempting to add evidence", "ev", ev)
+	evpool.logger.Info("Attempting to add evidence", "ev", ev)
 
 	// We have already verified this piece of evidence - no need to do it again
 	if evpool.isPending(ev) {
-		evpool.logger.Debug("Evidence already pending, ignoring this one", "ev", ev)
+		evpool.logger.Info("Evidence already pending, ignoring this one", "ev", ev)
 		return nil
 	}
 
@@ -144,7 +144,7 @@ func (evpool *Pool) AddEvidence(ev types.Evidence) error {
 	if evpool.isCommitted(ev) {
 		// this can happen if the peer that sent us the evidence is behind so we shouldn't
 		// punish the peer.
-		evpool.logger.Debug("Evidence was already committed, ignoring this one", "ev", ev)
+		evpool.logger.Info("Evidence was already committed, ignoring this one", "ev", ev)
 		return nil
 	}
 
@@ -513,13 +513,13 @@ func (evpool *Pool) processConsensusBuffer(state sm.State) {
 
 		// check if we already have this evidence
 		if evpool.isPending(dve) {
-			evpool.logger.Debug("evidence already pending; ignoring", "evidence", dve)
+			evpool.logger.Info("evidence already pending; ignoring", "evidence", dve)
 			continue
 		}
 
 		// check that the evidence is not already committed on chain
 		if evpool.isCommitted(dve) {
-			evpool.logger.Debug("evidence already committed; ignoring", "evidence", dve)
+			evpool.logger.Info("evidence already committed; ignoring", "evidence", dve)
 			continue
 		}
 

--- a/evidence/verify.go
+++ b/evidence/verify.go
@@ -106,6 +106,7 @@ func (evpool *Pool) verify(evidence types.Evidence) error {
 //     the conflicting header's commit
 //   - 2/3+ of the conflicting validator set correctly signed the conflicting block
 //   - the nodes trusted header at the same height as the conflicting header has a different hash
+//   - all signatures must be checked as this will be used as evidence
 //
 // CONTRACT: must run ValidateBasic() on the evidence before verifying
 //
@@ -115,7 +116,7 @@ func VerifyLightClientAttack(e *types.LightClientAttackEvidence, commonHeader, t
 	// In the case of lunatic attack there will be a different commonHeader height. Therefore the node perform a single
 	// verification jump between the common header and the conflicting one
 	if commonHeader.Height != e.ConflictingBlock.Height {
-		err := commonVals.VerifyCommitLightTrusting(trustedHeader.ChainID, e.ConflictingBlock.Commit, light.DefaultTrustLevel)
+		err := commonVals.VerifyCommitLightTrustingAllSignatures(trustedHeader.ChainID, e.ConflictingBlock.Commit, light.DefaultTrustLevel)
 		if err != nil {
 			return fmt.Errorf("skipping verification of conflicting block failed: %w", err)
 		}
@@ -127,7 +128,7 @@ func VerifyLightClientAttack(e *types.LightClientAttackEvidence, commonHeader, t
 	}
 
 	// Verify that the 2/3+ commits from the conflicting validator set were for the conflicting header
-	if err := e.ConflictingBlock.ValidatorSet.VerifyCommitLight(trustedHeader.ChainID, e.ConflictingBlock.Commit.BlockID,
+	if err := e.ConflictingBlock.ValidatorSet.VerifyCommitLightAllSignatures(trustedHeader.ChainID, e.ConflictingBlock.Commit.BlockID,
 		e.ConflictingBlock.Height, e.ConflictingBlock.Commit); err != nil {
 		return fmt.Errorf("invalid commit from conflicting block: %w", err)
 	}

--- a/test/e2e/app/app.go
+++ b/test/e2e/app/app.go
@@ -163,6 +163,19 @@ func (app *Application) DeliverTx(req abci.RequestDeliverTx) abci.ResponseDelive
 	return abci.ResponseDeliverTx{Code: code.CodeTypeOK}
 }
 
+func (app *Application) BeginBlock(req abci.RequestBeginBlock) abci.ResponseBeginBlock {
+	for _, ev := range req.ByzantineValidators {
+		app.logger.Info("Misbehavior. Slashing validator",
+			"validator_address", ev.GetValidator().Address,
+			"type", ev.GetType(),
+			"height", ev.GetHeight(),
+			"time", ev.GetTime(),
+			"total_voting_power", ev.GetTotalVotingPower(),
+		)
+	}
+	return abci.ResponseBeginBlock{}
+}
+
 // EndBlock implements ABCI.
 func (app *Application) EndBlock(req abci.RequestEndBlock) abci.ResponseEndBlock {
 	valUpdates, err := app.validatorUpdates(uint64(req.Height))

--- a/test/e2e/runner/evidence.go
+++ b/test/e2e/runner/evidence.go
@@ -25,7 +25,7 @@ import (
 // 1 in 4 evidence is light client evidence, the rest is duplicate vote evidence
 const lightClientEvidenceRatio = 4
 
-// InjectEvidence takes a running testnet and generates an amount of valid
+// InjectEvidence takes a running testnet and generates an amount of valid/invalid
 // evidence and broadcasts it to a random node through the rpc endpoint `/broadcast_evidence`.
 // Evidence is random and can be a mixture of LightClientAttackEvidence and
 // DuplicateVoteEvidence.
@@ -88,10 +88,12 @@ func InjectEvidence(ctx context.Context, r *rand.Rand, testnet *e2e.Testnet, amo
 	}
 
 	var ev types.Evidence
-	for i := 1; i <= amount; i++ {
+	for i := 0; i < amount; i++ {
+		validEv := true
 		if i%lightClientEvidenceRatio == 0 {
+			validEv = i%(lightClientEvidenceRatio*2) != 0 // Alternate valid and invalid evidence
 			ev, err = generateLightClientAttackEvidence(
-				ctx, privVals, evidenceHeight, valSet, testnet.Name, blockRes.Block.Time,
+				ctx, privVals, evidenceHeight, valSet, testnet.Name, blockRes.Block.Time, validEv,
 			)
 		} else {
 			ev, err = generateDuplicateVoteEvidence(
@@ -103,7 +105,15 @@ func InjectEvidence(ctx context.Context, r *rand.Rand, testnet *e2e.Testnet, amo
 		}
 
 		_, err := client.BroadcastEvidence(ctx, ev)
-		if err != nil {
+		if !validEv {
+			// The tests will count committed evidences later on,
+			// and only valid evidences will make it
+			amount++
+		}
+		if validEv != (err == nil) {
+			if err == nil {
+				return errors.New("submitting invalid evidence didn't return an error")
+			}
 			return err
 		}
 	}
@@ -148,6 +158,7 @@ func generateLightClientAttackEvidence(
 	vals *types.ValidatorSet,
 	chainID string,
 	evTime time.Time,
+	validEvidence bool,
 ) (*types.LightClientAttackEvidence, error) {
 	// forge a random header
 	forgedHeight := height + 2
@@ -157,7 +168,7 @@ func generateLightClientAttackEvidence(
 
 	// add a new bogus validator and remove an existing one to
 	// vary the validator set slightly
-	pv, conflictingVals, err := mutateValidatorSet(ctx, privVals, vals)
+	pv, conflictingVals, err := mutateValidatorSet(ctx, privVals, vals, !validEvidence)
 	if err != nil {
 		return nil, err
 	}
@@ -170,6 +181,11 @@ func generateLightClientAttackEvidence(
 	commit, err := test.MakeCommitFromVoteSet(blockID, voteSet, pv, forgedTime)
 	if err != nil {
 		return nil, err
+	}
+
+	// malleate the last signature of the commit by adding one to its first byte
+	if !validEvidence {
+		commit.Signatures[len(commit.Signatures)-1].Signature[0]++
 	}
 
 	ev := &types.LightClientAttackEvidence{
@@ -286,7 +302,11 @@ func makeBlockID(hash []byte, partSetSize uint32, partSetHash []byte) types.Bloc
 	}
 }
 
-func mutateValidatorSet(ctx context.Context, privVals []types.MockPV, vals *types.ValidatorSet,
+func mutateValidatorSet(
+	ctx context.Context,
+	privVals []types.MockPV,
+	vals *types.ValidatorSet,
+	nop bool,
 ) ([]types.PrivValidator, *types.ValidatorSet, error) {
 	newVal, newPrivVal, err := test.Validator(ctx, 10)
 	if err != nil {
@@ -294,10 +314,14 @@ func mutateValidatorSet(ctx context.Context, privVals []types.MockPV, vals *type
 	}
 
 	var newVals *types.ValidatorSet
-	if vals.Size() > 2 {
-		newVals = types.NewValidatorSet(append(vals.Copy().Validators[:vals.Size()-1], newVal))
+	if nop {
+		newVals = types.NewValidatorSet(vals.Copy().Validators)
 	} else {
-		newVals = types.NewValidatorSet(append(vals.Copy().Validators, newVal))
+		if vals.Size() > 2 {
+			newVals = types.NewValidatorSet(append(vals.Copy().Validators[:vals.Size()-1], newVal))
+		} else {
+			newVals = types.NewValidatorSet(append(vals.Copy().Validators, newVal))
+		}
 	}
 
 	// we need to sort the priv validators with the same index as the validator set

--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -766,7 +766,7 @@ func (vals *ValidatorSet) verifyCommitLightInternal(
 	for idx, commitSig := range commit.Signatures {
 		// No need to verify absent or nil votes if not counting all signatures,
 		// but need to verify nil votes if counting all signatures.
-		if !countAllSignatures && !commitSig.ForBlock() || countAllSignatures && commitSig.Absent() {
+		if (!countAllSignatures && !commitSig.ForBlock()) || (countAllSignatures && commitSig.Absent()) {
 			continue
 		}
 
@@ -788,7 +788,7 @@ func (vals *ValidatorSet) verifyCommitLightInternal(
 		}
 	}
 
-	if countAllSignatures && talliedVotingPower > votingPowerNeeded {
+	if talliedVotingPower > votingPowerNeeded {
 		return nil
 	}
 	return ErrNotEnoughVotingPowerSigned{Got: talliedVotingPower, Needed: votingPowerNeeded}
@@ -851,7 +851,7 @@ func (vals *ValidatorSet) verifyCommitLightTrustingInternal(
 	for idx, commitSig := range commit.Signatures {
 		// No need to verify absent or nil votes if not counting all signatures,
 		// but need to verify nil votes if counting all signatures.
-		if !countAllSignatures && !commitSig.ForBlock() || countAllSignatures && commitSig.Absent() {
+		if (!countAllSignatures && !commitSig.ForBlock()) || (countAllSignatures && commitSig.Absent()) {
 			continue
 		}
 
@@ -880,7 +880,7 @@ func (vals *ValidatorSet) verifyCommitLightTrustingInternal(
 			}
 		}
 	}
-	if countAllSignatures && talliedVotingPower > votingPowerNeeded {
+	if talliedVotingPower > votingPowerNeeded {
 		return nil
 	}
 	return ErrNotEnoughVotingPowerSigned{Got: talliedVotingPower, Needed: votingPowerNeeded}

--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -762,8 +762,7 @@ func (vals *ValidatorSet) verifyCommitLightInternal(
 	}
 
 	talliedVotingPower := int64(0)
-	totalVotingPower := vals.TotalVotingPower()
-	votingPowerNeeded := totalVotingPower * 2 / 3
+	votingPowerNeeded := vals.TotalVotingPower() * 2 / 3
 	for idx, commitSig := range commit.Signatures {
 		// No need to verify absent or nil votes if not counting all signatures,
 		// but need to verify nil votes if counting all signatures.
@@ -843,8 +842,7 @@ func (vals *ValidatorSet) verifyCommitLightTrustingInternal(
 	)
 
 	// Safely calculate voting power needed.
-	totalVotingPower := vals.TotalVotingPower()
-	totalVotingPowerMulByNumerator, overflow := safeMul(totalVotingPower, int64(trustLevel.Numerator))
+	totalVotingPowerMulByNumerator, overflow := safeMul(vals.TotalVotingPower(), int64(trustLevel.Numerator))
 	if overflow {
 		return errors.New("int64 overflow while calculating voting power needed. please provide smaller trustLevel numerator")
 	}


### PR DESCRIPTION
Contributes to #1749

The problem fixed by #1750 on`main`, `v1.x`, and `v0.38.x` also exists in previous release branches: when verifying an evidence of misbehavior, not all signatures are checked, opening the door to tampering with validators' signatures and identities.

This PR addresses this problem and also fixes a condition in `VerifyCommitLight` & `VerifyCommitLightTrusting` so that signatures of `nil` votes are also verified if we are "counting all signatures".

As I forgot to add a changelog in #1750 (apologies for that), I will create another PR with the changelog and backport it all the way to `v0.34.x` (EDIT: PR is #1807).

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

