### PR TITLE
feat(e2e): Log number of sent txs (success and failed)

### DIFF
--- a/.changelog/unreleased/improvements/2328-e2e-log-sent-txs
+++ b/.changelog/unreleased/improvements/2328-e2e-log-sent-txs
@@ -1,0 +1,2 @@
+- `[e2e]` Log the number of transactions that were sent successfully or failed.
+  ([\#2328](https://github.com/cometbft/cometbft/pull/2328))

--- a/test/e2e/runner/load.go
+++ b/test/e2e/runner/load.go
@@ -24,6 +24,7 @@ func Load(ctx context.Context, testnet *e2e.Testnet) error {
 	initialTimeout := 1 * time.Minute
 	stallTimeout := 30 * time.Second
 	chSuccess := make(chan struct{})
+	chFailed := make(chan struct{})
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -40,31 +41,39 @@ func Load(ctx context.Context, testnet *e2e.Testnet) error {
 		}
 
 		for w := 0; w < testnet.LoadTxConnections; w++ {
-			go loadProcess(ctx, txCh, chSuccess, n)
+			go loadProcess(ctx, txCh, chSuccess, chFailed, n)
 		}
 	}
 
-	// Monitor successful transactions, and abort on stalls.
-	success := 0
+	// Monitor successful and failed transactions, and abort on stalls.
+	success, failed := 0, 0
 	timeout := initialTimeout
 	for {
+		rate := log.NewLazySprintf("%.1f", float64(success)/time.Since(started).Seconds())
+
 		select {
 		case <-chSuccess:
 			success++
-			if testnet.LoadMaxTxs > 0 && success >= testnet.LoadMaxTxs {
-				logger.Info("load", "msg", log.NewLazySprintf("Ending transaction load after reaching %v txs (%.1f tx/s)...",
-					success, float64(success)/time.Since(started).Seconds()))
-				return nil
-			}
 			timeout = stallTimeout
+		case <-chFailed:
+			failed++
 		case <-time.After(timeout):
 			return fmt.Errorf("unable to submit transactions for %v", timeout)
 		case <-ctx.Done():
 			if success == 0 {
 				return errors.New("failed to submit any transactions")
 			}
-			logger.Info("load", "msg", log.NewLazySprintf("Ending transaction load after %v txs (%.1f tx/s)...",
-				success, float64(success)/time.Since(started).Seconds()))
+			logger.Info("load", "msg", log.NewLazySprintf("Ending transaction load after %v txs (%.1f tx/s)...", success, rate))
+			return nil
+		}
+
+		// Log every ~1 second the number of sent transactions.
+		if (success+failed)%testnet.LoadTxBatchSize == 0 {
+			logger.Debug("load", "success", success, "failed", failed, "tx/s", rate)
+		}
+
+		if testnet.LoadMaxTxs > 0 && success >= testnet.LoadMaxTxs {
+			logger.Info("load", "msg", log.NewLazySprintf("Ending transaction load after reaching %v txs (%.1f tx/s)...", success, rate))
 			return nil
 		}
 	}
@@ -135,7 +144,7 @@ func createTxBatch(ctx context.Context, txCh chan<- types.Tx, testnet *e2e.Testn
 
 // loadProcess processes transactions by sending transactions received on the txCh
 // to the client.
-func loadProcess(ctx context.Context, txCh <-chan types.Tx, chSuccess chan<- struct{}, n *e2e.Node) {
+func loadProcess(ctx context.Context, txCh <-chan types.Tx, chSuccess chan<- struct{}, chFailed chan<- struct{}, n *e2e.Node) {
 	var client *rpchttp.HTTP
 	var err error
 	s := struct{}{}
@@ -148,6 +157,8 @@ func loadProcess(ctx context.Context, txCh <-chan types.Tx, chSuccess chan<- str
 			}
 		}
 		if _, err = client.BroadcastTxSync(ctx, tx); err != nil {
+			logger.Error("failed to send transaction", "err", err)
+			chFailed <- s
 			continue
 		}
 		chSuccess <- s

--- a/test/e2e/runner/load.go
+++ b/test/e2e/runner/load.go
@@ -72,6 +72,7 @@ func Load(ctx context.Context, testnet *e2e.Testnet) error {
 			logger.Debug("load", "success", success, "failed", failed, "tx/s", rate)
 		}
 
+		// Check if reached max number of allowed transactions to send.
 		if testnet.LoadMaxTxs > 0 && success >= testnet.LoadMaxTxs {
 			logger.Info("load", "msg", log.NewLazySprintf("Ending transaction load after reaching %v txs (%v tx/s)...", success, rate))
 			return nil

--- a/test/e2e/runner/load.go
+++ b/test/e2e/runner/load.go
@@ -63,7 +63,7 @@ func Load(ctx context.Context, testnet *e2e.Testnet) error {
 			if success == 0 {
 				return errors.New("failed to submit any transactions")
 			}
-			logger.Info("load", "msg", log.NewLazySprintf("Ending transaction load after %v txs (%.1f tx/s)...", success, rate))
+			logger.Info("load", "msg", log.NewLazySprintf("Ending transaction load after %v txs (%v tx/s)...", success, rate))
 			return nil
 		}
 
@@ -73,7 +73,7 @@ func Load(ctx context.Context, testnet *e2e.Testnet) error {
 		}
 
 		if testnet.LoadMaxTxs > 0 && success >= testnet.LoadMaxTxs {
-			logger.Info("load", "msg", log.NewLazySprintf("Ending transaction load after reaching %v txs (%.1f tx/s)...", success, rate))
+			logger.Info("load", "msg", log.NewLazySprintf("Ending transaction load after reaching %v txs (%v tx/s)...", success, rate))
 			return nil
 		}
 	}

--- a/test/e2e/runner/load.go
+++ b/test/e2e/runner/load.go
@@ -68,8 +68,9 @@ func Load(ctx context.Context, testnet *e2e.Testnet) error {
 		}
 
 		// Log every ~1 second the number of sent transactions.
-		if (success+failed)%testnet.LoadTxBatchSize == 0 {
-			logger.Debug("load", "success", success, "failed", failed, "tx/s", rate)
+		total := success + failed
+		if total%testnet.LoadTxBatchSize == 0 {
+			logger.Debug("load", "success", success, "failed", failed, "success/total", log.NewLazySprintf("%.1f", success/total), "tx/s", rate)
 		}
 
 		// Check if reached max number of allowed transactions to send.


### PR DESCRIPTION
When we run e2e's `load` command there is no message telling if the txs were sent or not, and if not, for what reason (eg. mempool is full, txs is too large, wrong endpoint, etc.). This PR will log a message every ~1 second with the number of successfully sent and failed transactions.

---

#### PR checklist

- [ ] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
