### PR TITLE
Update localnet-start Makefile

### DIFF
--- a/networks/local/Makefile
+++ b/networks/local/Makefile
@@ -1,7 +1,7 @@
 # Makefile for the "localnode" docker image.
 
 all:
-	docker build --tag cometbft/localnode localnode
+	docker buildx build --platform linux/amd64 --tag cometbft/localnode localnode
 
 .PHONY: all
 


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->
This is yet another small infrastructure-related fix that does not impact current developers but makes life easier for newcomers. It is not part of the mainstream source code, so I didn't add it to unclog.

Situation:
- I'm building on an Apple M1 computer (darwin/arm64).
- I want to set up a localnet using the provided scripts (`make localnet-start`)
  - I cross-compile the binary to linux/amd64 as the docker image instructs.
  - The `localnode` docker container still fails.

Problem:
The `localnode` docker container is built using the host's architecture but expects x86_64 libraries within. This works perfectly fine on an older Intel Mac or a Linux host. But in my case Apple M1 is an arm64 architecture and localnode is built with that in mind. Then it expects to run x86_64 binaries.

Resolution:
Even though in 99% of the cases this is redundant, we should explicitly tell the docker build process that we want an x86_64 container. This can be done with the `--platform` parameter when using the `buildx` build system.

Fallout:
- No impact for current users.
- Apple M1 users can run `localnet-start`
- Old docker users will have to upgrade their engine to v19 or above. (v19 is three years old so I expect everyone has buildx already.)


---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

