### PR TITLE
fix(docker-compose): fix subnet

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,4 +67,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: 192.167.10.0/16
+        - subnet: 192.167.0.0/16


### PR DESCRIPTION
Error:

```
ERROR: invalid network config:
invalid subnet 192.167.10.0/16: it should be 192.167.0.0/16
```

OS: Ubuntu

Closes #2381

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] ~~Tests written/updated~~ (Verified manually)
- [ ] ~~Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)~~
- [ ] ~~Updated relevant documentation (`docs/` or `spec/`) and code comments~~
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
