### PR TITLE
blocksync: wait for poolRoutine to stop in (*Reactor).OnStop

### DIFF
--- a/.changelog/unreleased/bug-fixes/1879-blocksync-wait-for-pool-routine.md
+++ b/.changelog/unreleased/bug-fixes/1879-blocksync-wait-for-pool-routine.md
@@ -1,0 +1,2 @@
+- `[blocksync]` wait for `poolRoutine` to stop in `(*Reactor).OnStop`
+  ([\#1879](https://github.com/cometbft/cometbft/pull/1879))

--- a/internal/blocksync/reactor.go
+++ b/internal/blocksync/reactor.go
@@ -128,7 +128,10 @@ func (bcR *Reactor) OnStart() error {
 			return err
 		}
 		bcR.poolRoutineWg.Add(1)
-		go bcR.poolRoutine(false)
+		go func() {
+			defer bcR.poolRoutineWg.Done()
+			bcR.poolRoutine(false)
+		}()
 	}
 	return nil
 }
@@ -144,7 +147,10 @@ func (bcR *Reactor) SwitchToBlockSync(state sm.State) error {
 		return err
 	}
 	bcR.poolRoutineWg.Add(1)
-	go bcR.poolRoutine(true)
+	go func() {
+		defer bcR.poolRoutineWg.Done()
+		bcR.poolRoutine(false)
+	}()
 	return nil
 }
 
@@ -289,8 +295,6 @@ func (bcR *Reactor) Receive(e p2p.Envelope) {
 // Handle messages from the poolReactor telling the reactor what to do.
 // NOTE: Don't sleep in the FOR_LOOP or otherwise slow it down!
 func (bcR *Reactor) poolRoutine(stateSynced bool) {
-	defer bcR.poolRoutineWg.Done()
-
 	bcR.metrics.Syncing.Set(1)
 	defer bcR.metrics.Syncing.Set(0)
 

--- a/internal/blocksync/reactor.go
+++ b/internal/blocksync/reactor.go
@@ -149,7 +149,7 @@ func (bcR *Reactor) SwitchToBlockSync(state sm.State) error {
 	bcR.poolRoutineWg.Add(1)
 	go func() {
 		defer bcR.poolRoutineWg.Done()
-		bcR.poolRoutine(false)
+		bcR.poolRoutine(true)
 	}()
 	return nil
 }

--- a/internal/blocksync/reactor.go
+++ b/internal/blocksync/reactor.go
@@ -457,7 +457,7 @@ FOR_LOOP:
 			// iteration, break the loop if the BlockPool or the Reactor itself
 			// has quit. This avoids case ambiguity of the outer select when two
 			// channels are ready.
-			if !bcR.IsRunning() {
+			if !bcR.IsRunning() || !bcR.pool.IsRunning() {
 				break FOR_LOOP
 			}
 			// Try again quickly next loop.

--- a/internal/blocksync/reactor.go
+++ b/internal/blocksync/reactor.go
@@ -450,10 +450,13 @@ FOR_LOOP:
 			}
 
 			// Before priming didProcessCh for another check on the next
-			// iteration, break the loop if the BlockPool has quit. This avoids
-			// case ambiguity of the outer select when two channels are ready.
+			// iteration, break the loop if the BlockPool or the Reactor itself
+			// has quit. This avoids case ambiguity of the outer select when two
+			// channels are ready.
 			select {
 			case <-bcR.pool.Quit():
+				break FOR_LOOP
+			case <-bcR.Quit():
 				break FOR_LOOP
 			default:
 			}

--- a/internal/blocksync/reactor.go
+++ b/internal/blocksync/reactor.go
@@ -453,12 +453,8 @@ FOR_LOOP:
 			// iteration, break the loop if the BlockPool or the Reactor itself
 			// has quit. This avoids case ambiguity of the outer select when two
 			// channels are ready.
-			select {
-			case <-bcR.pool.Quit():
+			if !bcR.IsRunning() {
 				break FOR_LOOP
-			case <-bcR.Quit():
-				break FOR_LOOP
-			default:
 			}
 			// Try again quickly next loop.
 			didProcessCh <- struct{}{}


### PR DESCRIPTION
Resolves https://github.com/cometbft/cometbft/issues/1878

```
blocksync: wait for poolRoutine to stop in (*Reactor).OnStop

blocksync.(*Reactor).poolRoutine goroutine lifetime was not supervised,
so OnStop returning did not provide a guarantee that it was done.  As a
result, the other services could be stopped and a subsequent call to
bcR.blockExec.ApplyBlock would cause a panic, typically a leveldb
closed error.

This change uses a sync.WaitGroup to ensure that OnStop returns after
poolRoutine has returned.

This also triggers the poolRoutine method to return on a signal from
bcR.pool.Quit() instead of just bcR.Quit(), which seems to be important
as (*Reactor).OnStop itself can only stop the BlockPool (bcR.pool), while
the BaseReactor.BaseService's quit channel will only be closed _after_
(*Reactor).OnStop has returned.
```

A consequence of the issue can be unrecoverable node data, so it can be kinda nasty if the node is interrupted while in catch up.

---

#### PR checklist

- [ ] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

