### PR TITLE
Allow blocksync to not verify all signatures

### DIFF
--- a/internal/blocksync/reactor.go
+++ b/internal/blocksync/reactor.go
@@ -459,7 +459,7 @@ FOR_LOOP:
 			// first.Hash() doesn't verify the tx contents, so MakePartSet() is
 			// currently necessary.
 			// TODO(sergio): Should we also validate against the extended commit?
-			err = state.Validators.VerifyCommitLightAllSignatures(
+			err = state.Validators.VerifyCommitLight(
 				chainID, firstID, first.Height, second.LastCommit)
 
 			if err == nil {


### PR DESCRIPTION
Contributes to #1749

Following [this comment](https://github.com/cometbft/cometbft/pull/1750#discussion_r1431035852) in #1750, we are allowing blocksync to follow its pre-#1749 behavior: it won't verify all signatures unconditionally, but will exit the loop when enough voting power is verified.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

