### PR TITLE
test(consensus): test if untimely proposal is decided after multiple rounds

### DIFF
--- a/internal/consensus/common_test.go
+++ b/internal/consensus/common_test.go
@@ -538,8 +538,17 @@ func randStateWithAppImpl(
 	app abci.Application,
 	consensusParams *types.ConsensusParams,
 ) (*State, []*validatorStub) {
+	return randStateWithAppImplGenesisTime(nValidators, app, consensusParams, cmttime.Now())
+}
+
+func randStateWithAppImplGenesisTime(
+	nValidators int,
+	app abci.Application,
+	consensusParams *types.ConsensusParams,
+	genesisTime time.Time,
+) (*State, []*validatorStub) {
 	// Get State
-	state, privVals := randGenesisState(nValidators, consensusParams)
+	state, privVals := randGenesisStateWithTime(nValidators, consensusParams, genesisTime)
 
 	vss := make([]*validatorStub, nValidators)
 

--- a/internal/consensus/pbts_test.go
+++ b/internal/consensus/pbts_test.go
@@ -688,7 +688,7 @@ func TestPbtsAdaptiveMessageDelay(t *testing.T) {
 
 	c := test.ConsensusParams()
 	app := kvstore.NewInMemoryApplication()
-	genesisTime := cmttime.Now().Add(-5 * time.Second)
+	genesisTime := cmttime.Now().Add(-10 * time.Second)
 	cs, vss := randStateWithAppImplGenesisTime(numValidators, app, c, genesisTime)
 
 	myPrivKey, err := vss[0].GetPubKey()

--- a/internal/consensus/pbts_test.go
+++ b/internal/consensus/pbts_test.go
@@ -715,7 +715,7 @@ func TestPbtsAdaptiveMessageDelay(t *testing.T) {
 		maxDelta := c.Synchrony.MessageDelay + c.Synchrony.Precision
 
 		if proposer != 0 {
-			shift := maxDelta
+			shift := maxDelta + time.Second
 			ts := cmttime.Now().Add(-shift)
 			if ts.Before(genesisTime) {
 				ts = genesisTime


### PR DESCRIPTION
This test should fail with the current implementation in `feature/pbts`.

This test should pass when changes from  #2432 are implemented.

This is a proof of concept and should not be merged.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
