### PR TITLE
fix: remove gofumpt from pre-commit configuration 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,19 +10,6 @@ repos:
     - id: golangci-lint-full
       args: [--timeout, 10m] # for CI
 
- # gofumpt (does not have .pre-commmit-hooks.yaml)
- - repo: local
-   hooks:
-    - id: gofumpt
-      name: "gofumpt"
-      additional_dependencies:
-       - mvdan.cc/gofumpt@v0.6.0
-      entry: "gofumpt"
-      language: golang
-      args: [-w, .]
-      types: [go]
-      pass_filenames: false
-
  # codespell
  - repo: https://github.com/codespell-project/codespell
    rev: v2.2.6


### PR DESCRIPTION
gofumpt is a part of golangci-lint so this entry is redundant.

Additonally, there seem to have been some issues with it.  I think it is best to remove this. 



#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
