### PR TITLE
v0.38-experimental: Add CAT mempool support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -855,6 +855,11 @@ type MempoolConfig struct {
 	// the $CMTHOME env variable or --home cmd flag rather than overriding this
 	// struct field.
 	RootDir string `mapstructure:"home"`
+	// Mempool reactor, valid options:
+	// - "cat": reactor with push-pull gossip protocol
+	// - "" (default): reactor with flooding protocol
+	Reactor string `mapstructure:"reactor"`
+
 	// Recheck (default: true) defines whether CometBFT should recheck the
 	// validity for all remaining transaction in the mempool after a block.
 	// Since a block affects the application state, some transactions in the

--- a/config/toml.go
+++ b/config/toml.go
@@ -396,6 +396,11 @@ dial_timeout = "{{ .P2P.DialTimeout }}"
 #######################################################
 [mempool]
 
+# Mempool reactor. Valid options:
+# - "cat" for push-pull gossip protocol
+# - "": default reactor with flood protocol
+reactor = "{{ .Mempool.Reactor }}"
+
 # Recheck (default: true) defines whether CometBFT should recheck the
 # validity for all remaining transaction in the mempool after a block.
 # Since a block affects the application state, some transactions in the

--- a/consensus/replay_stubs.go
+++ b/consensus/replay_stubs.go
@@ -3,6 +3,7 @@ package consensus
 import (
 	"context"
 
+	abcicli "github.com/cometbft/cometbft/abci/client"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/libs/clist"
 	mempl "github.com/cometbft/cometbft/mempool"
@@ -20,9 +21,15 @@ func (emptyMempool) Lock()            {}
 func (emptyMempool) Unlock()          {}
 func (emptyMempool) Size() int        { return 0 }
 func (emptyMempool) SizeBytes() int64 { return 0 }
-func (emptyMempool) CheckTx(types.Tx, func(*abci.ResponseCheckTx), mempl.TxInfo) error {
-	return nil
+func (emptyMempool) CheckTx(tx types.Tx) (*abcicli.ReqRes, error) {
+	return nil, nil
 }
+
+func (emptyMempool) CheckNewTx(types.Tx) (*abcicli.ReqRes, error) {
+	return nil, nil
+}
+
+func (emptyMempool) InvokeNewTxReceivedOnReactor(types.TxKey) {}
 
 func (txmp emptyMempool) RemoveTxByKey(types.TxKey) error {
 	return nil

--- a/mempool/cache.go
+++ b/mempool/cache.go
@@ -7,67 +7,64 @@ import (
 	"github.com/cometbft/cometbft/types"
 )
 
-// TxCache defines an interface for raw transaction caching in a mempool.
+// TxCache defines an interface for transaction caching.
 // Currently, a TxCache does not allow direct reading or getting of transaction
 // values. A TxCache is used primarily to push transactions and removing
 // transactions. Pushing via Push returns a boolean telling the caller if the
 // transaction already exists in the cache or not.
-type TxCache interface {
+type TxCache[T comparable] interface {
 	// Reset resets the cache to an empty state.
 	Reset()
 
-	// Push adds the given raw transaction to the cache and returns true if it was
+	// Push adds the given transaction key to the cache and returns true if it was
 	// newly added. Otherwise, it returns false.
-	Push(tx types.Tx) bool
+	Push(v T) bool
 
-	// Remove removes the given raw transaction from the cache.
-	Remove(tx types.Tx)
+	// Remove removes the given transaction from the cache.
+	Remove(v T)
 
 	// Has reports whether tx is present in the cache. Checking for presence is
 	// not treated as an access of the value.
-	Has(tx types.Tx) bool
+	Has(v T) bool
 }
 
-var _ TxCache = (*LRUTxCache)(nil)
+var _ TxCache[types.TxKey] = (*LRUTxCache[types.TxKey])(nil)
 
-// LRUTxCache maintains a thread-safe LRU cache of raw transactions. The cache
-// only stores the hash of the raw transaction.
-type LRUTxCache struct {
+// LRUTxCache maintains a thread-safe LRU cache of transaction hashes (keys).
+type LRUTxCache[T comparable] struct {
 	mtx      cmtsync.Mutex
 	size     int
-	cacheMap map[types.TxKey]*list.Element
+	cacheMap map[T]*list.Element
 	list     *list.List
 }
 
-func NewLRUTxCache(cacheSize int) *LRUTxCache {
-	return &LRUTxCache{
+func NewLRUTxCache[T comparable](cacheSize int) *LRUTxCache[T] {
+	return &LRUTxCache[T]{
 		size:     cacheSize,
-		cacheMap: make(map[types.TxKey]*list.Element, cacheSize),
+		cacheMap: make(map[T]*list.Element, cacheSize),
 		list:     list.New(),
 	}
 }
 
 // GetList returns the underlying linked-list that backs the LRU cache. Note,
 // this should be used for testing purposes only!
-func (c *LRUTxCache) GetList() *list.List {
+func (c *LRUTxCache[T]) GetList() *list.List {
 	return c.list
 }
 
-func (c *LRUTxCache) Reset() {
+func (c *LRUTxCache[T]) Reset() {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
-	c.cacheMap = make(map[types.TxKey]*list.Element, c.size)
+	c.cacheMap = make(map[T]*list.Element, c.size)
 	c.list.Init()
 }
 
-func (c *LRUTxCache) Push(tx types.Tx) bool {
+func (c *LRUTxCache[T]) Push(v T) bool {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
-	key := tx.Key()
-
-	moved, ok := c.cacheMap[key]
+	moved, ok := c.cacheMap[v]
 	if ok {
 		c.list.MoveToBack(moved)
 		return false
@@ -76,45 +73,44 @@ func (c *LRUTxCache) Push(tx types.Tx) bool {
 	if c.list.Len() >= c.size {
 		front := c.list.Front()
 		if front != nil {
-			frontKey := front.Value.(types.TxKey)
+			frontKey := front.Value.(T)
 			delete(c.cacheMap, frontKey)
 			c.list.Remove(front)
 		}
 	}
 
-	e := c.list.PushBack(key)
-	c.cacheMap[key] = e
+	e := c.list.PushBack(v)
+	c.cacheMap[v] = e
 
 	return true
 }
 
-func (c *LRUTxCache) Remove(tx types.Tx) {
+func (c *LRUTxCache[T]) Remove(v T) {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
-	key := tx.Key()
-	e := c.cacheMap[key]
-	delete(c.cacheMap, key)
+	e := c.cacheMap[v]
+	delete(c.cacheMap, v)
 
 	if e != nil {
 		c.list.Remove(e)
 	}
 }
 
-func (c *LRUTxCache) Has(tx types.Tx) bool {
+func (c *LRUTxCache[T]) Has(v T) bool {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
-	_, ok := c.cacheMap[tx.Key()]
+	_, ok := c.cacheMap[v]
 	return ok
 }
 
-// NopTxCache defines a no-op raw transaction cache.
-type NopTxCache struct{}
+// NopTxCache defines a no-op transaction cache.
+type NopTxCache[T comparable] struct{}
 
-var _ TxCache = (*NopTxCache)(nil)
+var _ TxCache[types.TxKey] = (*NopTxCache[types.TxKey])(nil)
 
-func (NopTxCache) Reset()             {}
-func (NopTxCache) Push(types.Tx) bool { return true }
-func (NopTxCache) Remove(types.Tx)    {}
-func (NopTxCache) Has(types.Tx) bool  { return false }
+func (NopTxCache[T]) Reset()                {}
+func (NopTxCache[T]) Push(types.TxKey) bool { return true }
+func (NopTxCache[T]) Remove(types.TxKey)    {}
+func (NopTxCache[T]) Has(types.TxKey) bool  { return false }

--- a/mempool/cache_bench_test.go
+++ b/mempool/cache_bench_test.go
@@ -3,10 +3,12 @@ package mempool
 import (
 	"encoding/binary"
 	"testing"
+
+	"github.com/cometbft/cometbft/types"
 )
 
 func BenchmarkCacheInsertTime(b *testing.B) {
-	cache := NewLRUTxCache(b.N)
+	cache := NewLRUTxCache[types.TxKey](b.N)
 
 	txs := make([][]byte, b.N)
 	for i := 0; i < b.N; i++ {
@@ -17,25 +19,25 @@ func BenchmarkCacheInsertTime(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		cache.Push(txs[i])
+		cache.Push(types.Tx(txs[i]).Key())
 	}
 }
 
 // This benchmark is probably skewed, since we actually will be removing
 // txs in parallel, which may cause some overhead due to mutex locking.
 func BenchmarkCacheRemoveTime(b *testing.B) {
-	cache := NewLRUTxCache(b.N)
+	cache := NewLRUTxCache[types.TxKey](b.N)
 
 	txs := make([][]byte, b.N)
 	for i := 0; i < b.N; i++ {
 		txs[i] = make([]byte, 8)
 		binary.BigEndian.PutUint64(txs[i], uint64(i))
-		cache.Push(txs[i])
+		cache.Push(types.Tx(txs[i]).Key())
 	}
 
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		cache.Remove(txs[i])
+		cache.Remove(types.Tx(txs[i]).Key())
 	}
 }

--- a/mempool/cache_test.go
+++ b/mempool/cache_test.go
@@ -14,18 +14,18 @@ import (
 )
 
 func TestCacheRemove(t *testing.T) {
-	cache := NewLRUTxCache(100)
+	cache := NewLRUTxCache[types.TxKey](100)
 	numTxs := 10
 
-	txs := make([][]byte, numTxs)
+	txs := make([]types.TxKey, numTxs)
 	for i := 0; i < numTxs; i++ {
 		// probability of collision is 2**-256
 		txBytes := make([]byte, 32)
 		_, err := rand.Read(txBytes)
 		require.NoError(t, err)
 
-		txs[i] = txBytes
-		cache.Push(txBytes)
+		txs[i] = types.Tx(txBytes).Key()
+		cache.Push(txs[i])
 
 		// make sure its added to both the linked list and the map
 		require.Equal(t, i+1, len(cache.cacheMap))
@@ -84,7 +84,7 @@ func TestCacheAfterUpdate(t *testing.T) {
 			}, TxInfo{})
 		}
 
-		cache := mp.cache.(*LRUTxCache)
+		cache := mp.cache.(*LRUTxCache[types.TxKey])
 		node := cache.GetList().Front()
 		counter := 0
 		for node != nil {

--- a/mempool/cat/reactor.go
+++ b/mempool/cat/reactor.go
@@ -1,0 +1,442 @@
+package cat
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+	cfg "github.com/cometbft/cometbft/config"
+	"github.com/cometbft/cometbft/crypto/tmhash"
+	"github.com/cometbft/cometbft/libs/log"
+	"github.com/cometbft/cometbft/mempool"
+	"github.com/cometbft/cometbft/p2p"
+	protomem "github.com/cometbft/cometbft/proto/tendermint/mempool"
+	"github.com/cometbft/cometbft/types"
+)
+
+const (
+	// default duration to wait before considering a peer non-responsive
+	// and searching for the tx from a new peer
+	defaultGossipDelay = 200 * time.Millisecond
+
+	// Content Addressable Tx Pool gossips state based messages (SeenTx and WantTx) on a separate channel
+	// for cross compatibility
+	MempoolStateChannel = byte(0x31)
+
+	// peerHeightDiff signifies the tolerance in difference in height between the peer and the height
+	// the node received the tx
+	peerHeightDiff = 10
+)
+
+// Reactor handles mempool tx broadcasting amongst peers.
+// It maintains a map from peer ID to counter, to prevent gossiping txs to the
+// peers you received it from.
+type Reactor struct {
+	p2p.BaseReactor
+	config   *cfg.MempoolConfig
+	mempool  *mempool.CListMempool
+	peerIDs  sync.Map          // set of connected peers
+	requests *requestScheduler // to track requested transactions
+
+	// Thread-safe list of transactions peers have seen that we have not yet seen
+	seenByPeersSet *SeenTxSet
+}
+
+// NewReactor returns a new Reactor with the given config and mempool.
+func NewReactor(config *cfg.MempoolConfig, mp *mempool.CListMempool, logger log.Logger) *Reactor {
+	memR := &Reactor{
+		config:         config,
+		mempool:        mp,
+		requests:       newRequestScheduler(defaultGossipDelay, defaultGlobalRequestTimeout),
+		seenByPeersSet: NewSeenTxSet(),
+	}
+	memR.BaseReactor = *p2p.NewBaseReactor("Mempool", memR)
+	memR.SetLogger(logger)
+	memR.mempool.SetTxRemovedCallback(func(txKey types.TxKey) {
+		memR.seenByPeersSet.RemoveKey(txKey)
+	})
+	memR.mempool.SetNewTxReceivedCallback(func(txKey types.TxKey) {
+		// If we don't find the tx in the mempool, probably it is because it was
+		// invalid, so don't broadcast.
+		if memTx := memR.mempool.GetEntry(txKey); memTx != nil {
+			go memR.broadcastNewTx(memTx)
+		}
+	})
+	return memR
+}
+
+// InitPeer implements Reactor by creating a state for the peer.
+func (memR *Reactor) InitPeer(peer p2p.Peer) p2p.Peer {
+	memR.peerIDs.Store(peer.ID(), struct{}{})
+	return peer
+}
+
+// SetLogger sets the Logger on the reactor and the underlying mempool.
+func (memR *Reactor) SetLogger(l log.Logger) {
+	memR.Logger = l
+}
+
+// OnStart implements p2p.BaseReactor.
+func (memR *Reactor) OnStart() error {
+	if !memR.config.Broadcast {
+		memR.Logger.Info("Tx broadcasting is disabled")
+	}
+	return nil
+}
+
+// OnStop implements Service
+func (memR *Reactor) OnStop() {
+	// stop all the timers tracking outbound requests
+	memR.requests.Close()
+}
+
+// GetChannels implements Reactor by returning the list of channels for this
+// reactor.
+func (memR *Reactor) GetChannels() []*p2p.ChannelDescriptor {
+	largestTx := make([]byte, memR.config.MaxTxBytes)
+	batchMsg := protomem.Message{
+		Sum: &protomem.Message_Txs{
+			Txs: &protomem.Txs{Txs: [][]byte{largestTx}},
+		},
+	}
+
+	stateMsg := protomem.Message{
+		Sum: &protomem.Message_SeenTx{
+			SeenTx: &protomem.SeenTx{
+				TxKey: make([]byte, tmhash.Size),
+			},
+		},
+	}
+
+	return []*p2p.ChannelDescriptor{
+		{
+			ID:                  mempool.MempoolChannel,
+			Priority:            6,
+			RecvMessageCapacity: batchMsg.Size(),
+			MessageType:         &protomem.Message{},
+		},
+		{
+			ID:                  MempoolStateChannel,
+			Priority:            5,
+			RecvMessageCapacity: stateMsg.Size(),
+			MessageType:         &protomem.Message{},
+		},
+	}
+}
+
+// RemovePeer implements Reactor. For all current outbound requests to this
+// peer it will find a new peer to rerequest the same transactions.
+func (memR *Reactor) RemovePeer(peer p2p.Peer, reason interface{}) {
+	memR.peerIDs.Delete(peer.ID())
+	// remove and rerequest all pending outbound requests to that peer since we know
+	// we won't receive any responses from them.
+	outboundRequests := memR.requests.ClearAllRequestsFrom(peer.ID())
+	for key := range outboundRequests {
+		memR.mempool.Metrics.RequestedTxs.Add(1)
+		memR.findNewPeerToRequestTx(key)
+	}
+}
+
+// Receive implements Reactor.
+// It processes one of three messages: Txs, SeenTx, WantTx.
+func (memR *Reactor) Receive(e p2p.Envelope) {
+	switch msg := e.Message.(type) {
+
+	// A peer has sent us one or more transactions. This could be either because we requested them
+	// or because the peer received a new transaction and is broadcasting it to us.
+	// NOTE: This setup also means that we can support older mempool implementations that simply
+	// flooded the network with transactions.
+	case *protomem.Txs:
+		protoTxs := msg.GetTxs()
+		memR.Logger.Debug("Received Txs", "src", e.Src, "chId", e.ChannelID, "msg", e.Message, "len", len(protoTxs))
+		if len(protoTxs) == 0 {
+			memR.Logger.Error("received empty txs from peer", "src", e.Src)
+			return
+		}
+
+		peerID := e.Src.ID()
+		for _, txBytes := range protoTxs {
+			tx := types.Tx(txBytes)
+			key := tx.Key()
+
+			// If we requested the transaction, we mark it as received.
+			if memR.requests.Has(peerID, key) {
+				memR.requests.MarkReceived(peerID, key)
+				memR.Logger.Debug("received a response for a requested transaction", "peerID", peerID, "txKey", key)
+			} else {
+				// If we didn't request the transaction we simply mark the peer as having the
+				// tx (we'd have already done it if we were requesting the tx).
+				memR.markPeerHasTx(peerID, key)
+				memR.Logger.Debug("received new transaction", "peerID", peerID, "txKey", key)
+			}
+
+			reqRes, err := memR.mempool.CheckTx(tx)
+			if errors.Is(err, mempool.ErrTxInCache) {
+				memR.Logger.Debug("Tx already exists in cache", "tx", tx.String())
+			} else if err != nil {
+				memR.Logger.Info("Could not check tx", "tx", tx.String(), "err", err)
+			} else {
+				// Record the sender only when the transaction is valid and, as
+				// a consequence, added to the mempool. Senders are stored until
+				// the transaction is removed from the mempool. Note that it's
+				// possible a tx is still in the cache but no longer in the
+				// mempool. For example, after committing a block, txs are
+				// removed from mempool but not the cache.
+				reqRes.SetCallback(func(res *abci.Response) {
+					if res.GetCheckTx().Code == abci.CodeTypeOK {
+						memR.markPeerHasTx(e.Src.ID(), tx.Key())
+
+						// We broadcast only transactions that we deem valid and
+						// actually have in our mempool.
+						memR.broadcastSeenTx(key)
+					}
+				})
+			}
+		}
+
+	// A peer has indicated to us that it has a transaction. We first verify the txKey and
+	// mark that peer as having the transaction. Then we proceed with the following logic:
+	//
+	// 1. If we have the transaction, we do nothing.
+	// 2. If we don't yet have the tx but have an outgoing request for it, we do nothing.
+	// 3. If we recently evicted the tx and still don't have space for it, we do nothing.
+	// 4. Else, we request the transaction from that peer.
+	case *protomem.SeenTx:
+		txKey, err := types.TxKeyFromBytes(msg.TxKey)
+		if err != nil {
+			memR.Logger.Error("peer sent SeenTx with incorrect tx key", "err", err)
+			memR.Switch.StopPeerForError(e.Src, err)
+			return
+		}
+		memR.Logger.Debug("Received SeenTx", "src", e.Src, "chId", e.ChannelID, "txKey", txKey)
+		peerID := e.Src.ID()
+		memR.markPeerHasTx(peerID, txKey)
+
+		// Check if we don't already have the transaction and that it was recently rejected
+		if memR.mempool.InMempool(txKey) || memR.mempool.InCache(txKey) || memR.mempool.WasRejected(txKey) {
+			memR.Logger.Debug("received a seen tx for a tx we already have or is in cache or was rejected", "txKey", txKey)
+			return
+		}
+
+		// If we are already requesting that tx, then we don't need to go any further.
+		if _, exists := memR.requests.ForTx(txKey); exists {
+			memR.Logger.Debug("received a SeenTx message for a transaction we are already requesting", "txKey", txKey)
+			return
+		}
+
+		// We don't have the transaction, nor are we requesting it so we send the node
+		// a want msg
+		memR.requestTx(txKey, e.Src.ID())
+
+	// A peer is requesting a transaction that we have claimed to have. Find the specified
+	// transaction and broadcast it to the peer. We may no longer have the transaction
+	case *protomem.WantTx:
+		txKey, err := types.TxKeyFromBytes(msg.TxKey)
+		if err != nil {
+			memR.Logger.Error("peer sent WantTx with incorrect tx key", "err", err)
+			memR.Switch.StopPeerForError(e.Src, err)
+			return
+		}
+		memR.Logger.Debug("Received SeenTx", "src", e.Src, "chId", e.ChannelID, "txKey", txKey)
+		memR.sendRequestedTx(txKey, e.Src)
+
+	default:
+		memR.Logger.Error("Received unknown message type", "src", e.Src, "chId", e.ChannelID, "msg", e.Message)
+		memR.Switch.StopPeerForError(e.Src, fmt.Errorf("mempool cannot handle message of type: %T", e.Message))
+		return
+	}
+}
+
+func (memR *Reactor) sendRequestedTx(txKey types.TxKey, peer p2p.Peer) {
+	if !memR.config.Broadcast {
+		return
+	}
+
+	if memTx := memR.mempool.GetEntry(txKey); memTx != nil {
+		memR.Logger.Debug("sending a tx in response to a want msg", "peer", peer.ID())
+		txsMsg := p2p.Envelope{
+			ChannelID: mempool.MempoolChannel,
+			Message:   &protomem.Txs{Txs: [][]byte{memTx.GetTx()}},
+		}
+		if peer.Send(txsMsg) {
+			memR.markPeerHasTx(peer.ID(), txKey)
+		} else {
+			memR.Logger.Error("send Txs message with requested transactions failed", "txKey", txKey, "peerID", peer.ID())
+		}
+	}
+}
+
+// PeerHasTx marks that the transaction has been seen by a peer.
+func (memR *Reactor) markPeerHasTx(peerID p2p.ID, txKey types.TxKey) {
+	memR.Logger.Debug("mark that peer has tx", "peer", peerID, "txKey", txKey.String())
+	memR.seenByPeersSet.Add(txKey, peerID)
+}
+
+// PeerState describes the state of a peer.
+type PeerState interface {
+	GetHeight() int64
+}
+
+// broadcastSeenTx broadcasts a SeenTx message to all peers unless we
+// know they have already seen the transaction
+func (memR *Reactor) broadcastSeenTx(txKey types.TxKey) {
+	if !memR.config.Broadcast {
+		return
+	}
+
+	memR.Logger.Debug("Broadcasting SeenTx...", "tx", txKey.String())
+
+	msg := p2p.Envelope{
+		ChannelID: MempoolStateChannel,
+		Message:   &protomem.SeenTx{TxKey: txKey[:]},
+	}
+
+	// Add jitter to when the node broadcasts it's seen txs to stagger when nodes
+	// in the network broadcast their seenTx messages.
+	time.Sleep(time.Duration(rand.Intn(10)*10) * time.Millisecond) //nolint:gosec //BUG? Why stagger? So small
+
+	memR.peerIDs.Range(func(key, _ interface{}) bool {
+		peerID := key.(p2p.ID)
+		peer := memR.Switch.Peers().Get(peerID)
+		memR.Logger.Debug("Sending SeenTx...", "tx", txKey, "peer", peerID)
+
+		if peerState, ok := peer.Get(types.PeerStateKey).(PeerState); ok {
+			// make sure peer isn't too far behind. This can happen
+			// if the peer is block-synching still and catching up
+			// in which case we just skip sending the transaction
+			if peerState.GetHeight() < memR.mempool.Height()-peerHeightDiff {
+				memR.Logger.Debug("peer is too far behind us. Skipping broadcast of seen tx")
+				return true
+			}
+		}
+		// no need to send a seen tx message to a peer that already
+		// has that tx.
+		if memR.seenByPeersSet.Has(txKey, peerID) {
+			memR.Logger.Debug("Peer has seen the transaction, not sending SeenTx", "tx", txKey, "peer", peerID)
+			return true
+		}
+
+		if peer.Send(msg) {
+			memR.Logger.Debug("SeenTx sent", "tx", txKey, "peer", peerID)
+			return true
+		}
+		memR.Logger.Error("send SeenTx message failed", "txKey", txKey, "peerID", peer.ID())
+		return true
+	})
+}
+
+// broadcastNewTx broadcast new transaction to all peers unless we are already
+// sure they have seen the tx.
+func (memR *Reactor) broadcastNewTx(memTx *mempool.MempoolTx) {
+	if !memR.config.Broadcast {
+		return
+	}
+
+	tx := memTx.GetTx()
+	txKey := tx.Key()
+	memR.Logger.Debug("Broadcasting new transaction...", "tx", txKey.String())
+
+	msg := p2p.Envelope{
+		ChannelID: mempool.MempoolChannel,
+		Message:   &protomem.Txs{Txs: [][]byte{tx}},
+	}
+
+	memR.peerIDs.Range(func(key, _ interface{}) bool {
+		peerID := key.(p2p.ID)
+		peer := memR.Switch.Peers().Get(peerID)
+		memR.Logger.Debug("Sending new transaction to...", "tx", txKey, "peer", peerID)
+
+		if peerState, ok := peer.Get(types.PeerStateKey).(PeerState); ok {
+			// make sure peer isn't too far behind. This can happen
+			// if the peer is blocksyncing still and catching up
+			// in which case we just skip sending the transaction
+			if peerState.GetHeight() < memTx.Height()-peerHeightDiff {
+				memR.Logger.Debug("Peer is too far behind us, don't send new tx")
+				return true
+			}
+		}
+
+		if memR.seenByPeersSet.Has(txKey, peerID) {
+			memR.Logger.Debug("Peer has seen the transaction, not sending it", "tx", txKey, "peer", peerID)
+			return true
+		}
+
+		if peer.Send(msg) {
+			memR.Logger.Debug("New transaction sent", "tx", txKey, "peer", peerID)
+			memR.markPeerHasTx(peerID, txKey)
+			return true
+		}
+
+		memR.Logger.Error("send Txs message with new transactions failed", "txKey", txKey, "peerID", peerID)
+		return true
+	})
+}
+
+// requestTx requests a transaction from a peer and tracks it,
+// requesting it from another peer if the first peer does not respond.
+func (memR *Reactor) requestTx(txKey types.TxKey, peerID p2p.ID) {
+	if !memR.config.Broadcast {
+		return
+	}
+
+	if !memR.Switch.Peers().Has(peerID) {
+		// we have disconnected from the peer
+		return
+	}
+
+	memR.Logger.Debug("requesting tx", "txKey", txKey, "peerID", peerID)
+	peer := memR.Switch.Peers().Get(peerID)
+	msg := p2p.Envelope{
+		ChannelID: MempoolStateChannel,
+		Message:   &protomem.WantTx{TxKey: txKey[:]},
+	}
+	if peer.Send(msg) {
+		memR.mempool.Metrics.RequestedTxs.Add(1)
+		added := memR.requests.Add(txKey, peerID, memR.findNewPeerToRequestTx)
+		if !added {
+			memR.Logger.Error("have already marked a tx as requested", "txKey", txKey, "peerID", peerID)
+		}
+	} else {
+		memR.Logger.Error("send WantTx message failed", "txKey", txKey, "peerID", peerID)
+	}
+}
+
+// findNewPeerToSendTx finds a new peer that has already seen the transaction to
+// request a transaction from.
+func (memR *Reactor) findNewPeerToRequestTx(txKey types.TxKey) {
+	// ensure that we are connected to peers
+	if memR.Switch.Peers().Size() == 0 {
+		return
+	}
+
+	// pop the next peer in the list of remaining peers that have seen the tx
+	// and does not already have an outbound request for that tx
+	seenMap := memR.seenByPeersSet.Get(txKey)
+	var peerID *p2p.ID
+	for possiblePeer := range seenMap {
+		if !memR.requests.Has(possiblePeer, txKey) {
+			peerID = &possiblePeer
+			break
+		}
+	}
+
+	if peerID == nil {
+		// No other free peer has the transaction we are looking for.
+		// We give up 🤷‍♂️ and hope either a peer responds late or the tx
+		// is gossiped again
+		memR.mempool.Metrics.NoPeerForTx.Add(1)
+		memR.Logger.Info("no other peer has the tx we are looking for", "txKey", txKey)
+		return
+	}
+
+	if !memR.Switch.Peers().Has(*peerID) {
+		// we disconnected from that peer, retry again until we exhaust the list
+		memR.findNewPeerToRequestTx(txKey)
+	} else {
+		memR.mempool.Metrics.RerequestedTxs.Add(1)
+		memR.requestTx(txKey, *peerID)
+	}
+}

--- a/mempool/cat/requests.go
+++ b/mempool/cat/requests.go
@@ -1,0 +1,153 @@
+package cat
+
+import (
+	"sync"
+	"time"
+
+	"github.com/cometbft/cometbft/p2p"
+	"github.com/cometbft/cometbft/types"
+)
+
+const defaultGlobalRequestTimeout = 1 * time.Hour
+
+// requestScheduler tracks the lifecycle of outbound transaction requests.
+type requestScheduler struct {
+	mtx sync.Mutex
+
+	// responseTime is the time the scheduler
+	// waits for a response from a peer before
+	// invoking the callback
+	responseTime time.Duration
+
+	// globalTimeout represents the longest duration
+	// to wait for any late response (after the responseTime).
+	// After this period the request is garbage collected.
+	globalTimeout time.Duration
+
+	// requestsByPeer is a lookup table of requests by peer.
+	// Multiple transactions can be requested by a single peer at one
+	requestsByPeer map[p2p.ID]requestSet
+
+	// requestsByTx is a lookup table for requested txs.
+	// There can only be one request per tx.
+	requestsByTx map[types.TxKey]p2p.ID
+}
+
+type requestSet map[types.TxKey]*time.Timer
+
+func newRequestScheduler(responseTime, globalTimeout time.Duration) *requestScheduler {
+	return &requestScheduler{
+		responseTime:   responseTime,
+		globalTimeout:  globalTimeout,
+		requestsByPeer: make(map[p2p.ID]requestSet),
+		requestsByTx:   make(map[types.TxKey]p2p.ID),
+	}
+}
+
+// Return true iff the pair (txKey, peerID) was successfully added to the scheduler.
+func (r *requestScheduler) Add(txKey types.TxKey, peerID p2p.ID, onTimeout func(key types.TxKey)) bool {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	// not allowed to have more than one outgoing transaction at once
+	if _, ok := r.requestsByTx[txKey]; ok {
+		return false
+	}
+
+	timer := time.AfterFunc(r.responseTime, func() {
+		r.mtx.Lock()
+		delete(r.requestsByTx, txKey)
+		r.mtx.Unlock()
+
+		// trigger callback. Callback can `Add` the tx back to the scheduler
+		if onTimeout != nil {
+			onTimeout(txKey)
+		}
+
+		// We set another timeout because the peer could still send
+		// a late response after the first timeout and it's important
+		// to recognize that it is a transaction in response to a
+		// request and not a new transaction being broadcasted to the entire
+		// network. This timer cannot be stopped and is used to ensure
+		// garbage collection.
+		time.AfterFunc(r.globalTimeout, func() {
+			r.mtx.Lock()
+			defer r.mtx.Unlock()
+			delete(r.requestsByPeer[peerID], txKey)
+		})
+	})
+	if _, ok := r.requestsByPeer[peerID]; !ok {
+		r.requestsByPeer[peerID] = requestSet{txKey: timer}
+	} else {
+		r.requestsByPeer[peerID][txKey] = timer
+	}
+	r.requestsByTx[txKey] = peerID
+	return true
+}
+
+func (r *requestScheduler) ForTx(key types.TxKey) (p2p.ID, bool) {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	v, ok := r.requestsByTx[key]
+	return v, ok
+}
+
+func (r *requestScheduler) Has(peer p2p.ID, key types.TxKey) bool {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	requestSet, ok := r.requestsByPeer[peer]
+	if !ok {
+		return false
+	}
+	_, ok = requestSet[key]
+	return ok
+}
+
+func (r *requestScheduler) ClearAllRequestsFrom(peer p2p.ID) requestSet {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	requests, ok := r.requestsByPeer[peer]
+	if !ok {
+		return requestSet{}
+	}
+	for _, timer := range requests {
+		timer.Stop()
+	}
+	delete(r.requestsByPeer, peer)
+	return requests
+}
+
+func (r *requestScheduler) MarkReceived(peer p2p.ID, key types.TxKey) bool {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	if _, ok := r.requestsByPeer[peer]; !ok {
+		return false
+	}
+
+	if timer, ok := r.requestsByPeer[peer][key]; ok {
+		timer.Stop()
+	} else {
+		return false
+	}
+
+	delete(r.requestsByPeer[peer], key)
+	delete(r.requestsByTx, key)
+	return true
+}
+
+// Close stops all timers and clears all requests.
+// Add should never be called after `Close`.
+func (r *requestScheduler) Close() {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	for _, requestSet := range r.requestsByPeer {
+		for _, timer := range requestSet {
+			timer.Stop()
+		}
+	}
+}

--- a/mempool/cat/requests_test.go
+++ b/mempool/cat/requests_test.go
@@ -1,0 +1,145 @@
+package cat
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cometbft/cometbft/p2p"
+	"github.com/cometbft/cometbft/types"
+	"github.com/fortytw2/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestSchedulerRerequest(t *testing.T) {
+	var (
+		requests = newRequestScheduler(10*time.Millisecond, 1*time.Minute)
+		tx       = types.Tx("tx")
+		key      = tx.Key()
+		peerA    = p2p.ID("1") // should be non-zero
+		peerB    = p2p.ID("2")
+	)
+	t.Cleanup(requests.Close)
+
+	// check zero state
+	_, exists := requests.ForTx(key)
+	require.False(t, exists)
+	require.False(t, requests.Has(peerA, key))
+	// marking a tx that was never requested should return false
+	require.False(t, requests.MarkReceived(peerA, key))
+
+	// create a request
+	closeCh := make(chan struct{})
+	require.True(t, requests.Add(key, peerA, func(key types.TxKey) {
+		require.Equal(t, key, key)
+		// the first peer times out to respond so we ask the second peer
+		require.True(t, requests.Add(key, peerB, func(key types.TxKey) {
+			t.Fatal("did not expect to timeout")
+		}))
+		close(closeCh)
+	}))
+
+	// check that the request was added
+	peer, exists := requests.ForTx(key)
+	require.True(t, exists)
+	require.Equal(t, peerA, peer)
+	require.True(t, requests.Has(peerA, key))
+
+	// should not be able to add the same request again
+	require.False(t, requests.Add(key, peerA, nil))
+
+	// wait for the scheduler to invoke the timeout
+	<-closeCh
+
+	// check that the request stil exists
+	require.True(t, requests.Has(peerA, key))
+	// check that peerB was requested
+	require.True(t, requests.Has(peerB, key))
+
+	// There should still be a request for the Tx
+	peer, exists = requests.ForTx(key)
+	require.True(t, exists)
+	require.Equal(t, peerB, peer)
+
+	// record a response from peerB
+	require.True(t, requests.MarkReceived(peerB, key))
+
+	// peerA comes in later with a response but it's still
+	// considered a response from an earlier request
+	require.True(t, requests.MarkReceived(peerA, key))
+}
+
+func TestRequestSchedulerNonResponsivePeer(t *testing.T) {
+	var (
+		requests = newRequestScheduler(10*time.Millisecond, time.Millisecond)
+		tx       = types.Tx("tx")
+		key      = tx.Key()
+		peerA    = p2p.ID("1") // should be non-zero
+	)
+
+	require.True(t, requests.Add(key, peerA, nil))
+	require.Eventually(t, func() bool {
+		_, exists := requests.ForTx(key)
+		return !exists
+	}, 100*time.Millisecond, 5*time.Millisecond)
+}
+
+func TestRequestSchedulerConcurrencyAddsAndReads(t *testing.T) {
+	leaktest.CheckTimeout(t, time.Second)()
+	requests := newRequestScheduler(10*time.Millisecond, time.Millisecond)
+	defer requests.Close()
+
+	N := 5
+	keys := make([]types.TxKey, N)
+	for i := 0; i < N; i++ {
+		tx := types.Tx(fmt.Sprintf("tx%d", i))
+		keys[i] = tx.Key()
+	}
+
+	addWg := sync.WaitGroup{}
+	receiveWg := sync.WaitGroup{}
+	doneCh := make(chan struct{})
+	for i := 1; i < N*N; i++ {
+		addWg.Add(1)
+		go func(i int) {
+			defer addWg.Done()
+			peerID := p2p.ID(fmt.Sprintf("%d", i))
+			requests.Add(keys[i%N], peerID, nil)
+		}(i)
+	}
+	for i := 1; i < N*N; i++ {
+		receiveWg.Add(1)
+		go func(peer p2p.ID) {
+			defer receiveWg.Done()
+			markReceived := func() {
+				for _, key := range keys {
+					if requests.Has(peer, key) {
+						requests.MarkReceived(peer, key)
+					}
+				}
+			}
+			for {
+				select {
+				case <-doneCh:
+					// need to ensure this is run
+					// at least once after all adds
+					// are done
+					markReceived()
+					return
+				default:
+					markReceived()
+				}
+			}
+		}(p2p.ID(fmt.Sprintf("%d", i)))
+	}
+	addWg.Wait()
+	close(doneCh)
+
+	receiveWg.Wait()
+
+	for _, key := range keys {
+		_, exists := requests.ForTx(key)
+		require.False(t, exists)
+	}
+}

--- a/mempool/cat/seen_txs.go
+++ b/mempool/cat/seen_txs.go
@@ -1,0 +1,127 @@
+package cat
+
+import (
+	"time"
+
+	cmtsync "github.com/cometbft/cometbft/libs/sync"
+	"github.com/cometbft/cometbft/p2p"
+	"github.com/cometbft/cometbft/types"
+)
+
+// SeenTxSet records transactions that have been
+// seen by other peers but not yet by us
+type SeenTxSet struct {
+	mtx cmtsync.Mutex
+	set map[types.TxKey]timestampedPeerSet
+}
+
+type timestampedPeerSet struct {
+	peers map[p2p.ID]struct{}
+	time  time.Time // time at which the set was created
+}
+
+func NewSeenTxSet() *SeenTxSet {
+	return &SeenTxSet{
+		set: make(map[types.TxKey]timestampedPeerSet),
+	}
+}
+
+func (s *SeenTxSet) Add(txKey types.TxKey, peer p2p.ID) {
+	// if peer == 0 {
+	// 	return
+	// }
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	seenSet, exists := s.set[txKey]
+	if !exists {
+		s.set[txKey] = timestampedPeerSet{
+			peers: map[p2p.ID]struct{}{peer: {}},
+			time:  time.Now().UTC(),
+		}
+	} else {
+		seenSet.peers[peer] = struct{}{}
+	}
+}
+
+// only used in tests
+func (s *SeenTxSet) Pop(txKey types.TxKey) *p2p.ID {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	seenSet, exists := s.set[txKey]
+	if exists {
+		for peer := range seenSet.peers {
+			delete(seenSet.peers, peer)
+			return &peer
+		}
+	}
+	return nil
+}
+
+func (s *SeenTxSet) RemoveKey(txKey types.TxKey) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	delete(s.set, txKey)
+}
+
+func (s *SeenTxSet) Remove(txKey types.TxKey, peer p2p.ID) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	set, exists := s.set[txKey]
+	if exists {
+		if len(set.peers) == 1 {
+			delete(s.set, txKey)
+		} else {
+			delete(set.peers, peer)
+		}
+	}
+}
+
+// not used
+// func (s *SeenTxSet) Prune(limit time.Time) {
+// 	s.mtx.Lock()
+// 	defer s.mtx.Unlock()
+// 	for key, seenSet := range s.set {
+// 		if seenSet.time.Before(limit) {
+// 			delete(s.set, key)
+// 		}
+// 	}
+// }
+
+func (s *SeenTxSet) Has(txKey types.TxKey, peer p2p.ID) bool {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	seenSet, exists := s.set[txKey]
+	if !exists {
+		return false
+	}
+	_, has := seenSet.peers[peer]
+	return has
+}
+
+func (s *SeenTxSet) Get(txKey types.TxKey) map[p2p.ID]struct{} {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	seenSet, exists := s.set[txKey]
+	if !exists {
+		return nil
+	}
+	// make a copy of the struct to avoid concurrency issues
+	peers := make(map[p2p.ID]struct{}, len(seenSet.peers))
+	for peer := range seenSet.peers {
+		peers[peer] = struct{}{}
+	}
+	return peers
+}
+
+// Len returns the amount of cached items. Mostly used for testing.
+func (s *SeenTxSet) Len() int {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	return len(s.set)
+}
+
+func (s *SeenTxSet) Reset() {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	s.set = make(map[types.TxKey]timestampedPeerSet)
+}

--- a/mempool/cat/seen_txs_test.go
+++ b/mempool/cat/seen_txs_test.go
@@ -1,0 +1,85 @@
+package cat
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/p2p"
+	"github.com/cometbft/cometbft/types"
+)
+
+func TestSeenTxSet(t *testing.T) {
+	var (
+		tx1Key = types.Tx("tx1").Key()
+		tx2Key = types.Tx("tx2").Key()
+		tx3Key = types.Tx("tx3").Key()
+		peer1  = p2p.ID("1")
+		peer2  = p2p.ID("2")
+	)
+
+	seenSet := NewSeenTxSet()
+	require.Zero(t, seenSet.Pop(tx1Key))
+
+	seenSet.Add(tx1Key, peer1)
+	seenSet.Add(tx1Key, peer1)
+	require.Equal(t, 1, seenSet.Len())
+	seenSet.Add(tx1Key, peer2)
+	peers := seenSet.Get(tx1Key)
+	require.NotNil(t, peers)
+	require.Equal(t, map[p2p.ID]struct{}{peer1: {}, peer2: {}}, peers)
+	seenSet.Add(tx2Key, peer1)
+	seenSet.Add(tx3Key, peer1)
+	require.Equal(t, 3, seenSet.Len())
+	seenSet.RemoveKey(tx2Key)
+	require.Equal(t, 2, seenSet.Len())
+	require.Zero(t, seenSet.Pop(tx2Key))
+	require.Equal(t, peer1, *seenSet.Pop(tx3Key))
+}
+
+func TestSeenTxSetConcurrency(t *testing.T) {
+	seenSet := NewSeenTxSet()
+
+	const (
+		concurrency = 10
+		numTx       = 100
+	)
+
+	wg := sync.WaitGroup{}
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func(i uint16) {
+			defer wg.Done()
+			for i := 0; i < numTx; i++ {
+				tx := types.Tx([]byte(fmt.Sprintf("tx%d", i)))
+				seenSet.Add(tx.Key(), p2p.ID(fmt.Sprintf("%d", i)))
+			}
+		}(uint16(i % 2))
+	}
+	time.Sleep(time.Millisecond)
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func(peer uint16) {
+			defer wg.Done()
+			for i := 0; i < numTx; i++ {
+				tx := types.Tx([]byte(fmt.Sprintf("tx%d", i)))
+				seenSet.Has(tx.Key(), p2p.ID(fmt.Sprintf("%d", i)))
+			}
+		}(uint16(i % 2))
+	}
+	time.Sleep(time.Millisecond)
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func(peer uint16) {
+			defer wg.Done()
+			for i := numTx - 1; i >= 0; i-- {
+				tx := types.Tx([]byte(fmt.Sprintf("tx%d", i)))
+				seenSet.RemoveKey(tx.Key())
+			}
+		}(uint16(i % 2))
+	}
+	wg.Wait()
+}

--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -137,8 +137,8 @@ func TestReapMaxBytesMaxGas(t *testing.T) {
 	defer cleanup()
 
 	// Ensure gas calculation behaves as expected
-	checkTxs(t, mp, 1, UnknownPeerID)
-	tx0 := mp.TxsFront().Value.(*mempoolTx)
+	checkTxs(t, mp, 1)
+	tx0 := mp.TxsFront().Value.(*MempoolTx)
 	require.Equal(t, tx0.gasWanted, int64(1), "transactions gas was set incorrectly")
 	// ensure each tx is 20 bytes long
 	require.Equal(t, len(tx0.tx), 20, "Tx is longer than 20 bytes")
@@ -351,7 +351,7 @@ func TestMempool_KeepInvalidTxsInCache(t *testing.T) {
 		binary.BigEndian.PutUint64(a, 0)
 
 		// remove a from the cache to test (2)
-		mp.cache.Remove(a)
+		mp.cache.Remove(types.Tx(a).Key())
 
 		err := mp.CheckTx(a, nil, TxInfo{})
 		require.NoError(t, err)
@@ -661,8 +661,8 @@ func TestMempoolNoCacheOverflow(t *testing.T) {
 	defer cleanup()
 
 	// add tx0
-	var tx0 = kvstore.NewTxFromID(0)
-	err := mp.CheckTx(tx0, nil, TxInfo{})
+	tx0 := types.Tx(kvstore.NewTxFromID(0))
+	_, err := mp.CheckTx(tx0)
 	require.NoError(t, err)
 	err = mp.FlushAppConn()
 	require.NoError(t, err)
@@ -674,7 +674,7 @@ func TestMempoolNoCacheOverflow(t *testing.T) {
 	}
 	err = mp.FlushAppConn()
 	require.NoError(t, err)
-	assert.False(t, mp.cache.Has(kvstore.NewTxFromID(0)))
+	assert.False(t, mp.cache.Has(tx0.Key()))
 
 	// add again tx0
 	err = mp.CheckTx(tx0, nil, TxInfo{})
@@ -685,7 +685,7 @@ func TestMempoolNoCacheOverflow(t *testing.T) {
 	// tx0 should appear only once in mp.txs
 	found := 0
 	for e := mp.txs.Front(); e != nil; e = e.Next() {
-		if types.Tx.Key(e.Value.(*mempoolTx).tx) == types.Tx.Key(tx0) {
+		if types.Tx.Key(e.Value.(*MempoolTx).tx) == types.Tx.Key(tx0) {
 			found++
 		}
 	}

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 
+	abcicli "github.com/cometbft/cometbft/abci/client"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/types"
 )
@@ -32,7 +33,12 @@ const (
 type Mempool interface {
 	// CheckTx executes a new transaction against the application to determine
 	// its validity and whether it should be added to the mempool.
-	CheckTx(tx types.Tx, callback func(*abci.ResponseCheckTx), txInfo TxInfo) error
+	CheckTx(tx types.Tx) (*abcicli.ReqRes, error)
+
+	// From RPC endpoint
+	CheckNewTx(tx types.Tx) (*abcicli.ReqRes, error)
+
+	InvokeNewTxReceivedOnReactor(txKey types.TxKey)
 
 	// RemoveTxByKey removes a transaction, identified by its key,
 	// from the mempool.

--- a/mempool/mempoolTx.go
+++ b/mempool/mempoolTx.go
@@ -7,8 +7,8 @@ import (
 	"github.com/cometbft/cometbft/types"
 )
 
-// mempoolTx is an entry in the mempool
-type mempoolTx struct {
+// MempoolTx is an entry in the mempool
+type MempoolTx struct {
 	height    int64    // height that this tx had been validated in
 	gasWanted int64    // amount of gas this tx states it will require
 	tx        types.Tx // validated by the application
@@ -19,16 +19,20 @@ type mempoolTx struct {
 }
 
 // Height returns the height for this transaction
-func (memTx *mempoolTx) Height() int64 {
+func (memTx *MempoolTx) Height() int64 {
 	return atomic.LoadInt64(&memTx.height)
 }
 
-func (memTx *mempoolTx) isSender(peerID uint16) bool {
+func (memTx *MempoolTx) isSender(peerID uint16) bool {
 	_, ok := memTx.senders.Load(peerID)
 	return ok
 }
 
-func (memTx *mempoolTx) addSender(senderID uint16) bool {
+func (memTx *MempoolTx) addSender(senderID uint16) bool {
 	_, added := memTx.senders.LoadOrStore(senderID, true)
 	return added
+}
+
+func (memTx *MempoolTx) GetTx() types.Tx {
+	return memTx.tx
 }

--- a/mempool/metrics.gen.go
+++ b/mempool/metrics.gen.go
@@ -64,11 +64,30 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Name:      "active_outbound_connections",
 			Help:      "Number of connections being actively used for gossiping transactions (experimental feature).",
 		}, labels).With(labelsAndValues...),
+		RequestedTxs: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "requested_txs",
+			Help:      "Number of requested transactions (WantTx messages).",
+		}, labels).With(labelsAndValues...),
+		RerequestedTxs: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "rerequested_txs",
+			Help:      "Number of re-requested transactions.",
+		}, labels).With(labelsAndValues...),
+		NoPeerForTx: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "no_peer_for_tx",
+			Help:      "Number of times we cannot find a peer for a tx.",
+		}, labels).With(labelsAndValues...),
 	}
 }
 
 func NopMetrics() *Metrics {
 	return &Metrics{
+<<<<<<< HEAD
 		Size:                      discard.NewGauge(),
 		SizeBytes:                 discard.NewGauge(),
 		TxSizeBytes:               discard.NewHistogram(),
@@ -77,5 +96,16 @@ func NopMetrics() *Metrics {
 		EvictedTxs:                discard.NewCounter(),
 		RecheckTimes:              discard.NewCounter(),
 		ActiveOutboundConnections: discard.NewGauge(),
+=======
+		Size:               discard.NewGauge(),
+		TxSizeBytes:        discard.NewHistogram(),
+		FailedTxs:          discard.NewCounter(),
+		RejectedTxs:        discard.NewCounter(),
+		RecheckTimes:       discard.NewCounter(),
+		AlreadyReceivedTxs: discard.NewCounter(),
+		RequestedTxs:       discard.NewCounter(),
+		RerequestedTxs:     discard.NewCounter(),
+		NoPeerForTx:        discard.NewCounter(),
+>>>>>>> 094c67101 (Add CAT mempool reactor)
 	}
 }

--- a/mempool/metrics.go
+++ b/mempool/metrics.go
@@ -34,6 +34,10 @@ type Metrics struct {
 	//metrics:Number of rejected transactions.
 	RejectedTxs metrics.Counter
 
+	// Number of times transactions were received more than once.
+	//metrics:Number of duplicate transaction reception.
+	AlreadyReceivedTxs metrics.Counter
+
 	// EvictedTxs defines the number of evicted transactions. These are valid
 	// transactions that passed CheckTx and existed in the mempool but were later
 	// evicted to make room for higher priority valid transactions that passed
@@ -47,4 +51,20 @@ type Metrics struct {
 	// Number of connections being actively used for gossiping transactions
 	// (experimental feature).
 	ActiveOutboundConnections metrics.Gauge
+
+	// RequestedTxs defines the number of times that the node requested a
+	// tx to a peer
+	//metrics:Number of requested transactions (WantTx messages).
+	RequestedTxs metrics.Counter
+
+	// RerequestedTxs defines the number of times that a requested tx
+	// never received a response in time and a new request was made.
+	//metrics:Number of re-requested transactions.
+	RerequestedTxs metrics.Counter
+
+	// NoPeerForTx counts the number of times the reactor exhaust the list of
+	// peers looking for a transaction for which it has received a SeenTx
+	// message.
+	//metrics:Number of times we cannot find a peer for a tx.
+	NoPeerForTx metrics.Counter
 }

--- a/mempool/mocks/mempool.go
+++ b/mempool/mocks/mempool.go
@@ -16,9 +16,54 @@ type Mempool struct {
 	mock.Mock
 }
 
+<<<<<<< HEAD
 // CheckTx provides a mock function with given fields: tx, callback, txInfo
 func (_m *Mempool) CheckTx(tx types.Tx, callback func(*abcitypes.ResponseCheckTx), txInfo mempool.TxInfo) error {
 	ret := _m.Called(tx, callback, txInfo)
+=======
+// CheckNewTx provides a mock function with given fields: tx
+func (_m *Mempool) CheckNewTx(tx types.Tx) (*abcicli.ReqRes, error) {
+	ret := _m.Called(tx)
+
+	var r0 *abcicli.ReqRes
+	var r1 error
+	if rf, ok := ret.Get(0).(func(types.Tx) (*abcicli.ReqRes, error)); ok {
+		return rf(tx)
+	}
+	if rf, ok := ret.Get(0).(func(types.Tx) *abcicli.ReqRes); ok {
+		r0 = rf(tx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*abcicli.ReqRes)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(types.Tx) error); ok {
+		r1 = rf(tx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// CheckTx provides a mock function with given fields: tx
+func (_m *Mempool) CheckTx(tx types.Tx) (*abcicli.ReqRes, error) {
+	ret := _m.Called(tx)
+
+	var r0 *abcicli.ReqRes
+	var r1 error
+	if rf, ok := ret.Get(0).(func(types.Tx) (*abcicli.ReqRes, error)); ok {
+		return rf(tx)
+	}
+	if rf, ok := ret.Get(0).(func(types.Tx) *abcicli.ReqRes); ok {
+		r0 = rf(tx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*abcicli.ReqRes)
+		}
+	}
+>>>>>>> 094c67101 (Add CAT mempool reactor)
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(types.Tx, func(*abcitypes.ResponseCheckTx), mempool.TxInfo) error); ok {
@@ -52,6 +97,11 @@ func (_m *Mempool) FlushAppConn() error {
 	}
 
 	return r0
+}
+
+// InvokeNewTxReceivedOnReactor provides a mock function with given fields: txKey
+func (_m *Mempool) InvokeNewTxReceivedOnReactor(txKey types.TxKey) {
+	_m.Called(txKey)
 }
 
 // Lock provides a mock function with given fields:

--- a/mempool/reactor_test.go
+++ b/mempool/reactor_test.go
@@ -327,8 +327,7 @@ func makeAndConnectReactors(config *cfg.Config, n int) ([]*Reactor, []*p2p.Switc
 		mempool, cleanup := newMempoolWithApp(cc)
 		defer cleanup()
 
-		reactors[i] = NewReactor(config.Mempool, mempool) // so we dont start the consensus states
-		reactors[i].SetLogger(logger.With("validator", i))
+		reactors[i] = NewReactor(config.Mempool, mempool, logger.With("validator", i)) // so we don't start the consensus states
 	}
 
 	switches := p2p.MakeConnectedSwitches(config.P2P, n, func(i int, s *p2p.Switch) *p2p.Switch {

--- a/node/node.go
+++ b/node/node.go
@@ -19,6 +19,7 @@ import (
 	cs "github.com/cometbft/cometbft/consensus"
 	"github.com/cometbft/cometbft/evidence"
 	"github.com/cometbft/cometbft/light"
+	"github.com/cometbft/cometbft/mempool/cat"
 
 	"github.com/cometbft/cometbft/libs/log"
 	cmtpubsub "github.com/cometbft/cometbft/libs/pubsub"
@@ -371,7 +372,10 @@ func NewNodeWithContext(ctx context.Context,
 	logNodeStartupInfo(state, pubKey, logger, consensusLogger)
 
 	// Make MempoolReactor
-	mempool, mempoolReactor := createMempoolAndMempoolReactor(config, proxyApp, state, memplMetrics, logger)
+	mempool, mempoolReactor, err := createMempoolAndMempoolReactor(config, proxyApp, state, memplMetrics, logger)
+	if err != nil {
+		return nil, err
+	}
 
 	// Make Evidence Reactor
 	evidenceReactor, evidencePool, err := createEvidenceReactor(config, dbProvider, stateStore, blockStore, logger)
@@ -1026,6 +1030,10 @@ func makeNodeInfo(
 
 	if config.P2P.PexReactor {
 		nodeInfo.Channels = append(nodeInfo.Channels, pex.PexChannel)
+	}
+
+	if config.Mempool.Reactor == "cat" {
+		nodeInfo.Channels = append(nodeInfo.Channels, cat.MempoolStateChannel)
 	}
 
 	lAddr := config.P2P.ExternalAddress

--- a/proto/tendermint/mempool/message.go
+++ b/proto/tendermint/mempool/message.go
@@ -8,13 +8,31 @@ import (
 	"github.com/cometbft/cometbft/p2p"
 )
 
-var _ p2p.Wrapper = &Txs{}
-var _ p2p.Unwrapper = &Message{}
+var (
+	_ p2p.Wrapper   = &Txs{}
+	_ p2p.Wrapper   = &SeenTx{}
+	_ p2p.Wrapper   = &WantTx{}
+	_ p2p.Unwrapper = &Message{}
+)
 
 // Wrap implements the p2p Wrapper interface and wraps a mempool message.
 func (m *Txs) Wrap() proto.Message {
 	mm := &Message{}
 	mm.Sum = &Message_Txs{Txs: m}
+	return mm
+}
+
+// Wrap implements the p2p Wrapper interface and wraps a mempool seen tx message.
+func (m *SeenTx) Wrap() proto.Message {
+	mm := &Message{}
+	mm.Sum = &Message_SeenTx{SeenTx: m}
+	return mm
+}
+
+// Wrap implements the p2p Wrapper interface and wraps a mempool want tx message.
+func (m *WantTx) Wrap() proto.Message {
+	mm := &Message{}
+	mm.Sum = &Message_WantTx{WantTx: m}
 	return mm
 }
 
@@ -24,6 +42,12 @@ func (m *Message) Unwrap() (proto.Message, error) {
 	switch msg := m.Sum.(type) {
 	case *Message_Txs:
 		return m.GetTxs(), nil
+
+	case *Message_SeenTx:
+		return m.GetSeenTx(), nil
+
+	case *Message_WantTx:
+		return m.GetWantTx(), nil
 
 	default:
 		return nil, fmt.Errorf("unknown message: %T", msg)

--- a/proto/tendermint/mempool/types.pb.go
+++ b/proto/tendermint/mempool/types.pb.go
@@ -66,10 +66,100 @@ func (m *Txs) GetTxs() [][]byte {
 	return nil
 }
 
+type SeenTx struct {
+	TxKey []byte `protobuf:"bytes,1,opt,name=tx_key,json=txKey,proto3" json:"tx_key,omitempty"`
+}
+
+func (m *SeenTx) Reset()         { *m = SeenTx{} }
+func (m *SeenTx) String() string { return proto.CompactTextString(m) }
+func (*SeenTx) ProtoMessage()    {}
+func (*SeenTx) Descriptor() ([]byte, []int) {
+	return fileDescriptor_2af51926fdbcbc05, []int{1}
+}
+func (m *SeenTx) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *SeenTx) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_SeenTx.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *SeenTx) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SeenTx.Merge(m, src)
+}
+func (m *SeenTx) XXX_Size() int {
+	return m.Size()
+}
+func (m *SeenTx) XXX_DiscardUnknown() {
+	xxx_messageInfo_SeenTx.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_SeenTx proto.InternalMessageInfo
+
+func (m *SeenTx) GetTxKey() []byte {
+	if m != nil {
+		return m.TxKey
+	}
+	return nil
+}
+
+type WantTx struct {
+	TxKey []byte `protobuf:"bytes,1,opt,name=tx_key,json=txKey,proto3" json:"tx_key,omitempty"`
+}
+
+func (m *WantTx) Reset()         { *m = WantTx{} }
+func (m *WantTx) String() string { return proto.CompactTextString(m) }
+func (*WantTx) ProtoMessage()    {}
+func (*WantTx) Descriptor() ([]byte, []int) {
+	return fileDescriptor_2af51926fdbcbc05, []int{2}
+}
+func (m *WantTx) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *WantTx) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_WantTx.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *WantTx) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_WantTx.Merge(m, src)
+}
+func (m *WantTx) XXX_Size() int {
+	return m.Size()
+}
+func (m *WantTx) XXX_DiscardUnknown() {
+	xxx_messageInfo_WantTx.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_WantTx proto.InternalMessageInfo
+
+func (m *WantTx) GetTxKey() []byte {
+	if m != nil {
+		return m.TxKey
+	}
+	return nil
+}
+
 type Message struct {
 	// Types that are valid to be assigned to Sum:
 	//
 	//	*Message_Txs
+	//	*Message_SeenTx
+	//	*Message_WantTx
 	Sum isMessage_Sum `protobuf_oneof:"sum"`
 }
 
@@ -77,7 +167,7 @@ func (m *Message) Reset()         { *m = Message{} }
 func (m *Message) String() string { return proto.CompactTextString(m) }
 func (*Message) ProtoMessage()    {}
 func (*Message) Descriptor() ([]byte, []int) {
-	return fileDescriptor_2af51926fdbcbc05, []int{1}
+	return fileDescriptor_2af51926fdbcbc05, []int{3}
 }
 func (m *Message) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -115,8 +205,16 @@ type isMessage_Sum interface {
 type Message_Txs struct {
 	Txs *Txs `protobuf:"bytes,1,opt,name=txs,proto3,oneof" json:"txs,omitempty"`
 }
+type Message_SeenTx struct {
+	SeenTx *SeenTx `protobuf:"bytes,2,opt,name=seen_tx,json=seenTx,proto3,oneof" json:"seen_tx,omitempty"`
+}
+type Message_WantTx struct {
+	WantTx *WantTx `protobuf:"bytes,3,opt,name=want_tx,json=wantTx,proto3,oneof" json:"want_tx,omitempty"`
+}
 
-func (*Message_Txs) isMessage_Sum() {}
+func (*Message_Txs) isMessage_Sum()    {}
+func (*Message_SeenTx) isMessage_Sum() {}
+func (*Message_WantTx) isMessage_Sum() {}
 
 func (m *Message) GetSum() isMessage_Sum {
 	if m != nil {
@@ -132,34 +230,58 @@ func (m *Message) GetTxs() *Txs {
 	return nil
 }
 
+func (m *Message) GetSeenTx() *SeenTx {
+	if x, ok := m.GetSum().(*Message_SeenTx); ok {
+		return x.SeenTx
+	}
+	return nil
+}
+
+func (m *Message) GetWantTx() *WantTx {
+	if x, ok := m.GetSum().(*Message_WantTx); ok {
+		return x.WantTx
+	}
+	return nil
+}
+
 // XXX_OneofWrappers is for the internal use of the proto package.
 func (*Message) XXX_OneofWrappers() []interface{} {
 	return []interface{}{
 		(*Message_Txs)(nil),
+		(*Message_SeenTx)(nil),
+		(*Message_WantTx)(nil),
 	}
 }
 
 func init() {
 	proto.RegisterType((*Txs)(nil), "tendermint.mempool.Txs")
+	proto.RegisterType((*SeenTx)(nil), "tendermint.mempool.SeenTx")
+	proto.RegisterType((*WantTx)(nil), "tendermint.mempool.WantTx")
 	proto.RegisterType((*Message)(nil), "tendermint.mempool.Message")
 }
 
 func init() { proto.RegisterFile("tendermint/mempool/types.proto", fileDescriptor_2af51926fdbcbc05) }
 
 var fileDescriptor_2af51926fdbcbc05 = []byte{
-	// 184 bytes of a gzipped FileDescriptorProto
+	// 274 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x2b, 0x49, 0xcd, 0x4b,
 	0x49, 0x2d, 0xca, 0xcd, 0xcc, 0x2b, 0xd1, 0xcf, 0x4d, 0xcd, 0x2d, 0xc8, 0xcf, 0xcf, 0xd1, 0x2f,
 	0xa9, 0x2c, 0x48, 0x2d, 0xd6, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0x12, 0x42, 0xc8, 0xeb, 0x41,
 	0xe5, 0x95, 0xc4, 0xb9, 0x98, 0x43, 0x2a, 0x8a, 0x85, 0x04, 0xb8, 0x98, 0x4b, 0x2a, 0x8a, 0x25,
-	0x18, 0x15, 0x98, 0x35, 0x78, 0x82, 0x40, 0x4c, 0x25, 0x5b, 0x2e, 0x76, 0xdf, 0xd4, 0xe2, 0xe2,
-	0xc4, 0xf4, 0x54, 0x21, 0x6d, 0x98, 0x24, 0xa3, 0x06, 0xb7, 0x91, 0xb8, 0x1e, 0xa6, 0x29, 0x7a,
-	0x21, 0x15, 0xc5, 0x1e, 0x0c, 0x60, 0x7d, 0x4e, 0xac, 0x5c, 0xcc, 0xc5, 0xa5, 0xb9, 0x4e, 0xfe,
-	0x27, 0x1e, 0xc9, 0x31, 0x5e, 0x78, 0x24, 0xc7, 0xf8, 0xe0, 0x91, 0x1c, 0xe3, 0x84, 0xc7, 0x72,
-	0x0c, 0x17, 0x1e, 0xcb, 0x31, 0xdc, 0x78, 0x2c, 0xc7, 0x10, 0x65, 0x9a, 0x9e, 0x59, 0x92, 0x51,
-	0x9a, 0xa4, 0x97, 0x9c, 0x9f, 0xab, 0x9f, 0x9c, 0x9f, 0x9b, 0x5a, 0x92, 0x94, 0x56, 0x82, 0x60,
-	0x80, 0x5d, 0xaa, 0x8f, 0xe9, 0x91, 0x24, 0x36, 0xb0, 0x8c, 0x31, 0x20, 0x00, 0x00, 0xff, 0xff,
-	0x53, 0xc3, 0xc4, 0x0a, 0xe5, 0x00, 0x00, 0x00,
+	0x18, 0x15, 0x98, 0x35, 0x78, 0x82, 0x40, 0x4c, 0x25, 0x79, 0x2e, 0xb6, 0xe0, 0xd4, 0xd4, 0xbc,
+	0x90, 0x0a, 0x21, 0x51, 0x2e, 0xb6, 0x92, 0x8a, 0xf8, 0xec, 0xd4, 0x4a, 0x09, 0x46, 0x05, 0x46,
+	0x0d, 0x9e, 0x20, 0xd6, 0x92, 0x0a, 0xef, 0xd4, 0x4a, 0x90, 0x82, 0xf0, 0xc4, 0xbc, 0x12, 0xdc,
+	0x0a, 0x56, 0x33, 0x72, 0xb1, 0xfb, 0xa6, 0x16, 0x17, 0x27, 0xa6, 0xa7, 0x0a, 0x69, 0xc3, 0xcc,
+	0x67, 0xd4, 0xe0, 0x36, 0x12, 0xd7, 0xc3, 0x74, 0x88, 0x5e, 0x48, 0x45, 0xb1, 0x07, 0x03, 0xd8,
+	0x6a, 0x21, 0x53, 0x2e, 0xf6, 0xe2, 0xd4, 0xd4, 0xbc, 0xf8, 0x92, 0x0a, 0x09, 0x26, 0xb0, 0x06,
+	0x29, 0x6c, 0x1a, 0x20, 0xae, 0xf3, 0x60, 0x08, 0x62, 0x2b, 0x86, 0xb8, 0xd3, 0x94, 0x8b, 0xbd,
+	0x3c, 0x31, 0xaf, 0x04, 0xa4, 0x8d, 0x19, 0xb7, 0x36, 0x88, 0x9b, 0x41, 0xda, 0xca, 0xc1, 0x2c,
+	0x27, 0x56, 0x2e, 0xe6, 0xe2, 0xd2, 0x5c, 0x27, 0xff, 0x13, 0x8f, 0xe4, 0x18, 0x2f, 0x3c, 0x92,
+	0x63, 0x7c, 0xf0, 0x48, 0x8e, 0x71, 0xc2, 0x63, 0x39, 0x86, 0x0b, 0x8f, 0xe5, 0x18, 0x6e, 0x3c,
+	0x96, 0x63, 0x88, 0x32, 0x4d, 0xcf, 0x2c, 0xc9, 0x28, 0x4d, 0xd2, 0x4b, 0xce, 0xcf, 0xd5, 0x4f,
+	0xce, 0xcf, 0x4d, 0x2d, 0x49, 0x4a, 0x2b, 0x41, 0x30, 0xc0, 0x41, 0xab, 0x8f, 0x19, 0xf2, 0x49,
+	0x6c, 0x60, 0x19, 0x63, 0x40, 0x00, 0x00, 0x00, 0xff, 0xff, 0x66, 0x7b, 0xde, 0x37, 0x96, 0x01,
+	0x00, 0x00,
 }
 
 func (m *Txs) Marshal() (dAtA []byte, err error) {
@@ -190,6 +312,66 @@ func (m *Txs) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 			i--
 			dAtA[i] = 0xa
 		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *SeenTx) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *SeenTx) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *SeenTx) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.TxKey) > 0 {
+		i -= len(m.TxKey)
+		copy(dAtA[i:], m.TxKey)
+		i = encodeVarintTypes(dAtA, i, uint64(len(m.TxKey)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *WantTx) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *WantTx) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *WantTx) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.TxKey) > 0 {
+		i -= len(m.TxKey)
+		copy(dAtA[i:], m.TxKey)
+		i = encodeVarintTypes(dAtA, i, uint64(len(m.TxKey)))
+		i--
+		dAtA[i] = 0xa
 	}
 	return len(dAtA) - i, nil
 }
@@ -247,6 +429,48 @@ func (m *Message_Txs) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+func (m *Message_SeenTx) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Message_SeenTx) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.SeenTx != nil {
+		{
+			size, err := m.SeenTx.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintTypes(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x12
+	}
+	return len(dAtA) - i, nil
+}
+func (m *Message_WantTx) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Message_WantTx) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.WantTx != nil {
+		{
+			size, err := m.WantTx.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintTypes(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x1a
+	}
+	return len(dAtA) - i, nil
+}
 func encodeVarintTypes(dAtA []byte, offset int, v uint64) int {
 	offset -= sovTypes(v)
 	base := offset
@@ -273,6 +497,32 @@ func (m *Txs) Size() (n int) {
 	return n
 }
 
+func (m *SeenTx) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.TxKey)
+	if l > 0 {
+		n += 1 + l + sovTypes(uint64(l))
+	}
+	return n
+}
+
+func (m *WantTx) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.TxKey)
+	if l > 0 {
+		n += 1 + l + sovTypes(uint64(l))
+	}
+	return n
+}
+
 func (m *Message) Size() (n int) {
 	if m == nil {
 		return 0
@@ -293,6 +543,30 @@ func (m *Message_Txs) Size() (n int) {
 	_ = l
 	if m.Txs != nil {
 		l = m.Txs.Size()
+		n += 1 + l + sovTypes(uint64(l))
+	}
+	return n
+}
+func (m *Message_SeenTx) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.SeenTx != nil {
+		l = m.SeenTx.Size()
+		n += 1 + l + sovTypes(uint64(l))
+	}
+	return n
+}
+func (m *Message_WantTx) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.WantTx != nil {
+		l = m.WantTx.Size()
 		n += 1 + l + sovTypes(uint64(l))
 	}
 	return n
@@ -386,6 +660,174 @@ func (m *Txs) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+func (m *SeenTx) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTypes
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SeenTx: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SeenTx: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TxKey", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthTypes
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.TxKey = append(m.TxKey[:0], dAtA[iNdEx:postIndex]...)
+			if m.TxKey == nil {
+				m.TxKey = []byte{}
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTypes(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *WantTx) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTypes
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: WantTx: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: WantTx: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TxKey", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthTypes
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.TxKey = append(m.TxKey[:0], dAtA[iNdEx:postIndex]...)
+			if m.TxKey == nil {
+				m.TxKey = []byte{}
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTypes(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *Message) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -449,6 +891,76 @@ func (m *Message) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			m.Sum = &Message_Txs{v}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SeenTx", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTypes
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			v := &SeenTx{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			m.Sum = &Message_SeenTx{v}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field WantTx", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTypes
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			v := &WantTx{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			m.Sum = &Message_WantTx{v}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/proto/tendermint/mempool/types.proto
+++ b/proto/tendermint/mempool/types.proto
@@ -7,8 +7,18 @@ message Txs {
   repeated bytes txs = 1;
 }
 
+message SeenTx {
+  bytes tx_key = 1;
+}
+
+message WantTx {
+  bytes tx_key = 1;
+}
+
 message Message {
   oneof sum {
-    Txs txs = 1;
+    Txs    txs     = 1;
+    SeenTx seen_tx = 2;
+    WantTx want_tx = 3;
   }
 }

--- a/types/tx.go
+++ b/types/tx.go
@@ -39,6 +39,19 @@ func (tx Tx) String() string {
 	return fmt.Sprintf("Tx{%X}", []byte(tx))
 }
 
+func (key TxKey) String() string {
+	return fmt.Sprintf("TxKey{%X}", key[:])
+}
+
+func TxKeyFromBytes(bytes []byte) (TxKey, error) {
+	if len(bytes) != TxKeySize {
+		return TxKey{}, fmt.Errorf("incorrect tx key size. Expected %d bytes, got %d", TxKeySize, len(bytes))
+	}
+	var key TxKey
+	copy(key[:], bytes)
+	return key, nil
+}
+
 // Txs is a slice of Tx.
 type Txs []Tx
 
@@ -156,7 +169,6 @@ func (tp TxProof) Validate(dataHash []byte) error {
 }
 
 func (tp TxProof) ToProto() cmtproto.TxProof {
-
 	pbProof := tp.Proof.ToProto()
 
 	pbtp := cmtproto.TxProof{
@@ -167,8 +179,8 @@ func (tp TxProof) ToProto() cmtproto.TxProof {
 
 	return pbtp
 }
-func TxProofFromProto(pb cmtproto.TxProof) (TxProof, error) {
 
+func TxProofFromProto(pb cmtproto.TxProof) (TxProof, error) {
 	pbProof, err := merkle.ProofFromProto(pb.Proof)
 	if err != nil {
 		return TxProof{}, err


### PR DESCRIPTION
This is a port of the first commit from Hernan's work from branch `experimental/cat` onto v0.38-exp line. Specifically, I used the following command:

	git rebase --onto experimental/cat/0.38 0fa29a58ee82b81ffb735f9b296eb451a36c1e6d 094c67101a55acc4bf931cdacb4cc8576aa7fc47

Where:
- experimental/cat/0.38 is a new branch based on v0.38.x-experimental
- 094c67101a55acc4bf931cdacb4cc8576aa7fc47 is the first commit in Hernan's branch
- 0fa29a58ee82b81ffb735f9b296eb451a36c1e6d is the parent of the first commit.

Next steps:
1. Fix mockery & tests
2. Continue porting the other commits from Hernan's branch.

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

