### PR TITLE
chore(README.md): updating discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ in order of preference:
   GitHub](https://github.com/cometbft/cometbft/discussions)
 - Reach out to us via [Telegram](https://t.me/CometBFT)
 - [Join the chat on
-  Discord](https://discord.com/channels/669268347736686612/669283915743232011)
+  Discord](https://discord.com/channels/669268347736686612/1069933855307472906)
 
 More on how releases are conducted can be found [here](./RELEASES.md).
 


### PR DESCRIPTION
Updated discord's channel link to cometbft's channel. Current one is a channel verified don't have right to see (it shows up empty).

Also I believe it would be nice to add an invite link (https://discord.com/invite/cosmosnetwork) so people that aren't in already don't get an error message.

I thought of something like :

Join the [Discord](https://discord.com/invite/cosmosnetwork) and discuss in the [chat](https://discord.com/channels/669268347736686612/1069933855307472906)