### PR TITLE
feat(privval): allow different curves 

### DIFF
--- a/cmd/priv_val_server/main.go
+++ b/cmd/priv_val_server/main.go
@@ -42,7 +42,12 @@ func main() {
 		dialer = privval.DialUnixFn(address)
 	case "tcp":
 		connTimeout := 3 * time.Second // TODO
-		dialer = privval.DialTCPFn(address, connTimeout, ed25519.GenPrivKey())
+		key, err := ed25519.GenPrivKey()
+		if err != nil {
+			logger.Error("Failed to generate priv val key", "err", err)
+			os.Exit(1)
+		}
+		dialer = privval.DialTCPFn(address, connTimeout, key)
 	default:
 		logger.Error("Unknown protocol", "protocol", protocol)
 		os.Exit(1)

--- a/crypto/ed25519/bench_test.go
+++ b/crypto/ed25519/bench_test.go
@@ -13,18 +13,22 @@ import (
 
 func BenchmarkKeyGeneration(b *testing.B) {
 	benchmarkKeygenWrapper := func(reader io.Reader) crypto.PrivKey {
-		return genPrivKey(reader)
+		key, err := genPrivKey(reader)
+		require.NoError(b, err)
+		return key
 	}
 	benchmarking.BenchmarkKeyGeneration(b, benchmarkKeygenWrapper)
 }
 
 func BenchmarkSigning(b *testing.B) {
-	priv := GenPrivKey()
+	priv, err := GenPrivKey()
+	require.NoError(b, err)
 	benchmarking.BenchmarkSigning(b, priv)
 }
 
 func BenchmarkVerification(b *testing.B) {
-	priv := GenPrivKey()
+	priv, err := GenPrivKey()
+	require.NoError(b, err)
 	benchmarking.BenchmarkVerification(b, priv)
 }
 
@@ -39,7 +43,8 @@ func BenchmarkVerifyBatch(b *testing.B) {
 			pubs := make([]crypto.PubKey, 0, sigsCount)
 			sigs := make([][]byte, 0, sigsCount)
 			for i := 0; i < sigsCount; i++ {
-				priv := GenPrivKey()
+				priv, err := GenPrivKey()
+				require.NoError(b, err)
 				sig, _ := priv.Sign(msg)
 				pubs = append(pubs, priv.PubKey().(PubKey))
 				sigs = append(sigs, sig)

--- a/crypto/ed25519/ed25519.go
+++ b/crypto/ed25519/ed25519.go
@@ -134,18 +134,18 @@ func (privKey PrivKey) Type() string {
 // GenPrivKey generates a new ed25519 private key.
 // It uses OS randomness in conjunction with the current global random seed
 // in cometbft/libs/rand to generate the private key.
-func GenPrivKey() PrivKey {
+func GenPrivKey() (PrivKey, error) {
 	return genPrivKey(crypto.CReader())
 }
 
 // genPrivKey generates a new ed25519 private key using the provided reader.
-func genPrivKey(rand io.Reader) PrivKey {
+func genPrivKey(rand io.Reader) (PrivKey, error) {
 	_, priv, err := ed25519.GenerateKey(rand)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return PrivKey(priv)
+	return PrivKey(priv), nil
 }
 
 // GenPrivKeyFromSecret hashes the secret with SHA2, and uses

--- a/crypto/ed25519/ed25519_test.go
+++ b/crypto/ed25519/ed25519_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestSignAndValidateEd25519(t *testing.T) {
-	privKey := ed25519.GenPrivKey()
+	privKey, err := ed25519.GenPrivKey()
+	require.NoError(t, err)
 	pubKey := privKey.PubKey()
 
 	msg := crypto.CRandBytes(128)
@@ -32,7 +33,8 @@ func TestBatchSafe(t *testing.T) {
 	v := ed25519.NewBatchVerifier()
 
 	for i := 0; i <= 38; i++ {
-		priv := ed25519.GenPrivKey()
+		priv, err := ed25519.GenPrivKey()
+		require.NoError(t, err)
 		pub := priv.PubKey()
 
 		var msg []byte

--- a/privval/file.go
+++ b/privval/file.go
@@ -11,7 +11,6 @@ import (
 
 	cmtproto "github.com/cometbft/cometbft/api/cometbft/types/v1"
 	"github.com/cometbft/cometbft/crypto"
-	"github.com/cometbft/cometbft/crypto/ed25519"
 	cmtos "github.com/cometbft/cometbft/internal/os"
 	"github.com/cometbft/cometbft/internal/protoio"
 	"github.com/cometbft/cometbft/internal/tempfile"
@@ -184,8 +183,12 @@ func NewFilePV(privKey crypto.PrivKey, keyFilePath, stateFilePath string) *FileP
 
 // GenFilePV generates a new validator with randomly generated private key
 // and sets the filePaths, but does not call Save().
-func GenFilePV(keyFilePath, stateFilePath string) *FilePV {
-	return NewFilePV(ed25519.GenPrivKey(), keyFilePath, stateFilePath)
+func GenFilePV(keyFilePath, stateFilePath string, keyGen func() (crypto.PrivKey, error)) *FilePV {
+	key, err := keyGen()
+	if err != nil {
+		panic(err)
+	}
+	return NewFilePV(key, keyFilePath, stateFilePath)
 }
 
 // LoadFilePV loads a FilePV from the filePaths.  The FilePV handles double


### PR DESCRIPTION
This pr allows different curves to be used with privval file.go for generation. This avoids the need for application devs to write a tool to generate the keys. While its not hard to write the tool its life improvement 

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
