### PR TITLE
Fix `SaveBlockStoreState` signature on `v0.38.x`

### DIFF
--- a/store/store_test.go
+++ b/store/store_test.go
@@ -86,7 +86,7 @@ func TestLoadBlockStoreState(t *testing.T) {
 	for _, tc := range testCases {
 		db := dbm.NewMemDB()
 		batch := db.NewBatch()
-		SaveBlockStoreState(tc.bss, batch)
+		SaveBlockStoreStateBatch(tc.bss, batch)
 		err := batch.WriteSync()
 		require.NoError(t, err)
 		retrBSJ := LoadBlockStoreState(db)


### PR DESCRIPTION
Closes #2085

Added `SaveBlockStoreStateBatch` with the new functionality, while leaving `SaveBlockStoreState` with the same signature as in `v0.38.2`

---

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

