### PR TITLE
test(mempool): fix TestMempoolUpdateDoesNotPanicWhenApplicationMissedTx

### DIFF
--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -262,7 +262,8 @@ func TestMempoolUpdate(t *testing.T) {
 	}
 }
 
-// Test dropping CheckTx requests when rechecking transactions. Assumes an asynchronous ABCI client.
+// Test dropping CheckTx requests when rechecking transactions. It mocks an asynchronous connection
+// to the app.
 func TestMempoolUpdateDoesNotPanicWhenApplicationMissedTx(t *testing.T) {
 	var callback abciclient.Callback
 	mockClient := new(abciclimocks.Client)


### PR DESCRIPTION
The test `TestMempoolUpdateDoesNotPanicWhenApplicationMissedTx` has two problems:
- First, the test calls `reqRes.InvokeCallback()` on every CheckTx request-response, but there's no callback set on `reqRes` so the tx are not really added to the mempool at this point.
- Near the end, it makes two calls to `callback` on requests of type `CHECK_TX_TYPE_CHECK` when they should be of type `CHECK_TX_TYPE_RECHECK`. The intention here was to process the recheck responses; instead, the two txs are added to the mempool.