### PR TITLE
docs(light): fix broken link to spec

### DIFF
--- a/light/doc.go
+++ b/light/doc.go
@@ -121,7 +121,7 @@ See
 https://docs.cometbft.com/main/core/light-client.html
 for usage example.
 Or see
-https://github.com/cometbft/cometbft/tree/main/spec/consensus/light-client
+https://github.com/cometbft/cometbft/blob/main/spec/light-client/README.md
 for the full spec
 */
 package light


### PR DESCRIPTION
Came accross a deprecated link while reading the docs, figured I would update it in a quick PR instead of opening an issue or else.
Doesn't require testing or changelog entry.