### PR TITLE
fix(e2e): Fixing the bug in ABCI e2e tests

### DIFF
--- a/test/e2e/pkg/grammar/checker.go
+++ b/test/e2e/pkg/grammar/checker.go
@@ -91,7 +91,7 @@ func (g *Checker) filterLastHeight(reqs []*abci.Request) ([]*abci.Request, int) 
 	pos := len(reqs) - 1
 	cnt := 0
 	// Find the last commit.
-	for pos > 0 && g.getRequestTerminal(reqs[pos]) != Commit {
+	for pos >= 0 && g.getRequestTerminal(reqs[pos]) != Commit {
 		pos--
 		cnt++
 	}
@@ -129,6 +129,7 @@ func (g *Checker) Verify(reqs []*abci.Request, isCleanStart bool) (bool, error) 
 	if len(reqs) == 0 {
 		return false, errors.New("execution with no ABCI calls")
 	}
+	fullExecution := g.getExecutionString(reqs)
 	r := g.filterRequests(reqs)
 	// Check if the execution is incomplete.
 	if len(r) == 0 {
@@ -139,7 +140,7 @@ func (g *Checker) Verify(reqs []*abci.Request, isCleanStart bool) (bool, error) 
 	if errors == nil {
 		return true, nil
 	}
-	return false, fmt.Errorf("%v\nFull execution:\n%v", g.combineErrors(errors, g.cfg.NumberOfErrorsToShow), g.addHeightNumbersToTheExecution(execution))
+	return false, fmt.Errorf("%v\nFull execution:\n%v", g.combineErrors(errors, g.cfg.NumberOfErrorsToShow), g.addHeightNumbersToTheExecution(fullExecution))
 }
 
 // verifyCleanStart verifies if a specific execution is a valid execution.


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

Closes #2466.
The abci e2e tests were returning that the execution: `prepare_proposal process_proposal process_proposal` is not correct. The bug was in the part of the code that is filtering the last incomplete execution. 
The code was not working properly in case the first instance is already incomplete, and that is exactly what has happened here. The proposed fix should address this. Moreover, we modified the unit tests to capture the modifications. 

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
