### PR TITLE
Allow customization of metrics

### DIFF
--- a/internal/blocksync/metrics.gen.go
+++ b/internal/blocksync/metrics.gen.go
@@ -8,42 +8,38 @@ import (
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
 )
 
-func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
-	labels := []string{}
-	for i := 0; i < len(labelsAndValues); i += 2 {
-		labels = append(labels, labelsAndValues[i])
-	}
+func PrometheusMetrics(namespace string, labels ...string) *Metrics {
 	return &Metrics{
 		Syncing: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "syncing",
 			Help:      "Whether or not a node is block syncing. 1 if yes, 0 if no.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		NumTxs: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "num_txs",
 			Help:      "Number of transactions in the latest block.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		TotalTxs: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "total_txs",
 			Help:      "Total number of transactions.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		BlockSizeBytes: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "block_size_bytes",
 			Help:      "Size of the latest block.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		LatestBlockHeight: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "latest_block_height",
 			Help:      "The height of the latest block.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 	}
 }
 
@@ -54,5 +50,15 @@ func NopMetrics() *Metrics {
 		TotalTxs:          discard.NewGauge(),
 		BlockSizeBytes:    discard.NewGauge(),
 		LatestBlockHeight: discard.NewGauge(),
+	}
+}
+
+func (m *Metrics) With(labelsAndValues ...string) *Metrics {
+	return &Metrics{
+		Syncing:           m.Syncing.With(labelsAndValues...),
+		NumTxs:            m.NumTxs.With(labelsAndValues...),
+		TotalTxs:          m.TotalTxs.With(labelsAndValues...),
+		BlockSizeBytes:    m.BlockSizeBytes.With(labelsAndValues...),
+		LatestBlockHeight: m.LatestBlockHeight.With(labelsAndValues...),
 	}
 }

--- a/internal/consensus/metrics.gen.go
+++ b/internal/consensus/metrics.gen.go
@@ -8,30 +8,26 @@ import (
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
 )
 
-func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
-	labels := []string{}
-	for i := 0; i < len(labelsAndValues); i += 2 {
-		labels = append(labels, labelsAndValues[i])
-	}
+func PrometheusMetrics(namespace string, labels ...string) *Metrics {
 	return &Metrics{
 		Height: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "height",
 			Help:      "Height of the chain.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		ValidatorLastSignedHeight: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "validator_last_signed_height",
 			Help:      "Last height signed by this validator if the node is a validator.",
-		}, append(labels, "validator_address")).With(labelsAndValues...),
+		}, append(labels, "validator_address")),
 		Rounds: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "rounds",
 			Help:      "Number of rounds.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		RoundDurationSeconds: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
@@ -39,109 +35,109 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Help:      "Histogram of round duration.",
 
 			Buckets: stdprometheus.ExponentialBucketsRange(0.1, 100, 8),
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		Validators: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "validators",
 			Help:      "Number of validators.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		ValidatorsPower: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "validators_power",
 			Help:      "Total power of all validators.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		ValidatorPower: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "validator_power",
 			Help:      "Power of a validator.",
-		}, append(labels, "validator_address")).With(labelsAndValues...),
+		}, append(labels, "validator_address")),
 		ValidatorMissedBlocks: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "validator_missed_blocks",
 			Help:      "Amount of blocks missed per validator.",
-		}, append(labels, "validator_address")).With(labelsAndValues...),
+		}, append(labels, "validator_address")),
 		MissingValidators: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "missing_validators",
 			Help:      "Number of validators who did not sign.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		MissingValidatorsPower: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "missing_validators_power",
 			Help:      "Total power of the missing validators.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		ByzantineValidators: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "byzantine_validators",
 			Help:      "Number of validators who tried to double sign.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		ByzantineValidatorsPower: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "byzantine_validators_power",
 			Help:      "Total power of the byzantine validators.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		BlockIntervalSeconds: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "block_interval_seconds",
 			Help:      "Time between this and the last block.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		NumTxs: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "num_txs",
 			Help:      "Number of transactions.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		BlockSizeBytes: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "block_size_bytes",
 			Help:      "Size of the block.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		ChainSizeBytes: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "chain_size_bytes",
 			Help:      "Size of the chain in bytes.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		TotalTxs: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "total_txs",
 			Help:      "Total number of transactions.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		CommittedHeight: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "latest_block_height",
 			Help:      "The latest block height.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		BlockParts: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "block_parts",
 			Help:      "Number of block parts transmitted by each peer.",
-		}, append(labels, "peer_id")).With(labelsAndValues...),
+		}, append(labels, "peer_id")),
 		DuplicateBlockPart: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "duplicate_block_part",
 			Help:      "Number of times we received a duplicate block part",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		DuplicateVote: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "duplicate_vote",
 			Help:      "Number of times we received a duplicate vote",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		StepDurationSeconds: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
@@ -149,55 +145,55 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Help:      "Histogram of durations for each step in the consensus protocol.",
 
 			Buckets: stdprometheus.ExponentialBucketsRange(0.1, 100, 8),
-		}, append(labels, "step")).With(labelsAndValues...),
+		}, append(labels, "step")),
 		BlockGossipPartsReceived: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "block_gossip_parts_received",
 			Help:      "Number of block parts received by the node, separated by whether the part was relevant to the block the node is trying to gather or not.",
-		}, append(labels, "matches_current")).With(labelsAndValues...),
+		}, append(labels, "matches_current")),
 		QuorumPrevoteDelay: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "quorum_prevote_delay",
 			Help:      "Interval in seconds between the proposal timestamp and the timestamp of the earliest prevote that achieved a quorum.",
-		}, append(labels, "proposer_address")).With(labelsAndValues...),
+		}, append(labels, "proposer_address")),
 		FullPrevoteDelay: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "full_prevote_delay",
 			Help:      "Interval in seconds between the proposal timestamp and the timestamp of the latest prevote in a round where all validators voted.",
-		}, append(labels, "proposer_address")).With(labelsAndValues...),
+		}, append(labels, "proposer_address")),
 		VoteExtensionReceiveCount: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "vote_extension_receive_count",
 			Help:      "VoteExtensionReceiveCount is the number of vote extensions received by this node. The metric is annotated by the status of the vote extension from the application, either 'accepted' or 'rejected'.",
-		}, append(labels, "status")).With(labelsAndValues...),
+		}, append(labels, "status")),
 		ProposalReceiveCount: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "proposal_receive_count",
 			Help:      "ProposalReceiveCount is the total number of proposals received by this node since process start. The metric is annotated by the status of the proposal from the application, either 'accepted' or 'rejected'.",
-		}, append(labels, "status")).With(labelsAndValues...),
+		}, append(labels, "status")),
 		ProposalCreateCount: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "proposal_create_count",
 			Help:      "ProposalCreationCount is the total number of proposals created by this node since process start. The metric is annotated by the status of the proposal from the application, either 'accepted' or 'rejected'.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		RoundVotingPowerPercent: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "round_voting_power_percent",
 			Help:      "RoundVotingPowerPercent is the percentage of the total voting power received with a round. The value begins at 0 for each round and approaches 1.0 as additional voting power is observed. The metric is labeled by vote type.",
-		}, append(labels, "vote_type")).With(labelsAndValues...),
+		}, append(labels, "vote_type")),
 		LateVotes: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "late_votes",
 			Help:      "LateVotes stores the number of votes that were received by this node that correspond to earlier heights and rounds than this node is currently in.",
-		}, append(labels, "vote_type")).With(labelsAndValues...),
+		}, append(labels, "vote_type")),
 	}
 }
 
@@ -233,5 +229,40 @@ func NopMetrics() *Metrics {
 		ProposalCreateCount:       discard.NewCounter(),
 		RoundVotingPowerPercent:   discard.NewGauge(),
 		LateVotes:                 discard.NewCounter(),
+	}
+}
+
+func (m *Metrics) With(labelsAndValues ...string) *Metrics {
+	return &Metrics{
+		Height:                    m.Height.With(labelsAndValues...),
+		ValidatorLastSignedHeight: m.ValidatorLastSignedHeight.With(labelsAndValues...),
+		Rounds:                    m.Rounds.With(labelsAndValues...),
+		RoundDurationSeconds:      m.RoundDurationSeconds.With(labelsAndValues...),
+		Validators:                m.Validators.With(labelsAndValues...),
+		ValidatorsPower:           m.ValidatorsPower.With(labelsAndValues...),
+		ValidatorPower:            m.ValidatorPower.With(labelsAndValues...),
+		ValidatorMissedBlocks:     m.ValidatorMissedBlocks.With(labelsAndValues...),
+		MissingValidators:         m.MissingValidators.With(labelsAndValues...),
+		MissingValidatorsPower:    m.MissingValidatorsPower.With(labelsAndValues...),
+		ByzantineValidators:       m.ByzantineValidators.With(labelsAndValues...),
+		ByzantineValidatorsPower:  m.ByzantineValidatorsPower.With(labelsAndValues...),
+		BlockIntervalSeconds:      m.BlockIntervalSeconds.With(labelsAndValues...),
+		NumTxs:                    m.NumTxs.With(labelsAndValues...),
+		BlockSizeBytes:            m.BlockSizeBytes.With(labelsAndValues...),
+		ChainSizeBytes:            m.ChainSizeBytes.With(labelsAndValues...),
+		TotalTxs:                  m.TotalTxs.With(labelsAndValues...),
+		CommittedHeight:           m.CommittedHeight.With(labelsAndValues...),
+		BlockParts:                m.BlockParts.With(labelsAndValues...),
+		DuplicateBlockPart:        m.DuplicateBlockPart.With(labelsAndValues...),
+		DuplicateVote:             m.DuplicateVote.With(labelsAndValues...),
+		StepDurationSeconds:       m.StepDurationSeconds.With(labelsAndValues...),
+		BlockGossipPartsReceived:  m.BlockGossipPartsReceived.With(labelsAndValues...),
+		QuorumPrevoteDelay:        m.QuorumPrevoteDelay.With(labelsAndValues...),
+		FullPrevoteDelay:          m.FullPrevoteDelay.With(labelsAndValues...),
+		VoteExtensionReceiveCount: m.VoteExtensionReceiveCount.With(labelsAndValues...),
+		ProposalReceiveCount:      m.ProposalReceiveCount.With(labelsAndValues...),
+		ProposalCreateCount:       m.ProposalCreateCount.With(labelsAndValues...),
+		RoundVotingPowerPercent:   m.RoundVotingPowerPercent.With(labelsAndValues...),
+		LateVotes:                 m.LateVotes.With(labelsAndValues...),
 	}
 }

--- a/internal/state/metrics.gen.go
+++ b/internal/state/metrics.gen.go
@@ -8,11 +8,7 @@ import (
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
 )
 
-func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
-	labels := []string{}
-	for i := 0; i < len(labelsAndValues); i += 2 {
-		labels = append(labels, labelsAndValues[i])
-	}
+func PrometheusMetrics(namespace string, labels ...string) *Metrics {
 	return &Metrics{
 		BlockProcessingTime: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: namespace,
@@ -21,73 +17,73 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Help:      "Time spent processing FinalizeBlock",
 
 			Buckets: stdprometheus.LinearBuckets(1, 10, 10),
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		ConsensusParamUpdates: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "consensus_param_updates",
 			Help:      "Number of consensus parameter updates returned by the application since process start.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		ValidatorSetUpdates: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "validator_set_updates",
 			Help:      "Number of validator set updates returned by the application since process start.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		PruningServiceBlockRetainHeight: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "pruning_service_block_retain_height",
 			Help:      "PruningServiceBlockRetainHeight is the accepted block retain height set by the data companion",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		PruningServiceBlockResultsRetainHeight: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "pruning_service_block_results_retain_height",
 			Help:      "PruningServiceBlockResultsRetainHeight is the accepted block results retain height set by the data companion",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		PruningServiceTxIndexerRetainHeight: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "pruning_service_tx_indexer_retain_height",
 			Help:      "PruningServiceTxIndexerRetainHeight is the accepted transactions indices retain height set by the data companion",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		PruningServiceBlockIndexerRetainHeight: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "pruning_service_block_indexer_retain_height",
 			Help:      "PruningServiceBlockIndexerRetainHeight is the accepted blocks indices retain height set by the data companion",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		ApplicationBlockRetainHeight: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "application_block_retain_height",
 			Help:      "ApplicationBlockRetainHeight is the accepted block retain height set by the application",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		BlockStoreBaseHeight: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "block_store_base_height",
 			Help:      "BlockStoreBaseHeight shows the first height at which a block is available",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		ABCIResultsBaseHeight: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "abciresults_base_height",
 			Help:      "ABCIResultsBaseHeight shows the first height at which abci results are available",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		TxIndexerBaseHeight: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "tx_indexer_base_height",
 			Help:      "TxIndexerBaseHeight shows the first height at which tx indices are available",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		BlockIndexerBaseHeight: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "block_indexer_base_height",
 			Help:      "BlockIndexerBaseHeight shows the first height at which block indices are available",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 	}
 }
 
@@ -105,5 +101,22 @@ func NopMetrics() *Metrics {
 		ABCIResultsBaseHeight:                  discard.NewGauge(),
 		TxIndexerBaseHeight:                    discard.NewGauge(),
 		BlockIndexerBaseHeight:                 discard.NewGauge(),
+	}
+}
+
+func (m *Metrics) With(labelsAndValues ...string) *Metrics {
+	return &Metrics{
+		BlockProcessingTime:                    m.BlockProcessingTime.With(labelsAndValues...),
+		ConsensusParamUpdates:                  m.ConsensusParamUpdates.With(labelsAndValues...),
+		ValidatorSetUpdates:                    m.ValidatorSetUpdates.With(labelsAndValues...),
+		PruningServiceBlockRetainHeight:        m.PruningServiceBlockRetainHeight.With(labelsAndValues...),
+		PruningServiceBlockResultsRetainHeight: m.PruningServiceBlockResultsRetainHeight.With(labelsAndValues...),
+		PruningServiceTxIndexerRetainHeight:    m.PruningServiceTxIndexerRetainHeight.With(labelsAndValues...),
+		PruningServiceBlockIndexerRetainHeight: m.PruningServiceBlockIndexerRetainHeight.With(labelsAndValues...),
+		ApplicationBlockRetainHeight:           m.ApplicationBlockRetainHeight.With(labelsAndValues...),
+		BlockStoreBaseHeight:                   m.BlockStoreBaseHeight.With(labelsAndValues...),
+		ABCIResultsBaseHeight:                  m.ABCIResultsBaseHeight.With(labelsAndValues...),
+		TxIndexerBaseHeight:                    m.TxIndexerBaseHeight.With(labelsAndValues...),
+		BlockIndexerBaseHeight:                 m.BlockIndexerBaseHeight.With(labelsAndValues...),
 	}
 }

--- a/internal/statesync/metrics.gen.go
+++ b/internal/statesync/metrics.gen.go
@@ -8,23 +8,25 @@ import (
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
 )
 
-func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
-	labels := []string{}
-	for i := 0; i < len(labelsAndValues); i += 2 {
-		labels = append(labels, labelsAndValues[i])
-	}
+func PrometheusMetrics(namespace string, labels ...string) *Metrics {
 	return &Metrics{
 		Syncing: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "syncing",
 			Help:      "Whether or not a node is state syncing. 1 if yes, 0 if no.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 	}
 }
 
 func NopMetrics() *Metrics {
 	return &Metrics{
 		Syncing: discard.NewGauge(),
+	}
+}
+
+func (m *Metrics) With(labelsAndValues ...string) *Metrics {
+	return &Metrics{
+		Syncing: m.Syncing.With(labelsAndValues...),
 	}
 }

--- a/mempool/metrics.gen.go
+++ b/mempool/metrics.gen.go
@@ -8,24 +8,20 @@ import (
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
 )
 
-func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
-	labels := []string{}
-	for i := 0; i < len(labelsAndValues); i += 2 {
-		labels = append(labels, labelsAndValues[i])
-	}
+func PrometheusMetrics(namespace string, labels ...string) *Metrics {
 	return &Metrics{
 		Size: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "size",
 			Help:      "Number of uncommitted transactions in the mempool.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		SizeBytes: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "size_bytes",
 			Help:      "Total size of the mempool in bytes.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		TxSizeBytes: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
@@ -33,37 +29,37 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Help:      "Histogram of transaction sizes in bytes.",
 
 			Buckets: stdprometheus.ExponentialBuckets(1, 3, 7),
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		FailedTxs: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "failed_txs",
 			Help:      "Number of failed transactions.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		RejectedTxs: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "rejected_txs",
 			Help:      "Number of rejected transactions.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		RecheckTimes: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "recheck_times",
 			Help:      "Number of times transactions are rechecked in the mempool.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		AlreadyReceivedTxs: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "already_received_txs",
 			Help:      "Number of duplicate transaction reception.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		ActiveOutboundConnections: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "active_outbound_connections",
 			Help:      "Number of connections being actively used for gossiping transactions (experimental feature).",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 	}
 }
 
@@ -77,5 +73,18 @@ func NopMetrics() *Metrics {
 		RecheckTimes:              discard.NewCounter(),
 		AlreadyReceivedTxs:        discard.NewCounter(),
 		ActiveOutboundConnections: discard.NewGauge(),
+	}
+}
+
+func (m *Metrics) With(labelsAndValues ...string) *Metrics {
+	return &Metrics{
+		Size:                      m.Size.With(labelsAndValues...),
+		SizeBytes:                 m.SizeBytes.With(labelsAndValues...),
+		TxSizeBytes:               m.TxSizeBytes.With(labelsAndValues...),
+		FailedTxs:                 m.FailedTxs.With(labelsAndValues...),
+		RejectedTxs:               m.RejectedTxs.With(labelsAndValues...),
+		RecheckTimes:              m.RecheckTimes.With(labelsAndValues...),
+		AlreadyReceivedTxs:        m.AlreadyReceivedTxs.With(labelsAndValues...),
+		ActiveOutboundConnections: m.ActiveOutboundConnections.With(labelsAndValues...),
 	}
 }

--- a/node/metrics.go
+++ b/node/metrics.go
@@ -1,0 +1,57 @@
+// Package metrics exports metrics types so that applications can use them.
+package node
+
+import (
+	"github.com/cometbft/cometbft/config"
+	"github.com/cometbft/cometbft/internal/blocksync"
+	"github.com/cometbft/cometbft/internal/consensus"
+	sm "github.com/cometbft/cometbft/internal/state"
+	"github.com/cometbft/cometbft/internal/statesync"
+	"github.com/cometbft/cometbft/mempool"
+	"github.com/cometbft/cometbft/p2p"
+	"github.com/cometbft/cometbft/proxy"
+)
+
+type Metrics struct {
+	Consensus *ConsensusMetrics
+	P2P       *P2PMetrics
+	Mempool   *MempoolMetrics
+	State     *StateMetrics
+	Proxy     *ProxyMetrics
+	Blocksync *BlocksyncMetrics
+	Statesync *StatesyncMetrics
+}
+
+func PrometheusMetrics(config *config.InstrumentationConfig, labels ...string) *Metrics {
+	return &Metrics{consensus.PrometheusMetrics(config.Namespace, labels...),
+		p2p.PrometheusMetrics(config.Namespace, labels...),
+		mempool.PrometheusMetrics(config.Namespace, labels...),
+		sm.PrometheusMetrics(config.Namespace, labels...),
+		proxy.PrometheusMetrics(config.Namespace, labels...),
+		blocksync.PrometheusMetrics(config.Namespace, labels...),
+		statesync.PrometheusMetrics(config.Namespace, labels...)}
+}
+
+func NopMetrics() *Metrics {
+	return &Metrics{consensus.NopMetrics(), p2p.NopMetrics(), mempool.NopMetrics(), sm.NopMetrics(), proxy.NopMetrics(), blocksync.NopMetrics(), statesync.NopMetrics()}
+}
+
+type ConsensusMetrics = consensus.Metrics
+type P2PMetrics = p2p.Metrics
+type MempoolMetrics = mempool.Metrics
+type StateMetrics = sm.Metrics
+type ProxyMetrics = proxy.Metrics
+type BlocksyncMetrics = blocksync.Metrics
+type StatesyncMetrics = statesync.Metrics
+
+func (a *Metrics) With(labelsAndValues ...string) *Metrics {
+	return &Metrics{
+		Consensus: a.Consensus.With(labelsAndValues...),
+		P2P:       a.P2P.With(labelsAndValues...),
+		Mempool:   a.Mempool.With(labelsAndValues...),
+		State:     a.State.With(labelsAndValues...),
+		Proxy:     a.Proxy.With(labelsAndValues...),
+		Blocksync: a.Blocksync.With(labelsAndValues...),
+		Statesync: a.Statesync.With(labelsAndValues...),
+	}
+}

--- a/node/metrics_test.go
+++ b/node/metrics_test.go
@@ -1,0 +1,20 @@
+package node
+
+import (
+	"github.com/cometbft/cometbft/config"
+)
+
+func ExampleMetrics() {
+	config := &config.InstrumentationConfig{
+		Namespace:  "cometbft",
+		Prometheus: true,
+	}
+
+	// Register the metrics once
+	shared := PrometheusMetrics(config, "chain_id")
+
+	// Create a new metrics object from the shared one
+	_ = MetricsProvider(func(chainID string) *Metrics {
+		return shared.With("chain_id", chainID)
+	})
+}

--- a/node/node.go
+++ b/node/node.go
@@ -299,7 +299,8 @@ func NewNode(ctx context.Context,
 		logger.Error("Failed to delete genesis doc from DB ", err)
 	}
 
-	csMetrics, p2pMetrics, memplMetrics, smMetrics, abciMetrics, bsMetrics, ssMetrics := metricsProvider(genDoc.ChainID)
+	allMetrics := metricsProvider(genDoc.ChainID)
+	csMetrics, p2pMetrics, memplMetrics, smMetrics, abciMetrics, bsMetrics, ssMetrics := allMetrics.Consensus, allMetrics.P2P, allMetrics.Mempool, allMetrics.State, allMetrics.Proxy, allMetrics.Blocksync, allMetrics.Statesync
 
 	// Create the proxyApp and establish connections to the ABCI app (consensus, mempool, query).
 	proxyApp, err := createAndStartProxyAppConns(clientCreator, logger, abciMetrics)

--- a/node/setup.go
+++ b/node/setup.go
@@ -97,22 +97,16 @@ func DefaultNewNode(config *cfg.Config, logger log.Logger) (*Node, error) {
 }
 
 // MetricsProvider returns a consensus, p2p and mempool Metrics.
-type MetricsProvider func(chainID string) (*cs.Metrics, *p2p.Metrics, *mempl.Metrics, *sm.Metrics, *proxy.Metrics, *blocksync.Metrics, *statesync.Metrics)
+type MetricsProvider func(chainID string) *Metrics
 
 // DefaultMetricsProvider returns Metrics build using Prometheus client library
 // if Prometheus is enabled. Otherwise, it returns no-op Metrics.
 func DefaultMetricsProvider(config *cfg.InstrumentationConfig) MetricsProvider {
-	return func(chainID string) (*cs.Metrics, *p2p.Metrics, *mempl.Metrics, *sm.Metrics, *proxy.Metrics, *blocksync.Metrics, *statesync.Metrics) {
+	return func(chainID string) *Metrics {
 		if config.Prometheus {
-			return cs.PrometheusMetrics(config.Namespace, "chain_id", chainID),
-				p2p.PrometheusMetrics(config.Namespace, "chain_id", chainID),
-				mempl.PrometheusMetrics(config.Namespace, "chain_id", chainID),
-				sm.PrometheusMetrics(config.Namespace, "chain_id", chainID),
-				proxy.PrometheusMetrics(config.Namespace, "chain_id", chainID),
-				blocksync.PrometheusMetrics(config.Namespace, "chain_id", chainID),
-				statesync.PrometheusMetrics(config.Namespace, "chain_id", chainID)
+			return PrometheusMetrics(config, "chain_id").With("chain_id", chainID)
 		}
-		return cs.NopMetrics(), p2p.NopMetrics(), mempl.NopMetrics(), sm.NopMetrics(), proxy.NopMetrics(), blocksync.NopMetrics(), statesync.NopMetrics()
+		return NopMetrics()
 	}
 }
 

--- a/p2p/metrics.gen.go
+++ b/p2p/metrics.gen.go
@@ -8,54 +8,50 @@ import (
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
 )
 
-func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
-	labels := []string{}
-	for i := 0; i < len(labelsAndValues); i += 2 {
-		labels = append(labels, labelsAndValues[i])
-	}
+func PrometheusMetrics(namespace string, labels ...string) *Metrics {
 	return &Metrics{
 		Peers: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "peers",
 			Help:      "Number of peers.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		PeerReceiveBytesTotal: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "peer_receive_bytes_total",
 			Help:      "Number of bytes received from a given peer.",
-		}, append(labels, "peer_id", "chID")).With(labelsAndValues...),
+		}, append(labels, "peer_id", "chID")),
 		PeerSendBytesTotal: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "peer_send_bytes_total",
 			Help:      "Number of bytes sent to a given peer.",
-		}, append(labels, "peer_id", "chID")).With(labelsAndValues...),
+		}, append(labels, "peer_id", "chID")),
 		PeerPendingSendBytes: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "peer_pending_send_bytes",
 			Help:      "Pending bytes to be sent to a given peer.",
-		}, append(labels, "peer_id")).With(labelsAndValues...),
+		}, append(labels, "peer_id")),
 		NumTxs: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "num_txs",
 			Help:      "Number of transactions submitted by each peer.",
-		}, append(labels, "peer_id")).With(labelsAndValues...),
+		}, append(labels, "peer_id")),
 		MessageReceiveBytesTotal: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "message_receive_bytes_total",
 			Help:      "Number of bytes of each message type received.",
-		}, append(labels, "message_type")).With(labelsAndValues...),
+		}, append(labels, "message_type")),
 		MessageSendBytesTotal: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "message_send_bytes_total",
 			Help:      "Number of bytes of each message type sent.",
-		}, append(labels, "message_type")).With(labelsAndValues...),
+		}, append(labels, "message_type")),
 	}
 }
 
@@ -68,5 +64,17 @@ func NopMetrics() *Metrics {
 		NumTxs:                   discard.NewGauge(),
 		MessageReceiveBytesTotal: discard.NewCounter(),
 		MessageSendBytesTotal:    discard.NewCounter(),
+	}
+}
+
+func (m *Metrics) With(labelsAndValues ...string) *Metrics {
+	return &Metrics{
+		Peers:                    m.Peers.With(labelsAndValues...),
+		PeerReceiveBytesTotal:    m.PeerReceiveBytesTotal.With(labelsAndValues...),
+		PeerSendBytesTotal:       m.PeerSendBytesTotal.With(labelsAndValues...),
+		PeerPendingSendBytes:     m.PeerPendingSendBytes.With(labelsAndValues...),
+		NumTxs:                   m.NumTxs.With(labelsAndValues...),
+		MessageReceiveBytesTotal: m.MessageReceiveBytesTotal.With(labelsAndValues...),
+		MessageSendBytesTotal:    m.MessageSendBytesTotal.With(labelsAndValues...),
 	}
 }

--- a/proxy/metrics.gen.go
+++ b/proxy/metrics.gen.go
@@ -8,11 +8,7 @@ import (
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
 )
 
-func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
-	labels := []string{}
-	for i := 0; i < len(labelsAndValues); i += 2 {
-		labels = append(labels, labelsAndValues[i])
-	}
+func PrometheusMetrics(namespace string, labels ...string) *Metrics {
 	return &Metrics{
 		MethodTimingSeconds: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: namespace,
@@ -21,12 +17,18 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Help:      "Timing for each ABCI method.",
 
 			Buckets: []float64{.0001, .0004, .002, .009, .02, .1, .65, 2, 6, 25},
-		}, append(labels, "method", "type")).With(labelsAndValues...),
+		}, append(labels, "method", "type")),
 	}
 }
 
 func NopMetrics() *Metrics {
 	return &Metrics{
 		MethodTimingSeconds: discard.NewHistogram(),
+	}
+}
+
+func (m *Metrics) With(labelsAndValues ...string) *Metrics {
+	return &Metrics{
+		MethodTimingSeconds: m.MethodTimingSeconds.With(labelsAndValues...),
 	}
 }

--- a/scripts/metricsgen/testdata/basic/metrics.gen.go
+++ b/scripts/metricsgen/testdata/basic/metrics.gen.go
@@ -8,23 +8,25 @@ import (
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
 )
 
-func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
-	labels := []string{}
-	for i := 0; i < len(labelsAndValues); i += 2 {
-		labels = append(labels, labelsAndValues[i])
-	}
+func PrometheusMetrics(namespace string, labels ...string) *Metrics {
 	return &Metrics{
 		Height: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "height",
 			Help:      "simple metric that tracks the height of the chain.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 	}
 }
 
 func NopMetrics() *Metrics {
 	return &Metrics{
 		Height: discard.NewGauge(),
+	}
+}
+
+func (m *Metrics) With(labelsAndValues ...string) *Metrics {
+	return &Metrics{
+		Height: m.Height.With(labelsAndValues...),
 	}
 }

--- a/scripts/metricsgen/testdata/commented/metrics.gen.go
+++ b/scripts/metricsgen/testdata/commented/metrics.gen.go
@@ -8,23 +8,25 @@ import (
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
 )
 
-func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
-	labels := []string{}
-	for i := 0; i < len(labelsAndValues); i += 2 {
-		labels = append(labels, labelsAndValues[i])
-	}
+func PrometheusMetrics(namespace string, labels ...string) *Metrics {
 	return &Metrics{
 		Field: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "field",
 			Help:      "Height of the chain. We expect multi-line comments to parse correctly.",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 	}
 }
 
 func NopMetrics() *Metrics {
 	return &Metrics{
 		Field: discard.NewGauge(),
+	}
+}
+
+func (m *Metrics) With(labelsAndValues ...string) *Metrics {
+	return &Metrics{
+		Field: m.Field.With(labelsAndValues...),
 	}
 }

--- a/scripts/metricsgen/testdata/tags/metrics.gen.go
+++ b/scripts/metricsgen/testdata/tags/metrics.gen.go
@@ -8,18 +8,14 @@ import (
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
 )
 
-func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
-	labels := []string{}
-	for i := 0; i < len(labelsAndValues); i += 2 {
-		labels = append(labels, labelsAndValues[i])
-	}
+func PrometheusMetrics(namespace string, labels ...string) *Metrics {
 	return &Metrics{
 		WithLabels: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "with_labels",
 			Help:      "",
-		}, append(labels, "step", "time")).With(labelsAndValues...),
+		}, append(labels, "step", "time")),
 		WithExpBuckets: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
@@ -27,7 +23,7 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Help:      "",
 
 			Buckets: stdprometheus.ExponentialBuckets(.1, 100, 8),
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		WithBuckets: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
@@ -35,13 +31,13 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Help:      "",
 
 			Buckets: []float64{1, 2, 3, 4, 5},
-		}, labels).With(labelsAndValues...),
+		}, labels),
 		Named: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "metric_with_name",
 			Help:      "",
-		}, labels).With(labelsAndValues...),
+		}, labels),
 	}
 }
 
@@ -51,5 +47,14 @@ func NopMetrics() *Metrics {
 		WithExpBuckets: discard.NewHistogram(),
 		WithBuckets:    discard.NewHistogram(),
 		Named:          discard.NewCounter(),
+	}
+}
+
+func (m *Metrics) With(labelsAndValues ...string) *Metrics {
+	return &Metrics{
+		WithLabels:     m.WithLabels.With(labelsAndValues...),
+		WithExpBuckets: m.WithExpBuckets.With(labelsAndValues...),
+		WithBuckets:    m.WithBuckets.With(labelsAndValues...),
+		Named:          m.Named.With(labelsAndValues...),
 	}
 }


### PR DESCRIPTION
This is a proof of concept for allowing applications to manage the labels applied to metrics. The application I work on (written in Go) incorporates two related but distinct CometBFT networks. Thus each node runs two CometBFT nodes within the same process. Due to how CometBFT initializes metrics, I am forced to use a different namespace for metrics for each node, which leads to unpleasantly awkward queries in Grafana.

The change I propose:
1. Modifies the `PrometheusMetrics` methods so that they **do not apply labels** immediately.
2. Adds helper `With` methods so that change (1) is not a burden.
3. Exposes metrics struct types (some are currently internal).

As a result:
- Applications can add their own labels that are applied to all metrics.
- My application can register the metrics once with the default namespace, instead of being forced to register with different namespaces to avoid a panic. See the example in node/metrics_test.go.
- I can use more natural queries.

Here's a comparison of a query before and after:
```
// Returns multiple different metric names due to the wildcard
{__name__=~"cometbft_.*_consensus_num_txs"}

// All results have the same name, with different label sets (like a normal query)
cometbft_consensus_num_txs
```