### PR TITLE
perf(crypto/merkle, crypto/tmhash): simplify+optimize SHA256 hashing of multiple byteslices

### DIFF
--- a/.changelog/unreleased/improvements/1921-crypto-merkle-innerHash.md
+++ b/.changelog/unreleased/improvements/1921-crypto-merkle-innerHash.md
@@ -1,0 +1,1 @@
+- `[crypto/merkle]` faster calculation of hashes ([#1921](https://github.com/cometbft/cometbft/pull/1921))

--- a/crypto/merkle/bench_test.go
+++ b/crypto/merkle/bench_test.go
@@ -1,0 +1,42 @@
+package merkle
+
+import (
+	"crypto/sha256"
+	"strings"
+	"testing"
+)
+
+var sink any = nil
+
+type innerHashTest struct {
+	left, right string
+}
+
+var innerHashTests = []*innerHashTest{
+	{"aaaaaaaaaaaaaaa", "                    "},
+	{"", ""},
+	{"                        ", "a    ff     b    f1    a"},
+	{"ffff122fff", "ffff122fff"},
+	{"😎💡✅alalalalalalalalalallalallaallalaallalalalalalalalaallalalalalalala", "😎💡✅alalalalalalalalalallalallaallalaallalalalalalalalaallalalalalalalaffff122fff"},
+	{strings.Repeat("ff", 1<<10), strings.Repeat("00af", 4<<10)},
+	{strings.Repeat("f", sha256.Size), strings.Repeat("00af", 10<<10)},
+	{"aaaaaaaaaaaaaaaaaaaaaaaaaaaffff122fffaaaaaaaaa", "aaaaaaaaaffff1aaaaaaaaaaaaaaaaaa22fffaaaaaaaaa"},
+}
+
+func BenchmarkInnerHash(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		for _, tt := range innerHashTests {
+			got := innerHash([]byte(tt.left), []byte(tt.right))
+			if g, w := len(got), sha256.Size; g != w {
+				b.Fatalf("size discrepancy: got %d, want %d", g, w)
+			}
+			sink = got
+		}
+	}
+
+	if sink == nil {
+		b.Fatal("Benchmark did not run!")
+	}
+}

--- a/crypto/merkle/hash.go
+++ b/crypto/merkle/hash.go
@@ -32,11 +32,7 @@ func leafHashOpt(s hash.Hash, leaf []byte) []byte {
 
 // returns tmhash(0x01 || left || right).
 func innerHash(left []byte, right []byte) []byte {
-	data := make([]byte, len(innerPrefix)+len(left)+len(right))
-	n := copy(data, innerPrefix)
-	n += copy(data[n:], left)
-	copy(data[n:], right)
-	return tmhash.Sum(data)
+	return tmhash.SumMany(innerPrefix, left, right)
 }
 
 func innerHashOpt(s hash.Hash, left []byte, right []byte) []byte {

--- a/crypto/tmhash/bench_test.go
+++ b/crypto/tmhash/bench_test.go
@@ -1,0 +1,52 @@
+package tmhash
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"strings"
+	"testing"
+)
+
+var sink any = nil
+
+var manySlices = []struct {
+        name string
+	in   [][]byte
+	want [32]byte
+}{
+	{
+                name: "all empty",
+		in:   [][]byte{[]byte(""), []byte("")},
+		want: sha256.Sum256(nil),
+	},
+	{
+                name: "ax6",
+		in:   [][]byte{[]byte("aaaa"), []byte("😎"), []byte("aaaa")},
+		want: sha256.Sum256([]byte("aaaa😎aaaa")),
+	},
+	{
+                name: "composite joined",
+		in:   [][]byte{bytes.Repeat([]byte("a"), 1<<10), []byte("AA"), bytes.Repeat([]byte("z"), 100)},
+		want: sha256.Sum256([]byte(strings.Repeat("a", 1<<10) + "AA" + strings.Repeat("z", 100))),
+	},
+}
+
+func BenchmarkSHA256Many(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		for _, tt := range manySlices {
+			got := SumMany(tt.in[0], tt.in[1:]...)
+			if !bytes.Equal(got, tt.want[:]) {
+				b.Fatalf("Outward checksum mismatch for %q\n\tGot:  %x\n\tWant: %x", tt.name, got, tt.want)
+			}
+			sink = got
+		}
+	}
+
+	if sink == nil {
+		b.Fatal("Benchmark did not run!")
+	}
+
+	sink = nil
+}

--- a/crypto/tmhash/hash.go
+++ b/crypto/tmhash/hash.go
@@ -21,6 +21,18 @@ func Sum(bz []byte) []byte {
 	return h[:]
 }
 
+// SumMany takes at least 1 byteslice along with a variadic
+// number of other byteslices and produces the SHA256 sum from
+// hashing them as if they were 1 joined slice.
+func SumMany(data []byte, rest ...[]byte) []byte {
+	h := sha256.New()
+	h.Write(data)
+	for _, data := range rest {
+		h.Write(data)
+	}
+	return h.Sum(nil)
+}
+
 //-------------------------------------------------------------
 
 const (


### PR DESCRIPTION
This change adds a more efficient API in tmhash with "SumMany" whose job is to produce the SHA256 sum of multiple byteslices. It is used inside crypto/merkle.innerHash which used a naive and inefficient way of hashing multiple byteslices. Benchmark results reflect these improvements:

```shell
$ benchstat before.txt after.txt
name         old time/op    new time/op    delta
InnerHash-8     161µs ± 1%     160µs ± 5%     ~     (p=0.143 n=10+10)

name         old alloc/op   new alloc/op   delta
InnerHash-8    69.1kB ± 0%    60.1kB ± 0%  -12.98%  (p=0.000 n=10+9)

name         old allocs/op  new allocs/op  delta
InnerHash-8      24.0 ± 0%      23.0 ± 0%   -4.17%  (p=0.000 n=10+10)
```

Fixes #1881