### PR TITLE
fix: temporary fix for `api` dependency

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -166,21 +166,26 @@ backport branch (see above). Otherwise:
      release.
    * Ensure that `UPGRADING.md` is up-to-date and includes notes on any breaking
      changes or other upgrading flows.
-4. Prepare the versioning:
+4. Check the dependency to `github.com/cometbft/cometbft/api` in the `go.mod`
+   directory. If it does not point to an official api version, edit it
+   so that it points to one. You may need to tag a new version of the api
+   if the last version is too old (i.e., it does not contain the latest
+   changes to the protos).
+5. Prepare the versioning:
    * Bump CometBFT version in  `version.go`
    * Bump P2P and block protocol versions in  `version.go`, if necessary.
      Check the changelog for breaking changes in these components.
    * Bump ABCI protocol version in `version.go`, if necessary
-5. Open a PR with these changes against the backport branch.
-6. Once these changes have landed on the backport branch, be sure to pull them
+6. Open a PR with these changes against the backport branch.
+7. Once these changes have landed on the backport branch, be sure to pull them
    back down locally.
-7. Once you have the changes locally, create the new tag, specifying a name and
+8. Once you have the changes locally, create the new tag, specifying a name and
    a tag "message":
    `git tag -a v2.0.0-rc1 -s -m "Release Candidate v2.0.0-rc1`
-8. Push the tag back up to origin:
+9.  Push the tag back up to origin:
    `git push origin v2.0.0-rc1`
    Now the tag should be available on the repo's releases page.
-9. Future pre-releases will continue to be built off of this branch.
+10. Future pre-releases will continue to be built off of this branch.
 
 ## Major release
 
@@ -194,6 +199,11 @@ Before performing these steps, be sure the
 1. Start on the backport branch (e.g. `v2.x`)
 2. Run integration tests (`make test_integrations`) and the E2E nightlies.
 3. Prepare the release:
+   * Check the dependency to `github.com/cometbft/cometbft/api` in the `go.mod`
+     directory. If it does not point to an official api version, edit it
+     so that it points to one. You may need to tag a new version of the api
+     if the last version is too old (i.e., it does not contain the latest
+     changes to the protos).
    * Do a [release][unclog-release] with [unclog] for the desired version,
      ensuring that you write up a good summary of the major highlights of the
      release that users would be interested in.
@@ -226,6 +236,11 @@ To create a patch release:
 1. Checkout the long-lived backport branch: `git checkout v2.x`
 2. Run integration tests (`make test_integrations`) and the nightlies.
 3. Check out a new branch and prepare the release:
+   * Check the dependency to `github.com/cometbft/cometbft/api` in the `go.mod`
+     directory. If it does not point to an official api version, edit it
+     so that it points to one. You may need to tag a new version of the api
+     if the last version is too old (i.e., it does not contain the latest
+     changes to the protos).
    * Do a [release][unclog-release] with [unclog] for the desired version,
      ensuring that you write up a good summary of the major highlights of the
      release that users would be interested in.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -167,7 +167,7 @@ backport branch (see above). Otherwise:
    * Ensure that `UPGRADING.md` is up-to-date and includes notes on any breaking
      changes or other upgrading flows.
 4. Check the dependency to `github.com/cometbft/cometbft/api` in the `go.mod`
-   directory. If it does not point to an official api version, edit it
+   file. If it does not point to an official api version, edit it
    so that it points to one. You may need to tag a new version of the api
    if the last version is too old (i.e., it does not contain the latest
    changes to the protos).
@@ -200,7 +200,7 @@ Before performing these steps, be sure the
 2. Run integration tests (`make test_integrations`) and the E2E nightlies.
 3. Prepare the release:
    * Check the dependency to `github.com/cometbft/cometbft/api` in the `go.mod`
-     directory. If it does not point to an official api version, edit it
+     file. If it does not point to an official api version, edit it
      so that it points to one. You may need to tag a new version of the api
      if the last version is too old (i.e., it does not contain the latest
      changes to the protos).
@@ -237,7 +237,7 @@ To create a patch release:
 2. Run integration tests (`make test_integrations`) and the nightlies.
 3. Check out a new branch and prepare the release:
    * Check the dependency to `github.com/cometbft/cometbft/api` in the `go.mod`
-     directory. If it does not point to an official api version, edit it
+     file. If it does not point to an official api version, edit it
      so that it points to one. You may need to tag a new version of the api
      if the last version is too old (i.e., it does not contain the latest
      changes to the protos).

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/btcsuite/btcd/btcutil v1.1.5
 	github.com/cometbft/cometbft-db v0.11.0
 	github.com/cometbft/cometbft-load-test v0.1.0
-	github.com/cometbft/cometbft/api v1.0.0-alpha.1
+	github.com/cometbft/cometbft/api v0.0.0-20240311183503-2f0dc67ee8d5
 	github.com/cosmos/gogoproto v1.4.11
 	github.com/go-git/go-git/v5 v5.11.0
 	github.com/goccmack/goutil v1.2.3

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,8 @@ github.com/cometbft/cometbft-db v0.11.0 h1:M3Lscmpogx5NTbb1EGyGDaFRdsoLWrUWimFEy
 github.com/cometbft/cometbft-db v0.11.0/go.mod h1:GDPJAC/iFHNjmZZPN8V8C1yr/eyityhi2W1hz2MGKSc=
 github.com/cometbft/cometbft-load-test v0.1.0 h1:Axw5oVXlQqZLVUHVxmULSfEtpEuaUMmoeM560hvBAmw=
 github.com/cometbft/cometbft-load-test v0.1.0/go.mod h1:QEXKZ2L5SH1gEw6DRSKYpd3nDCWrzIejaHxwYdgKtkc=
-github.com/cometbft/cometbft/api v1.0.0-alpha.1 h1:/Ey3EyNgY7aO3fl8TvNOpipfRWQCIIC3iN1M5+jJIZI=
-github.com/cometbft/cometbft/api v1.0.0-alpha.1/go.mod h1:5vJTKMdvGufLjyQ0fqSfZ1Dbr7xENK170gUunyT7UL8=
+github.com/cometbft/cometbft/api v0.0.0-20240311183503-2f0dc67ee8d5 h1:8Vtxw4cY5taKaTPfV/t4iDpWmxxXGpjrx0/ajKCEBAM=
+github.com/cometbft/cometbft/api v0.0.0-20240311183503-2f0dc67ee8d5/go.mod h1:H52lgJKkSPeVpTcKr9a4nrSpyr6s1B352SWa6ajNHv0=
 github.com/containerd/continuity v0.3.0 h1:nisirsYROK15TAMVukJOUyGJjz4BNQJBVsNvAXZJ/eg=
 github.com/containerd/continuity v0.3.0/go.mod h1:wJEAIwKOm/pBZuBd0JmeTvnLquTB1Ag8espWhkykbPM=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=


### PR DESCRIPTION
The current `go.mod` points to CometBFT version `v1.0.0-alpha.1`. After merging `feature/pbts` onto `main` there are changes in protobufs that aren't included in that version.

This PR add a temporary fix that will work until:
* we tag a new `alpha` version of CometBFT
* we tag the final `api` version as part of the release process

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
