### PR TITLE
fix(e2e): Reduce flakiness of TestGRPC_GetBlockResults

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -485,12 +485,28 @@ means that you shouldn't update someone else's branch for them; even if it seems
 like you're doing them a favor, you may be interfering with their git flow in
 some way!)
 
-### Formatting
+### Formatting & Linting
 
-Make sure to format your code with [gofumpt](https://github.com/mvdan/gofumpt).
-To install a Git pre-commit hook, run `make gofumpt-pre-commit`. The hook
-automatically applies `gofumpt` to the staged Go files, so you don't need to do
-anything.
+When submitting a change, please make sure to:
+
+1. Format the code using [gofumpt](https://github.com/mvdan/gofumpt)
+2. Lint the code using [golangci-lint](https://golangci-lint.run/)
+3. Check the code and docs for spelling errors using [codespell](https://github.com/codespell-project/codespell).
+
+It's recommended to install a Git pre-commit hook: `make pre-commit`. The hook will
+automatically run the above steps for you every time you commit something. You
+can also do this manually with `make lint`.
+
+The pre-commit hook uses [the pre-commit framework](https://pre-commit.com/).
+If you have Python 3 installed, you don't need to do anything else. Otherwise,
+please refer to [the installation guide](https://pre-commit.com/#install).
+
+In rare cases, you may want to skip the pre-commit hook. You can do so by adding
+`-n` (or `--no-verify`) flag to `git commit`:
+
+```bash
+git commit -n -m "add X"
+```
 
 #### Merging Pull Requests
 

--- a/test/e2e/tests/block_test.go
+++ b/test/e2e/tests/block_test.go
@@ -27,7 +27,13 @@ func TestBlock_Header(t *testing.T) {
 		first := status.SyncInfo.EarliestBlockHeight
 		last := status.SyncInfo.LatestBlockHeight
 		if node.RetainBlocks > 0 {
-			first++ // avoid race conditions with block pruning
+			// This was done in case pruning is activated.
+			// As it happens in the background this lowers the chances
+			// that the block at height=first will be pruned by the time we test
+			// this. If this test starts to fail often, it is worth revisiting this logic.
+			// To reproduce this failure locally, it is advised to set the storage.pruning.interval
+			// to 1s instead of 10s.
+			first += int64(node.RetainBlocks) // avoid race conditions with block pruning
 		}
 
 		for _, block := range blocks {

--- a/test/e2e/tests/grpc_test.go
+++ b/test/e2e/tests/grpc_test.go
@@ -106,7 +106,11 @@ func TestGRPC_GetBlockResults(t *testing.T) {
 		first := status.SyncInfo.EarliestBlockHeight
 		last := status.SyncInfo.LatestBlockHeight
 		if node.RetainBlocks > 0 {
-			first++
+			// This was done in case pruning is activated.
+			// As it happens in the background this lowers the chances
+			// that the block at height=first will be pruned by the time we test
+			// this. If this test starts to fail often, it is worth revisiting this logic.
+			first += int64(node.RetainBlocks)
 		}
 
 		ctx, ctxCancel := context.WithTimeout(context.Background(), time.Minute)
@@ -136,7 +140,7 @@ func TestGRPC_GetBlockResults(t *testing.T) {
 		errorCases := []struct {
 			requestHeight int64
 		}{
-			{first - 2},
+			{first - int64(node.RetainBlocks) - 2},
 			{last + 100000},
 		}
 

--- a/test/e2e/tests/grpc_test.go
+++ b/test/e2e/tests/grpc_test.go
@@ -110,6 +110,8 @@ func TestGRPC_GetBlockResults(t *testing.T) {
 			// As it happens in the background this lowers the chances
 			// that the block at height=first will be pruned by the time we test
 			// this. If this test starts to fail often, it is worth revisiting this logic.
+			// To reproduce this failure locally, it is advised to set the storage.pruning.interval
+			// to 1s instead of 10s.
 			first += int64(node.RetainBlocks)
 		}
 

--- a/test/e2e/tests/validator_test.go
+++ b/test/e2e/tests/validator_test.go
@@ -30,7 +30,13 @@ func TestValidator_Sets(t *testing.T) {
 
 		// skip first block if node is pruning blocks, to avoid race conditions
 		if node.RetainBlocks > 0 {
-			first++
+			// This was done in case pruning is activated.
+			// As it happens in the background this lowers the chances
+			// that the block at height=first will be pruned by the time we test
+			// this. If this test starts to fail often, it is worth revisiting this logic.
+			// To reproduce this failure locally, it is advised to set the storage.pruning.interval
+			// to 1s instead of 10s.
+			first += int64(node.RetainBlocks)
 		}
 
 		valSchedule := newValidatorSchedule(*node.Testnet)


### PR DESCRIPTION

The test is failing often due to the fact that it asks for the first block via RPC Status then waits to be notified about the latest height via gRPC and then requests block results at the first and last heights. If pruning is happening fast enough, there is a high chance the results will be pruned at the time of asking.

This fix is not making the behaviour fully deterministic but increases the chances the block is still around because it sets the first height to be the last reported first height + retain blocks. 


<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
