### PR TITLE
fix(e2e): Increase timeout when waiting for new block

### DIFF
--- a/test/e2e/tests/app_test.go
+++ b/test/e2e/tests/app_test.go
@@ -56,7 +56,7 @@ func TestApp_Hash(t *testing.T) {
 			require.NoError(t, err)
 			require.NotZero(t, status.SyncInfo.LatestBlockHeight)
 			return status.SyncInfo.LatestBlockHeight >= requestedHeight
-		}, 5*time.Second, 500*time.Millisecond)
+		}, 30*time.Second, 500*time.Millisecond)
 
 		block, err := client.Block(ctx, &requestedHeight)
 		require.NoError(t, err)


### PR DESCRIPTION
Some nightly test scenarios are failing because the test that checks that new blocks are being created timeouts. This happens on larger networks with many perturbations, on a few heights. Currently the timeout is 5 seconds, but in some cases it takes the network more than 20 seconds to create a block, so this PR changes it to 30 seconds.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
