### PR TITLE
fix(p2p): make PeerSet.Remove more efficient

### DIFF
--- a/p2p/bench_test.go
+++ b/p2p/bench_test.go
@@ -1,0 +1,39 @@
+package p2p
+
+import (
+	"testing"
+)
+
+var sink any = nil
+
+func BenchmarkPeerSetRemoveOne(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		testPeerSetAddRemoveOne(b)
+		sink = i
+	}
+
+	if sink == nil {
+		b.Fatal("Benchmark did not run!")
+	}
+
+	// Reset the sink.
+	sink = nil
+}
+
+func BenchmarkPeerSetRemoveMany(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		testPeerSetAddRemoveMany(b)
+		sink = i
+	}
+
+	if sink == nil {
+		b.Fatal("Benchmark did not run!")
+	}
+
+	// Reset the sink.
+	sink = nil
+}

--- a/p2p/peer_set_test.go
+++ b/p2p/peer_set_test.go
@@ -48,13 +48,19 @@ func newMockPeer(ip net.IP) *mockPeer {
 }
 
 func TestPeerSetAddRemoveOne(t *testing.T) {
+	testPeerSetAddRemoveOne(t)
+}
+
+func testPeerSetAddRemoveOne(tb testing.TB) {
+	tb.Helper()
+
 	peerSet := NewPeerSet()
 
 	var peerList []Peer
 	for i := 0; i < 5; i++ {
 		p := newMockPeer(net.IP{127, 0, 0, byte(i)})
 		if err := peerSet.Add(p); err != nil {
-			t.Error(err)
+			tb.Error(err)
 		}
 		peerList = append(peerList, p)
 	}
@@ -63,14 +69,14 @@ func TestPeerSetAddRemoveOne(t *testing.T) {
 	// 1. Test removing from the front
 	for i, peerAtFront := range peerList {
 		removed := peerSet.Remove(peerAtFront)
-		assert.True(t, removed)
+		assert.True(tb, removed)
 		wantSize := n - i - 1
 		for j := 0; j < 2; j++ {
-			assert.False(t, false, peerSet.Has(peerAtFront.ID()), "#%d Run #%d: failed to remove peer", i, j)
-			assert.Equal(t, wantSize, peerSet.Size(), "#%d Run #%d: failed to remove peer and decrement size", i, j)
+			assert.False(tb, false, peerSet.Has(peerAtFront.ID()), "#%d Run #%d: failed to remove peer", i, j)
+			assert.Equal(tb, wantSize, peerSet.Size(), "#%d Run #%d: failed to remove peer and decrement size", i, j)
 			// Test the route of removing the now non-existent element
 			removed := peerSet.Remove(peerAtFront)
-			assert.False(t, removed)
+			assert.False(tb, removed)
 		}
 	}
 
@@ -78,7 +84,7 @@ func TestPeerSetAddRemoveOne(t *testing.T) {
 	// a) Replenish the peerSet
 	for _, peer := range peerList {
 		if err := peerSet.Add(peer); err != nil {
-			t.Error(err)
+			tb.Error(err)
 		}
 	}
 
@@ -86,13 +92,19 @@ func TestPeerSetAddRemoveOne(t *testing.T) {
 	for i := n - 1; i >= 0; i-- {
 		peerAtEnd := peerList[i]
 		removed := peerSet.Remove(peerAtEnd)
-		assert.True(t, removed)
-		assert.False(t, false, peerSet.Has(peerAtEnd.ID()), "#%d: failed to remove item at end", i)
-		assert.Equal(t, i, peerSet.Size(), "#%d: differing sizes after peerSet.Remove(atEndPeer)", i)
+		assert.True(tb, removed)
+		assert.False(tb, false, peerSet.Has(peerAtEnd.ID()), "#%d: failed to remove item at end", i)
+		assert.Equal(tb, i, peerSet.Size(), "#%d: differing sizes after peerSet.Remove(atEndPeer)", i)
 	}
 }
 
 func TestPeerSetAddRemoveMany(t *testing.T) {
+	testPeerSetAddRemoveMany(t)
+}
+
+func testPeerSetAddRemoveMany(tb testing.TB) {
+	tb.Helper()
+
 	peerSet := NewPeerSet()
 
 	peers := []Peer{}
@@ -100,22 +112,22 @@ func TestPeerSetAddRemoveMany(t *testing.T) {
 	for i := 0; i < N; i++ {
 		peer := newMockPeer(net.IP{127, 0, 0, byte(i)})
 		if err := peerSet.Add(peer); err != nil {
-			t.Errorf("failed to add new peer")
+			tb.Errorf("failed to add new peer")
 		}
 		if peerSet.Size() != i+1 {
-			t.Errorf("failed to add new peer and increment size")
+			tb.Errorf("failed to add new peer and increment size")
 		}
 		peers = append(peers, peer)
 	}
 
 	for i, peer := range peers {
 		removed := peerSet.Remove(peer)
-		assert.True(t, removed)
+		assert.True(tb, removed)
 		if peerSet.Has(peer.ID()) {
-			t.Errorf("failed to remove peer")
+			tb.Errorf("failed to remove peer")
 		}
 		if peerSet.Size() != len(peers)-i-1 {
-			t.Errorf("failed to remove peer and decrement size")
+			tb.Errorf("failed to remove peer and decrement size")
 		}
 	}
 }

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -364,6 +364,13 @@ func (sw *Switch) StopPeerGracefully(peer Peer) {
 }
 
 func (sw *Switch) stopAndRemovePeer(peer Peer, reason interface{}) {
+	if peer == nil {
+		// This condition can occur due to the fact that Switch.OnStop uses stale data and
+		// there is no easy fix for it per https://github.com/cometbft/cometbft/issues/2158
+		sw.Logger.Error("nil peer passed in for stopAndRemovePeer")
+		return
+	}
+
 	sw.transport.Cleanup(peer)
 	if err := peer.Stop(); err != nil {
 		sw.Logger.Error("error while stopping peer", "error", err) // TODO: should return error to be handled accordingly


### PR DESCRIPTION
This change makes PeerSet.Remove much more efficient simply by using more idiomatic Go re-slicing to avoid the prior mechanisms of creating fresh peer set lists on just a single remove. While here also added a remedy for a found bug #2158 due to an abstraction that returns a stale slice to its caller in Switch.OnStop.

Benchmark results:

```shell
$ benchstat before.txt after.txt
name                 old time/op    new time/op    delta
PeerSetRemoveOne-8     90.5µs ± 4%    95.9µs ±13%     ~     (p=0.218 n=10+10)
PeerSetRemoveMany-8    1.58ms ± 4%    1.50ms ± 1%   -4.98%  (p=0.000 n=10+8)

name                 old alloc/op   new alloc/op   delta
PeerSetRemoveOne-8     8.48kB ± 0%    7.92kB ± 0%   -6.60%  (p=0.000 n=10+10)
PeerSetRemoveMany-8     149kB ± 0%      65kB ± 0%  -56.44%  (p=0.000 n=10+10)

name                 old allocs/op  new allocs/op  delta
PeerSetRemoveOne-8       85.0 ± 0%      73.0 ± 0%  -14.12%  (p=0.000 n=10+10)
PeerSetRemoveMany-8     1.32k ± 0%     1.22k ± 0%   -7.51%  (p=0.000 n=10+10)
```

which savings become so much more when peers are removed much more frequently for a longer period of time and could mitigate DOS vectors.

Fixes #2157
Fixes #2158