### PR TITLE
chore: remove replace directive from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -143,8 +143,6 @@ require (
 	gotest.tools v2.2.0+incompatible // indirect
 )
 
-replace github.com/cometbft/cometbft/api => ./api
-
 retract (
 	// a regression was introduced
 	v0.38.4


### PR DESCRIPTION
To make the module usable remotely again, it should not have
the `replace` directive.