### PR TITLE
Extend kvstore example add with with key types

### DIFF
--- a/abci/example/kvstore/README.md
+++ b/abci/example/kvstore/README.md
@@ -8,9 +8,10 @@ The app has no replay protection (other than what the mempool provides).
 Validator set changes are effected using the following transaction format:
 
 ```md
-"val:pubkey1!power1,pubkey2!power2,pubkey3!power3"
+"val:pubkeytype1!pubkey1!power1,pubkeytype2!pubkey2!power2,pubkeytype3!pubkey3!power3"
 ```
 
-where `pubkeyN` is a base64-encoded 32-byte ed25519 key and `powerN` is a new voting power for the validator with `pubkeyN` (possibly a new one).
+where `pubkeyN` is a base64-encoded 32-byte key, `pubkeytypeN` is a string representing the key type,
+and `powerN` is a new voting power for the validator with `pubkeyN` (possibly a new one).
 To remove a validator from the validator set, set power to `0`.
 There is no sybil protection against new validators joining.

--- a/abci/example/kvstore/helpers.go
+++ b/abci/example/kvstore/helpers.go
@@ -75,5 +75,6 @@ func MakeValSetChangeTx(pubkey pbcrypto.PublicKey, power int64) []byte {
 		panic(err)
 	}
 	pubStr := base64.StdEncoding.EncodeToString(pk.Bytes())
-	return []byte(fmt.Sprintf("%s%s!%d", ValidatorPrefix, pubStr, power))
+	pubTypeStr := pk.Type()
+	return []byte(fmt.Sprintf("%s%s!%s!%d", ValidatorPrefix, pubTypeStr, pubStr, power))
 }


### PR DESCRIPTION

The kvstore in examples is only able to deal with `ed25519` key types. This PR allows devs to play around with other key types.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

