### PR TITLE
Manual backport of #2066 to `v0.38.x`

### DIFF
--- a/.changelog/unreleased/improvements/2065-e2e-vote-ext-activation.md
+++ b/.changelog/unreleased/improvements/2065-e2e-vote-ext-activation.md
@@ -1,0 +1,5 @@
+- `[e2e]` Add manifest option `VoteExtensionsUpdateHeight` to test
+  vote extension activation via `InitChain` and `FinalizeBlock`.
+  Also, extend the manifest generator to produce different values
+  of this new option
+  ([\#2065](https://github.com/cometbft/cometbft/pull/2065))

--- a/test/e2e/networks/ci.toml
+++ b/test/e2e/networks/ci.toml
@@ -3,6 +3,7 @@
 
 ipv6 = true
 initial_height = 1000
+vote_extensions_update_height = 1004
 vote_extensions_enable_height = 1007
 evidence = 5
 initial_state = { initial01 = "a", initial02 = "b", initial03 = "c" }

--- a/test/e2e/node/config.go
+++ b/test/e2e/node/config.go
@@ -11,30 +11,34 @@ import (
 
 // Config is the application configuration.
 type Config struct {
-	ChainID          string                      `toml:"chain_id"`
-	Listen           string                      `toml:"listen"`
-	Protocol         string                      `toml:"protocol"`
-	Dir              string                      `toml:"dir"`
-	Mode             string                      `toml:"mode"`
-	PersistInterval  uint64                      `toml:"persist_interval"`
-	SnapshotInterval uint64                      `toml:"snapshot_interval"`
-	RetainBlocks     uint64                      `toml:"retain_blocks"`
-	ValidatorUpdates map[string]map[string]uint8 `toml:"validator_update"`
-	PrivValServer    string                      `toml:"privval_server"`
-	PrivValKey       string                      `toml:"privval_key"`
-	PrivValState     string                      `toml:"privval_state"`
-	KeyType          string                      `toml:"key_type"`
+	ChainID                    string                      `toml:"chain_id"`
+	Listen                     string                      `toml:"listen"`
+	Protocol                   string                      `toml:"protocol"`
+	Dir                        string                      `toml:"dir"`
+	Mode                       string                      `toml:"mode"`
+	PersistInterval            uint64                      `toml:"persist_interval"`
+	SnapshotInterval           uint64                      `toml:"snapshot_interval"`
+	RetainBlocks               uint64                      `toml:"retain_blocks"`
+	ValidatorUpdates           map[string]map[string]uint8 `toml:"validator_update"`
+	PrivValServer              string                      `toml:"privval_server"`
+	PrivValKey                 string                      `toml:"privval_key"`
+	PrivValState               string                      `toml:"privval_state"`
+	KeyType                    string                      `toml:"key_type"`
+	VoteExtensionsEnableHeight int64                       `toml:"vote_extensions_enable_height"`
+	VoteExtensionsUpdateHeight int64                       `toml:"vote_extensions_update_height"`
 }
 
 // App extracts out the application specific configuration parameters
 func (cfg *Config) App() *app.Config {
 	return &app.Config{
-		Dir:              cfg.Dir,
-		SnapshotInterval: cfg.SnapshotInterval,
-		RetainBlocks:     cfg.RetainBlocks,
-		KeyType:          cfg.KeyType,
-		ValidatorUpdates: cfg.ValidatorUpdates,
-		PersistInterval:  cfg.PersistInterval,
+		Dir:                        cfg.Dir,
+		SnapshotInterval:           cfg.SnapshotInterval,
+		RetainBlocks:               cfg.RetainBlocks,
+		KeyType:                    cfg.KeyType,
+		ValidatorUpdates:           cfg.ValidatorUpdates,
+		PersistInterval:            cfg.PersistInterval,
+		VoteExtensionsEnableHeight: cfg.VoteExtensionsEnableHeight,
+		VoteExtensionsUpdateHeight: cfg.VoteExtensionsUpdateHeight,
 	}
 }
 

--- a/test/e2e/pkg/manifest.go
+++ b/test/e2e/pkg/manifest.go
@@ -56,11 +56,6 @@ type Manifest struct {
 	// testnet via the RPC endpoint of a random node. Default is 0
 	Evidence int `toml:"evidence"`
 
-	// VoteExtensionsEnableHeight configures the first height during which
-	// the chain will use and require vote extension data to be present
-	// in precommit messages.
-	VoteExtensionsEnableHeight int64 `toml:"vote_extensions_enable_height"`
-
 	// ABCIProtocol specifies the protocol used to communicate with the ABCI
 	// application: "unix", "tcp", "grpc", "builtin" or "builtin_connsync".
 	//
@@ -93,6 +88,16 @@ type Manifest struct {
 	// Defaults to false (disabled).
 	Prometheus bool `toml:"prometheus"`
 
+	// VoteExtensionsEnableHeight configures the first height during which
+	// the chain will use and require vote extension data to be present
+	// in precommit messages.
+	VoteExtensionsEnableHeight int64 `toml:"vote_extensions_enable_height"`
+
+	// VoteExtensionsUpdateHeight configures the height at which consensus
+	// param VoteExtensionsEnableHeight will be set.
+	// -1 denotes it is set at genesis.
+	// 0 denotes it is set at InitChain.
+	VoteExtensionsUpdateHeight int64 `toml:"vote_extensions_update_height"`
 	// Maximum number of peers to which the node gossips transactions
 	ExperimentalMaxGossipConnectionsToPersistentPeers    uint `toml:"experimental_max_gossip_connections_to_persistent_peers"`
 	ExperimentalMaxGossipConnectionsToNonPersistentPeers uint `toml:"experimental_max_gossip_connections_to_non_persistent_peers"`

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -88,6 +88,7 @@ type Testnet struct {
 	UpgradeVersion                                       string
 	Prometheus                                           bool
 	VoteExtensionsEnableHeight                           int64
+	VoteExtensionsUpdateHeight                           int64
 	ExperimentalMaxGossipConnectionsToPersistentPeers    uint
 	ExperimentalMaxGossipConnectionsToNonPersistentPeers uint
 }
@@ -167,6 +168,7 @@ func NewTestnetFromManifest(manifest Manifest, file string, ifd InfrastructureDa
 		UpgradeVersion:             manifest.UpgradeVersion,
 		Prometheus:                 manifest.Prometheus,
 		VoteExtensionsEnableHeight: manifest.VoteExtensionsEnableHeight,
+		VoteExtensionsUpdateHeight: manifest.VoteExtensionsUpdateHeight,
 		ExperimentalMaxGossipConnectionsToPersistentPeers:    manifest.ExperimentalMaxGossipConnectionsToPersistentPeers,
 		ExperimentalMaxGossipConnectionsToNonPersistentPeers: manifest.ExperimentalMaxGossipConnectionsToNonPersistentPeers,
 	}
@@ -340,6 +342,37 @@ func (t Testnet) Validate() error {
 	}
 	if len(t.Nodes) == 0 {
 		return errors.New("network has no nodes")
+	}
+	if t.VoteExtensionsUpdateHeight < -1 {
+		return fmt.Errorf("value of VoteExtensionsUpdateHeight must be positive, 0 (InitChain), "+
+			"or -1 (Genesis); update height %d", t.VoteExtensionsUpdateHeight)
+	}
+	if t.VoteExtensionsEnableHeight < 0 {
+		return fmt.Errorf("value of VoteExtensionsEnableHeight must be positive, or 0 (disable); "+
+			"enable height %d", t.VoteExtensionsEnableHeight)
+	}
+	if t.VoteExtensionsUpdateHeight > 0 && t.VoteExtensionsUpdateHeight < t.InitialHeight {
+		return fmt.Errorf("a value of VoteExtensionsUpdateHeight greater than 0 "+
+			"must not be less than InitialHeight; "+
+			"update height %d, initial height %d",
+			t.VoteExtensionsUpdateHeight, t.InitialHeight,
+		)
+	}
+	if t.VoteExtensionsEnableHeight > 0 {
+		if t.VoteExtensionsEnableHeight < t.InitialHeight {
+			return fmt.Errorf("a value of VoteExtensionsEnableHeight greater than 0 "+
+				"must not be less than InitialHeight; "+
+				"enable height %d, initial height %d",
+				t.VoteExtensionsEnableHeight, t.InitialHeight,
+			)
+		}
+		if t.VoteExtensionsEnableHeight <= t.VoteExtensionsUpdateHeight {
+			return fmt.Errorf("a value of VoteExtensionsEnableHeight greater than 0 "+
+				"must be greater than VoteExtensionsUpdateHeight; "+
+				"update height %d, enable height %d",
+				t.VoteExtensionsUpdateHeight, t.VoteExtensionsEnableHeight,
+			)
+		}
 	}
 	for _, node := range t.Nodes {
 		if err := node.Validate(t); err != nil {

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -137,7 +137,9 @@ func MakeGenesis(testnet *e2e.Testnet) (types.GenesisDoc, error) {
 	genesis.ConsensusParams.Version.App = 1
 	genesis.ConsensusParams.Evidence.MaxAgeNumBlocks = e2e.EvidenceAgeHeight
 	genesis.ConsensusParams.Evidence.MaxAgeDuration = e2e.EvidenceAgeTime
-	genesis.ConsensusParams.ABCI.VoteExtensionsEnableHeight = testnet.VoteExtensionsEnableHeight
+	if testnet.VoteExtensionsUpdateHeight == -1 {
+		genesis.ConsensusParams.ABCI.VoteExtensionsEnableHeight = testnet.VoteExtensionsEnableHeight
+	}
 	for validator, power := range testnet.Validators {
 		genesis.Validators = append(genesis.Validators, types.GenesisValidator{
 			Name:    validator.Name,
@@ -260,20 +262,22 @@ func MakeConfig(node *e2e.Node) (*config.Config, error) {
 // MakeAppConfig generates an ABCI application config for a node.
 func MakeAppConfig(node *e2e.Node) ([]byte, error) {
 	cfg := map[string]interface{}{
-		"chain_id":               node.Testnet.Name,
-		"dir":                    "data/app",
-		"listen":                 AppAddressUNIX,
-		"mode":                   node.Mode,
-		"protocol":               "socket",
-		"persist_interval":       node.PersistInterval,
-		"snapshot_interval":      node.SnapshotInterval,
-		"retain_blocks":          node.RetainBlocks,
-		"key_type":               node.PrivvalKey.Type(),
-		"prepare_proposal_delay": node.Testnet.PrepareProposalDelay,
-		"process_proposal_delay": node.Testnet.ProcessProposalDelay,
-		"check_tx_delay":         node.Testnet.CheckTxDelay,
-		"vote_extension_delay":   node.Testnet.VoteExtensionDelay,
-		"finalize_block_delay":   node.Testnet.FinalizeBlockDelay,
+		"chain_id":                      node.Testnet.Name,
+		"dir":                           "data/app",
+		"listen":                        AppAddressUNIX,
+		"mode":                          node.Mode,
+		"protocol":                      "socket",
+		"persist_interval":              node.PersistInterval,
+		"snapshot_interval":             node.SnapshotInterval,
+		"retain_blocks":                 node.RetainBlocks,
+		"key_type":                      node.PrivvalKey.Type(),
+		"prepare_proposal_delay":        node.Testnet.PrepareProposalDelay,
+		"process_proposal_delay":        node.Testnet.ProcessProposalDelay,
+		"check_tx_delay":                node.Testnet.CheckTxDelay,
+		"vote_extension_delay":          node.Testnet.VoteExtensionDelay,
+		"finalize_block_delay":          node.Testnet.FinalizeBlockDelay,
+		"vote_extensions_enable_height": node.Testnet.VoteExtensionsEnableHeight,
+		"vote_extensions_update_height": node.Testnet.VoteExtensionsUpdateHeight,
 	}
 	switch node.ABCIProtocol {
 	case e2e.ProtocolUNIX:


### PR DESCRIPTION
Backport of #2066, addressing #2065 on branch `v0.38.x`

The reason for the back to be manual is the many conflicts (which have already been solved).

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

