### PR TITLE
Fixes the spec inform about invalid extensions in `last_commit`

### DIFF
--- a/spec/abci/abci++_app_requirements.md
+++ b/spec/abci/abci++_app_requirements.md
@@ -6,52 +6,52 @@ title: Requirements for the Application
 # Requirements for the Application
 
 - [Requirements for the Application](#requirements-for-the-application)
-  - [Formal Requirements](#formal-requirements)
-    - [Consensus Connection Requirements](#consensus-connection-requirements)
-    - [Mempool Connection Requirements](#mempool-connection-requirements)
-  - [Managing the Application state and related topics](#managing-the-application-state-and-related-topics)
-    - [Connection State](#connection-state)
-      - [Concurrency](#concurrency)
-      - [FinalizeBlock](#finalizeblock)
-      - [Commit](#commit)
-      - [Candidate States](#candidate-states)
-    - [States and ABCI++ Connections](#states-and-abci-connections)
-      - [Consensus Connection](#consensus-connection)
-      - [Mempool Connection](#mempool-connection)
-        - [Replay Protection](#replay-protection)
-      - [Info/Query Connection](#infoquery-connection)
-      - [Snapshot Connection](#snapshot-connection)
-    - [Transaction Results](#transaction-results)
-      - [Gas](#gas)
-      - [Specifics of `CheckTxResponse`](#specifics-of-checktxresponse)
-      - [Specifics of `ExecTxResult`](#specifics-of-exectxresult)
-    - [Updating the Validator Set](#updating-the-validator-set)
-    - [Consensus Parameters](#consensus-parameters)
-      - [List of Parameters](#list-of-parameters)
-        - [BlockParams.MaxBytes](#blockparamsmaxbytes)
-        - [BlockParams.MaxGas](#blockparamsmaxgas)
-        - [EvidenceParams.MaxAgeDuration](#evidenceparamsmaxageduration)
-        - [EvidenceParams.MaxAgeNumBlocks](#evidenceparamsmaxagenumblocks)
-        - [EvidenceParams.MaxBytes](#evidenceparamsmaxbytes)
-        - [ValidatorParams.PubKeyTypes](#validatorparamspubkeytypes)
-        - [VersionParams.App](#versionparamsapp)
-        - [ABCIParams.VoteExtensionsEnableHeight](#abciparamsvoteextensionsenableheight)
-      - [Updating Consensus Parameters](#updating-consensus-parameters)
-        - [`InitChain`](#initchain)
-        - [`FinalizeBlock`, `PrepareProposal`/`ProcessProposal`](#finalizeblock-prepareproposalprocessproposal)
-    - [`Query`](#query)
-      - [Query Proofs](#query-proofs)
-      - [Peer Filtering](#peer-filtering)
-      - [Paths](#paths)
-    - [Crash Recovery](#crash-recovery)
-    - [State Sync](#state-sync)
-      - [Taking Snapshots](#taking-snapshots)
-      - [Bootstrapping a Node](#bootstrapping-a-node)
-        - [Snapshot Discovery](#snapshot-discovery)
-        - [Snapshot Restoration](#snapshot-restoration)
-        - [Snapshot Verification](#snapshot-verification)
-        - [Transition to Consensus](#transition-to-consensus)
-  - [Application configuration required to switch to ABCI 2.0](#application-configuration-required-to-switch-to-abci-20)
+    - [Formal Requirements](#formal-requirements)
+        - [Consensus Connection Requirements](#consensus-connection-requirements)
+        - [Mempool Connection Requirements](#mempool-connection-requirements)
+    - [Managing the Application state and related topics](#managing-the-application-state-and-related-topics)
+        - [Connection State](#connection-state)
+            - [Concurrency](#concurrency)
+            - [FinalizeBlock](#finalizeblock)
+            - [Commit](#commit)
+            - [Candidate States](#candidate-states)
+        - [States and ABCI++ Connections](#states-and-abci-connections)
+            - [Consensus Connection](#consensus-connection)
+            - [Mempool Connection](#mempool-connection)
+                - [Replay Protection](#replay-protection)
+            - [Info/Query Connection](#infoquery-connection)
+            - [Snapshot Connection](#snapshot-connection)
+        - [Transaction Results](#transaction-results)
+            - [Gas](#gas)
+            - [Specifics of `CheckTxResponse`](#specifics-of-checktxresponse)
+            - [Specifics of `ExecTxResult`](#specifics-of-exectxresult)
+        - [Updating the Validator Set](#updating-the-validator-set)
+        - [Consensus Parameters](#consensus-parameters)
+            - [List of Parameters](#list-of-parameters)
+                - [BlockParams.MaxBytes](#blockparamsmaxbytes)
+                - [BlockParams.MaxGas](#blockparamsmaxgas)
+                - [EvidenceParams.MaxAgeDuration](#evidenceparamsmaxageduration)
+                - [EvidenceParams.MaxAgeNumBlocks](#evidenceparamsmaxagenumblocks)
+                - [EvidenceParams.MaxBytes](#evidenceparamsmaxbytes)
+                - [ValidatorParams.PubKeyTypes](#validatorparamspubkeytypes)
+                - [VersionParams.App](#versionparamsapp)
+                - [ABCIParams.VoteExtensionsEnableHeight](#abciparamsvoteextensionsenableheight)
+            - [Updating Consensus Parameters](#updating-consensus-parameters)
+                - [`InitChain`](#initchain)
+                - [`FinalizeBlock`, `PrepareProposal`/`ProcessProposal`](#finalizeblock-prepareproposalprocessproposal)
+        - [`Query`](#query)
+            - [Query Proofs](#query-proofs)
+            - [Peer Filtering](#peer-filtering)
+            - [Paths](#paths)
+        - [Crash Recovery](#crash-recovery)
+        - [State Sync](#state-sync)
+            - [Taking Snapshots](#taking-snapshots)
+            - [Bootstrapping a Node](#bootstrapping-a-node)
+                - [Snapshot Discovery](#snapshot-discovery)
+                - [Snapshot Restoration](#snapshot-restoration)
+                - [Snapshot Verification](#snapshot-verification)
+                - [Transition to Consensus](#transition-to-consensus)
+    - [Application configuration required to switch to ABCI 2.0](#application-configuration-required-to-switch-to-abci-20)
 
 ## Formal Requirements
 
@@ -73,7 +73,7 @@ returns via `PrepareProposalResponse` to CometBFT, also known as the prepared pr
 
 Process *p*'s prepared proposal can differ in two different rounds where *p* is the proposer.
 
-* Requirement 1 [`PrepareProposal`, timeliness]: If *p*'s Application fully executes prepared blocks in
+- Requirement 1 [`PrepareProposal`, timeliness]: If *p*'s Application fully executes prepared blocks in
   `PrepareProposal` and the network is in a synchronous period while processes *p* and *q* are in *r<sub>p</sub>*,
   then the value of *TimeoutPropose* at *q* must be such that *q*'s propose timer does not time out
   (which would result in *q* prevoting `nil` in *r<sub>p</sub>*).
@@ -86,7 +86,7 @@ compromise liveness because even though `TimeoutPropose` is used as the initial
 value for proposal timeouts, CometBFT will be dynamically adjust these timeouts
 such that they will eventually be enough for completing `PrepareProposal`.
 
-* Requirement 2 [`PrepareProposal`, tx-size]: When *p*'s Application calls `PrepareProposal`, the
+- Requirement 2 [`PrepareProposal`, tx-size]: When *p*'s Application calls `PrepareProposal`, the
   total size in bytes of the transactions returned does not exceed `PrepareProposalRequest.max_tx_bytes`.
 
 Busy blockchains might seek to gain full visibility into transactions in CometBFT's mempool,
@@ -98,7 +98,7 @@ Under these settings, the aggregated size of all transactions may exceed `Prepar
 Hence, Requirement 2 ensures that the size in bytes of the transaction list returned by the application will never
 cause the resulting block to go beyond its byte size limit.
 
-* Requirement 3 [`PrepareProposal`, `ProcessProposal`, coherence]: For any two correct processes *p* and *q*,
+- Requirement 3 [`PrepareProposal`, `ProcessProposal`, coherence]: For any two correct processes *p* and *q*,
   if *q*'s CometBFT calls `ProcessProposal` on *u<sub>p</sub>*,
   *q*'s Application returns Accept in `ProcessProposalResponse`.
 
@@ -111,12 +111,12 @@ likely hit the bug at the same time. This would result in most (or all) processe
 serious consequences on CometBFT's liveness that this entails. Due to its criticality, Requirement 3 is a
 target for extensive testing and automated verification.
 
-* Requirement 4 [`ProcessProposal`, determinism-1]: `ProcessProposal` is a (deterministic) function of the current
+- Requirement 4 [`ProcessProposal`, determinism-1]: `ProcessProposal` is a (deterministic) function of the current
   state and the block that is about to be applied. In other words, for any correct process *p*, and any arbitrary block *u*,
   if *p*'s CometBFT calls `ProcessProposal` on *u* at height *h*,
   then *p*'s Application's acceptance or rejection **exclusively** depends on *u* and *s<sub>p,h-1</sub>*.
 
-* Requirement 5 [`ProcessProposal`, determinism-2]: For any two correct processes *p* and *q*, and any arbitrary
+- Requirement 5 [`ProcessProposal`, determinism-2]: For any two correct processes *p* and *q*, and any arbitrary
   block *u*,
   if *p*'s (resp. *q*'s) CometBFT calls `ProcessProposal` on *u* at height *h*,
   then *p*'s Application accepts *u* if and only if *q*'s Application accepts *u*.
@@ -144,7 +144,7 @@ Let *e<sup>r</sup><sub>p</sub>* be the vote extension that the Application of a 
 Let *w<sup>r</sup><sub>p</sub>* be the proposed block that *p*'s CometBFT passes to the Application via `ExtendVoteRequest`
 in round *r*, height *h*.
 
-* Requirement 6 [`ExtendVote`, `VerifyVoteExtension`, coherence]: For any two different correct
+- Requirement 6 [`ExtendVote`, `VerifyVoteExtension`, coherence]: For any two different correct
   processes *p* and *q*, if *q* receives *e<sup>r</sup><sub>p</sub>* from *p* in height *h*, *q*'s
   Application returns Accept in `VerifyVoteExtensionResponse`.
 
@@ -156,13 +156,13 @@ However, if there is a (deterministic) bug in `ExtendVote` or `VerifyVoteExtensi
 we will face the same liveness issues as described for Requirement 5, as Precommit messages with invalid vote
 extensions will be discarded.
 
-* Requirement 7 [`VerifyVoteExtension`, determinism-1]: `VerifyVoteExtension` is a (deterministic) function of
+- Requirement 7 [`VerifyVoteExtension`, determinism-1]: `VerifyVoteExtension` is a (deterministic) function of
   the current state, the vote extension received, and the prepared proposal that the extension refers to.
   In other words, for any correct process *p*, and any arbitrary vote extension *e*, and any arbitrary
   block *w*, if *p*'s (resp. *q*'s) CometBFT calls `VerifyVoteExtension` on *e* and *w* at height *h*,
   then *p*'s Application's acceptance or rejection **exclusively** depends on *e*, *w* and *s<sub>p,h-1</sub>*.
 
-* Requirement 8 [`VerifyVoteExtension`, determinism-2]: For any two correct processes *p* and *q*,
+- Requirement 8 [`VerifyVoteExtension`, determinism-2]: For any two correct processes *p* and *q*,
   and any arbitrary vote extension *e*, and any arbitrary block *w*,
   if *p*'s (resp. *q*'s) CometBFT calls `VerifyVoteExtension` on *e* and *w* at height *h*,
   then *p*'s Application accepts *e* if and only if *q*'s Application accepts *e*.
@@ -177,11 +177,11 @@ Requirements 7 and 8 can be violated by a bug inducing non-determinism in
 Extra care should be put in the implementation of `ExtendVote` and `VerifyVoteExtension`.
 As a general rule, `VerifyVoteExtension` SHOULD always accept the vote extension.
 
-* Requirement 9 [*all*, no-side-effects]: *p*'s calls to `PrepareProposal`,
+- Requirement 9 [*all*, no-side-effects]: *p*'s calls to `PrepareProposal`,
   `ProcessProposal`, `ExtendVote`, and `VerifyVoteExtension` at height *h* do
   not modify *s<sub>p,h-1</sub>*.
 
-* Requirement 10 [`ExtendVote`, `FinalizeBlock`, non-dependency]: for any correct process *p*,
+- Requirement 10 [`ExtendVote`, `FinalizeBlock`, non-dependency]: for any correct process *p*,
 and any vote extension *e* that *p* received at height *h*, the computation of
 *s<sub>p,h</sub>* does not depend on *e*.
 
@@ -189,10 +189,10 @@ The call to correct process *p*'s `FinalizeBlock` at height *h*, with block *v<s
 passed as parameter, creates state *s<sub>p,h</sub>*.
 Additionally, *p*'s `FinalizeBlock` creates a set of transaction results *T<sub>p,h</sub>*.
 
-* Requirement 11 [`FinalizeBlock`, determinism-1]: For any correct process *p*,
+- Requirement 11 [`FinalizeBlock`, determinism-1]: For any correct process *p*,
   *s<sub>p,h</sub>* exclusively depends on *s<sub>p,h-1</sub>* and *v<sub>p,h</sub>*.
 
-* Requirement 12 [`FinalizeBlock`, determinism-2]: For any correct process *p*,
+- Requirement 12 [`FinalizeBlock`, determinism-2]: For any correct process *p*,
   the contents of *T<sub>p,h</sub>* exclusively depend on *s<sub>p,h-1</sub>* and *v<sub>p,h</sub>*.
 
 Note that Requirements 11 and 12, combined with the Agreement property of consensus ensure
@@ -202,14 +202,14 @@ Also, notice that neither `PrepareProposal` nor `ExtendVote` have determinism-re
 requirements associated.
 Indeed, `PrepareProposal` is not required to be deterministic:
 
-* *u<sub>p</sub>* may depend on *v<sub>p</sub>* and *s<sub>p,h-1</sub>*, but may also depend on other values or operations.
-* *v<sub>p</sub> = v<sub>q</sub> &#8655; u<sub>p</sub> = u<sub>q</sub>*.
+- *u<sub>p</sub>* may depend on *v<sub>p</sub>* and *s<sub>p,h-1</sub>*, but may also depend on other values or operations.
+- *v<sub>p</sub> = v<sub>q</sub> &#8655; u<sub>p</sub> = u<sub>q</sub>*.
 
 Likewise, `ExtendVote` can also be non-deterministic:
 
-* *e<sup>r</sup><sub>p</sub>* may depend on *w<sup>r</sup><sub>p</sub>* and *s<sub>p,h-1</sub>*,
+- *e<sup>r</sup><sub>p</sub>* may depend on *w<sup>r</sup><sub>p</sub>* and *s<sub>p,h-1</sub>*,
   but may also depend on other values or operations.
-* *w<sup>r</sup><sub>p</sub> = w<sup>r</sup><sub>q</sub> &#8655;
+- *w<sup>r</sup><sub>p</sub> = w<sup>r</sup><sub>q</sub> &#8655;
   e<sup>r</sup><sub>p</sub> = e<sup>r</sup><sub>q</sub>*
 
 ### Mempool Connection Requirements
@@ -226,7 +226,7 @@ we define *CheckTxCode<sub>tx,p,h</sub>* as the singleton value of *CheckTxCodes
 If *CheckTxCodes<sub>tx,p,h</sub>* is not a singleton set, *CheckTxCode<sub>tx,p,h</sub>* is undefined.
 Let predicate *OK(CheckTxCode<sub>tx,p,h</sub>)* denote whether *CheckTxCode<sub>tx,p,h</sub>* is `SUCCESS`.
 
-* Requirement 13 [`CheckTx`, eventual non-oscillation]: For any transaction *tx*,
+- Requirement 13 [`CheckTx`, eventual non-oscillation]: For any transaction *tx*,
   there exists a boolean value *b*,
   and a height *h<sub>stable</sub>* such that,
   for any correct process *p*,
@@ -325,22 +325,22 @@ Likewise, CometBFT calls `ProcessProposal` upon reception of a proposed block fr
 network. The proposed block's data
 that is disclosed to the Application by these two methods is the following:
 
-* the transaction list
-* the `LastCommit` referring to the previous block
-* the block header's hash (except in `PrepareProposal`, where it is not known yet)
-* list of validators that misbehaved
-* the block's timestamp
-* `NextValidatorsHash`
-* Proposer address
+- the transaction list
+- the `LastCommit` referring to the previous block
+- the block header's hash (except in `PrepareProposal`, where it is not known yet)
+- list of validators that misbehaved
+- the block's timestamp
+- `NextValidatorsHash`
+- Proposer address
 
 The Application may decide to *immediately* execute the given block (i.e., upon `PrepareProposal`
 or `ProcessProposal`). There are two main reasons why the Application may want to do this:
 
-* *Avoiding invalid transactions in blocks*.
+- *Avoiding invalid transactions in blocks*.
   In order to be sure that the block does not contain *any* invalid transaction, there may be
   no way other than fully executing the transactions in the block as though it was the *decided*
   block.
-* *Quick `FinalizeBlock` execution*.
+- *Quick `FinalizeBlock` execution*.
   Upon reception of the decided block via `FinalizeBlock`, if that same block was executed
   upon `PrepareProposal` or `ProcessProposal` and the resulting state was kept in memory, the
   Application can simply apply that state (faster) to the main state, rather than reexecuting
@@ -479,8 +479,8 @@ or validation should fail before it can use more resources than it requested.
 
 When `MaxGas > -1`, CometBFT enforces the following rules:
 
-* `GasWanted <= MaxGas` for every transaction in the mempool
-* `(sum of GasWanted in a block) <= MaxGas` when proposing a block
+- `GasWanted <= MaxGas` for every transaction in the mempool
+- `(sum of GasWanted in a block) <= MaxGas` when proposing a block
 
 If `MaxGas == -1`, no rules about gas are enforced.
 
@@ -498,7 +498,7 @@ it can use `PrepareProposal` and `ProcessProposal` to enforce that `(sum of GasW
 in all proposed or prevoted blocks,
 we have:
 
-* `(sum of GasUsed in a block) <= MaxGas` for every block
+- `(sum of GasUsed in a block) <= MaxGas` for every block
 
 The `GasUsed` field is ignored by CometBFT.
 
@@ -559,21 +559,21 @@ duplicates, the block execution will fail irrecoverably.
 Structure `ValidatorUpdate` contains a public key, which is used to identify the validator:
 The public key currently supports three types:
 
-* `ed25519`
-* `secp256k1`
-* `sr25519`
+- `ed25519`
+- `secp256k1`
+- `sr25519`
 
 Structure `ValidatorUpdate` also contains an `ìnt64` field denoting the validator's new power.
 Applications must ensure that
 `ValidatorUpdate` structures abide by the following rules:
 
-* power must be non-negative
-* if power is set to 0, the validator must be in the validator set; it will be removed from the set
-* if power is greater than 0:
-    * if the validator is not in the validator set, it will be added to the
+- power must be non-negative
+- if power is set to 0, the validator must be in the validator set; it will be removed from the set
+- if power is greater than 0:
+    - if the validator is not in the validator set, it will be added to the
       set with the given power
-    * if the validator is in the validator set, its power will be adjusted to the given power
-* the total power of the new validator set must not exceed `MaxTotalVotingPower`, where
+    - if the validator is in the validator set, its power will be adjusted to the given power
+- the total power of the new validator set must not exceed `MaxTotalVotingPower`, where
   `MaxTotalVotingPower = MaxInt64 / 8`
 
 Note the updates returned after processing the block at height `H` will only take effect
@@ -620,7 +620,7 @@ This is enforced by the consensus algorithm.
 This implies a maximum transaction size that is this `MaxBytes`, less the expected size of
 the header, the validator set, and any included evidence in the block.
 
-The Application should be aware that honest validators _may_ produce and
+The Application should be aware that honest validators *may* produce and
 broadcast blocks with up to the configured `MaxBytes` size.
 As a result, the consensus
 [timeout parameters](../../docs/explanation/core/configuration.md#consensus-timeouts-explained)
@@ -788,8 +788,8 @@ include vote extensions yet, but `ExtendVote` and `VerifyVoteExtension` will
 be called. Then, when reaching height `H+1`, `PrepareProposal` will
 include the vote extensions from height `H`. For all heights after `H`
 
-* vote extensions cannot be disabled,
-* they are mandatory: all precommit messages sent MUST have an extension
+- vote extensions cannot be disabled,
+- they are mandatory: all precommit messages sent MUST have an extension
   attached. Nevertheless, the application MAY provide 0-length
   extensions.
 
@@ -861,9 +861,9 @@ For such applications, the `AppHash` provides a much more efficient way to verif
 ABCI applications can take advantage of more efficient light-client proofs for
 their state as follows:
 
-* return the Merkle root of the deterministic application state in
+- return the Merkle root of the deterministic application state in
   `FinalizeBlockResponse.Data`. This Merkle root will be included as the `AppHash` in the next block.
-* return efficient Merkle proofs about that application state in `QueryResponse.Proof`
+- return efficient Merkle proofs about that application state in `QueryResponse.Proof`
   that can be verified using the `AppHash` of the corresponding block.
 
 For instance, this allows an application's light-client to verify proofs of
@@ -898,9 +898,9 @@ the list should match the `AppHash` being verified against.
 When CometBFT connects to a peer, it sends two queries to the ABCI application
 using the following paths, with no additional data:
 
-* `/p2p/filter/addr/<IP:PORT>`, where `<IP:PORT>` denote the IP address and
+- `/p2p/filter/addr/<IP:PORT>`, where `<IP:PORT>` denote the IP address and
   the port of the connection
-* `p2p/filter/id/<ID>`, where `<ID>` is the peer node ID (ie. the
+- `p2p/filter/id/<ID>`, where `<ID>` is the peer node ID (ie. the
   pubkey.Address() for the peer's PubKey)
 
 If either of these queries return a non-zero ABCI code, CometBFT will refuse
@@ -930,6 +930,7 @@ committed state of the app. The app MUST return information consistent with the
 last block for which it successfully completed `Commit`.
 
 The three steps performed before the state of a height is considered persisted are:
+
 - The block is stored by CometBFT in the blockstore
 - CometBFT has stored the state returned by the application through `FinalizeBlockResponse`
 - The application has committed its state within `Commit`.
@@ -963,6 +964,7 @@ and the operations for this height are repeated entirely):
 
 Based on the sequence of these events, CometBFT will panic if any of the steps in the sequence happen out of order,
 that is if:
+
 - The application has persisted a block at a height higher than the blocked saved during `state_stored`.
 - The `block_stored` step persisted a block at a height smaller than the `state_stored`
 - And the difference between the heights of the blocks persisted by `state_stored` and `block_stored` is more
@@ -997,20 +999,20 @@ Applications that want to support state syncing must take state snapshots at reg
 this is accomplished is entirely up to the application. A snapshot consists of some metadata and
 a set of binary chunks in an arbitrary format:
 
-* `Height (uint64)`: The height at which the snapshot is taken. It must be taken after the given
+- `Height (uint64)`: The height at which the snapshot is taken. It must be taken after the given
   height has been committed, and must not contain data from any later heights.
 
-* `Format (uint32)`: An arbitrary snapshot format identifier. This can be used to version snapshot
+- `Format (uint32)`: An arbitrary snapshot format identifier. This can be used to version snapshot
   formats, e.g. to switch from Protobuf to MessagePack for serialization. The application can use
   this when restoring to choose whether to accept or reject a snapshot.
 
-* `Chunks (uint32)`: The number of chunks in the snapshot. Each chunk contains arbitrary binary
+- `Chunks (uint32)`: The number of chunks in the snapshot. Each chunk contains arbitrary binary
   data, and should be less than 16 MB; 10 MB is a good starting point.
 
-* `Hash ([]byte)`: An arbitrary hash of the snapshot. This is used to check whether a snapshot is
+- `Hash ([]byte)`: An arbitrary hash of the snapshot. This is used to check whether a snapshot is
   the same across nodes when downloading chunks.
 
-* `Metadata ([]byte)`: Arbitrary snapshot metadata, e.g. chunk hashes for verification or any other
+- `Metadata ([]byte)`: Arbitrary snapshot metadata, e.g. chunk hashes for verification or any other
   necessary info.
 
 For a snapshot to be considered the same across nodes, all of these fields must be identical. When
@@ -1021,14 +1023,14 @@ application via the ABCI `ListSnapshots` method to discover available snapshots,
 snapshot chunks via `LoadSnapshotChunk`. The application is free to choose how to implement this
 and which formats to use, but must provide the following guarantees:
 
-* **Consistent:** A snapshot must be taken at a single isolated height, unaffected by
+- **Consistent:** A snapshot must be taken at a single isolated height, unaffected by
   concurrent writes. This can be accomplished by using a data store that supports ACID
   transactions with snapshot isolation.
 
-* **Asynchronous:** Taking a snapshot can be time-consuming, so it must not halt chain progress,
+- **Asynchronous:** Taking a snapshot can be time-consuming, so it must not halt chain progress,
   for example by running in a separate thread.
 
-* **Deterministic:** A snapshot taken at the same height in the same format must be identical
+- **Deterministic:** A snapshot taken at the same height in the same format must be identical
   (at the byte level) across nodes, including all metadata. This ensures good availability of
   chunks, and that they fit together across nodes.
 
@@ -1113,9 +1115,9 @@ Once the snapshots have all been restored, CometBFT gathers additional informati
 bootstrapping the node (e.g. chain ID, consensus parameters, validator sets, and block headers)
 from the genesis file and light client RPC servers. It also calls `Info` to verify the following:
 
-* that the app hash from the snapshot it has delivered to the Application matches the apphash
+- that the app hash from the snapshot it has delivered to the Application matches the apphash
   stored in the next height's block
-* that the version that the Application returns in `InfoResponse` matches the version in the
+- that the version that the Application returns in `InfoResponse` matches the version in the
   current height's block header
 
 Once the state machine has been restored and CometBFT has gathered this additional
@@ -1139,8 +1141,8 @@ There is a newly introduced [**consensus parameter**](./abci%2B%2B_app_requireme
 This parameter represents the height at which vote extensions are
 required for consensus to proceed, with 0 being the default value (no vote extensions).
 A chain can enable vote extensions either:
-* at genesis by setting `VoteExtensionsEnableHeight` to be equal, e.g., to the `InitialHeight`
-* or via the application logic by changing the `ConsensusParam` to configure the
+- at genesis by setting `VoteExtensionsEnableHeight` to be equal, e.g., to the `InitialHeight`
+- or via the application logic by changing the `ConsensusParam` to configure the
 `VoteExtensionsEnableHeight`.
 
 Once the (coordinated) upgrade to ABCI 2.0 has taken place, at height  *h<sub>u</sub>*,

--- a/spec/abci/abci++_basic_concepts.md
+++ b/spec/abci/abci++_basic_concepts.md
@@ -6,21 +6,21 @@ title: Overview and basic concepts
 ## Outline
 
 - [Overview and basic concepts](#overview-and-basic-concepts)
-  - [ABCI++ vs. ABCI](#abci-vs-abci)
-  - [Method overview](#method-overview)
-    - [Consensus/block execution methods](#consensusblock-execution-methods)
-    - [Mempool methods](#mempool-methods)
-    - [Info methods](#info-methods)
-    - [State-sync methods](#state-sync-methods)
-    - [Other methods](#other-methods)
-  - [Proposal timeout](#proposal-timeout)
-  - [Deterministic State-Machine Replication](#deterministic-state-machine-replication)
-  - [Events](#events)
-  - [Evidence](#evidence)
-  - [Errors](#errors)
-    - [`CheckTx`](#checktx)
-    - [`ExecTxResult` (as part of `FinalizeBlock`)](#exectxresult-as-part-of-finalizeblock)
-    - [`Query`](#query)
+    - [ABCI++ vs. ABCI](#abci-vs-abci)
+    - [Method overview](#method-overview)
+        - [Consensus/block execution methods](#consensusblock-execution-methods)
+        - [Mempool methods](#mempool-methods)
+        - [Info methods](#info-methods)
+        - [State-sync methods](#state-sync-methods)
+        - [Other methods](#other-methods)
+    - [Proposal timeout](#proposal-timeout)
+    - [Deterministic State-Machine Replication](#deterministic-state-machine-replication)
+    - [Events](#events)
+    - [Evidence](#evidence)
+    - [Errors](#errors)
+        - [`CheckTx`](#checktx)
+        - [`ExecTxResult` (as part of `FinalizeBlock`)](#exectxresult-as-part-of-finalizeblock)
+        - [`Query`](#query)
 
 # Overview and basic concepts
 
@@ -75,7 +75,7 @@ call sequences of these methods.
   proposer to perform application-dependent work in a block before proposing it.
   This enables, for instance, batch optimizations to a block, which has been empirically
   demonstrated to be a key component for improved performance. Method `PrepareProposal` is called
-  every time CometBFT is about to broadcast a Proposal message and _validValue_ is `nil`.
+  every time CometBFT is about to broadcast a Proposal message and *validValue* is `nil`.
   CometBFT gathers outstanding transactions from the
   mempool, generates a block header, and uses them to create a block to propose. Then, it calls
   `PrepareProposal` with the newly created proposal, called *raw proposal*. The Application
@@ -88,7 +88,7 @@ call sequences of these methods.
   perform application-dependent work in a proposed block. This enables features such as immediate
   block execution, and allows the Application to reject invalid blocks.
 
-  CometBFT calls it when it receives a proposal and _validValue_ is `nil`.
+  CometBFT calls it when it receives a proposal and *validValue* is `nil`.
   The Application cannot modify the proposal at this point but can reject it if
   invalid. If that is the case, the consensus algorithm will prevote `nil` on the proposal, which has
   strong liveness implications for CometBFT. As a general rule, the Application
@@ -114,10 +114,10 @@ call sequences of these methods.
   This has a negative impact on liveness, i.e., if vote extensions repeatedly cannot be
   verified by correct validators, the consensus algorithm may not be able to finalize a block even if sufficiently
   many (+2/3) validators send precommit votes for that block. Thus, `VerifyVoteExtension`
-  should be used with special care.
+  should be implemented with special care.
   As a general rule, an Application that detects an invalid vote extension SHOULD
   accept it in `VerifyVoteExtensionResponse` and ignore it in its own logic. CometBFT calls it when
-  a process receives a precommit message with a (possibly empty) vote extension.
+  a process receives a precommit message with a (possibly empty) vote extension, for the current height.
   The logic in `VerifyVoteExtension` MUST be deterministic.
 
 - [**FinalizeBlock:**](./abci++_methods.md#finalizeblock) It delivers a decided block to the
@@ -251,7 +251,8 @@ time during `FinalizeBlock`; they must only apply state changes in `Commit`.
 
 Additionally, vote extensions or the validation thereof (via `ExtendVote` or
 `VerifyVoteExtension`) must *never* have side effects on the current state.
-They can only be used when their data is provided in a `PrepareProposal` call.
+Their data can only be used when provided in a `PrepareProposal` call, but again,
+without side effects to the app state.
 
 If there is some non-determinism in the state machine, consensus will eventually
 fail as nodes disagree over the correct values for the block header. The

--- a/spec/abci/abci++_methods.md
+++ b/spec/abci/abci++_methods.md
@@ -330,8 +330,9 @@ title: Methods
     * `PrepareProposalRequest`'s fields `txs`, `misbehavior`, `height`, `time`,
       `next_validators_hash`, and `proposer_address` are the same as in `ProcessProposalRequest`
       and `FinalizeBlockRequest`.
-    * `PrepareProposalRequest.local_last_commit` is a set of the precommit votes that allowed the
-      decision of the previous block, together with their corresponding vote extensions.
+    * `PrepareProposalRequest.local_last_commit` is a set of the precommit votes for the previous
+      height, including the ones that led to the decision of the previous block,
+      together with their corresponding vote extensions.
     * The `height`, `time`, and `proposer_address` values match the values from the header of the
       proposed block.
     * `PrepareProposalRequest` contains a preliminary set of transactions `txs` that CometBFT
@@ -378,7 +379,7 @@ title: Methods
        -->
     * If CometBFT fails to validate the `PrepareProposalResponse`, CometBFT will assume the
       Application is faulty and crash.
-    * The implementation of `PrepareProposal` can be non-deterministic.
+    * The implementation of `PrepareProposal` MAY be non-deterministic.
 
 
 #### When does CometBFT call "PrepareProposal" ?
@@ -404,6 +405,9 @@ and _p_'s _validValue_ is `nil`:
         * modify transactions (e.g. aggregate them). As explained above, this compromises client traceability, unless
           it is implemented at the Application level.
         * reorder transactions - the Application reorders transactions in the list
+    * the Application MAY use the vote extensions in the commit info to modify the proposal, in which case it suggested
+     that extensions are validated in the same maner as done in `VerifyVoteExtension`, since extensions of votes included
+     in the commit info after the minimum of +2/3 had been reached, have not been verified.
 4. The Application includes the transaction list (whether modified or not) in the return parameters
    (see the rules in section _Usage_), and returns from the call.
 5. _p_ uses the (possibly) modified block as _p_'s proposal in round _r_, height _h_.
@@ -449,7 +453,7 @@ the consensus algorithm will use it as proposal and will not call `PreparePropos
     * The height and time values match the values from the header of the proposed block.
     * If `ProcessProposalResponse.status` is `REJECT`, consensus assumes the proposal received
       is not valid.
-    * The Application MAY fully execute the block &mdash; immediate execution
+    * The Application MAY fully execute the block (immediate execution)
     * The implementation of `ProcessProposal` MUST be deterministic. Moreover, the value of
       `ProcessProposalResponse.status` MUST **exclusively** depend on the parameters passed in
       the `ProcessProposalRequest`, and the last committed Application state
@@ -567,7 +571,7 @@ a [CanonicalVoteExtension](../core/data_structures.md#canonicalvoteextension) fi
       that the Application running at the process that sent the vote chose not to extend it.
       CometBFT will always call `VerifyVoteExtension`, even for 0 length vote extensions.
     * `VerifyVoteExtension` is not called for precommit votes sent by the local process.
-    * `VerifyVoteExtensionRequest.hash` refers to a proposed block. There is not guarantee that
+    * `VerifyVoteExtensionRequest.hash` refers to a proposed block. There is no guarantee that
       this proposed block has previously been exposed to the Application via `ProcessProposal`.
     * If `VerifyVoteExtensionResponse.status` is `REJECT`, the consensus algorithm will reject the whole received vote.
       See the [Requirements](./abci++_app_requirements.md) section to understand the potential
@@ -594,6 +598,12 @@ message for round _r_, height _h_ from validator _q_ (_q_ &ne; _p_):
      vote extension in its internal data structures. It will be used to populate the [ExtendedCommitInfo](#extendedcommitinfo)
      structure in calls to `PrepareProposal`, in rounds of height _h + 1_ where _p_ is the proposer.
    * `REJECT`, _p_ will deem the Precommit message invalid and discard it.
+
+When a node _p_ is in consensus round _0_, height _h_, and _p_ receives a Precommit
+message for CommitRound _r_, height _h-1_ from validator _q_ (_q_ &ne; _p_), _p_
+may add the Precommit message and associated extension to [ExtendedCommitInfo](#extendedcommitinfo)
+without calling `VerifyVoteExtension` to verify it.
+
 
 ### FinalizeBlock
 


### PR DESCRIPTION
Implements strategy 1a, as described in #2361 

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
