### PR TITLE
test: untimely proposals must be decided after multiple rounds

### DIFF
--- a/internal/consensus/common_test.go
+++ b/internal/consensus/common_test.go
@@ -538,8 +538,17 @@ func randStateWithAppImpl(
 	app abci.Application,
 	consensusParams *types.ConsensusParams,
 ) (*State, []*validatorStub) {
+	return randStateWithAppImplGenesisTime(nValidators, app, consensusParams, cmttime.Now())
+}
+
+func randStateWithAppImplGenesisTime(
+	nValidators int,
+	app abci.Application,
+	consensusParams *types.ConsensusParams,
+	genesisTime time.Time,
+) (*State, []*validatorStub) {
 	// Get State
-	state, privVals := randGenesisState(nValidators, consensusParams)
+	state, privVals := randGenesisStateWithTime(nValidators, consensusParams, genesisTime)
 
 	vss := make([]*validatorStub, nValidators)
 

--- a/internal/consensus/pbts_test.go
+++ b/internal/consensus/pbts_test.go
@@ -688,7 +688,7 @@ func TestPbtsAdaptiveMessageDelay(t *testing.T) {
 
 	c := test.ConsensusParams()
 	app := kvstore.NewInMemoryApplication()
-	genesisTime := cmttime.Now().Add(-5 * time.Second)
+	genesisTime := cmttime.Now().Add(-10 * time.Second)
 	cs, vss := randStateWithAppImplGenesisTime(numValidators, app, c, genesisTime)
 
 	myPrivKey, err := vss[0].GetPubKey()

--- a/internal/consensus/pbts_test.go
+++ b/internal/consensus/pbts_test.go
@@ -702,6 +702,8 @@ func TestPbtsAdaptiveMessageDelay(t *testing.T) {
 	height, round := cs.Height, cs.Round
 	chainID := cs.state.ChainID
 
+	originMaxDelta := c.Synchrony.Precision + c.Synchrony.MessageDelay
+
 	maximumRound := round + 10
 	startTestRound(cs, height, round)
 
@@ -712,10 +714,12 @@ func TestPbtsAdaptiveMessageDelay(t *testing.T) {
 		t.Log("Starting round", round)
 		ensureNewRound(newRoundCh, height, round)
 		proposer := election(height, round)
-		maxDelta := c.Synchrony.MessageDelay + c.Synchrony.Precision
+		ac := types.AdaptiveSynchronyParams(c.Synchrony.Precision,
+			c.Synchrony.MessageDelay, round)
+		maxDelta := ac.Precision + ac.MessageDelay
 
 		if proposer != 0 {
-			shift := maxDelta + time.Second
+			shift := originMaxDelta + c.Synchrony.MessageDelay/2
 			ts := cmttime.Now().Add(-shift)
 			if ts.Before(genesisTime) {
 				ts = genesisTime

--- a/internal/consensus/pbts_test.go
+++ b/internal/consensus/pbts_test.go
@@ -715,7 +715,7 @@ func TestPbtsAdaptiveMessageDelay(t *testing.T) {
 		maxDelta := c.Synchrony.MessageDelay + c.Synchrony.Precision
 
 		if proposer != 0 {
-			shift := maxDelta
+			shift := maxDelta + time.Second
 			ts := cmttime.Now().Add(-shift)
 			if ts.Before(genesisTime) {
 				ts = genesisTime

--- a/internal/consensus/pbts_test.go
+++ b/internal/consensus/pbts_test.go
@@ -691,9 +691,9 @@ func TestPbtsAdaptiveMessageDelay(t *testing.T) {
 	genesisTime := cmttime.Now().Add(-10 * time.Second)
 	cs, vss := randStateWithAppImplGenesisTime(numValidators, app, c, genesisTime)
 
-	myPrivKey, err := vss[0].GetPubKey()
+	myPubKey, err := vss[0].GetPubKey()
 	require.NoError(t, err)
-	myAddress := myPrivKey.Address()
+	myAddress := myPubKey.Address()
 
 	proposalCh := subscribe(cs.eventBus, types.EventQueryCompleteProposal)
 	newRoundCh := subscribe(cs.eventBus, types.EventQueryNewRound)


### PR DESCRIPTION
Adds a test unit to attest the proper operation, from consensus' point of view, of the changes introduced by #2431.

Addresses  #2432.

---

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
