### PR TITLE
config: Remove unused `max_batch_bytes`

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -885,10 +885,6 @@ type MempoolConfig struct {
 	// Maximum size of a single transaction
 	// NOTE: the max size of a tx transmitted over the network is {max_tx_bytes}.
 	MaxTxBytes int `mapstructure:"max_tx_bytes"`
-	// Maximum size of a batch of transactions to send to a peer
-	// Including space needed by encoding (one varint per transaction).
-	// XXX: Unused due to https://github.com/tendermint/tendermint/issues/5796
-	MaxBatchBytes int `mapstructure:"max_batch_bytes"`
 	// Experimental parameters to limit gossiping txs to up to the specified number of peers.
 	// We use two independent upper values for persistent and non-persistent peers.
 	// Unconditional peers are not affected by this feature.

--- a/config/toml.go
+++ b/config/toml.go
@@ -430,11 +430,6 @@ keep-invalid-txs-in-cache = {{ .Mempool.KeepInvalidTxsInCache }}
 # NOTE: the max size of a tx transmitted over the network is {max_tx_bytes}.
 max_tx_bytes = {{ .Mempool.MaxTxBytes }}
 
-# Maximum size of a batch of transactions to send to a peer
-# Including space needed by encoding (one varint per transaction).
-# XXX: Unused due to https://github.com/tendermint/tendermint/issues/5796
-max_batch_bytes = {{ .Mempool.MaxBatchBytes }}
-
 # Experimental parameters to limit gossiping txs to up to the specified number of peers.
 # We use two independent upper values for persistent and non-persistent peers.
 # Unconditional peers are not affected by this feature.

--- a/docs/core/configuration.md
+++ b/docs/core/configuration.md
@@ -355,11 +355,6 @@ keep-invalid-txs-in-cache = false
 # NOTE: the max size of a tx transmitted over the network is {max_tx_bytes}.
 max_tx_bytes = 1048576
 
-# Maximum size of a batch of transactions to send to a peer
-# Including space needed by encoding (one `varint` per transaction).
-# XXX: Unused due to https://github.com/tendermint/tendermint/issues/5796
-max_batch_bytes = 0
-
 #######################################################
 ###         State Sync Configuration Options        ###
 #######################################################


### PR DESCRIPTION
This configuration is not used anymore; it's a leftover of batching txs in the mempool, which was deprecated (https://github.com/tendermint/tendermint/pull/5800)
