### PR TITLE
feat(consensus): improve logging for timely and untimely messages

### DIFF
--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1401,14 +1401,20 @@ func (cs *State) defaultDoPrevote(height int64, round int32) {
 		if cs.Proposal.POLRound == -1 && cs.LockedRound == -1 && !cs.proposalIsTimely() {
 			minimumDifference, maximumDifference := cs.timelyProposalMargins()
 			logger.Debug("prevote step: Proposal is not timely; prevoting nil",
-				"proposed",
-				cmttime.Canonical(cs.Proposal.Timestamp).Format(time.RFC3339Nano),
-				"received",
-				cmttime.Canonical(cs.ProposalReceiveTime).Format(time.RFC3339Nano),
+				"timestamp", cs.Proposal.Timestamp.Format(time.RFC3339Nano),
+				"receive_time", cs.ProposalReceiveTime.Format(time.RFC3339Nano),
+				"timestamp_difference", cs.ProposalReceiveTime.Sub(cs.Proposal.Timestamp),
 				"minimum_difference", minimumDifference,
 				"maximum_difference", maximumDifference)
 			cs.signAddVote(types.PrevoteType, nil, types.PartSetHeader{}, nil)
 			return
+		}
+
+		if cs.Proposal.POLRound == -1 {
+			logger.Debug("prevote step: Proposal is timely",
+				"timestamp", cs.Proposal.Timestamp.Format(time.RFC3339Nano),
+				"receive_time", cs.ProposalReceiveTime.Format(time.RFC3339Nano),
+				"timestamp_difference", cs.ProposalReceiveTime.Sub(cs.Proposal.Timestamp))
 		}
 	}
 

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1400,6 +1400,7 @@ func (cs *State) defaultDoPrevote(height int64, round int32) {
 
 		if cs.Proposal.POLRound == -1 && !cs.proposalIsTimely() {
 			lowerBound, upperBound := cs.timelyProposalMargins()
+			// TODO: use Warn level once available.
 			logger.Info("prevote step: Proposal is not timely; prevoting nil",
 				"timestamp", cs.Proposal.Timestamp.Format(time.RFC3339Nano),
 				"receive_time", cs.ProposalReceiveTime.Format(time.RFC3339Nano),

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1399,13 +1399,13 @@ func (cs *State) defaultDoPrevote(height int64, round int32) {
 		}
 
 		if cs.Proposal.POLRound == -1 && cs.LockedRound == -1 && !cs.proposalIsTimely() {
-			minimumDifference, maximumDifference := cs.timelyProposalMargins()
-			logger.Debug("prevote step: Proposal is not timely; prevoting nil",
+			lowerBound, upperBound := cs.timelyProposalMargins()
+			logger.Info("prevote step: Proposal is not timely; prevoting nil",
 				"timestamp", cs.Proposal.Timestamp.Format(time.RFC3339Nano),
 				"receive_time", cs.ProposalReceiveTime.Format(time.RFC3339Nano),
 				"timestamp_difference", cs.ProposalReceiveTime.Sub(cs.Proposal.Timestamp),
-				"minimum_difference", minimumDifference,
-				"maximum_difference", maximumDifference)
+				"lower_bound", lowerBound,
+				"upper_bound", upperBound)
 			cs.signAddVote(types.PrevoteType, nil, types.PartSetHeader{}, nil)
 			return
 		}

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1390,7 +1390,7 @@ func (cs *State) defaultDoPrevote(height int64, round int32) {
 	}
 
 	// Timestamp validation using Proposed-Based TimeStamp (PBTS) algorithm.
-	// See: https://github.com/cometbft/cometbft/blob/main/spec/consensus/proposer-based-timestamp/README.md
+	// See: https://github.com/cometbft/cometbft/blob/main/spec/consensus/proposer-based-timestamp/
 	if cs.isPBTSEnabled(height) {
 		if !cs.Proposal.Timestamp.Equal(cs.ProposalBlock.Header.Time) {
 			logger.Debug("prevote step: proposal timestamp not equal; prevoting nil")
@@ -1398,7 +1398,7 @@ func (cs *State) defaultDoPrevote(height int64, round int32) {
 			return
 		}
 
-		if cs.Proposal.POLRound == -1 && cs.LockedRound == -1 && !cs.proposalIsTimely() {
+		if cs.Proposal.POLRound == -1 && !cs.proposalIsTimely() {
 			lowerBound, upperBound := cs.timelyProposalMargins()
 			logger.Info("prevote step: Proposal is not timely; prevoting nil",
 				"timestamp", cs.Proposal.Timestamp.Format(time.RFC3339Nano),

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -2693,14 +2693,16 @@ func repairWalFile(src, dst string) error {
 
 func (cs *State) calculateProposalTimestampDifferenceMetric() {
 	if cs.Proposal != nil && cs.Proposal.POLRound == -1 {
+		// If PBTS is disabled, default SynchronyParams are used
 		tp := types.AdaptiveSynchronyParams(
 			cs.state.ConsensusParams.Synchrony.Precision,
 			cs.state.ConsensusParams.Synchrony.MessageDelay,
-			cs.Round,
+			cs.Proposal.Round,
 		)
 
 		isTimely := cs.Proposal.IsTimely(cs.ProposalReceiveTime, tp)
-		cs.metrics.ProposalTimestampDifference.With("is_timely", strconv.FormatBool(isTimely)).
+		cs.metrics.ProposalTimestampDifference.
+			With("is_timely", strconv.FormatBool(isTimely)).
 			Observe(cs.ProposalReceiveTime.Sub(cs.Proposal.Timestamp).Seconds())
 	}
 }


### PR DESCRIPTION
Addresses  #2320.

For instance, the new logging of timely/untimely messages is:

```
$ go test -v -run TestPBTSEnableHeight | grep timely
I[2024-03-01|13:36:37.072] prevote step: Proposal is not timely; prevoting nil module=consensus height=4 round=0 timestamp=2024-03-01T12:36:38.071256Z receive_time=2024-03-01T12:36:37.072355Z timestamp_difference=-998.901ms lower_bound=-500ms upper_bound=2.5s
D[2024-03-01|13:36:37.998] prevote step: Proposal is timely             module=consensus height=4 round=1 timestamp=2024-03-01T12:36:37.997463Z receive_time=2024-03-01T12:36:37.997737Z timestamp_difference=274µs
D[2024-03-01|13:36:38.014] prevote step: Proposal is timely             module=consensus height=5 round=0 timestamp=2024-03-01T12:36:38.014012Z receive_time=2024-03-01T12:36:38.01419Z timestamp_difference=178µs
```

Notice that untimely messages are logging in INFO level, while timely messages are logging in DEBUG level.

Note: I had to force push this branch because the changes were conflicting a lot with parallel changes. This PR now only addresses logging, metrics are left for another PR.

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
