### PR TITLE
feat(metrics): more buckets for ProposalTimestampDifference

### DIFF
--- a/internal/consensus/metrics.go
+++ b/internal/consensus/metrics.go
@@ -125,11 +125,20 @@ type Metrics struct {
 	// in.
 	LateVotes metrics.Counter `metrics_labels:"vote_type"`
 
-	// ProposalTimestampDifference is the difference between the timestamp in
-	// the proposal message and the local time of the validator at the time
-	// that the validator received the message.
-	// metrics:Difference between the timestamp in the proposal message and the local time of the validator at the time it received the message.
-	ProposalTimestampDifference metrics.Histogram `metrics_bucketsizes:"-10, -.5, -.025, 0, .1, .5, 1, 1.5, 2, 10" metrics_labels:"is_timely"`
+	// ProposalTimestampDifference is the difference between the local time
+	// of the validator at the time it receives a proposal message, and the
+	// timestamp of the received proposal message.
+	//
+	// The value of this metric is not expected to be negative, as it would
+	// mean that the proposal's timestamp is in the future. This indicates
+	// that the proposer's and this node's clocks are desynchronized.
+	//
+	// A positive value of this metric reflects the message delay from the
+	// proposer to this node, for the delivery of a Proposal message. This
+	// metric thus should drive the definition of values for the consensus
+	// parameter SynchronyParams.MessageDelay, used by the PBTS algorithm.
+	// metrics:Difference in seconds between the local time when a proposal message is received and the timestamp in the proposal message.
+	ProposalTimestampDifference metrics.Histogram `metrics_bucketsizes:"-1.5, -1.0, -0.5, 0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 6.0, 8.0, 10.0" metrics_labels:"is_timely"`
 }
 
 func (m *Metrics) MarkProposalProcessed(accepted bool) {


### PR DESCRIPTION
Contributes to #2323.

Add several buckets to better track `ProposalTimestampDifference` in QA experiments.

Buckets:  `-Inf, -1.5, -1.0, -0.5, 0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 6.0, 8.0, 10.0, +Inf`

If they are too much, let me know.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
