### PR TITLE
Fix paths to scripts/metricsgen in go:generate commands

### DIFF
--- a/internal/blocksync/metrics.go
+++ b/internal/blocksync/metrics.go
@@ -12,7 +12,7 @@ const (
 	MetricsSubsystem = "blocksync"
 )
 
-//go:generate go run ../scripts/metricsgen -struct=Metrics
+//go:generate go run ../../scripts/metricsgen -struct=Metrics
 
 // Metrics contains metrics exposed by this package.
 type Metrics struct {

--- a/internal/consensus/metrics.go
+++ b/internal/consensus/metrics.go
@@ -16,7 +16,7 @@ const (
 	MetricsSubsystem = "consensus"
 )
 
-//go:generate go run ../scripts/metricsgen -struct=Metrics
+//go:generate go run ../../scripts/metricsgen -struct=Metrics
 
 // Metrics contains metrics exposed by this package.
 type Metrics struct {

--- a/internal/state/metrics.go
+++ b/internal/state/metrics.go
@@ -10,7 +10,7 @@ const (
 	MetricsSubsystem = "state"
 )
 
-//go:generate go run ../scripts/metricsgen -struct=Metrics
+//go:generate go run ../../scripts/metricsgen -struct=Metrics
 
 // Metrics contains metrics exposed by this package.
 type Metrics struct {

--- a/internal/statesync/metrics.go
+++ b/internal/statesync/metrics.go
@@ -10,7 +10,7 @@ const (
 	MetricsSubsystem = "statesync"
 )
 
-//go:generate go run ../scripts/metricsgen -struct=Metrics
+//go:generate go run ../../scripts/metricsgen -struct=Metrics
 
 // Metrics contains metrics exposed by this package.
 type Metrics struct {


### PR DESCRIPTION
Some paths to the script `metricsgen` were broken when the files were moved to `internal/`.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

