### PR TITLE
fix(e2e): path to latency script files in DO

### DIFF
--- a/test/e2e/pkg/infra/digitalocean/digitalocean.go
+++ b/test/e2e/pkg/infra/digitalocean/digitalocean.go
@@ -55,7 +55,7 @@ func (p Provider) StartNodes(ctx context.Context, nodes ...*e2e.Node) error {
 // SetLatency prepares and executes the latency-setter script in the given node.
 func (p Provider) SetLatency(ctx context.Context, node *e2e.Node) error {
 	// Directory in the DigitalOcean node that contains all latency files.
-	remoteDir := "/root/cometbft/test/e2e/latency/"
+	remoteDir := "/root/cometbft/test/e2e/pkg/latency/"
 
 	playbook := "- name: e2e custom playbook\n" +
 		"  hosts: all\n" +


### PR DESCRIPTION
Running testnets with latency emulation in DO is failing because of we are looking for the script files in the wrong location.

Related to #1587

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
