### PR TITLE
fix(ci): lint ci fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,6 +234,11 @@ lint:
 	@go run github.com/golangci/golangci-lint/cmd/golangci-lint@latest run
 .PHONY: lint
 
+lint-fix:
+	@echo "--> Running linter with fix"
+	@go run github.com/golangci/golangci-lint/cmd/golangci-lint@latest run --fix
+.PHONY: lint-fix
+
 # https://github.com/cometbft/cometbft/pull/1925#issuecomment-1875127862
 # Revisit using lint-format after CometBFT v1 release and/or after 2024-06-01.
 #lint-format:

--- a/types/params.go
+++ b/types/params.go
@@ -215,7 +215,7 @@ func (params ConsensusParams) ValidateBasic() error {
 // | 6 | *                     | <=height               | vote extensions cannot be updated to a past height
 // | 7 | <=0                   | > height (*)           | nil
 // | 8 | (> 0) <=height        | > height (*)           | vote extensions cannot be modified once enabled
-// | 9 | (> 0) > height        | > height (*)           | nil
+// | 9 | (> 0) > height        | > height (*)           | nil.
 func (params ConsensusParams) ValidateUpdate(updated *cmtproto.ConsensusParams, h int64) error {
 	// 1
 	if updated == nil || updated.Abci == nil {


### PR DESCRIPTION
This pr fixed a small lint error and added `lint-fix` to Makefile, introducing a convenient way for developers to fix make lint errors

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

