### PR TITLE
feat: app hash error channel 

### DIFF
--- a/internal/blocksync/reactor.go
+++ b/internal/blocksync/reactor.go
@@ -3,6 +3,7 @@ package blocksync
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	bcproto "github.com/cometbft/cometbft/api/cometbft/blocksync/v1"
@@ -61,8 +62,9 @@ type Reactor struct {
 	pool      *BlockPool
 	blockSync bool
 
-	requestsCh <-chan BlockRequest
-	errorsCh   <-chan peerError
+	requestsCh      <-chan BlockRequest
+	errorsCh        <-chan peerError
+	appHashErrorsCh chan p2p.AppHashError
 
 	switchToConsensusMs int
 
@@ -89,8 +91,9 @@ func NewReactor(state sm.State, blockExec *sm.BlockExecutor, store *store.BlockS
 	}
 	requestsCh := make(chan BlockRequest, maxTotalRequesters)
 
-	const capacity = 1000                      // must be bigger than peers count
-	errorsCh := make(chan peerError, capacity) // so we don't block in #Receive#pool.AddBlock
+	const capacity = 1000                          // must be bigger than peers count
+	errorsCh := make(chan peerError, capacity)     // so we don't block in #Receive#pool.AddBlock
+	appHashErrorsCh := make(chan p2p.AppHashError) // create an unbuffered channel to stream appHash errors
 
 	startHeight := storeHeight + 1
 	if startHeight == 1 {
@@ -99,14 +102,15 @@ func NewReactor(state sm.State, blockExec *sm.BlockExecutor, store *store.BlockS
 	pool := NewBlockPool(startHeight, requestsCh, errorsCh)
 
 	bcR := &Reactor{
-		initialState: state,
-		blockExec:    blockExec,
-		store:        store,
-		pool:         pool,
-		blockSync:    blockSync,
-		requestsCh:   requestsCh,
-		errorsCh:     errorsCh,
-		metrics:      metrics,
+		initialState:    state,
+		blockExec:       blockExec,
+		store:           store,
+		pool:            pool,
+		blockSync:       blockSync,
+		requestsCh:      requestsCh,
+		errorsCh:        errorsCh,
+		appHashErrorsCh: appHashErrorsCh,
+		metrics:         metrics,
 	}
 	bcR.BaseReactor = *p2p.NewBaseReactor("Reactor", bcR)
 	return bcR
@@ -475,6 +479,19 @@ FOR_LOOP:
 				}
 			}
 			if err != nil {
+				// If this is an appHash or lastResultsHash error, also pass to the appHashError channel.
+				if strings.Contains(err.Error(), "wrong Block.Header.AppHash") {
+					bcR.BaseReactor.AppHashErrorChanBR <- p2p.AppHashError{
+						Err:    err,
+						Height: uint64(first.Height),
+					}
+				} else if strings.Contains(err.Error(), "wrong Block.Header.LastResultsHash") {
+					bcR.BaseReactor.AppHashErrorChanBR <- p2p.AppHashError{
+						Err:    err,
+						Height: uint64(first.Height - 1),
+					}
+				}
+
 				bcR.Logger.Error("Error in validation", "err", err)
 				peerID := bcR.pool.RedoRequest(first.Height)
 				peer := bcR.Switch.Peers().Get(peerID)
@@ -537,4 +554,8 @@ func (bcR *Reactor) BroadcastStatusRequest() {
 		ChannelID: BlocksyncChannel,
 		Message:   &bcproto.StatusRequest{},
 	})
+}
+
+func (bcR *Reactor) AppHashErrorsCh() chan p2p.AppHashError {
+	return bcR.appHashErrorsCh
 }

--- a/internal/consensus/byzantine_test.go
+++ b/internal/consensus/byzantine_test.go
@@ -593,3 +593,5 @@ func (br *ByzantineReactor) Receive(e p2p.Envelope) {
 	br.reactor.Receive(e)
 }
 func (br *ByzantineReactor) InitPeer(peer p2p.Peer) p2p.Peer { return peer }
+
+func (br *ByzantineReactor) AppHashErrorsCh() chan p2p.AppHashError { return nil }

--- a/mempool/nop_mempool.go
+++ b/mempool/nop_mempool.go
@@ -109,3 +109,6 @@ func (*NopMempoolReactor) Receive(p2p.Envelope) {}
 
 // SetSwitch does nothing.
 func (*NopMempoolReactor) SetSwitch(*p2p.Switch) {}
+
+// AppHashErrorsCh always returns nil.
+func (*NopMempoolReactor) AppHashErrorsCh() chan p2p.AppHashError { return nil }

--- a/node/node.go
+++ b/node/node.go
@@ -891,6 +891,11 @@ func (n *Node) ConsensusReactor() *cs.Reactor {
 	return n.consensusReactor
 }
 
+// BCReactor returns the Node's BlockchainReactor.
+func (n *Node) BCReactor() p2p.Reactor {
+	return n.bcReactor
+}
+
 // MempoolReactor returns the Node's mempool reactor.
 func (n *Node) MempoolReactor() p2p.Reactor {
 	return n.mempoolReactor


### PR DESCRIPTION
This PR implements an error channel which allows cometBFT to stream app hash errors to the sdk. With this information, the sdk can provide a more useful error message, specifically the hash of every module at the problematic block height.

![Screenshot 2024-01-02 at 9 58 28 PM](https://github.com/cometbft/cometbft/assets/40078083/5113aff4-d01a-4b8b-aa8c-feb252728dc8)

The respective cosmos sdk PR: https://github.com/osmosis-labs/cosmos-sdk/pull/500

Osmosis will be using this fork in our next release. Would be great to have this upstreamed here!