### PR TITLE
fix(Makefile): gofumpt no longer needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,6 @@ testdata-metrics:
 #? mockery: Generate test mocks
 mockery:
 	go generate -run="./scripts/mockery_generate.sh" ./...
-	@go run mvdan.cc/gofumpt@latest -l -w .
 .PHONY: mockery
 
 ###############################################################################


### PR DESCRIPTION
It looks like `go generate -run="./scripts/mockery_generate.sh" ./...` produces correctly formatted (from `gofumpt` perspective) output.

Closes #2212
