### PR TITLE
feat: add support for state sync at specific height

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -984,6 +984,7 @@ type StateSyncConfig struct {
 	DiscoveryTime       time.Duration `mapstructure:"discovery_time"`
 	ChunkRequestTimeout time.Duration `mapstructure:"chunk_request_timeout"`
 	ChunkFetchers       int32         `mapstructure:"chunk_fetchers"`
+	TargetHeight 	  	int64         `mapstructure:"target_height"`
 }
 
 func (cfg *StateSyncConfig) TrustHashBytes() []byte {

--- a/internal/statesync/reactor.go
+++ b/internal/statesync/reactor.go
@@ -261,7 +261,7 @@ func (r *Reactor) recentSnapshots(n uint32) ([]*snapshot, error) {
 
 // Sync runs a state sync, returning the new state and last commit at the snapshot height.
 // The caller must store the state and commit in the state database and block store.
-func (r *Reactor) Sync(stateProvider StateProvider, discoveryTime time.Duration) (sm.State, *types.Commit, error) {
+func (r *Reactor) Sync(stateProvider StateProvider, targetHeight int64, discoveryTime time.Duration) (sm.State, *types.Commit, error) {
 	r.mtx.Lock()
 	if r.syncer != nil {
 		r.mtx.Unlock()
@@ -283,7 +283,7 @@ func (r *Reactor) Sync(stateProvider StateProvider, discoveryTime time.Duration)
 
 	hook()
 
-	state, commit, err := r.syncer.SyncAny(discoveryTime, hook)
+	state, commit, err := r.syncer.SyncAny(discoveryTime, targetHeight, hook)
 
 	r.mtx.Lock()
 	r.syncer = nil

--- a/internal/statesync/snapshots.go
+++ b/internal/statesync/snapshots.go
@@ -2,6 +2,7 @@ package statesync
 
 import (
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"math/rand"
 	"sort"
@@ -124,6 +125,19 @@ func (p *snapshotPool) Best() *snapshot {
 		return nil
 	}
 	return ranked[0]
+}
+
+// At returns the known snapshot at the height.
+// If there are multiple snapshots or no snapshot at the height, it will return nil.
+func (p *snapshotPool) At(height uint64) (*snapshot, error) {
+	keys := p.heightIndex[height]
+	if len(keys) > 1 {
+		return nil, errors.New("multiple snapshots at height")
+	}
+	for key := range keys {
+		return p.snapshots[key], nil
+	}
+	return nil, errors.New("no snapshot at height")
 }
 
 // GetPeer returns a random peer for a snapshot, if any.

--- a/internal/statesync/syncer_test.go
+++ b/internal/statesync/syncer_test.go
@@ -211,7 +211,7 @@ func TestSyncer_SyncAny(t *testing.T) {
 		LastBlockAppHash: []byte("app_hash"),
 	}, nil)
 
-	newState, lastCommit, err := syncer.SyncAny(0, func() {})
+	newState, lastCommit, err := syncer.SyncAny(0, 0, func() {})
 	require.NoError(t, err)
 
 	time.Sleep(50 * time.Millisecond) // wait for peers to receive requests
@@ -233,7 +233,7 @@ func TestSyncer_SyncAny(t *testing.T) {
 
 func TestSyncer_SyncAny_noSnapshots(t *testing.T) {
 	syncer, _ := setupOfferSyncer()
-	_, _, err := syncer.SyncAny(0, func() {})
+	_, _, err := syncer.SyncAny(0, 0, func() {})
 	assert.Equal(t, errNoSnapshots, err)
 }
 
@@ -247,7 +247,7 @@ func TestSyncer_SyncAny_abort(t *testing.T) {
 		Snapshot: toABCI(s), AppHash: []byte("app_hash"),
 	}).Once().Return(&abci.OfferSnapshotResponse{Result: abci.OFFER_SNAPSHOT_RESULT_ABORT}, nil)
 
-	_, _, err = syncer.SyncAny(0, func() {})
+	_, _, err = syncer.SyncAny(0, 0, func() {})
 	assert.Equal(t, errAbort, err)
 	connSnapshot.AssertExpectations(t)
 }
@@ -278,7 +278,7 @@ func TestSyncer_SyncAny_reject(t *testing.T) {
 		Snapshot: toABCI(s11), AppHash: []byte("app_hash"),
 	}).Once().Return(&abci.OfferSnapshotResponse{Result: abci.OFFER_SNAPSHOT_RESULT_REJECT}, nil)
 
-	_, _, err = syncer.SyncAny(0, func() {})
+	_, _, err = syncer.SyncAny(0, 0, func() {})
 	assert.Equal(t, errNoSnapshots, err)
 	connSnapshot.AssertExpectations(t)
 }
@@ -305,7 +305,7 @@ func TestSyncer_SyncAny_reject_format(t *testing.T) {
 		Snapshot: toABCI(s11), AppHash: []byte("app_hash"),
 	}).Once().Return(&abci.OfferSnapshotResponse{Result: abci.OFFER_SNAPSHOT_RESULT_ABORT}, nil)
 
-	_, _, err = syncer.SyncAny(0, func() {})
+	_, _, err = syncer.SyncAny(0, 0, func() {})
 	assert.Equal(t, errAbort, err)
 	connSnapshot.AssertExpectations(t)
 }
@@ -343,7 +343,7 @@ func TestSyncer_SyncAny_reject_sender(t *testing.T) {
 		Snapshot: toABCI(sa), AppHash: []byte("app_hash"),
 	}).Once().Return(&abci.OfferSnapshotResponse{Result: abci.OFFER_SNAPSHOT_RESULT_REJECT}, nil)
 
-	_, _, err = syncer.SyncAny(0, func() {})
+	_, _, err = syncer.SyncAny(0, 0, func() {})
 	assert.Equal(t, errNoSnapshots, err)
 	connSnapshot.AssertExpectations(t)
 }
@@ -359,7 +359,7 @@ func TestSyncer_SyncAny_abciError(t *testing.T) {
 		Snapshot: toABCI(s), AppHash: []byte("app_hash"),
 	}).Once().Return(nil, errBoom)
 
-	_, _, err = syncer.SyncAny(0, func() {})
+	_, _, err = syncer.SyncAny(0, 0, func() {})
 	assert.True(t, errors.Is(err, errBoom))
 	connSnapshot.AssertExpectations(t)
 }

--- a/node/setup.go
+++ b/node/setup.go
@@ -534,7 +534,7 @@ func startStateSync(
 	}
 
 	go func() {
-		state, commit, err := ssR.Sync(stateProvider, config.DiscoveryTime)
+		state, commit, err := ssR.Sync(stateProvider, config.TargetHeight, config.DiscoveryTime)
 		if err != nil {
 			ssR.Logger.Error("State sync failed", "err", err)
 			return


### PR DESCRIPTION
### Description

This pr is to introduce an enhancement to support state sync at a specific block height.

### Rationale

In the current code, state sync automatically selects the best (usually the most recent) snapshot for syncing, which may not be very convenient. Sometimes, we might prefer to sync to a specific height of our choosing.

### Changes

Notable changes:
* add support for state sync at a specific block height

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

