### PR TITLE
ci: Remove unused `tests` target when compiling e2e

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build
         working-directory: test/e2e
         # Run two make jobs in parallel, since we can't run steps in parallel.
-        run: make -j2 docker runner tests
+        run: make -j2 docker runner
         if: "env.GIT_DIFF != ''"
 
       - name: Run CI testnet


### PR DESCRIPTION
There's no `tests` target in the Makefile. The command outputs `make: Nothing to be done for 'tests'`.
