### PR TITLE
chore: blocksync improv settings

### DIFF
--- a/internal/blocksync/pool.go
+++ b/internal/blocksync/pool.go
@@ -32,7 +32,7 @@ const (
 	requestIntervalMS         = 2
 	maxTotalRequesters        = 600
 	maxPendingRequests        = maxTotalRequesters
-	maxPendingRequestsPerPeer = 20
+	maxPendingRequestsPerPeer = 10
 	requestRetrySeconds       = 30
 
 	// peerConnWait is the time that must have elapsed since the pool routine
@@ -586,7 +586,7 @@ func (peer *bpPeer) onTimeout() {
 
 //-------------------------------------
 
-const minBlocksForSingleRequest = 30
+const minBlocksForSingleRequest = 50
 
 // bpRequester requests a block from a peer.
 //


### PR DESCRIPTION
This implements a peerConnWait time that the pool routine waits before sending requests. We were previously always taking 45 seconds to start, but this was because when we started sending requests for the first x blocks, we only had a pool of peers of size 1, causing wait times to occur.

I have tested this on multiple benchmarks and there is no longer a wait time.

I have also increased the minBlocksForSingleRequest to 50 and decreased maxPendingRequestsPerPeer to 10. These values have behaved more reliably than the current settings.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
