### PR TITLE
fix: lint errors introduced with the latest merge

### DIFF
--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -1,4 +1,3 @@
-// nolint: goconst
 package e2e
 
 import (
@@ -403,7 +402,7 @@ func (t Testnet) Validate() error {
 	}
 	if t.VoteExtensionsUpdateHeight > 0 && t.VoteExtensionsUpdateHeight < t.InitialHeight {
 		return fmt.Errorf("a value of VoteExtensionsUpdateHeight greater than 0 "+
-			"must not be less than InitialHeight; "+
+			"must not be less than InitialHeight; "+ //nolint: goconst
 			"update height %d, initial height %d",
 			t.VoteExtensionsUpdateHeight, t.InitialHeight,
 		)

--- a/types/params_test.go
+++ b/types/params_test.go
@@ -1,4 +1,3 @@
-// nolint: dupl
 package types
 
 import (
@@ -610,8 +609,8 @@ func TestConsensusParamsUpdate_EnableHeight(t *testing.T) {
 	}
 }
 
-func TestProto(t *testing.T) {
-	params := []ConsensusParams{
+func consensusParamsForTestProto() []ConsensusParams {
+	return []ConsensusParams{
 		makeParams(makeParamsArgs{blockBytes: 4, blockGas: 2, evidenceAge: 3, maxEvidenceBytes: 1, voteExtensionHeight: 1}),
 		makeParams(makeParamsArgs{blockBytes: 4, blockGas: 2, evidenceAge: 3, maxEvidenceBytes: 1, pbtsHeight: 1}),
 		makeParams(makeParamsArgs{blockBytes: 4, blockGas: 2, evidenceAge: 3, maxEvidenceBytes: 1, voteExtensionHeight: 1, pbtsHeight: 1}),
@@ -633,6 +632,10 @@ func TestProto(t *testing.T) {
 		makeParams(makeParamsArgs{voteExtensionHeight: 100, pbtsHeight: 42}),
 		makeParams(makeParamsArgs{pbtsHeight: 100}),
 	}
+}
+
+func TestProto(t *testing.T) {
+	params := consensusParamsForTestProto()
 
 	for i := range params {
 		pbParams := params[i].ToProto()
@@ -644,28 +647,7 @@ func TestProto(t *testing.T) {
 }
 
 func TestProtoUpgrade(t *testing.T) {
-	params := []ConsensusParams{
-		makeParams(makeParamsArgs{blockBytes: 4, blockGas: 2, evidenceAge: 3, maxEvidenceBytes: 1, voteExtensionHeight: 1}),
-		makeParams(makeParamsArgs{blockBytes: 4, blockGas: 2, evidenceAge: 3, maxEvidenceBytes: 1, pbtsHeight: 1}),
-		makeParams(makeParamsArgs{blockBytes: 4, blockGas: 2, evidenceAge: 3, maxEvidenceBytes: 1, voteExtensionHeight: 1, pbtsHeight: 1}),
-		makeParams(makeParamsArgs{blockBytes: 1, blockGas: 4, evidenceAge: 3, maxEvidenceBytes: 1, voteExtensionHeight: 1}),
-		makeParams(makeParamsArgs{blockBytes: 1, blockGas: 4, evidenceAge: 3, maxEvidenceBytes: 1, pbtsHeight: 1}),
-		makeParams(makeParamsArgs{blockBytes: 1, blockGas: 4, evidenceAge: 3, maxEvidenceBytes: 1, voteExtensionHeight: 1, pbtsHeight: 1}),
-		makeParams(makeParamsArgs{blockBytes: 1, blockGas: 2, evidenceAge: 4, maxEvidenceBytes: 1, voteExtensionHeight: 1}),
-		makeParams(makeParamsArgs{blockBytes: 1, blockGas: 2, evidenceAge: 4, maxEvidenceBytes: 1, pbtsHeight: 1}),
-		makeParams(makeParamsArgs{blockBytes: 1, blockGas: 2, evidenceAge: 4, maxEvidenceBytes: 1, voteExtensionHeight: 1, pbtsHeight: 1}),
-		makeParams(makeParamsArgs{blockBytes: 2, blockGas: 5, evidenceAge: 7, maxEvidenceBytes: 1, voteExtensionHeight: 1}),
-		makeParams(makeParamsArgs{blockBytes: 1, blockGas: 7, evidenceAge: 6, maxEvidenceBytes: 1, voteExtensionHeight: 1}),
-		makeParams(makeParamsArgs{blockBytes: 9, blockGas: 5, evidenceAge: 4, maxEvidenceBytes: 1, voteExtensionHeight: 1}),
-		makeParams(makeParamsArgs{blockBytes: 7, blockGas: 8, evidenceAge: 9, maxEvidenceBytes: 1, voteExtensionHeight: 1}),
-		makeParams(makeParamsArgs{blockBytes: 4, blockGas: 6, evidenceAge: 5, maxEvidenceBytes: 1, voteExtensionHeight: 1}),
-		makeParams(makeParamsArgs{precision: time.Second, messageDelay: time.Minute}),
-		makeParams(makeParamsArgs{precision: time.Nanosecond, messageDelay: time.Millisecond}),
-		makeParams(makeParamsArgs{voteExtensionHeight: 100}),
-		makeParams(makeParamsArgs{pbtsHeight: 100}),
-		makeParams(makeParamsArgs{voteExtensionHeight: 100, pbtsHeight: 42}),
-		makeParams(makeParamsArgs{pbtsHeight: 100}),
-	}
+	params := consensusParamsForTestProto()
 
 	for i := range params {
 		pbParams := params[i].ToProto()


### PR DESCRIPTION
Contributes to #1731

After some troubleshooting, I realized that, for two `// nolint` added at the beginning of files in #2494, the `gofumpt` and the `golangci-lint-full` have contradictory rules. So the first one removes the space between `//` and `nolint` and the second adds it back 🤯. The problem has been to _find_ this, as, at the end no files where modified whereas both linters were saying they were modifying some files.

To work around this problem, I changed the way to fix the original lint issues.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
