### PR TITLE
fix: if-return and early-return

### DIFF
--- a/.changelog/unreleased/fix/2215.md
+++ b/.changelog/unreleased/fix/2215.md
@@ -1,1 +1,0 @@
-fix: use more idiomatic early return pattern, and if-return linter.

--- a/.changelog/unreleased/fix/2215.md
+++ b/.changelog/unreleased/fix/2215.md
@@ -1,0 +1,1 @@
+fix: use more idiomatic early return pattern, and if-return linter.

--- a/abci/example/kvstore/kvstore.go
+++ b/abci/example/kvstore/kvstore.go
@@ -202,6 +202,7 @@ func (app *Application) FinalizeBlock(_ context.Context, req *types.FinalizeBloc
 	for _, ev := range req.Misbehavior {
 		if ev.Type == types.MISBEHAVIOR_TYPE_DUPLICATE_VOTE {
 			addr := string(ev.Validator.Address)
+			//nolint:revive // this is a false positive from early-return
 			if pubKey, ok := app.valAddrToPubKeyMap[addr]; ok {
 				app.valUpdates = append(app.valUpdates, types.ValidatorUpdate{
 					PubKey: pubKey,

--- a/internal/blocksync/pool.go
+++ b/internal/blocksync/pool.go
@@ -214,11 +214,6 @@ func (pool *BlockPool) PopRequest() {
 	pool.mtx.Lock()
 	defer pool.mtx.Unlock()
 
-	/*  The block can disappear at any time, due to removePeer().
-	if r := pool.requesters[pool.height]; r == nil || r.block == nil {
-		PanicSanity("PopRequest() requires a valid block")
-	}
-	*/
 	r := pool.requesters[pool.height]
 	if r == nil {
 		panic(fmt.Sprintf("Expected requester to pop, got nothing at height %v", pool.height))

--- a/internal/consensus/types/height_vote_set.go
+++ b/internal/consensus/types/height_vote_set.go
@@ -138,15 +138,15 @@ func (hvs *HeightVoteSet) AddVote(vote *types.Vote, peerID p2p.ID, extEnabled bo
 	}
 	voteSet := hvs.getVoteSet(vote.Round, vote.Type)
 	if voteSet == nil {
-		if rndz := hvs.peerCatchupRounds[peerID]; len(rndz) < 2 {
-			hvs.addRound(vote.Round)
-			voteSet = hvs.getVoteSet(vote.Round, vote.Type)
-			hvs.peerCatchupRounds[peerID] = append(rndz, vote.Round)
-		} else {
+		rndz := hvs.peerCatchupRounds[peerID]
+		if len(rndz) >= 2 {
 			// punish peer
 			err = ErrGotVoteFromUnwantedRound
 			return
 		}
+		hvs.addRound(vote.Round)
+		voteSet = hvs.getVoteSet(vote.Round, vote.Type)
+		hvs.peerCatchupRounds[peerID] = append(rndz, vote.Round)
 	}
 	added, err = voteSet.AddVote(vote)
 	return

--- a/internal/flowrate/io.go
+++ b/internal/flowrate/io.go
@@ -97,11 +97,10 @@ func (w *Writer) Write(p []byte) (n int, err error) {
 	var c int
 	for len(p) > 0 && err == nil {
 		s := p[:w.Limit(len(p), w.limit, w.block)]
-		if len(s) > 0 {
-			c, err = w.IO(w.Writer.Write(s))
-		} else {
+		if len(s) == 0 {
 			return n, ErrLimit
 		}
+		c, err = w.IO(w.Writer.Write(s))
 		p = p[c:]
 		n += c
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -528,6 +528,8 @@ func (bs *BlockStore) saveBlockToBatch(
 	// NOTE: we can delete this at a later height
 	pbsc := seenCommit.ToProto()
 	seenCommitBytes := mustEncode(pbsc)
+
+	//nolint:revive // this is a false positive from if-return
 	if err := batch.Set(calcSeenCommitKey(height), seenCommitBytes); err != nil {
 		return err
 	}

--- a/light/client.go
+++ b/light/client.go
@@ -344,13 +344,13 @@ func (c *Client) checkTrustedHeaderUsingOptions(ctx context.Context, options Tru
 		action := fmt.Sprintf(
 			"Prev. trusted header's hash %X doesn't match hash %X from primary provider. Remove all the stored light blocks?",
 			c.latestTrustedBlock.Hash(), primaryHash)
-		if c.confirmationFn(action) {
-			err := c.Cleanup()
-			if err != nil {
-				return fmt.Errorf("failed to cleanup: %w", err)
-			}
-		} else {
+		if !c.confirmationFn(action) {
 			return errors.New("refused to remove the stored light blocks despite hashes mismatch")
+		}
+
+		err := c.Cleanup()
+		if err != nil {
+			return fmt.Errorf("failed to cleanup: %w", err)
 		}
 	}
 

--- a/privval/signer_dialer_endpoint.go
+++ b/privval/signer_dialer_endpoint.go
@@ -76,17 +76,17 @@ func (sd *SignerDialerEndpoint) ensureConnection() error {
 	retries := 0
 	for retries < sd.maxConnRetries {
 		conn, err := sd.dialer()
-
 		if err != nil {
 			retries++
 			sd.Logger.Debug("SignerDialer: Reconnection failed", "retries", retries, "max", sd.maxConnRetries, "err", err)
 			// Wait between retries
 			time.Sleep(sd.retryWait)
-		} else {
-			sd.SetConnection(conn)
-			sd.Logger.Debug("SignerDialer: Connection Ready")
-			return nil
+			continue
 		}
+
+		sd.SetConnection(conn)
+		sd.Logger.Debug("SignerDialer: Connection Ready")
+		return nil
 	}
 
 	sd.Logger.Debug("SignerDialer: Max retries exceeded", "retries", retries, "max", sd.maxConnRetries)

--- a/rpc/jsonrpc/client/decode.go
+++ b/rpc/jsonrpc/client/decode.go
@@ -88,11 +88,10 @@ func validateResponseIDs(ids, expectedIDs []types.JSONRPCIntID) error {
 	}
 
 	for i, id := range ids {
-		if m[id] {
-			delete(m, id)
-		} else {
+		if !m[id] {
 			return fmt.Errorf("unsolicited ID #%d: %v", i, id)
 		}
+		delete(m, id)
 	}
 
 	return nil

--- a/rpc/jsonrpc/client/ws_client.go
+++ b/rpc/jsonrpc/client/ws_client.go
@@ -297,7 +297,7 @@ func (c *WSClient) reconnect() error {
 		time.Sleep(backoffDuration)
 
 		err := c.dial()
-		if err != nil {
+		if err != nil { //nolint:revive // this is a false positive from early-return
 			c.Logger.Error("failed to redial", "err", err)
 		} else {
 			c.Logger.Info("reconnected")

--- a/rpc/jsonrpc/server/http_uri_handler.go
+++ b/rpc/jsonrpc/server/http_uri_handler.go
@@ -128,19 +128,14 @@ func jsonStringToArg(rt reflect.Type, arg string) (reflect.Value, error) {
 func nonJSONStringToArg(rt reflect.Type, arg string) (reflect.Value, bool, error) {
 	if rt.Kind() == reflect.Ptr {
 		rv1, ok, err := nonJSONStringToArg(rt.Elem(), arg)
-		switch {
-		case err != nil:
-			return reflect.Value{}, false, err
-		case ok:
-			rv := reflect.New(rt.Elem())
-			rv.Elem().Set(rv1)
-			return rv, true, nil
-		default:
-			return reflect.Value{}, false, nil
+		if err != nil || !ok {
+			return reflect.Value{}, ok, err
 		}
-	} else {
-		return _nonJSONStringToArg(rt, arg)
+		rv := reflect.New(rt.Elem())
+		rv.Elem().Set(rv1)
+		return rv, true, nil
 	}
+	return _nonJSONStringToArg(rt, arg)
 }
 
 // NOTE: rt.Kind() isn't a pointer.

--- a/test/e2e/app/state.go
+++ b/test/e2e/app/state.go
@@ -63,14 +63,13 @@ func (s *State) load() error {
 	bz, err := os.ReadFile(s.currentFile)
 	if err != nil {
 		// if the current state doesn't exist then we try recover from the previous state
-		if errors.Is(err, os.ErrNotExist) {
-			bz, err = os.ReadFile(s.previousFile)
-			if err != nil {
-				return fmt.Errorf("failed to read both current and previous state (%q): %w",
-					s.previousFile, err)
-			}
-		} else {
+		if !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("failed to read state from %q: %w", s.currentFile, err)
+		}
+		bz, err = os.ReadFile(s.previousFile)
+		if err != nil {
+			return fmt.Errorf("failed to read both current and previous state (%q): %w",
+				s.previousFile, err)
 		}
 	}
 	if err := json.Unmarshal(bz, s); err != nil {

--- a/test/e2e/pkg/infra/docker/docker.go
+++ b/test/e2e/pkg/infra/docker/docker.go
@@ -84,13 +84,10 @@ func (p Provider) SetLatency(ctx context.Context, node *e2e.Node) error {
 	}
 
 	// Execute the latency setter script in the container.
-	if err := ExecVerbose(ctx, "exec", "--privileged", node.Name,
+	return ExecVerbose(ctx, "exec", "--privileged", node.Name,
 		filepath.Join(containerDir, "latency-setter.py"), "set",
 		filepath.Join(containerDir, filepath.Base(p.IPZonesFilePath())),
-		filepath.Join(containerDir, "aws-latencies.csv"), "eth0"); err != nil {
-		return err
-	}
-	return nil
+		filepath.Join(containerDir, "aws-latencies.csv"), "eth0")
 }
 
 // dockerComposeBytes generates a Docker Compose config file for a testnet and returns the


### PR DESCRIPTION
This is cherry-picked from:

* #1907

There were a number of opportunities to simplify code in comet by using revive's if-return and early-return linters.  This PR does not enable the linters as default, but instead just applies the fixes suggested by them.

There are two cases where I've marked conditionals with //nolint -- they're both a little bit odd and it may make sense to look deeper into weather it is possible to benefit from early returns. 

As we've seen in the break statements in #1907 using a linter can help to enforce good practices across the entire repository and uncover issues.

## inspired by

* #2156 

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
