### PR TITLE
Moved `MedianTime` out of `internal` folder

### DIFF
--- a/internal/state/validation.go
+++ b/internal/state/validation.go
@@ -121,7 +121,7 @@ func validateBlock(state State, block *types.Block) error {
 			)
 		}
 		if !state.ConsensusParams.Feature.PbtsEnabled(block.Height) {
-			medianTime := MedianTime(block.LastCommit, state.LastValidators)
+			medianTime := block.LastCommit.MedianTime(state.LastValidators)
 			if !block.Time.Equal(medianTime) {
 				return fmt.Errorf("invalid block time. Expected %v, got %v",
 					medianTime.Format(time.RFC3339Nano),

--- a/test/e2e/tests/block_test.go
+++ b/test/e2e/tests/block_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/cometbft/cometbft/internal/state"
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 )
 
@@ -121,7 +120,7 @@ func TestBlock_Time(t *testing.T) {
 
 		valSchedule.Increment(1)
 		if testnet.PbtsEnableHeight == 0 || block.Height < testnet.PbtsEnableHeight {
-			expTime := state.MedianTime(block.LastCommit, valSchedule.Set)
+			expTime := block.LastCommit.MedianTime(valSchedule.Set)
 			require.Equal(t, expTime, block.Time, "height=%d", block.Height)
 		}
 	}

--- a/types/block.go
+++ b/types/block.go
@@ -19,6 +19,7 @@ import (
 	cmtsync "github.com/cometbft/cometbft/internal/sync"
 	cmtbytes "github.com/cometbft/cometbft/libs/bytes"
 	cmtmath "github.com/cometbft/cometbft/libs/math"
+	cmttime "github.com/cometbft/cometbft/types/time"
 	"github.com/cometbft/cometbft/version"
 )
 
@@ -915,6 +916,32 @@ func (commit *Commit) ValidateBasic() error {
 		}
 	}
 	return nil
+}
+
+// MedianTime computes the median time for a Commit based on the associated validator set.
+// The median time is the weighted median of the Timestamp fields of the commit votes,
+// with heights defined by the validator's voting powers.
+// The BFT Time algorithm ensures that the computed median time is always picked among
+// the timestamps produced by honest processes, i.e., faulty processes cannot arbitrarily
+// increase or decrease the median time.
+// See: https://github.com/cometbft/cometbft/blob/main/spec/consensus/bft-time.md
+func (commit *Commit) MedianTime(validators *ValidatorSet) time.Time {
+	weightedTimes := make([]*cmttime.WeightedTime, len(commit.Signatures))
+	totalVotingPower := int64(0)
+
+	for i, commitSig := range commit.Signatures {
+		if commitSig.BlockIDFlag == BlockIDFlagAbsent {
+			continue
+		}
+		_, validator := validators.GetByAddress(commitSig.ValidatorAddress)
+		// If there's no condition, TestValidateBlockCommit panics; not needed normally.
+		if validator != nil {
+			totalVotingPower += validator.VotingPower
+			weightedTimes[i] = cmttime.NewWeightedTime(commitSig.Timestamp, validator.VotingPower)
+		}
+	}
+
+	return cmttime.WeightedMedian(weightedTimes, totalVotingPower)
 }
 
 // Hash returns the hash of the commit.


### PR DESCRIPTION
As per title.
Goal is that apps, such as `e2e` app, don't need to import packages in the the `internal` folder

Contributes to #2063

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
