### PR TITLE
feat: custom dependencies order

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,6 +45,7 @@ linters:
     - structcheck
     - tagliatelle
     - typecheck
+    # Prefer unparam over revive's unused param. It is more thorough in its checking.
     - unparam
     - varcheck
     - varnamelen
@@ -76,10 +77,16 @@ linters-settings:
     max-blank-identifiers: 3
   goconst:
     ignore-tests: true
-  maligned:
-    suggest-new: true
   misspell:
     locale: US
+  gci:
+    sections:
+      - standard # Standard section: captures all standard packages.
+      - default # Default section: contains all imports that could not be matched to another section type.
+      - blank # blank imports
+      - dot # dot imports
+      - prefix(github.com/cometbft/cometbft, github.com/cometbft/cometbft-db)
+    custom-order: true
   depguard:
     rules:
       main:

--- a/abci/client/grpc_client.go
+++ b/abci/client/grpc_client.go
@@ -7,11 +7,12 @@ import (
 	"sync"
 	"time"
 
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
 	"github.com/cometbft/cometbft/abci/types"
 	cmtnet "github.com/cometbft/cometbft/internal/net"
 	"github.com/cometbft/cometbft/internal/service"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 var _ Client = (*grpcClient)(nil)

--- a/abci/client/grpc_client_test.go
+++ b/abci/client/grpc_client_test.go
@@ -8,14 +8,15 @@ import (
 	"testing"
 	"time"
 
-	abciserver "github.com/cometbft/cometbft/abci/server"
-	"github.com/cometbft/cometbft/abci/types"
-	cmtnet "github.com/cometbft/cometbft/internal/net"
-	"github.com/cometbft/cometbft/libs/log"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+
+	abciserver "github.com/cometbft/cometbft/abci/server"
+	"github.com/cometbft/cometbft/abci/types"
+	cmtnet "github.com/cometbft/cometbft/internal/net"
+	"github.com/cometbft/cometbft/libs/log"
 )
 
 func TestGRPC(t *testing.T) {

--- a/abci/client/socket_client_test.go
+++ b/abci/client/socket_client_test.go
@@ -9,12 +9,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	abcicli "github.com/cometbft/cometbft/abci/client"
 	"github.com/cometbft/cometbft/abci/server"
 	"github.com/cometbft/cometbft/abci/types"
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
 	"github.com/cometbft/cometbft/internal/service"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCalls(t *testing.T) {

--- a/abci/cmd/abci-cli/abci-cli.go
+++ b/abci/cmd/abci-cli/abci-cli.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	abcicli "github.com/cometbft/cometbft/abci/client"
 	"github.com/cometbft/cometbft/abci/example/kvstore"
 	"github.com/cometbft/cometbft/abci/server"
@@ -18,7 +20,6 @@ import (
 	crypto "github.com/cometbft/cometbft/api/cometbft/crypto/v1"
 	cmtos "github.com/cometbft/cometbft/internal/os"
 	"github.com/cometbft/cometbft/libs/log"
-	"github.com/spf13/cobra"
 )
 
 // client is a global variable so it can be reused by the console.

--- a/abci/example/kvstore/kvstore_test.go
+++ b/abci/example/kvstore/kvstore_test.go
@@ -6,11 +6,12 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	abcicli "github.com/cometbft/cometbft/abci/client"
 	abciserver "github.com/cometbft/cometbft/abci/server"
 	"github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/libs/log"
-	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/abci/server/grpc_server.go
+++ b/abci/server/grpc_server.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"net"
 
+	"google.golang.org/grpc"
+
 	"github.com/cometbft/cometbft/abci/types"
 	cmtnet "github.com/cometbft/cometbft/internal/net"
 	"github.com/cometbft/cometbft/internal/service"
-	"google.golang.org/grpc"
 )
 
 type GRPCServer struct {

--- a/abci/tests/client_server_test.go
+++ b/abci/tests/client_server_test.go
@@ -3,10 +3,11 @@ package tests
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	abciclient "github.com/cometbft/cometbft/abci/client"
 	"github.com/cometbft/cometbft/abci/example/kvstore"
 	abciserver "github.com/cometbft/cometbft/abci/server"
-	"github.com/stretchr/testify/require"
 )
 
 func TestClientServerNoAddrPrefix(t *testing.T) {

--- a/abci/types/messages.go
+++ b/abci/types/messages.go
@@ -4,9 +4,10 @@ import (
 	"io"
 	"math"
 
+	"github.com/cosmos/gogoproto/proto"
+
 	pb "github.com/cometbft/cometbft/api/cometbft/abci/v1"
 	"github.com/cometbft/cometbft/internal/protoio"
-	"github.com/cosmos/gogoproto/proto"
 )
 
 const (

--- a/abci/types/messages_test.go
+++ b/abci/types/messages_test.go
@@ -6,10 +6,11 @@ import (
 	"strings"
 	"testing"
 
-	cmtproto "github.com/cometbft/cometbft/api/cometbft/types/v1"
 	"github.com/cosmos/gogoproto/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	cmtproto "github.com/cometbft/cometbft/api/cometbft/types/v1"
 )
 
 func TestMarshalJSON(t *testing.T) {

--- a/abci/types/types.go
+++ b/abci/types/types.go
@@ -4,8 +4,9 @@ package types
 import (
 	"encoding/json"
 
-	v1 "github.com/cometbft/cometbft/api/cometbft/abci/v1"
 	"github.com/cosmos/gogoproto/grpc"
+
+	v1 "github.com/cometbft/cometbft/api/cometbft/abci/v1"
 )
 
 type (

--- a/abci/types/types_test.go
+++ b/abci/types/types_test.go
@@ -3,10 +3,11 @@ package types_test
 import (
 	"testing"
 
-	abci "github.com/cometbft/cometbft/abci/types"
-	"github.com/cometbft/cometbft/crypto/merkle"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/cometbft/cometbft/crypto/merkle"
 )
 
 func TestHashAndProveResults(t *testing.T) {

--- a/cmd/cometbft/commands/compact.go
+++ b/cmd/cometbft/commands/compact.go
@@ -5,11 +5,12 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/cometbft/cometbft/libs/log"
 	"github.com/spf13/cobra"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	"github.com/syndtr/goleveldb/leveldb/util"
+
+	"github.com/cometbft/cometbft/libs/log"
 )
 
 var CompactGoLevelDBCmd = &cobra.Command{

--- a/cmd/cometbft/commands/debug/debug.go
+++ b/cmd/cometbft/commands/debug/debug.go
@@ -3,8 +3,9 @@ package debug
 import (
 	"os"
 
-	"github.com/cometbft/cometbft/libs/log"
 	"github.com/spf13/cobra"
+
+	"github.com/cometbft/cometbft/libs/log"
 )
 
 var (

--- a/cmd/cometbft/commands/debug/dump.go
+++ b/cmd/cometbft/commands/debug/dump.go
@@ -7,11 +7,12 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
 	cfg "github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/libs/cli"
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var dumpCmd = &cobra.Command{

--- a/cmd/cometbft/commands/debug/kill.go
+++ b/cmd/cometbft/commands/debug/kill.go
@@ -10,11 +10,12 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
 	cfg "github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/libs/cli"
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var killCmd = &cobra.Command{

--- a/cmd/cometbft/commands/gen_node_key.go
+++ b/cmd/cometbft/commands/gen_node_key.go
@@ -3,9 +3,10 @@ package commands
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	cmtos "github.com/cometbft/cometbft/internal/os"
 	"github.com/cometbft/cometbft/p2p"
-	"github.com/spf13/cobra"
 )
 
 // GenNodeKeyCmd allows the generation of a node key. It prints node's ID to

--- a/cmd/cometbft/commands/gen_validator.go
+++ b/cmd/cometbft/commands/gen_validator.go
@@ -3,9 +3,10 @@ package commands
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	cmtjson "github.com/cometbft/cometbft/libs/json"
 	"github.com/cometbft/cometbft/privval"
-	"github.com/spf13/cobra"
 )
 
 // GenValidatorCmd allows the generation of a keypair for a

--- a/cmd/cometbft/commands/init.go
+++ b/cmd/cometbft/commands/init.go
@@ -3,6 +3,8 @@ package commands
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	cfg "github.com/cometbft/cometbft/config"
 	cmtos "github.com/cometbft/cometbft/internal/os"
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
@@ -10,7 +12,6 @@ import (
 	"github.com/cometbft/cometbft/privval"
 	"github.com/cometbft/cometbft/types"
 	cmttime "github.com/cometbft/cometbft/types/time"
-	"github.com/spf13/cobra"
 )
 
 // InitFilesCmd initializes a fresh CometBFT instance.

--- a/cmd/cometbft/commands/inspect.go
+++ b/cmd/cometbft/commands/inspect.go
@@ -6,13 +6,14 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/spf13/cobra"
+
 	cfg "github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/internal/inspect"
 	"github.com/cometbft/cometbft/internal/state"
 	"github.com/cometbft/cometbft/internal/state/indexer/block"
 	"github.com/cometbft/cometbft/internal/store"
 	"github.com/cometbft/cometbft/types"
-	"github.com/spf13/cobra"
 )
 
 // InspectCmd is the command for starting an inspect server.

--- a/cmd/cometbft/commands/light.go
+++ b/cmd/cometbft/commands/light.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	dbm "github.com/cometbft/cometbft-db"
 	cmtos "github.com/cometbft/cometbft/internal/os"
 	"github.com/cometbft/cometbft/libs/log"
@@ -20,7 +22,6 @@ import (
 	lrpc "github.com/cometbft/cometbft/light/rpc"
 	dbs "github.com/cometbft/cometbft/light/store/db"
 	rpcserver "github.com/cometbft/cometbft/rpc/jsonrpc/server"
-	"github.com/spf13/cobra"
 )
 
 // LightCmd represents the base command when called without any subcommands.

--- a/cmd/cometbft/commands/reindex_event.go
+++ b/cmd/cometbft/commands/reindex_event.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	dbm "github.com/cometbft/cometbft-db"
 	abcitypes "github.com/cometbft/cometbft/abci/types"
 	cmtcfg "github.com/cometbft/cometbft/config"
@@ -16,7 +18,6 @@ import (
 	"github.com/cometbft/cometbft/internal/state/txindex"
 	"github.com/cometbft/cometbft/internal/state/txindex/kv"
 	"github.com/cometbft/cometbft/types"
-	"github.com/spf13/cobra"
 )
 
 const (

--- a/cmd/cometbft/commands/reindex_event_test.go
+++ b/cmd/cometbft/commands/reindex_event_test.go
@@ -5,6 +5,10 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	dbm "github.com/cometbft/cometbft-db"
 	abcitypes "github.com/cometbft/cometbft/abci/types"
 	cmtcfg "github.com/cometbft/cometbft/config"
@@ -13,9 +17,6 @@ import (
 	txmocks "github.com/cometbft/cometbft/internal/state/txindex/mocks"
 	"github.com/cometbft/cometbft/internal/test"
 	"github.com/cometbft/cometbft/types"
-	"github.com/spf13/cobra"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/cmd/cometbft/commands/reset.go
+++ b/cmd/cometbft/commands/reset.go
@@ -4,10 +4,11 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/spf13/cobra"
+
 	cmtos "github.com/cometbft/cometbft/internal/os"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/privval"
-	"github.com/spf13/cobra"
 )
 
 // ResetAllCmd removes the database of this CometBFT core

--- a/cmd/cometbft/commands/reset_test.go
+++ b/cmd/cometbft/commands/reset_test.go
@@ -4,9 +4,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	cfg "github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/privval"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_ResetAll(t *testing.T) {

--- a/cmd/cometbft/commands/rollback.go
+++ b/cmd/cometbft/commands/rollback.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/spf13/cobra"
+
 	dbm "github.com/cometbft/cometbft-db"
 	cfg "github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/internal/os"
 	"github.com/cometbft/cometbft/internal/state"
 	"github.com/cometbft/cometbft/internal/store"
-	"github.com/spf13/cobra"
 )
 
 var removeBlock = false

--- a/cmd/cometbft/commands/root.go
+++ b/cmd/cometbft/commands/root.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
 	cfg "github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/libs/cli"
 	cmtflags "github.com/cometbft/cometbft/libs/cli/flags"
 	"github.com/cometbft/cometbft/libs/log"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var (

--- a/cmd/cometbft/commands/root_test.go
+++ b/cmd/cometbft/commands/root_test.go
@@ -7,13 +7,14 @@ import (
 	"strconv"
 	"testing"
 
-	cfg "github.com/cometbft/cometbft/config"
-	cmtos "github.com/cometbft/cometbft/internal/os"
-	"github.com/cometbft/cometbft/libs/cli"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	cfg "github.com/cometbft/cometbft/config"
+	cmtos "github.com/cometbft/cometbft/internal/os"
+	"github.com/cometbft/cometbft/libs/cli"
 )
 
 // clearConfig clears env vars, the given root dir, and resets viper.

--- a/cmd/cometbft/commands/run_node.go
+++ b/cmd/cometbft/commands/run_node.go
@@ -4,9 +4,10 @@ import (
 	"encoding/hex"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	cmtos "github.com/cometbft/cometbft/internal/os"
 	nm "github.com/cometbft/cometbft/node"
-	"github.com/spf13/cobra"
 )
 
 var genesisHash []byte

--- a/cmd/cometbft/commands/show_node_id.go
+++ b/cmd/cometbft/commands/show_node_id.go
@@ -3,8 +3,9 @@ package commands
 import (
 	"fmt"
 
-	"github.com/cometbft/cometbft/p2p"
 	"github.com/spf13/cobra"
+
+	"github.com/cometbft/cometbft/p2p"
 )
 
 // ShowNodeIDCmd dumps node's ID to the standard output.

--- a/cmd/cometbft/commands/show_validator.go
+++ b/cmd/cometbft/commands/show_validator.go
@@ -3,10 +3,11 @@ package commands
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	cmtos "github.com/cometbft/cometbft/internal/os"
 	cmtjson "github.com/cometbft/cometbft/libs/json"
 	"github.com/cometbft/cometbft/privval"
-	"github.com/spf13/cobra"
 )
 
 // ShowValidatorCmd adds capabilities for showing the validator info.

--- a/cmd/cometbft/commands/testnet.go
+++ b/cmd/cometbft/commands/testnet.go
@@ -7,6 +7,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
 	cfg "github.com/cometbft/cometbft/config"
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
 	"github.com/cometbft/cometbft/libs/bytes"
@@ -14,8 +17,6 @@ import (
 	"github.com/cometbft/cometbft/privval"
 	"github.com/cometbft/cometbft/types"
 	cmttime "github.com/cometbft/cometbft/types/time"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var (

--- a/cmd/cometbft/commands/version.go
+++ b/cmd/cometbft/commands/version.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/cometbft/cometbft/version"
 	"github.com/spf13/cobra"
+
+	"github.com/cometbft/cometbft/version"
 )
 
 // VersionCmd ...

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cometbft/cometbft/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/config"
 )
 
 func TestDefaultConfig(t *testing.T) {

--- a/config/toml_test.go
+++ b/config/toml_test.go
@@ -5,10 +5,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/cometbft/cometbft/config"
-	"github.com/cometbft/cometbft/internal/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/config"
+	"github.com/cometbft/cometbft/internal/test"
 )
 
 func ensureFiles(t *testing.T, rootDir string, files ...string) {

--- a/crypto/ed25519/bench_test.go
+++ b/crypto/ed25519/bench_test.go
@@ -5,9 +5,10 @@ import (
 	"io"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/crypto/internal/benchmarking"
-	"github.com/stretchr/testify/require"
 )
 
 func BenchmarkKeyGeneration(b *testing.B) {

--- a/crypto/ed25519/ed25519.go
+++ b/crypto/ed25519/ed25519.go
@@ -7,11 +7,12 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/oasisprotocol/curve25519-voi/primitives/ed25519"
+	"github.com/oasisprotocol/curve25519-voi/primitives/ed25519/extra/cache"
+
 	"github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/crypto/tmhash"
 	cmtjson "github.com/cometbft/cometbft/libs/json"
-	"github.com/oasisprotocol/curve25519-voi/primitives/ed25519"
-	"github.com/oasisprotocol/curve25519-voi/primitives/ed25519/extra/cache"
 )
 
 var (

--- a/crypto/ed25519/ed25519_test.go
+++ b/crypto/ed25519/ed25519_test.go
@@ -3,10 +3,11 @@ package ed25519_test
 import (
 	"testing"
 
-	"github.com/cometbft/cometbft/crypto"
-	"github.com/cometbft/cometbft/crypto/ed25519"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/crypto"
+	"github.com/cometbft/cometbft/crypto/ed25519"
 )
 
 func TestSignAndValidateEd25519(t *testing.T) {

--- a/crypto/merkle/proof_test.go
+++ b/crypto/merkle/proof_test.go
@@ -6,10 +6,11 @@ import (
 	"fmt"
 	"testing"
 
-	cmtcrypto "github.com/cometbft/cometbft/api/cometbft/crypto/v1"
-	"github.com/cometbft/cometbft/crypto/tmhash"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	cmtcrypto "github.com/cometbft/cometbft/api/cometbft/crypto/v1"
+	"github.com/cometbft/cometbft/crypto/tmhash"
 )
 
 const ProofOpDomino = "test:domino"

--- a/crypto/merkle/tree_test.go
+++ b/crypto/merkle/tree_test.go
@@ -4,11 +4,12 @@ import (
 	"encoding/hex"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/cometbft/cometbft/crypto/tmhash"
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
 	"github.com/cometbft/cometbft/libs/test"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type testItem []byte

--- a/crypto/random_test.go
+++ b/crypto/random_test.go
@@ -3,8 +3,9 @@ package crypto_test
 import (
 	"testing"
 
-	"github.com/cometbft/cometbft/crypto"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/crypto"
 )
 
 // the purpose of this test is primarily to ensure that the randomness

--- a/crypto/secp256k1/secp256k1.go
+++ b/crypto/secp256k1/secp256k1.go
@@ -10,9 +10,10 @@ import (
 
 	secp256k1 "github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
+	"golang.org/x/crypto/ripemd160" //nolint: staticcheck // necessary for Bitcoin address format
+
 	"github.com/cometbft/cometbft/crypto"
 	cmtjson "github.com/cometbft/cometbft/libs/json"
-	"golang.org/x/crypto/ripemd160" //nolint: staticcheck // necessary for Bitcoin address format
 )
 
 // -------------------------------------.

--- a/crypto/secp256k1/secp256k1_test.go
+++ b/crypto/secp256k1/secp256k1_test.go
@@ -7,10 +7,11 @@ import (
 
 	underlyingSecp256k1 "github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil/base58"
-	"github.com/cometbft/cometbft/crypto"
-	"github.com/cometbft/cometbft/crypto/secp256k1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/crypto"
+	"github.com/cometbft/cometbft/crypto/secp256k1"
 )
 
 type keyData struct {

--- a/crypto/sr25519/batch.go
+++ b/crypto/sr25519/batch.go
@@ -4,8 +4,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/cometbft/cometbft/crypto"
 	"github.com/oasisprotocol/curve25519-voi/primitives/sr25519"
+
+	"github.com/cometbft/cometbft/crypto"
 )
 
 var _ crypto.BatchVerifier = &BatchVerifier{}

--- a/crypto/sr25519/bench_test.go
+++ b/crypto/sr25519/bench_test.go
@@ -5,9 +5,10 @@ import (
 	"io"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/crypto/internal/benchmarking"
-	"github.com/stretchr/testify/require"
 )
 
 func BenchmarkKeyGeneration(b *testing.B) {

--- a/crypto/sr25519/privkey.go
+++ b/crypto/sr25519/privkey.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/cometbft/cometbft/crypto"
 	"github.com/oasisprotocol/curve25519-voi/primitives/sr25519"
+
+	"github.com/cometbft/cometbft/crypto"
 )
 
 var (

--- a/crypto/sr25519/pubkey.go
+++ b/crypto/sr25519/pubkey.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/oasisprotocol/curve25519-voi/primitives/sr25519"
+
 	"github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/crypto/tmhash"
-	"github.com/oasisprotocol/curve25519-voi/primitives/sr25519"
 )
 
 var _ crypto.PubKey = PubKey{}

--- a/crypto/sr25519/sr25519_test.go
+++ b/crypto/sr25519/sr25519_test.go
@@ -5,10 +5,11 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/cometbft/cometbft/crypto"
-	"github.com/cometbft/cometbft/crypto/sr25519"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/crypto"
+	"github.com/cometbft/cometbft/crypto/sr25519"
 )
 
 func TestSignAndValidateSr25519(t *testing.T) {

--- a/crypto/tmhash/hash_test.go
+++ b/crypto/tmhash/hash_test.go
@@ -4,9 +4,10 @@ import (
 	"crypto/sha256"
 	"testing"
 
-	"github.com/cometbft/cometbft/crypto/tmhash"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/crypto/tmhash"
 )
 
 func TestHash(t *testing.T) {

--- a/crypto/xsalsa20symmetric/symmetric.go
+++ b/crypto/xsalsa20symmetric/symmetric.go
@@ -4,8 +4,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/cometbft/cometbft/crypto"
 	"golang.org/x/crypto/nacl/secretbox"
+
+	"github.com/cometbft/cometbft/crypto"
 )
 
 // TODO, make this into a struct that implements crypto.Symmetric.

--- a/crypto/xsalsa20symmetric/symmetric_test.go
+++ b/crypto/xsalsa20symmetric/symmetric_test.go
@@ -3,10 +3,11 @@ package xsalsa20symmetric
 import (
 	"testing"
 
-	"github.com/cometbft/cometbft/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
+
+	"github.com/cometbft/cometbft/crypto"
 )
 
 func TestSimple(t *testing.T) {

--- a/internal/autofile/autofile_test.go
+++ b/internal/autofile/autofile_test.go
@@ -7,9 +7,10 @@ import (
 	"testing"
 	"time"
 
-	cmtos "github.com/cometbft/cometbft/internal/os"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	cmtos "github.com/cometbft/cometbft/internal/os"
 )
 
 func TestSIGHUP(t *testing.T) {

--- a/internal/autofile/group_test.go
+++ b/internal/autofile/group_test.go
@@ -6,10 +6,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	cmtos "github.com/cometbft/cometbft/internal/os"
-	cmtrand "github.com/cometbft/cometbft/internal/rand"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	cmtos "github.com/cometbft/cometbft/internal/os"
+	cmtrand "github.com/cometbft/cometbft/internal/rand"
 )
 
 func createTestGroupWithHeadSizeLimit(t *testing.T, headSizeLimit int64) *Group {

--- a/internal/bits/bit_array_test.go
+++ b/internal/bits/bit_array_test.go
@@ -6,9 +6,10 @@ import (
 	"fmt"
 	"testing"
 
-	cmtrand "github.com/cometbft/cometbft/internal/rand"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	cmtrand "github.com/cometbft/cometbft/internal/rand"
 )
 
 func randBitArray(bits int) *BitArray {

--- a/internal/blocksync/metrics.go
+++ b/internal/blocksync/metrics.go
@@ -1,8 +1,9 @@
 package blocksync
 
 import (
-	"github.com/cometbft/cometbft/types"
 	"github.com/go-kit/kit/metrics"
+
+	"github.com/cometbft/cometbft/types"
 )
 
 const (

--- a/internal/blocksync/msgs.go
+++ b/internal/blocksync/msgs.go
@@ -3,9 +3,10 @@ package blocksync
 import (
 	"fmt"
 
+	"github.com/cosmos/gogoproto/proto"
+
 	bcproto "github.com/cometbft/cometbft/api/cometbft/blocksync/v1"
 	"github.com/cometbft/cometbft/types"
-	"github.com/cosmos/gogoproto/proto"
 )
 
 const (

--- a/internal/blocksync/msgs_test.go
+++ b/internal/blocksync/msgs_test.go
@@ -5,12 +5,13 @@ import (
 	"math"
 	"testing"
 
-	bcproto "github.com/cometbft/cometbft/api/cometbft/blocksync/v1"
-	"github.com/cometbft/cometbft/internal/blocksync"
-	"github.com/cometbft/cometbft/types"
 	"github.com/cosmos/gogoproto/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	bcproto "github.com/cometbft/cometbft/api/cometbft/blocksync/v1"
+	"github.com/cometbft/cometbft/internal/blocksync"
+	"github.com/cometbft/cometbft/types"
 )
 
 func TestBcBlockRequestMessageValidateBasic(t *testing.T) {

--- a/internal/blocksync/pool_test.go
+++ b/internal/blocksync/pool_test.go
@@ -5,12 +5,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/p2p"
 	"github.com/cometbft/cometbft/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func init() {

--- a/internal/blocksync/reactor_test.go
+++ b/internal/blocksync/reactor_test.go
@@ -7,6 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	dbm "github.com/cometbft/cometbft-db"
 	abci "github.com/cometbft/cometbft/abci/types"
 	cfg "github.com/cometbft/cometbft/config"
@@ -19,9 +23,6 @@ import (
 	"github.com/cometbft/cometbft/proxy"
 	"github.com/cometbft/cometbft/types"
 	cmttime "github.com/cometbft/cometbft/types/time"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 var config *cfg.Config

--- a/internal/clist/clist_test.go
+++ b/internal/clist/clist_test.go
@@ -7,8 +7,9 @@ import (
 	"testing"
 	"time"
 
-	cmtrand "github.com/cometbft/cometbft/internal/rand"
 	"github.com/stretchr/testify/assert"
+
+	cmtrand "github.com/cometbft/cometbft/internal/rand"
 )
 
 func TestPanicOnMaxLength(t *testing.T) {

--- a/internal/consensus/byzantine_test.go
+++ b/internal/consensus/byzantine_test.go
@@ -9,6 +9,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	dbm "github.com/cometbft/cometbft-db"
 	abcicli "github.com/cometbft/cometbft/abci/client"
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -23,8 +26,6 @@ import (
 	"github.com/cometbft/cometbft/p2p"
 	"github.com/cometbft/cometbft/proxy"
 	"github.com/cometbft/cometbft/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 //----------------------------------------------

--- a/internal/consensus/common_test.go
+++ b/internal/consensus/common_test.go
@@ -12,6 +12,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log/term"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	dbm "github.com/cometbft/cometbft-db"
 	abcicli "github.com/cometbft/cometbft/abci/client"
 	"github.com/cometbft/cometbft/abci/example/kvstore"
@@ -33,9 +37,6 @@ import (
 	"github.com/cometbft/cometbft/proxy"
 	"github.com/cometbft/cometbft/types"
 	cmttime "github.com/cometbft/cometbft/types/time"
-	"github.com/go-kit/log/term"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/internal/consensus/mempool_test.go
+++ b/internal/consensus/mempool_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	dbm "github.com/cometbft/cometbft-db"
 	"github.com/cometbft/cometbft/abci/example/kvstore"
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -14,8 +17,6 @@ import (
 	mempl "github.com/cometbft/cometbft/mempool"
 	"github.com/cometbft/cometbft/proxy"
 	"github.com/cometbft/cometbft/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // for testing.

--- a/internal/consensus/metrics.go
+++ b/internal/consensus/metrics.go
@@ -4,9 +4,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-kit/kit/metrics"
+
 	cstypes "github.com/cometbft/cometbft/internal/consensus/types"
 	"github.com/cometbft/cometbft/types"
-	"github.com/go-kit/kit/metrics"
 )
 
 const (

--- a/internal/consensus/msgs.go
+++ b/internal/consensus/msgs.go
@@ -3,6 +3,8 @@ package consensus
 import (
 	"fmt"
 
+	"github.com/cosmos/gogoproto/proto"
+
 	cmtcons "github.com/cometbft/cometbft/api/cometbft/consensus/v1"
 	cmtproto "github.com/cometbft/cometbft/api/cometbft/types/v1"
 	"github.com/cometbft/cometbft/internal/bits"
@@ -11,7 +13,6 @@ import (
 	"github.com/cometbft/cometbft/p2p"
 	"github.com/cometbft/cometbft/types"
 	cmterrors "github.com/cometbft/cometbft/types/errors"
-	"github.com/cosmos/gogoproto/proto"
 )
 
 // TODO: This needs to be removed, but WALToProto depends on this.

--- a/internal/consensus/msgs_test.go
+++ b/internal/consensus/msgs_test.go
@@ -6,6 +6,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cosmos/gogoproto/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	cmtcons "github.com/cometbft/cometbft/api/cometbft/consensus/v1"
 	cmtproto "github.com/cometbft/cometbft/api/cometbft/types/v1"
 	"github.com/cometbft/cometbft/crypto/merkle"
@@ -13,9 +17,6 @@ import (
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
 	"github.com/cometbft/cometbft/p2p"
 	"github.com/cometbft/cometbft/types"
-	"github.com/cosmos/gogoproto/proto"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestMsgToProto(t *testing.T) {

--- a/internal/consensus/reactor_test.go
+++ b/internal/consensus/reactor_test.go
@@ -9,6 +9,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	dbm "github.com/cometbft/cometbft-db"
 	abcicli "github.com/cometbft/cometbft/abci/client"
 	"github.com/cometbft/cometbft/abci/example/kvstore"
@@ -32,9 +36,6 @@ import (
 	"github.com/cometbft/cometbft/proxy"
 	"github.com/cometbft/cometbft/types"
 	cmterrors "github.com/cometbft/cometbft/types/errors"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 //----------------------------------------------

--- a/internal/consensus/replay_test.go
+++ b/internal/consensus/replay_test.go
@@ -12,6 +12,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cosmos/gogoproto/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	dbm "github.com/cometbft/cometbft-db"
 	"github.com/cometbft/cometbft/abci/example/kvstore"
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -28,10 +33,6 @@ import (
 	"github.com/cometbft/cometbft/privval"
 	"github.com/cometbft/cometbft/proxy"
 	"github.com/cometbft/cometbft/types"
-	"github.com/cosmos/gogoproto/proto"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -11,6 +11,8 @@ import (
 	"sort"
 	"time"
 
+	"github.com/cosmos/gogoproto/proto"
+
 	cmtproto "github.com/cometbft/cometbft/api/cometbft/types/v1"
 	cfg "github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/crypto"
@@ -28,7 +30,6 @@ import (
 	"github.com/cometbft/cometbft/types"
 	cmterrors "github.com/cometbft/cometbft/types/errors"
 	cmttime "github.com/cometbft/cometbft/types/time"
-	"github.com/cosmos/gogoproto/proto"
 )
 
 var msgQueueSize = 1000

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -8,6 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	"github.com/cometbft/cometbft/abci/example/kvstore"
 	abci "github.com/cometbft/cometbft/abci/types"
 	abcimocks "github.com/cometbft/cometbft/abci/types/mocks"
@@ -22,9 +26,6 @@ import (
 	"github.com/cometbft/cometbft/libs/log"
 	p2pmock "github.com/cometbft/cometbft/p2p/mock"
 	"github.com/cometbft/cometbft/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 /*

--- a/internal/consensus/types/height_vote_set_test.go
+++ b/internal/consensus/types/height_vote_set_test.go
@@ -4,13 +4,14 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	cfg "github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/crypto/tmhash"
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
 	"github.com/cometbft/cometbft/internal/test"
 	"github.com/cometbft/cometbft/types"
 	cmttime "github.com/cometbft/cometbft/types/time"
-	"github.com/stretchr/testify/require"
 )
 
 var config *cfg.Config // NOTE: must be reset for each _test.go file

--- a/internal/consensus/wal.go
+++ b/internal/consensus/wal.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/cosmos/gogoproto/proto"
+
 	cmtcons "github.com/cometbft/cometbft/api/cometbft/consensus/v1"
 	auto "github.com/cometbft/cometbft/internal/autofile"
 	cmtos "github.com/cometbft/cometbft/internal/os"
@@ -17,7 +19,6 @@ import (
 	"github.com/cometbft/cometbft/libs/log"
 	cmterrors "github.com/cometbft/cometbft/types/errors"
 	cmttime "github.com/cometbft/cometbft/types/time"
-	"github.com/cosmos/gogoproto/proto"
 )
 
 const (

--- a/internal/consensus/wal_test.go
+++ b/internal/consensus/wal_test.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	cfg "github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/crypto/merkle"
 	"github.com/cometbft/cometbft/internal/autofile"
@@ -16,8 +19,6 @@ import (
 	"github.com/cometbft/cometbft/libs/log"
 	cmttypes "github.com/cometbft/cometbft/types"
 	cmttime "github.com/cometbft/cometbft/types/time"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/internal/events/events_test.go
+++ b/internal/events/events_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cometbft/cometbft/internal/rand"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/internal/rand"
 )
 
 // TestAddListenerForEventFireOnce sets up an EventSwitch, subscribes a single

--- a/internal/evidence/pool.go
+++ b/internal/evidence/pool.go
@@ -7,6 +7,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cosmos/gogoproto/proto"
+	gogotypes "github.com/cosmos/gogoproto/types"
+
 	dbm "github.com/cometbft/cometbft-db"
 	cmtproto "github.com/cometbft/cometbft/api/cometbft/types/v1"
 	clist "github.com/cometbft/cometbft/internal/clist"
@@ -14,8 +17,6 @@ import (
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/types"
 	cmterrors "github.com/cometbft/cometbft/types/errors"
-	"github.com/cosmos/gogoproto/proto"
-	gogotypes "github.com/cosmos/gogoproto/types"
 )
 
 const (

--- a/internal/evidence/pool_test.go
+++ b/internal/evidence/pool_test.go
@@ -5,6 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	dbm "github.com/cometbft/cometbft-db"
 	cmtversion "github.com/cometbft/cometbft/api/cometbft/version/v1"
 	"github.com/cometbft/cometbft/internal/evidence"
@@ -16,9 +20,6 @@ import (
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/types"
 	"github.com/cometbft/cometbft/version"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {

--- a/internal/evidence/reactor.go
+++ b/internal/evidence/reactor.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cosmos/gogoproto/proto"
+
 	cmtproto "github.com/cometbft/cometbft/api/cometbft/types/v1"
 	clist "github.com/cometbft/cometbft/internal/clist"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/p2p"
 	"github.com/cometbft/cometbft/types"
-	"github.com/cosmos/gogoproto/proto"
 )
 
 const (

--- a/internal/evidence/reactor_test.go
+++ b/internal/evidence/reactor_test.go
@@ -7,6 +7,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fortytw2/leaktest"
+	"github.com/go-kit/log/term"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	dbm "github.com/cometbft/cometbft-db"
 	cmtproto "github.com/cometbft/cometbft/api/cometbft/types/v1"
 	cfg "github.com/cometbft/cometbft/config"
@@ -19,11 +25,6 @@ import (
 	"github.com/cometbft/cometbft/p2p"
 	p2pmocks "github.com/cometbft/cometbft/p2p/mocks"
 	"github.com/cometbft/cometbft/types"
-	"github.com/fortytw2/leaktest"
-	"github.com/go-kit/log/term"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 var (

--- a/internal/evidence/verify_test.go
+++ b/internal/evidence/verify_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	dbm "github.com/cometbft/cometbft-db"
 	cmtversion "github.com/cometbft/cometbft/api/cometbft/version/v1"
 	"github.com/cometbft/cometbft/crypto"
@@ -17,8 +20,6 @@ import (
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/types"
 	"github.com/cometbft/cometbft/version"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -6,6 +6,8 @@ import (
 	"net"
 	"os"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/internal/inspect/rpc"
 	"github.com/cometbft/cometbft/internal/state"
@@ -17,7 +19,6 @@ import (
 	"github.com/cometbft/cometbft/libs/log"
 	rpccore "github.com/cometbft/cometbft/rpc/core"
 	"github.com/cometbft/cometbft/types"
-	"golang.org/x/sync/errgroup"
 )
 
 var logger = log.NewTMLogger(log.NewSyncWriter(os.Stdout))

--- a/internal/inspect/inspect_test.go
+++ b/internal/inspect/inspect_test.go
@@ -10,6 +10,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fortytw2/leaktest"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	abcitypes "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/internal/inspect"
@@ -20,9 +24,6 @@ import (
 	"github.com/cometbft/cometbft/internal/test"
 	httpclient "github.com/cometbft/cometbft/rpc/client/http"
 	"github.com/cometbft/cometbft/types"
-	"github.com/fortytw2/leaktest"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 func TestInspectConstructor(t *testing.T) {

--- a/internal/inspect/rpc/rpc.go
+++ b/internal/inspect/rpc/rpc.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/rs/cors"
+
 	"github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/internal/state"
 	"github.com/cometbft/cometbft/internal/state/indexer"
@@ -12,7 +14,6 @@ import (
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/rpc/core"
 	"github.com/cometbft/cometbft/rpc/jsonrpc/server"
-	"github.com/rs/cors"
 )
 
 // Server defines parameters for running an Inspector rpc server.

--- a/internal/protoio/io_test.go
+++ b/internal/protoio/io_test.go
@@ -37,10 +37,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cometbft/cometbft/internal/protoio"
 	"github.com/cosmos/gogoproto/proto"
 	"github.com/cosmos/gogoproto/test"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/internal/protoio"
 )
 
 func iotest(writer protoio.WriteCloser, reader protoio.ReadCloser) error {

--- a/internal/pubsub/example_test.go
+++ b/internal/pubsub/example_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/cometbft/cometbft/internal/pubsub"
 	"github.com/cometbft/cometbft/internal/pubsub/query"
 	"github.com/cometbft/cometbft/libs/log"
-	"github.com/stretchr/testify/require"
 )
 
 func TestExample(t *testing.T) {

--- a/internal/pubsub/pubsub_test.go
+++ b/internal/pubsub/pubsub_test.go
@@ -7,11 +7,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/cometbft/cometbft/internal/pubsub"
 	"github.com/cometbft/cometbft/internal/pubsub/query"
 	"github.com/cometbft/cometbft/libs/log"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/internal/pubsub/query/query_test.go
+++ b/internal/pubsub/query/query_test.go
@@ -8,11 +8,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/internal/pubsub"
 	"github.com/cometbft/cometbft/internal/pubsub/query"
 	"github.com/cometbft/cometbft/internal/pubsub/query/syntax"
-	"github.com/stretchr/testify/require"
 )
 
 var _ pubsub.Query = (*query.Query)(nil)

--- a/internal/state/execution_test.go
+++ b/internal/state/execution_test.go
@@ -6,6 +6,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	dbm "github.com/cometbft/cometbft-db"
 	abciclientmocks "github.com/cometbft/cometbft/abci/client/mocks"
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -27,9 +31,6 @@ import (
 	"github.com/cometbft/cometbft/types"
 	cmttime "github.com/cometbft/cometbft/types/time"
 	"github.com/cometbft/cometbft/version"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 var (

--- a/internal/state/indexer/block/kv/kv.go
+++ b/internal/state/indexer/block/kv/kv.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/google/orderedcode"
+
 	dbm "github.com/cometbft/cometbft-db"
 	abci "github.com/cometbft/cometbft/abci/types"
 	idxutil "github.com/cometbft/cometbft/internal/indexer"
@@ -19,7 +21,6 @@ import (
 	"github.com/cometbft/cometbft/internal/state/indexer"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/types"
-	"github.com/google/orderedcode"
 )
 
 var (

--- a/internal/state/indexer/block/kv/kv_test.go
+++ b/internal/state/indexer/block/kv/kv_test.go
@@ -9,6 +9,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
+
 	db "github.com/cometbft/cometbft-db"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/internal/pubsub/query"
@@ -16,8 +19,6 @@ import (
 	"github.com/cometbft/cometbft/internal/state/txindex/kv"
 	"github.com/cometbft/cometbft/internal/test"
 	"github.com/cometbft/cometbft/types"
-	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 )
 
 func TestBlockerIndexer_Prune(t *testing.T) {

--- a/internal/state/indexer/block/kv/util.go
+++ b/internal/state/indexer/block/kv/util.go
@@ -6,11 +6,12 @@ import (
 	"math/big"
 	"strconv"
 
+	"github.com/google/orderedcode"
+
 	idxutil "github.com/cometbft/cometbft/internal/indexer"
 	"github.com/cometbft/cometbft/internal/pubsub/query/syntax"
 	"github.com/cometbft/cometbft/internal/state/indexer"
 	"github.com/cometbft/cometbft/types"
-	"github.com/google/orderedcode"
 )
 
 type HeightInfo struct {

--- a/internal/state/indexer/sink/psql/psql.go
+++ b/internal/state/indexer/sink/psql/psql.go
@@ -10,10 +10,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cosmos/gogoproto/proto"
+
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/internal/pubsub/query"
 	"github.com/cometbft/cometbft/types"
-	"github.com/cosmos/gogoproto/proto"
 )
 
 const (

--- a/internal/state/indexer/sink/psql/psql_test.go
+++ b/internal/state/indexer/sink/psql/psql_test.go
@@ -12,16 +12,18 @@ import (
 	"time"
 
 	"github.com/adlio/schema"
-	abci "github.com/cometbft/cometbft/abci/types"
-	"github.com/cometbft/cometbft/internal/state/txindex"
-	tmlog "github.com/cometbft/cometbft/libs/log"
-	"github.com/cometbft/cometbft/types"
 	"github.com/cosmos/gogoproto/proto"
-	_ "github.com/lib/pq"
 	"github.com/ory/dockertest"
 	"github.com/ory/dockertest/docker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	_ "github.com/lib/pq"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/cometbft/cometbft/internal/state/txindex"
+	tmlog "github.com/cometbft/cometbft/libs/log"
+	"github.com/cometbft/cometbft/types"
 )
 
 var (

--- a/internal/state/pruner_test.go
+++ b/internal/state/pruner_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
+
 	db "github.com/cometbft/cometbft-db"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/internal/pubsub/query"
@@ -17,8 +20,6 @@ import (
 	"github.com/cometbft/cometbft/internal/test"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/types"
-	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 )
 
 func TestPruneBlockIndexerToRetainHeight(t *testing.T) {

--- a/internal/state/rollback_test.go
+++ b/internal/state/rollback_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	dbm "github.com/cometbft/cometbft-db"
 	cmtstate "github.com/cometbft/cometbft/api/cometbft/state/v1"
 	cmtversion "github.com/cometbft/cometbft/api/cometbft/version/v1"
@@ -15,7 +17,6 @@ import (
 	"github.com/cometbft/cometbft/internal/store"
 	"github.com/cometbft/cometbft/types"
 	"github.com/cometbft/cometbft/version"
-	"github.com/stretchr/testify/require"
 )
 
 func TestRollback(t *testing.T) {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -7,12 +7,13 @@ import (
 	"os"
 	"time"
 
+	"github.com/cosmos/gogoproto/proto"
+
 	cmtstate "github.com/cometbft/cometbft/api/cometbft/state/v1"
 	cmtversion "github.com/cometbft/cometbft/api/cometbft/version/v1"
 	"github.com/cometbft/cometbft/types"
 	cmttime "github.com/cometbft/cometbft/types/time"
 	"github.com/cometbft/cometbft/version"
-	"github.com/cosmos/gogoproto/proto"
 )
 
 // database keys.

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -9,6 +9,9 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	dbm "github.com/cometbft/cometbft-db"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/crypto/ed25519"
@@ -17,8 +20,6 @@ import (
 	sm "github.com/cometbft/cometbft/internal/state"
 	"github.com/cometbft/cometbft/internal/test"
 	"github.com/cometbft/cometbft/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // setupTestCase does setup common to all test cases.

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/cosmos/gogoproto/proto"
+
 	dbm "github.com/cometbft/cometbft-db"
 	abci "github.com/cometbft/cometbft/abci/types"
 	cmtstate "github.com/cometbft/cometbft/api/cometbft/state/v1"
@@ -12,7 +14,6 @@ import (
 	cmtos "github.com/cometbft/cometbft/internal/os"
 	cmtmath "github.com/cometbft/cometbft/libs/math"
 	"github.com/cometbft/cometbft/types"
-	"github.com/cosmos/gogoproto/proto"
 )
 
 const (

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	dbm "github.com/cometbft/cometbft-db"
 	abci "github.com/cometbft/cometbft/abci/types"
 	cmtstate "github.com/cometbft/cometbft/api/cometbft/state/v1"
@@ -19,8 +22,6 @@ import (
 	"github.com/cometbft/cometbft/internal/test"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestStoreLoadValidators(t *testing.T) {

--- a/internal/state/tx_filter_test.go
+++ b/internal/state/tx_filter_test.go
@@ -4,11 +4,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	dbm "github.com/cometbft/cometbft-db"
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
 	sm "github.com/cometbft/cometbft/internal/state"
 	"github.com/cometbft/cometbft/types"
-	"github.com/stretchr/testify/require"
 )
 
 func TestTxFilter(t *testing.T) {

--- a/internal/state/txindex/indexer_service_test.go
+++ b/internal/state/txindex/indexer_service_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	db "github.com/cometbft/cometbft-db"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/internal/state/indexer"
@@ -13,7 +15,6 @@ import (
 	"github.com/cometbft/cometbft/internal/state/txindex/kv"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/types"
-	"github.com/stretchr/testify/require"
 )
 
 func TestIndexerServiceIndexesBlocks(t *testing.T) {

--- a/internal/state/txindex/kv/kv.go
+++ b/internal/state/txindex/kv/kv.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cosmos/gogoproto/proto"
+
 	dbm "github.com/cometbft/cometbft-db"
 	abci "github.com/cometbft/cometbft/abci/types"
 	idxutil "github.com/cometbft/cometbft/internal/indexer"
@@ -22,7 +24,6 @@ import (
 	"github.com/cometbft/cometbft/internal/state/txindex"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/types"
-	"github.com/cosmos/gogoproto/proto"
 )
 
 const (

--- a/internal/state/txindex/kv/kv_test.go
+++ b/internal/state/txindex/kv/kv_test.go
@@ -7,6 +7,11 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cosmos/gogoproto/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
+
 	db "github.com/cometbft/cometbft-db"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/internal/pubsub/query"
@@ -14,10 +19,6 @@ import (
 	blockidxkv "github.com/cometbft/cometbft/internal/state/indexer/block/kv"
 	"github.com/cometbft/cometbft/internal/state/txindex"
 	"github.com/cometbft/cometbft/types"
-	"github.com/cosmos/gogoproto/proto"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 )
 
 func TestTxIndex(t *testing.T) {

--- a/internal/state/txindex/kv/utils.go
+++ b/internal/state/txindex/kv/utils.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/google/orderedcode"
+
 	abci "github.com/cometbft/cometbft/abci/types"
 	idxutil "github.com/cometbft/cometbft/internal/indexer"
 	cmtsyntax "github.com/cometbft/cometbft/internal/pubsub/query/syntax"
 	"github.com/cometbft/cometbft/internal/state/indexer"
 	"github.com/cometbft/cometbft/types"
-	"github.com/google/orderedcode"
 )
 
 type HeightInfo struct {

--- a/internal/state/validation_test.go
+++ b/internal/state/validation_test.go
@@ -4,6 +4,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	dbm "github.com/cometbft/cometbft-db"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/crypto/ed25519"
@@ -17,9 +21,6 @@ import (
 	"github.com/cometbft/cometbft/types"
 	cmterrors "github.com/cometbft/cometbft/types/errors"
 	cmttime "github.com/cometbft/cometbft/types/time"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 const validationTestsStopHeight int64 = 10

--- a/internal/statesync/chunks_test.go
+++ b/internal/statesync/chunks_test.go
@@ -4,9 +4,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cometbft/cometbft/p2p"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/p2p"
 )
 
 func setupChunkQueue(t *testing.T) (*chunkQueue, func()) {

--- a/internal/statesync/messages.go
+++ b/internal/statesync/messages.go
@@ -4,8 +4,9 @@ import (
 	"errors"
 	"fmt"
 
-	ssproto "github.com/cometbft/cometbft/api/cometbft/statesync/v1"
 	"github.com/cosmos/gogoproto/proto"
+
+	ssproto "github.com/cometbft/cometbft/api/cometbft/statesync/v1"
 )
 
 const (

--- a/internal/statesync/messages_test.go
+++ b/internal/statesync/messages_test.go
@@ -4,11 +4,12 @@ import (
 	"encoding/hex"
 	"testing"
 
+	"github.com/cosmos/gogoproto/proto"
+	"github.com/stretchr/testify/require"
+
 	ssproto "github.com/cometbft/cometbft/api/cometbft/statesync/v1"
 	cmtproto "github.com/cometbft/cometbft/api/cometbft/types/v1"
 	"github.com/cometbft/cometbft/types"
-	"github.com/cosmos/gogoproto/proto"
-	"github.com/stretchr/testify/require"
 )
 
 func TestValidateMsg(t *testing.T) {

--- a/internal/statesync/reactor_test.go
+++ b/internal/statesync/reactor_test.go
@@ -4,16 +4,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cosmos/gogoproto/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	abci "github.com/cometbft/cometbft/abci/types"
 	ssproto "github.com/cometbft/cometbft/api/cometbft/statesync/v1"
 	"github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/p2p"
 	p2pmocks "github.com/cometbft/cometbft/p2p/mocks"
 	proxymocks "github.com/cometbft/cometbft/proxy/mocks"
-	"github.com/cosmos/gogoproto/proto"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 func TestReactor_Receive_ChunkRequest(t *testing.T) {

--- a/internal/statesync/snapshots_test.go
+++ b/internal/statesync/snapshots_test.go
@@ -3,10 +3,11 @@ package statesync
 import (
 	"testing"
 
-	"github.com/cometbft/cometbft/p2p"
-	p2pmocks "github.com/cometbft/cometbft/p2p/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/p2p"
+	p2pmocks "github.com/cometbft/cometbft/p2p/mocks"
 )
 
 func TestSnapshot_Key(t *testing.T) {

--- a/internal/statesync/syncer_test.go
+++ b/internal/statesync/syncer_test.go
@@ -5,6 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	abci "github.com/cometbft/cometbft/abci/types"
 	cmtstate "github.com/cometbft/cometbft/api/cometbft/state/v1"
 	ssproto "github.com/cometbft/cometbft/api/cometbft/statesync/v1"
@@ -20,9 +24,6 @@ import (
 	proxymocks "github.com/cometbft/cometbft/proxy/mocks"
 	"github.com/cometbft/cometbft/types"
 	"github.com/cometbft/cometbft/version"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 const testAppVersion = 9

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/cosmos/gogoproto/proto"
+
 	dbm "github.com/cometbft/cometbft-db"
 	cmtstore "github.com/cometbft/cometbft/api/cometbft/store/v1"
 	cmtproto "github.com/cometbft/cometbft/api/cometbft/types/v1"
@@ -13,7 +15,6 @@ import (
 	cmtsync "github.com/cometbft/cometbft/internal/sync"
 	"github.com/cometbft/cometbft/types"
 	cmterrors "github.com/cometbft/cometbft/types/errors"
-	"github.com/cosmos/gogoproto/proto"
 )
 
 // Assuming the length of a block part is 64kB (`types.BlockPartSizeBytes`),

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -8,6 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cosmos/gogoproto/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	dbm "github.com/cometbft/cometbft-db"
 	cmtstore "github.com/cometbft/cometbft/api/cometbft/store/v1"
 	cmtversion "github.com/cometbft/cometbft/api/cometbft/version/v1"
@@ -24,9 +28,6 @@ import (
 	"github.com/cometbft/cometbft/types"
 	cmttime "github.com/cometbft/cometbft/types/time"
 	"github.com/cometbft/cometbft/version"
-	"github.com/cosmos/gogoproto/proto"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // make an extended commit with a single vote containing just the height and a

--- a/internal/tempfile/tempfile_test.go
+++ b/internal/tempfile/tempfile_test.go
@@ -8,8 +8,9 @@ import (
 	"os"
 	testing "testing"
 
-	cmtrand "github.com/cometbft/cometbft/internal/rand"
 	"github.com/stretchr/testify/require"
+
+	cmtrand "github.com/cometbft/cometbft/internal/rand"
 )
 
 func TestWriteFileAtomic(t *testing.T) {

--- a/internal/test/block.go
+++ b/internal/test/block.go
@@ -4,11 +4,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/crypto/tmhash"
 	"github.com/cometbft/cometbft/types"
 	"github.com/cometbft/cometbft/version"
-	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/internal/test/factory_test.go
+++ b/internal/test/factory_test.go
@@ -3,8 +3,9 @@ package test
 import (
 	"testing"
 
-	"github.com/cometbft/cometbft/types"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/types"
 )
 
 func TestMakeHeader(t *testing.T) {

--- a/internal/test/validator.go
+++ b/internal/test/validator.go
@@ -5,8 +5,9 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/cometbft/cometbft/types"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/types"
 )
 
 func Validator(_ context.Context, votingPower int64) (*types.Validator, types.PrivValidator, error) {

--- a/internal/timer/throttle_timer_test.go
+++ b/internal/timer/throttle_timer_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 	"time"
 
-	cmtsync "github.com/cometbft/cometbft/internal/sync"
 	asrt "github.com/stretchr/testify/assert"
+
+	cmtsync "github.com/cometbft/cometbft/internal/sync"
 )
 
 type thCounter struct {

--- a/libs/json/decoder_test.go
+++ b/libs/json/decoder_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cometbft/cometbft/libs/json"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/libs/json"
 )
 
 func TestUnmarshal(t *testing.T) {

--- a/libs/json/encoder_test.go
+++ b/libs/json/encoder_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cometbft/cometbft/libs/json"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/libs/json"
 )
 
 func TestMarshal(t *testing.T) {

--- a/libs/log/tmfmt_logger_test.go
+++ b/libs/log/tmfmt_logger_test.go
@@ -8,9 +8,10 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/cometbft/cometbft/libs/log"
 	kitlog "github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/cometbft/cometbft/libs/log"
 )
 
 func TestTMFmtLogger(t *testing.T) {

--- a/libs/log/tracing_logger_test.go
+++ b/libs/log/tracing_logger_test.go
@@ -7,8 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cometbft/cometbft/libs/log"
 	"github.com/pkg/errors"
+
+	"github.com/cometbft/cometbft/libs/log"
 )
 
 func TestTracingLogger(t *testing.T) {

--- a/light/client_test.go
+++ b/light/client_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	dbm "github.com/cometbft/cometbft-db"
 	"github.com/cometbft/cometbft/internal/test"
 	"github.com/cometbft/cometbft/libs/log"
@@ -14,8 +17,6 @@ import (
 	mockp "github.com/cometbft/cometbft/light/provider/mock"
 	dbs "github.com/cometbft/cometbft/light/store/db"
 	"github.com/cometbft/cometbft/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/light/detector_test.go
+++ b/light/detector_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	dbm "github.com/cometbft/cometbft-db"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/light"
@@ -11,8 +14,6 @@ import (
 	mockp "github.com/cometbft/cometbft/light/provider/mock"
 	dbs "github.com/cometbft/cometbft/light/store/db"
 	"github.com/cometbft/cometbft/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestLightClientAttackEvidence_Lunatic(t *testing.T) {

--- a/light/provider/http/http_test.go
+++ b/light/provider/http/http_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/cometbft/cometbft/abci/example/kvstore"
 	"github.com/cometbft/cometbft/light/provider"
 	lighthttp "github.com/cometbft/cometbft/light/provider/http"
@@ -14,8 +17,6 @@ import (
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 	rpctest "github.com/cometbft/cometbft/rpc/test"
 	"github.com/cometbft/cometbft/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNewProvider(t *testing.T) {

--- a/light/store/db/db_test.go
+++ b/light/store/db/db_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	dbm "github.com/cometbft/cometbft-db"
 	cmtversion "github.com/cometbft/cometbft/api/cometbft/version/v1"
 	"github.com/cometbft/cometbft/crypto"
@@ -12,8 +15,6 @@ import (
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
 	"github.com/cometbft/cometbft/types"
 	"github.com/cometbft/cometbft/version"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestLast_FirstLightBlockHeight(t *testing.T) {

--- a/light/verifier_test.go
+++ b/light/verifier_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	cmtmath "github.com/cometbft/cometbft/libs/math"
 	"github.com/cometbft/cometbft/light"
 	"github.com/cometbft/cometbft/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/mempool/bench_test.go
+++ b/mempool/bench_test.go
@@ -5,14 +5,15 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/cometbft/cometbft/abci/example/kvstore"
 	abciserver "github.com/cometbft/cometbft/abci/server"
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
 	"github.com/cometbft/cometbft/internal/test"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/proxy"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func BenchmarkReap(b *testing.B) {

--- a/mempool/cache_test.go
+++ b/mempool/cache_test.go
@@ -6,11 +6,12 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/cometbft/cometbft/abci/example/kvstore"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/proxy"
 	"github.com/cometbft/cometbft/types"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCacheRemove(t *testing.T) {

--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -10,6 +10,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cosmos/gogoproto/proto"
+	gogotypes "github.com/cosmos/gogoproto/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	abciclient "github.com/cometbft/cometbft/abci/client"
 	abciclimocks "github.com/cometbft/cometbft/abci/client/mocks"
 	"github.com/cometbft/cometbft/abci/example/kvstore"
@@ -22,11 +28,6 @@ import (
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/proxy"
 	"github.com/cometbft/cometbft/types"
-	"github.com/cosmos/gogoproto/proto"
-	gogotypes "github.com/cosmos/gogoproto/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 // A cleanupFunc cleans up any config / test files created for a particular

--- a/mempool/nop_mempool_test.go
+++ b/mempool/nop_mempool_test.go
@@ -3,9 +3,10 @@ package mempool
 import (
 	"testing"
 
-	"github.com/cometbft/cometbft/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/types"
 )
 
 var tx = types.Tx([]byte{0x01})

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -7,6 +7,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/sync/semaphore"
+
 	abci "github.com/cometbft/cometbft/abci/types"
 	protomem "github.com/cometbft/cometbft/api/cometbft/mempool/v1"
 	cfg "github.com/cometbft/cometbft/config"
@@ -15,7 +17,6 @@ import (
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/p2p"
 	"github.com/cometbft/cometbft/types"
-	"golang.org/x/sync/semaphore"
 )
 
 // Reactor handles mempool tx broadcasting amongst peers.

--- a/mempool/reactor_test.go
+++ b/mempool/reactor_test.go
@@ -8,6 +8,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fortytw2/leaktest"
+	"github.com/go-kit/log/term"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/cometbft/cometbft/abci/example/kvstore"
 	abci "github.com/cometbft/cometbft/abci/types"
 	memproto "github.com/cometbft/cometbft/api/cometbft/mempool/v1"
@@ -16,10 +21,6 @@ import (
 	"github.com/cometbft/cometbft/p2p"
 	"github.com/cometbft/cometbft/proxy"
 	"github.com/cometbft/cometbft/types"
-	"github.com/fortytw2/leaktest"
-	"github.com/go-kit/log/term"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/node/node.go
+++ b/node/node.go
@@ -7,9 +7,14 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	_ "net/http/pprof" //nolint: gosec
 	"os"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/rs/cors"
+
+	_ "net/http/pprof" //nolint: gosec
 
 	cfg "github.com/cometbft/cometbft/config"
 	bc "github.com/cometbft/cometbft/internal/blocksync"
@@ -36,9 +41,6 @@ import (
 	"github.com/cometbft/cometbft/types"
 	cmttime "github.com/cometbft/cometbft/types/time"
 	"github.com/cometbft/cometbft/version"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/rs/cors"
 )
 
 // Node is the highest level interface to a full CometBFT node.

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -12,6 +12,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	dbm "github.com/cometbft/cometbft-db"
 	"github.com/cometbft/cometbft/abci/example/kvstore"
 	cfg "github.com/cometbft/cometbft/config"
@@ -33,8 +36,6 @@ import (
 	"github.com/cometbft/cometbft/proxy"
 	"github.com/cometbft/cometbft/types"
 	cmttime "github.com/cometbft/cometbft/types/time"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNodeStartStop(t *testing.T) {

--- a/node/setup.go
+++ b/node/setup.go
@@ -10,9 +10,8 @@ import (
 	"strings"
 	"time"
 
-	_ "net/http/pprof" //nolint: gosec // securely exposed on separate, optional port
-
 	_ "github.com/lib/pq" // provide the psql db driver
+	_ "net/http/pprof"    //nolint: gosec // securely exposed on separate, optional port
 
 	dbm "github.com/cometbft/cometbft-db"
 	abci "github.com/cometbft/cometbft/abci/types"

--- a/node/setup.go
+++ b/node/setup.go
@@ -10,8 +10,9 @@ import (
 	"strings"
 	"time"
 
-	_ "github.com/lib/pq" // provide the psql db driver
-	_ "net/http/pprof"    //nolint: gosec // securely exposed on separate, optional port
+	_ "net/http/pprof" //nolint: gosec,gci // securely exposed on separate, optional port
+
+	_ "github.com/lib/pq" //nolint: gci // provide the psql db driver.
 
 	dbm "github.com/cometbft/cometbft-db"
 	abci "github.com/cometbft/cometbft/abci/types"

--- a/node/setup.go
+++ b/node/setup.go
@@ -6,10 +6,13 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net"
-	_ "net/http/pprof" //nolint: gosec // securely exposed on separate, optional port
 	"os"
 	"strings"
 	"time"
+
+	_ "net/http/pprof" //nolint: gosec // securely exposed on separate, optional port
+
+	_ "github.com/lib/pq" // provide the psql db driver
 
 	dbm "github.com/cometbft/cometbft-db"
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -34,7 +37,6 @@ import (
 	"github.com/cometbft/cometbft/proxy"
 	"github.com/cometbft/cometbft/types"
 	"github.com/cometbft/cometbft/version"
-	_ "github.com/lib/pq" // provide the psql db driver
 )
 
 const readHeaderTimeout = 10 * time.Second

--- a/p2p/conn/connection.go
+++ b/p2p/conn/connection.go
@@ -12,6 +12,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cosmos/gogoproto/proto"
+
 	tmp2p "github.com/cometbft/cometbft/api/cometbft/p2p/v1"
 	"github.com/cometbft/cometbft/config"
 	flow "github.com/cometbft/cometbft/internal/flowrate"
@@ -21,7 +23,6 @@ import (
 	"github.com/cometbft/cometbft/internal/timer"
 	"github.com/cometbft/cometbft/libs/log"
 	cmtmath "github.com/cometbft/cometbft/libs/math"
-	"github.com/cosmos/gogoproto/proto"
 )
 
 const (

--- a/p2p/conn/connection_test.go
+++ b/p2p/conn/connection_test.go
@@ -6,14 +6,15 @@ import (
 	"testing"
 	"time"
 
-	tmp2p "github.com/cometbft/cometbft/api/cometbft/p2p/v1"
-	pbtypes "github.com/cometbft/cometbft/api/cometbft/types/v1"
-	"github.com/cometbft/cometbft/internal/protoio"
-	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cosmos/gogoproto/proto"
 	"github.com/fortytw2/leaktest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	tmp2p "github.com/cometbft/cometbft/api/cometbft/p2p/v1"
+	pbtypes "github.com/cometbft/cometbft/api/cometbft/types/v1"
+	"github.com/cometbft/cometbft/internal/protoio"
+	"github.com/cometbft/cometbft/libs/log"
 )
 
 const maxPingPongPacketSize = 1024 // bytes

--- a/p2p/conn/evil_secret_connection_test.go
+++ b/p2p/conn/evil_secret_connection_test.go
@@ -6,16 +6,17 @@ import (
 	"io"
 	"testing"
 
-	tmp2p "github.com/cometbft/cometbft/api/cometbft/p2p/v1"
-	"github.com/cometbft/cometbft/crypto"
-	"github.com/cometbft/cometbft/crypto/ed25519"
-	cryptoenc "github.com/cometbft/cometbft/crypto/encoding"
-	"github.com/cometbft/cometbft/internal/protoio"
 	gogotypes "github.com/cosmos/gogoproto/types"
 	"github.com/oasisprotocol/curve25519-voi/primitives/merlin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/chacha20poly1305"
+
+	tmp2p "github.com/cometbft/cometbft/api/cometbft/p2p/v1"
+	"github.com/cometbft/cometbft/crypto"
+	"github.com/cometbft/cometbft/crypto/ed25519"
+	cryptoenc "github.com/cometbft/cometbft/crypto/encoding"
+	"github.com/cometbft/cometbft/internal/protoio"
 )
 
 type buffer struct {

--- a/p2p/conn/secret_connection.go
+++ b/p2p/conn/secret_connection.go
@@ -13,13 +13,6 @@ import (
 	"net"
 	"time"
 
-	tmp2p "github.com/cometbft/cometbft/api/cometbft/p2p/v1"
-	"github.com/cometbft/cometbft/crypto"
-	"github.com/cometbft/cometbft/crypto/ed25519"
-	cryptoenc "github.com/cometbft/cometbft/crypto/encoding"
-	"github.com/cometbft/cometbft/internal/async"
-	"github.com/cometbft/cometbft/internal/protoio"
-	cmtsync "github.com/cometbft/cometbft/internal/sync"
 	gogotypes "github.com/cosmos/gogoproto/types"
 	pool "github.com/libp2p/go-buffer-pool"
 	"github.com/oasisprotocol/curve25519-voi/primitives/merlin"
@@ -27,6 +20,14 @@ import (
 	"golang.org/x/crypto/curve25519"
 	"golang.org/x/crypto/hkdf"
 	"golang.org/x/crypto/nacl/box"
+
+	tmp2p "github.com/cometbft/cometbft/api/cometbft/p2p/v1"
+	"github.com/cometbft/cometbft/crypto"
+	"github.com/cometbft/cometbft/crypto/ed25519"
+	cryptoenc "github.com/cometbft/cometbft/crypto/encoding"
+	"github.com/cometbft/cometbft/internal/async"
+	"github.com/cometbft/cometbft/internal/protoio"
+	cmtsync "github.com/cometbft/cometbft/internal/sync"
 )
 
 // 4 + 1024 == 1028 total frame size.

--- a/p2p/conn/secret_connection_test.go
+++ b/p2p/conn/secret_connection_test.go
@@ -14,14 +14,15 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/crypto/ed25519"
 	"github.com/cometbft/cometbft/crypto/sr25519"
 	"github.com/cometbft/cometbft/internal/async"
 	cmtos "github.com/cometbft/cometbft/internal/os"
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // Run go test -update from within this module

--- a/p2p/key_test.go
+++ b/p2p/key_test.go
@@ -6,10 +6,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/cometbft/cometbft/crypto/ed25519"
-	cmtrand "github.com/cometbft/cometbft/internal/rand"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/crypto/ed25519"
+	cmtrand "github.com/cometbft/cometbft/internal/rand"
 )
 
 func TestLoadOrGenNodeKey(t *testing.T) {

--- a/p2p/node_info_test.go
+++ b/p2p/node_info_test.go
@@ -3,9 +3,10 @@ package p2p
 import (
 	"testing"
 
-	"github.com/cometbft/cometbft/crypto/ed25519"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/crypto/ed25519"
 )
 
 func TestNodeInfoValidate(t *testing.T) {

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -6,12 +6,13 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/cosmos/gogoproto/proto"
+
 	"github.com/cometbft/cometbft/internal/cmap"
 	"github.com/cometbft/cometbft/internal/service"
 	"github.com/cometbft/cometbft/libs/log"
 	cmtconn "github.com/cometbft/cometbft/p2p/conn"
 	"github.com/cometbft/cometbft/types"
-	"github.com/cosmos/gogoproto/proto"
 )
 
 //go:generate ../scripts/mockery_generate.sh Peer

--- a/p2p/peer_set_test.go
+++ b/p2p/peer_set_test.go
@@ -5,9 +5,10 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/cometbft/cometbft/crypto/ed25519"
 	"github.com/cometbft/cometbft/internal/service"
-	"github.com/stretchr/testify/assert"
 )
 
 // mockPeer for testing the PeerSet.

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -7,6 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cosmos/gogoproto/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	p2p "github.com/cometbft/cometbft/api/cometbft/p2p/v1"
 	"github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/crypto"
@@ -14,9 +18,6 @@ import (
 	"github.com/cometbft/cometbft/libs/bytes"
 	"github.com/cometbft/cometbft/libs/log"
 	cmtconn "github.com/cometbft/cometbft/p2p/conn"
-	"github.com/cosmos/gogoproto/proto"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestPeerBasic(t *testing.T) {

--- a/p2p/pex/addrbook.go
+++ b/p2p/pex/addrbook.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/minio/highwayhash"
+
 	"github.com/cometbft/cometbft/crypto"
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
 	"github.com/cometbft/cometbft/internal/service"
@@ -21,7 +23,6 @@ import (
 	"github.com/cometbft/cometbft/libs/log"
 	cmtmath "github.com/cometbft/cometbft/libs/math"
 	"github.com/cometbft/cometbft/p2p"
-	"github.com/minio/highwayhash"
 )
 
 const (

--- a/p2p/pex/addrbook_test.go
+++ b/p2p/pex/addrbook_test.go
@@ -9,12 +9,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
 	"github.com/cometbft/cometbft/libs/log"
 	cmtmath "github.com/cometbft/cometbft/libs/math"
 	"github.com/cometbft/cometbft/p2p"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // FIXME These tests should not rely on .(*addrBook) assertions

--- a/p2p/pex/pex_reactor_test.go
+++ b/p2p/pex/pex_reactor_test.go
@@ -8,15 +8,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cosmos/gogoproto/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	tmp2p "github.com/cometbft/cometbft/api/cometbft/p2p/v1"
 	"github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/p2p"
 	"github.com/cometbft/cometbft/p2p/mock"
 	"github.com/cometbft/cometbft/types"
-	"github.com/cosmos/gogoproto/proto"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var cfg *config.P2PConfig

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -6,12 +6,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cosmos/gogoproto/proto"
+
 	"github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/internal/cmap"
 	"github.com/cometbft/cometbft/internal/rand"
 	"github.com/cometbft/cometbft/internal/service"
 	"github.com/cometbft/cometbft/p2p/conn"
-	"github.com/cosmos/gogoproto/proto"
 )
 
 const (

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -14,16 +14,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cosmos/gogoproto/proto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	p2pproto "github.com/cometbft/cometbft/api/cometbft/p2p/v1"
 	"github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/crypto/ed25519"
 	cmtsync "github.com/cometbft/cometbft/internal/sync"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/p2p/conn"
-	"github.com/cosmos/gogoproto/proto"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var cfg *config.P2PConfig

--- a/p2p/transport.go
+++ b/p2p/transport.go
@@ -6,12 +6,13 @@ import (
 	"net"
 	"time"
 
+	"github.com/cosmos/gogoproto/proto"
+	"golang.org/x/net/netutil"
+
 	tmp2p "github.com/cometbft/cometbft/api/cometbft/p2p/v1"
 	"github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/internal/protoio"
 	"github.com/cometbft/cometbft/p2p/conn"
-	"github.com/cosmos/gogoproto/proto"
-	"golang.org/x/net/netutil"
 )
 
 const (

--- a/p2p/types.go
+++ b/p2p/types.go
@@ -1,10 +1,11 @@
 package p2p
 
 import (
+	"github.com/cosmos/gogoproto/proto"
+
 	tmp2p "github.com/cometbft/cometbft/api/cometbft/p2p/v1"
 	"github.com/cometbft/cometbft/p2p/conn"
 	"github.com/cometbft/cometbft/types"
-	"github.com/cosmos/gogoproto/proto"
 )
 
 type (

--- a/privval/file.go
+++ b/privval/file.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/cosmos/gogoproto/proto"
+
 	cmtproto "github.com/cometbft/cometbft/api/cometbft/types/v1"
 	"github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/crypto/ed25519"
@@ -17,7 +19,6 @@ import (
 	cmtjson "github.com/cometbft/cometbft/libs/json"
 	"github.com/cometbft/cometbft/types"
 	cmttime "github.com/cometbft/cometbft/types/time"
-	"github.com/cosmos/gogoproto/proto"
 )
 
 // TODO: type ?

--- a/privval/file_test.go
+++ b/privval/file_test.go
@@ -7,14 +7,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/cometbft/cometbft/crypto/ed25519"
 	"github.com/cometbft/cometbft/crypto/tmhash"
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
 	cmtjson "github.com/cometbft/cometbft/libs/json"
 	"github.com/cometbft/cometbft/types"
 	cmttime "github.com/cometbft/cometbft/types/time"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestGenLoadValidator(t *testing.T) {

--- a/privval/msgs.go
+++ b/privval/msgs.go
@@ -3,8 +3,9 @@ package privval
 import (
 	"fmt"
 
-	pvproto "github.com/cometbft/cometbft/api/cometbft/privval/v1"
 	"github.com/cosmos/gogoproto/proto"
+
+	pvproto "github.com/cometbft/cometbft/api/cometbft/privval/v1"
 )
 
 // TODO: Add ChainIDRequest

--- a/privval/msgs_test.go
+++ b/privval/msgs_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cosmos/gogoproto/proto"
+	"github.com/stretchr/testify/require"
+
 	cryptoproto "github.com/cometbft/cometbft/api/cometbft/crypto/v1"
 	privproto "github.com/cometbft/cometbft/api/cometbft/privval/v1"
 	cmtproto "github.com/cometbft/cometbft/api/cometbft/types/v1"
@@ -13,8 +16,6 @@ import (
 	cryptoenc "github.com/cometbft/cometbft/crypto/encoding"
 	"github.com/cometbft/cometbft/crypto/tmhash"
 	"github.com/cometbft/cometbft/types"
-	"github.com/cosmos/gogoproto/proto"
-	"github.com/stretchr/testify/require"
 )
 
 var stamp = time.Date(2019, 10, 13, 16, 14, 44, 0, time.UTC)

--- a/privval/signer_client_test.go
+++ b/privval/signer_client_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	cryptoproto "github.com/cometbft/cometbft/api/cometbft/crypto/v1"
 	privvalproto "github.com/cometbft/cometbft/api/cometbft/privval/v1"
 	"github.com/cometbft/cometbft/crypto"
@@ -12,8 +15,6 @@ import (
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
 	"github.com/cometbft/cometbft/types"
 	cmterrors "github.com/cometbft/cometbft/types/errors"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type signerTestCase struct {

--- a/privval/signer_listener_endpoint_test.go
+++ b/privval/signer_listener_endpoint_test.go
@@ -5,13 +5,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/cometbft/cometbft/crypto/ed25519"
 	cmtnet "github.com/cometbft/cometbft/internal/net"
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var (

--- a/privval/socket_dialers_test.go
+++ b/privval/socket_dialers_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cometbft/cometbft/crypto/ed25519"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/crypto/ed25519"
 )
 
 func getDialerTestCases(t *testing.T) []dialerTestCase {

--- a/proxy/app_conn.go
+++ b/proxy/app_conn.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"time"
 
+	"github.com/go-kit/kit/metrics"
+
 	abcicli "github.com/cometbft/cometbft/abci/client"
 	types "github.com/cometbft/cometbft/abci/types"
-	"github.com/go-kit/kit/metrics"
 )
 
 //go:generate ../scripts/mockery_generate.sh AppConnConsensus|AppConnMempool|AppConnQuery|AppConnSnapshot

--- a/proxy/multi_app_conn_test.go
+++ b/proxy/multi_app_conn_test.go
@@ -8,10 +8,11 @@ import (
 	"testing"
 	"time"
 
-	abcimocks "github.com/cometbft/cometbft/abci/client/mocks"
-	"github.com/cometbft/cometbft/proxy/mocks"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
+	abcimocks "github.com/cometbft/cometbft/abci/client/mocks"
+	"github.com/cometbft/cometbft/proxy/mocks"
 )
 
 func TestAppConns_Start_Stop(t *testing.T) {

--- a/rpc/client/event_test.go
+++ b/rpc/client/event_test.go
@@ -7,13 +7,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	abci "github.com/cometbft/cometbft/abci/types"
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
 	"github.com/cometbft/cometbft/rpc/client"
 	ctypes "github.com/cometbft/cometbft/rpc/core/types"
 	"github.com/cometbft/cometbft/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var waitForEventTimeout = 8 * time.Second

--- a/rpc/client/evidence_test.go
+++ b/rpc/client/evidence_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/crypto/ed25519"
 	cryptoenc "github.com/cometbft/cometbft/crypto/encoding"
@@ -16,8 +19,6 @@ import (
 	"github.com/cometbft/cometbft/rpc/client"
 	rpctest "github.com/cometbft/cometbft/rpc/test"
 	"github.com/cometbft/cometbft/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // For some reason the empty node used in tests has a time of

--- a/rpc/client/helpers_test.go
+++ b/rpc/client/helpers_test.go
@@ -5,11 +5,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/cometbft/cometbft/rpc/client"
 	"github.com/cometbft/cometbft/rpc/client/mock"
 	ctypes "github.com/cometbft/cometbft/rpc/core/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestWaitForHeight(t *testing.T) {

--- a/rpc/client/mock/status_test.go
+++ b/rpc/client/mock/status_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/cometbft/cometbft/libs/bytes"
 	"github.com/cometbft/cometbft/rpc/client/mock"
 	ctypes "github.com/cometbft/cometbft/rpc/core/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestStatus(t *testing.T) {

--- a/rpc/client/rpc_test.go
+++ b/rpc/client/rpc_test.go
@@ -11,6 +11,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	abci "github.com/cometbft/cometbft/abci/types"
 	cmtjson "github.com/cometbft/cometbft/libs/json"
 	"github.com/cometbft/cometbft/libs/log"
@@ -22,8 +25,6 @@ import (
 	rpcclient "github.com/cometbft/cometbft/rpc/jsonrpc/client"
 	rpctest "github.com/cometbft/cometbft/rpc/test"
 	"github.com/cometbft/cometbft/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var ctx = context.Background()

--- a/rpc/core/blocks_test.go
+++ b/rpc/core/blocks_test.go
@@ -4,14 +4,15 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	dbm "github.com/cometbft/cometbft-db"
 	abci "github.com/cometbft/cometbft/abci/types"
 	sm "github.com/cometbft/cometbft/internal/state"
 	"github.com/cometbft/cometbft/internal/state/mocks"
 	ctypes "github.com/cometbft/cometbft/rpc/core/types"
 	rpctypes "github.com/cometbft/cometbft/rpc/jsonrpc/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestBlockchainInfo(t *testing.T) {

--- a/rpc/core/net_test.go
+++ b/rpc/core/net_test.go
@@ -3,12 +3,13 @@ package core
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	cfg "github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/p2p"
 	rpctypes "github.com/cometbft/cometbft/rpc/jsonrpc/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestUnsafeDialSeeds(t *testing.T) {

--- a/rpc/core/types/responses_test.go
+++ b/rpc/core/types/responses_test.go
@@ -3,8 +3,9 @@ package coretypes
 import (
 	"testing"
 
-	"github.com/cometbft/cometbft/p2p"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/cometbft/cometbft/p2p"
 )
 
 func TestStatusIndexer(t *testing.T) {

--- a/rpc/grpc/client/block_results_service.go
+++ b/rpc/grpc/client/block_results_service.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cosmos/gogoproto/grpc"
+
 	abci "github.com/cometbft/cometbft/abci/types"
 	brs "github.com/cometbft/cometbft/api/cometbft/services/block_results/v1"
 	cmtproto "github.com/cometbft/cometbft/api/cometbft/types/v1"
-	"github.com/cosmos/gogoproto/grpc"
 )
 
 type BlockResults struct {

--- a/rpc/grpc/client/block_service.go
+++ b/rpc/grpc/client/block_service.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cosmos/gogoproto/grpc"
+
 	blocksvc "github.com/cometbft/cometbft/api/cometbft/services/block/v1"
 	cmtproto "github.com/cometbft/cometbft/api/cometbft/types/v1"
 	"github.com/cometbft/cometbft/types"
-	"github.com/cosmos/gogoproto/grpc"
 )
 
 // Block data returned by the CometBFT BlockService gRPC API.

--- a/rpc/grpc/client/client.go
+++ b/rpc/grpc/client/client.go
@@ -9,9 +9,10 @@ import (
 	"fmt"
 	"net"
 
-	cmtnet "github.com/cometbft/cometbft/internal/net"
 	ggrpc "google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+
+	cmtnet "github.com/cometbft/cometbft/internal/net"
 )
 
 type Option func(*clientBuilder)

--- a/rpc/grpc/client/privileged/privileged.go
+++ b/rpc/grpc/client/privileged/privileged.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"net"
 
-	cmtnet "github.com/cometbft/cometbft/internal/net"
 	ggrpc "google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+
+	cmtnet "github.com/cometbft/cometbft/internal/net"
 )
 
 type Option func(*clientBuilder)

--- a/rpc/grpc/client/privileged/pruning_service.go
+++ b/rpc/grpc/client/privileged/pruning_service.go
@@ -3,8 +3,9 @@ package privileged
 import (
 	"context"
 
-	pbsvc "github.com/cometbft/cometbft/api/cometbft/services/pruning/v1"
 	"github.com/cosmos/gogoproto/grpc"
+
+	pbsvc "github.com/cometbft/cometbft/api/cometbft/services/pruning/v1"
 )
 
 // RetainHeights provides information on which block height limits have been

--- a/rpc/grpc/client/version_service.go
+++ b/rpc/grpc/client/version_service.go
@@ -3,8 +3,9 @@ package client
 import (
 	"context"
 
-	pbsvc "github.com/cometbft/cometbft/api/cometbft/services/version/v1"
 	"github.com/cosmos/gogoproto/grpc"
+
+	pbsvc "github.com/cometbft/cometbft/api/cometbft/services/version/v1"
 )
 
 // Version provides version information about a particular CometBFT node.

--- a/rpc/grpc/server/privileged/privileged.go
+++ b/rpc/grpc/server/privileged/privileged.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"net"
 
+	"google.golang.org/grpc"
+
 	pbpruningsvc "github.com/cometbft/cometbft/api/cometbft/services/pruning/v1"
 	sm "github.com/cometbft/cometbft/internal/state"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/rpc/grpc/server/services/pruningservice"
-	"google.golang.org/grpc"
 )
 
 // Option is any function that allows for configuration of the gRPC server

--- a/rpc/grpc/server/server.go
+++ b/rpc/grpc/server/server.go
@@ -5,6 +5,8 @@ import (
 	"net"
 	"strings"
 
+	"google.golang.org/grpc"
+
 	pbblocksvc "github.com/cometbft/cometbft/api/cometbft/services/block/v1"
 	brs "github.com/cometbft/cometbft/api/cometbft/services/block_results/v1"
 	pbversionsvc "github.com/cometbft/cometbft/api/cometbft/services/version/v1"
@@ -15,7 +17,6 @@ import (
 	"github.com/cometbft/cometbft/rpc/grpc/server/services/blockservice"
 	"github.com/cometbft/cometbft/rpc/grpc/server/services/versionservice"
 	"github.com/cometbft/cometbft/types"
-	"google.golang.org/grpc"
 )
 
 // Option is any function that allows for configuration of the gRPC server

--- a/rpc/grpc/server/services/blockresultservice/service.go
+++ b/rpc/grpc/server/services/blockresultservice/service.go
@@ -3,12 +3,13 @@ package blockresultservice
 import (
 	"context"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	brs "github.com/cometbft/cometbft/api/cometbft/services/block_results/v1"
 	sm "github.com/cometbft/cometbft/internal/state"
 	"github.com/cometbft/cometbft/internal/store"
 	"github.com/cometbft/cometbft/libs/log"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 type blockResultsService struct {

--- a/rpc/grpc/server/services/blockservice/service.go
+++ b/rpc/grpc/server/services/blockservice/service.go
@@ -4,6 +4,9 @@ import (
 	context "context"
 	"fmt"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	blocksvc "github.com/cometbft/cometbft/api/cometbft/services/block/v1"
 	ptypes "github.com/cometbft/cometbft/api/cometbft/types/v1"
 	cmtpubsub "github.com/cometbft/cometbft/internal/pubsub"
@@ -11,8 +14,6 @@ import (
 	"github.com/cometbft/cometbft/internal/store"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/types"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 type blockServiceServer struct {

--- a/rpc/grpc/server/services/pruningservice/service.go
+++ b/rpc/grpc/server/services/pruningservice/service.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"math"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	pbsvc "github.com/cometbft/cometbft/api/cometbft/services/pruning/v1"
 	"github.com/cometbft/cometbft/internal/rpctrace"
 	sm "github.com/cometbft/cometbft/internal/state"
 	"github.com/cometbft/cometbft/libs/log"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 type pruningServiceServer struct {

--- a/rpc/jsonrpc/client/ws_client.go
+++ b/rpc/jsonrpc/client/ws_client.go
@@ -9,13 +9,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gorilla/websocket"
+	metrics "github.com/rcrowley/go-metrics"
+
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
 	"github.com/cometbft/cometbft/internal/service"
 	cmtsync "github.com/cometbft/cometbft/internal/sync"
 	"github.com/cometbft/cometbft/libs/log"
 	types "github.com/cometbft/cometbft/rpc/jsonrpc/types"
-	"github.com/gorilla/websocket"
-	metrics "github.com/rcrowley/go-metrics"
 )
 
 const (

--- a/rpc/jsonrpc/client/ws_client_test.go
+++ b/rpc/jsonrpc/client/ws_client_test.go
@@ -9,11 +9,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+
 	cmtsync "github.com/cometbft/cometbft/internal/sync"
 	"github.com/cometbft/cometbft/libs/log"
 	types "github.com/cometbft/cometbft/rpc/jsonrpc/types"
-	"github.com/gorilla/websocket"
-	"github.com/stretchr/testify/require"
 )
 
 var wsCallTimeout = 5 * time.Second

--- a/rpc/jsonrpc/jsonrpc_test.go
+++ b/rpc/jsonrpc/jsonrpc_test.go
@@ -15,15 +15,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log/term"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
 	cmtbytes "github.com/cometbft/cometbft/libs/bytes"
 	"github.com/cometbft/cometbft/libs/log"
 	client "github.com/cometbft/cometbft/rpc/jsonrpc/client"
 	server "github.com/cometbft/cometbft/rpc/jsonrpc/server"
 	types "github.com/cometbft/cometbft/rpc/jsonrpc/types"
-	"github.com/go-kit/log/term"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // Client and Server should work over tcp or unix sockets.

--- a/rpc/jsonrpc/server/http_json_handler_test.go
+++ b/rpc/jsonrpc/server/http_json_handler_test.go
@@ -9,10 +9,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cometbft/cometbft/libs/log"
-	types "github.com/cometbft/cometbft/rpc/jsonrpc/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/libs/log"
+	types "github.com/cometbft/cometbft/rpc/jsonrpc/types"
 )
 
 func testMux() *http.ServeMux {

--- a/rpc/jsonrpc/server/http_server.go
+++ b/rpc/jsonrpc/server/http_server.go
@@ -14,9 +14,10 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/net/netutil"
+
 	"github.com/cometbft/cometbft/libs/log"
 	types "github.com/cometbft/cometbft/rpc/jsonrpc/types"
-	"golang.org/x/net/netutil"
 )
 
 // Config is a RPC server configuration.

--- a/rpc/jsonrpc/server/http_server_test.go
+++ b/rpc/jsonrpc/server/http_server_test.go
@@ -13,10 +13,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cometbft/cometbft/libs/log"
-	types "github.com/cometbft/cometbft/rpc/jsonrpc/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/libs/log"
+	types "github.com/cometbft/cometbft/rpc/jsonrpc/types"
 )
 
 type sampleResult struct {

--- a/rpc/jsonrpc/server/parse_test.go
+++ b/rpc/jsonrpc/server/parse_test.go
@@ -7,10 +7,11 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/cometbft/cometbft/libs/bytes"
-	types "github.com/cometbft/cometbft/rpc/jsonrpc/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/libs/bytes"
+	types "github.com/cometbft/cometbft/rpc/jsonrpc/types"
 )
 
 func TestParseJSONMap(t *testing.T) {

--- a/rpc/jsonrpc/server/ws_handler.go
+++ b/rpc/jsonrpc/server/ws_handler.go
@@ -10,10 +10,11 @@ import (
 	"runtime/debug"
 	"time"
 
+	"github.com/gorilla/websocket"
+
 	"github.com/cometbft/cometbft/internal/service"
 	"github.com/cometbft/cometbft/libs/log"
 	types "github.com/cometbft/cometbft/rpc/jsonrpc/types"
-	"github.com/gorilla/websocket"
 )
 
 // WebSocket handler

--- a/rpc/jsonrpc/server/ws_handler_test.go
+++ b/rpc/jsonrpc/server/ws_handler_test.go
@@ -5,10 +5,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/cometbft/cometbft/libs/log"
-	types "github.com/cometbft/cometbft/rpc/jsonrpc/types"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/libs/log"
+	types "github.com/cometbft/cometbft/rpc/jsonrpc/types"
 )
 
 func TestWebsocketManagerHandler(t *testing.T) {

--- a/scripts/metricsgen/metricsdiff/metricsdiff_test.go
+++ b/scripts/metricsgen/metricsdiff/metricsdiff_test.go
@@ -5,8 +5,9 @@ import (
 	"io"
 	"testing"
 
-	metricsdiff "github.com/cometbft/cometbft/scripts/metricsgen/metricsdiff"
 	"github.com/stretchr/testify/require"
+
+	metricsdiff "github.com/cometbft/cometbft/scripts/metricsgen/metricsdiff"
 )
 
 func TestDiff(t *testing.T) {

--- a/scripts/metricsgen/metricsgen_test.go
+++ b/scripts/metricsgen/metricsgen_test.go
@@ -11,8 +11,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	metricsgen "github.com/cometbft/cometbft/scripts/metricsgen"
 	"github.com/stretchr/testify/require"
+
+	metricsgen "github.com/cometbft/cometbft/scripts/metricsgen"
 )
 
 const testDataDir = "./testdata"

--- a/test/e2e/app/log_abci.go
+++ b/test/e2e/app/log_abci.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"strings"
 
-	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cosmos/gogoproto/proto"
+
+	abci "github.com/cometbft/cometbft/abci/types"
 )
 
 const AbciReq = "abci-req"

--- a/test/e2e/app/log_abci_test.go
+++ b/test/e2e/app/log_abci_test.go
@@ -3,8 +3,9 @@ package app
 import (
 	"testing"
 
-	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/stretchr/testify/require"
+
+	abci "github.com/cometbft/cometbft/abci/types"
 )
 
 // Tests for logging each type of requests.

--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -10,10 +10,11 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
-	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
-	"github.com/cometbft/cometbft/version"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/object"
+
+	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
+	"github.com/cometbft/cometbft/version"
 )
 
 var (

--- a/test/e2e/generator/generate_test.go
+++ b/test/e2e/generator/generate_test.go
@@ -6,9 +6,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 )
 
 // TestGenerator tests that only valid manifests are generated.

--- a/test/e2e/generator/main.go
+++ b/test/e2e/generator/main.go
@@ -7,8 +7,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/cometbft/cometbft/libs/log"
 	"github.com/spf13/cobra"
+
+	"github.com/cometbft/cometbft/libs/log"
 )
 
 const (

--- a/test/e2e/node/config.go
+++ b/test/e2e/node/config.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
+
 	"github.com/cometbft/cometbft/test/e2e/app"
 	cmterrors "github.com/cometbft/cometbft/types/errors"
 )

--- a/test/e2e/node/main.go
+++ b/test/e2e/node/main.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/spf13/viper"
+
 	"github.com/cometbft/cometbft/abci/server"
 	"github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/crypto/ed25519"
@@ -28,7 +30,6 @@ import (
 	rpcserver "github.com/cometbft/cometbft/rpc/jsonrpc/server"
 	"github.com/cometbft/cometbft/test/e2e/app"
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
-	"github.com/spf13/viper"
 )
 
 var logger = log.NewTMLogger(log.NewSyncWriter(os.Stdout))

--- a/test/e2e/pkg/grammar/checker_test.go
+++ b/test/e2e/pkg/grammar/checker_test.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/stretchr/testify/require"
+
+	abci "github.com/cometbft/cometbft/abci/types"
 )
 
 var (

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"bytes"
 	"context"
-	_ "embed"
 	"encoding/csv"
 	"errors"
 	"fmt"
@@ -17,6 +16,8 @@ import (
 	"strings"
 	"text/template"
 	"time"
+
+	_ "embed"
 
 	"github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/crypto/ed25519"

--- a/test/e2e/runner/load.go
+++ b/test/e2e/runner/load.go
@@ -7,12 +7,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/cometbft/cometbft/libs/log"
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 	"github.com/cometbft/cometbft/test/loadtime/payload"
 	"github.com/cometbft/cometbft/types"
-	"github.com/google/uuid"
 )
 
 const workerPoolSize = 16

--- a/test/e2e/runner/main.go
+++ b/test/e2e/runner/main.go
@@ -8,12 +8,13 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/spf13/cobra"
+
 	"github.com/cometbft/cometbft/libs/log"
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 	"github.com/cometbft/cometbft/test/e2e/pkg/infra"
 	"github.com/cometbft/cometbft/test/e2e/pkg/infra/digitalocean"
 	"github.com/cometbft/cometbft/test/e2e/pkg/infra/docker"
-	"github.com/spf13/cobra"
 )
 
 const randomSeed = 2308084734268

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
+
 	"github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/crypto/ed25519"
 	"github.com/cometbft/cometbft/libs/log"

--- a/test/e2e/tests/abci_test.go
+++ b/test/e2e/tests/abci_test.go
@@ -3,9 +3,10 @@ package e2e_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 	"github.com/cometbft/cometbft/test/e2e/pkg/grammar"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCheckABCIGrammar(t *testing.T) {

--- a/test/e2e/tests/app_test.go
+++ b/test/e2e/tests/app_test.go
@@ -9,10 +9,11 @@ import (
 	"testing"
 	"time"
 
-	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
-	"github.com/cometbft/cometbft/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
+	"github.com/cometbft/cometbft/types"
 )
 
 // Tests that any initial state given in genesis has made it into the app.

--- a/test/e2e/tests/block_test.go
+++ b/test/e2e/tests/block_test.go
@@ -3,9 +3,10 @@ package e2e_test
 import (
 	"testing"
 
-	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 )
 
 // Tests that block headers are identical across nodes where present.

--- a/test/e2e/tests/e2e_test.go
+++ b/test/e2e/tests/e2e_test.go
@@ -9,13 +9,14 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	abci "github.com/cometbft/cometbft/abci/types"
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 	rpctypes "github.com/cometbft/cometbft/rpc/core/types"
 	"github.com/cometbft/cometbft/test/e2e/app"
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 	"github.com/cometbft/cometbft/types"
-	"github.com/stretchr/testify/require"
 )
 
 func init() {

--- a/test/e2e/tests/grpc_test.go
+++ b/test/e2e/tests/grpc_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	coretypes "github.com/cometbft/cometbft/rpc/core/types"
 	"github.com/cometbft/cometbft/rpc/grpc/client/privileged"
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 	"github.com/cometbft/cometbft/version"
-	"github.com/stretchr/testify/require"
 )
 
 func TestGRPC_Version(t *testing.T) {

--- a/test/e2e/tests/net_test.go
+++ b/test/e2e/tests/net_test.go
@@ -3,8 +3,9 @@ package e2e_test
 import (
 	"testing"
 
-	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 	"github.com/stretchr/testify/require"
+
+	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 )
 
 // Tests that all nodes have peered with each other, regardless of discovery method.

--- a/test/e2e/tests/validator_test.go
+++ b/test/e2e/tests/validator_test.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 	"github.com/cometbft/cometbft/types"
-	"github.com/stretchr/testify/require"
 )
 
 // Tests that validator sets are available and correct according to

--- a/test/fuzz/mempool/fuzz_test.go
+++ b/test/fuzz/mempool/fuzz_test.go
@@ -6,8 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	mempl "github.com/cometbft/cometbft/test/fuzz/mempool"
 	"github.com/stretchr/testify/require"
+
+	mempl "github.com/cometbft/cometbft/test/fuzz/mempool"
 )
 
 const testdataCasesDir = "testdata/cases"

--- a/test/loadtime/cmd/load/main.go
+++ b/test/loadtime/cmd/load/main.go
@@ -3,9 +3,10 @@ package main
 import (
 	"fmt"
 
-	"github.com/cometbft/cometbft/test/loadtime/payload"
 	"github.com/google/uuid"
 	"github.com/informalsystems/tm-load-test/pkg/loadtest"
+
+	"github.com/cometbft/cometbft/test/loadtime/payload"
 )
 
 // Ensure all of the interfaces are correctly satisfied.

--- a/test/loadtime/payload/payload_test.go
+++ b/test/loadtime/payload/payload_test.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/cometbft/cometbft/test/loadtime/payload"
 	"github.com/google/uuid"
+
+	"github.com/cometbft/cometbft/test/loadtime/payload"
 )
 
 const payloadSizeTarget = 1024 // 1kb

--- a/test/loadtime/report/report.go
+++ b/test/loadtime/report/report.go
@@ -6,10 +6,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cometbft/cometbft/test/loadtime/payload"
-	"github.com/cometbft/cometbft/types"
 	"github.com/gofrs/uuid"
 	"gonum.org/v1/gonum/stat"
+
+	"github.com/cometbft/cometbft/test/loadtime/payload"
+	"github.com/cometbft/cometbft/types"
 )
 
 // BlockStore defines the set of methods needed by the report generator from

--- a/test/loadtime/report/report_test.go
+++ b/test/loadtime/report/report_test.go
@@ -4,11 +4,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
 	"github.com/cometbft/cometbft/test/loadtime/payload"
 	"github.com/cometbft/cometbft/test/loadtime/report"
 	"github.com/cometbft/cometbft/types"
-	"github.com/google/uuid"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (

--- a/types/block.go
+++ b/types/block.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cosmos/gogoproto/proto"
+	gogotypes "github.com/cosmos/gogoproto/types"
+
 	cmtproto "github.com/cometbft/cometbft/api/cometbft/types/v1"
 	cmtversion "github.com/cometbft/cometbft/api/cometbft/version/v1"
 	"github.com/cometbft/cometbft/crypto"
@@ -17,8 +20,6 @@ import (
 	cmtbytes "github.com/cometbft/cometbft/libs/bytes"
 	cmtmath "github.com/cometbft/cometbft/libs/math"
 	"github.com/cometbft/cometbft/version"
-	"github.com/cosmos/gogoproto/proto"
-	gogotypes "github.com/cosmos/gogoproto/types"
 )
 
 const (

--- a/types/block_meta_test.go
+++ b/types/block_meta_test.go
@@ -3,9 +3,10 @@ package types
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/cometbft/cometbft/crypto/tmhash"
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
-	"github.com/stretchr/testify/require"
 )
 
 func TestBlockMeta_ToProto(t *testing.T) {

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -9,6 +9,10 @@ import (
 	"testing"
 	"time"
 
+	gogotypes "github.com/cosmos/gogoproto/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	cmtversion "github.com/cometbft/cometbft/api/cometbft/version/v1"
 	"github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/crypto/merkle"
@@ -18,9 +22,6 @@ import (
 	"github.com/cometbft/cometbft/libs/bytes"
 	cmttime "github.com/cometbft/cometbft/types/time"
 	"github.com/cometbft/cometbft/version"
-	gogotypes "github.com/cosmos/gogoproto/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {

--- a/types/encoding_helper.go
+++ b/types/encoding_helper.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	"github.com/cometbft/cometbft/libs/bytes"
 	gogotypes "github.com/cosmos/gogoproto/types"
+
+	"github.com/cometbft/cometbft/libs/bytes"
 )
 
 // cdcEncode returns nil if the input is nil, otherwise returns

--- a/types/event_bus_test.go
+++ b/types/event_bus_test.go
@@ -7,11 +7,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	abci "github.com/cometbft/cometbft/abci/types"
 	cmtpubsub "github.com/cometbft/cometbft/internal/pubsub"
 	cmtquery "github.com/cometbft/cometbft/internal/pubsub/query"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestEventBusPublishEventTx(t *testing.T) {

--- a/types/evidence_test.go
+++ b/types/evidence_test.go
@@ -5,13 +5,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	cmtversion "github.com/cometbft/cometbft/api/cometbft/version/v1"
 	"github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/crypto/tmhash"
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
 	"github.com/cometbft/cometbft/version"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var defaultVoteTime = time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)

--- a/types/genesis_test.go
+++ b/types/genesis_test.go
@@ -4,11 +4,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/cometbft/cometbft/crypto/ed25519"
 	cmtjson "github.com/cometbft/cometbft/libs/json"
 	cmttime "github.com/cometbft/cometbft/types/time"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestGenesisBad(t *testing.T) {

--- a/types/light_test.go
+++ b/types/light_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	cmtversion "github.com/cometbft/cometbft/api/cometbft/version/v1"
 	"github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/version"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestLightBlockValidateBasic(t *testing.T) {

--- a/types/params_test.go
+++ b/types/params_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 	"time"
 
-	cmtproto "github.com/cometbft/cometbft/api/cometbft/types/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	cmtproto "github.com/cometbft/cometbft/api/cometbft/types/v1"
 )
 
 var (

--- a/types/part_set_test.go
+++ b/types/part_set_test.go
@@ -4,10 +4,11 @@ import (
 	"io"
 	"testing"
 
-	"github.com/cometbft/cometbft/crypto/merkle"
-	cmtrand "github.com/cometbft/cometbft/internal/rand"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/crypto/merkle"
+	cmtrand "github.com/cometbft/cometbft/internal/rand"
 )
 
 const (

--- a/types/proposal_test.go
+++ b/types/proposal_test.go
@@ -5,13 +5,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cosmos/gogoproto/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	cmtproto "github.com/cometbft/cometbft/api/cometbft/types/v1"
 	"github.com/cometbft/cometbft/crypto/tmhash"
 	"github.com/cometbft/cometbft/internal/protoio"
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
-	"github.com/cosmos/gogoproto/proto"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var (

--- a/types/protobuf_test.go
+++ b/types/protobuf_test.go
@@ -3,12 +3,13 @@ package types
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/crypto/ed25519"
 	cryptoenc "github.com/cometbft/cometbft/crypto/encoding"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestABCIPubKey(t *testing.T) {

--- a/types/results_test.go
+++ b/types/results_test.go
@@ -3,9 +3,10 @@ package types
 import (
 	"testing"
 
-	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	abci "github.com/cometbft/cometbft/abci/types"
 )
 
 func TestABCIResults(t *testing.T) {

--- a/types/test_util.go
+++ b/types/test_util.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	cmtversion "github.com/cometbft/cometbft/api/cometbft/version/v1"
 	"github.com/cometbft/cometbft/version"
-	"github.com/stretchr/testify/require"
 )
 
 func MakeExtCommit(blockID BlockID, height int64, round int32,

--- a/types/tx_test.go
+++ b/types/tx_test.go
@@ -5,11 +5,12 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	cmtproto "github.com/cometbft/cometbft/api/cometbft/types/v1"
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
 	ctest "github.com/cometbft/cometbft/libs/test"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func makeTxs(cnt, size int) Txs {

--- a/types/validation_test.go
+++ b/types/validation_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 	"time"
 
-	cmtmath "github.com/cometbft/cometbft/libs/math"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	cmtmath "github.com/cometbft/cometbft/libs/math"
 )
 
 // Check VerifyCommit, VerifyCommitLight and VerifyCommitLightTrusting basic

--- a/types/validator_set_test.go
+++ b/types/validator_set_test.go
@@ -9,13 +9,14 @@ import (
 	"testing"
 	"testing/quick"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	cmtproto "github.com/cometbft/cometbft/api/cometbft/types/v1"
 	"github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/crypto/ed25519"
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
 	cmtmath "github.com/cometbft/cometbft/libs/math"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestValidatorSetBasic(t *testing.T) {

--- a/types/vote_set_test.go
+++ b/types/vote_set_test.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/cometbft/cometbft/crypto"
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
 	cmttime "github.com/cometbft/cometbft/types/time"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestVoteSet_AddVote_Good(t *testing.T) {

--- a/types/vote_test.go
+++ b/types/vote_test.go
@@ -4,15 +4,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cosmos/gogoproto/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	cmtproto "github.com/cometbft/cometbft/api/cometbft/types/v1"
 	"github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/crypto/ed25519"
 	"github.com/cometbft/cometbft/crypto/tmhash"
 	"github.com/cometbft/cometbft/internal/protoio"
 	cmttime "github.com/cometbft/cometbft/types/time"
-	"github.com/cosmos/gogoproto/proto"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func examplePrevote() *Vote {


### PR DESCRIPTION
In https://github.com/cometbft/cometbft/pull/1838, I've set (or reset) dependencies order to default:

https://golangci-lint.run/usage/linters/#gci

```
# Default: ["standard", "default"]
    sections:
      - standard # Standard section: captures all standard packages.
      - default # Default section: contains all imports that could not be matched to another section type.
```

This PR updates dependencies ordering to `custom`, which matches more with what we previously had. 

```
  gci:
    sections:
      - standard # Standard section: captures all standard packages.
      - default # Default section: contains all imports that could not be matched to another section type.
      - blank # blank imports
      - dot # dot imports
      - prefix(github.com/cometbft/cometbft, github.com/cometbft/cometbft-db)
    custom-order: true
```

Sorry for the back and forth.

---

#### PR checklist

- [ ] ~~Tests written/updated~~
- [ ] ~~Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)~~
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments

