### PR TITLE
spec: fix typo in `encoding.md`

### DIFF
--- a/spec/core/encoding.md
+++ b/spec/core/encoding.md
@@ -41,7 +41,7 @@ include details of the private keys beyond their type and name.
 
 ### Key Types
 
-Each type specifies it's own pubkey, address, and signature format.
+Each type specifies its own pubkey, address, and signature format.
 
 #### Ed25519
 


### PR DESCRIPTION
this is a trivial commit, fixing a typo i found while reading through the encoding specification.