### PR TITLE
fix(protos): new buf tag aligned with v1-alpha.2 release

### DIFF
--- a/proto/buf.lock
+++ b/proto/buf.lock
@@ -4,5 +4,5 @@ deps:
   - remote: buf.build
     owner: cosmos
     repository: gogo-proto
-    commit: 5e5b9fdd01804356895f8f79a6f1ddc1
-    digest: shake256:0b85da49e2e5f9ebc4806eae058e2f56096ff3b1c59d1fb7c190413dd15f45dd456f0b69ced9059341c80795d2b6c943de15b120a9e0308b499e43e4b5fc2952
+    commit: 88ef6483f90f478fb938c37dde52ece3
+    digest: shake256:89c45df2aa11e0cff97b0d695436713db3d993d76792e9f8dc1ae90e6ab9a9bec55503d48ceedd6b86069ab07d3041b32001b2bfe0227fa725dd515ff381e5ba


### PR DESCRIPTION
> [!IMPORTANT]
> These changes have already been committed into `v1.x` branch in commit 5a2e40fb. I mistakenly pushed those changes into `v1.x` without opening a PR as we usually do.
> The present PR brings those changes into `main`.

<details>

<summary>Process used to create this PR h/t Sergio</summary>

```sh
create a branch on top of `origin/main`
then, `git cherry-pick 5a2e40fb` (fix any conflicts)
then, open a PR (against `main`) asking to only review the changes and explain they have already been committed to v1.x
```

</details>

## Original commit message

The branch contains updates we have pushed to buf following the recent changes in protos on the `v1.x` branch, specifically the updates in commit: https://buf.build/cometbft/cometbft/activity/commit/4a62c99d422068a5165429b62a7eb824df46cca9

which includes tag `4a62c99d422068a5165429b62a7eb824df46cca9`

We manually audited the changes here: https://buf.build/cometbft/cometbft/compare/c0d3497e35d649538679874acdd86660..8bf8294c2d044d049e9c60cbf1f44cce

This is a result of the following commands:

```sh
git checkout v1.x
cd /proto
buf lint
buf mod update
buf build
buf push --tag "$(git rev-parse HEAD)"
```

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] ~~Tests written/updated~~
- [ ] ~~Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)~~ not needed
- [ ] ~~Updated relevant documentation (`docs/` or `spec/`) and code comments~~
- [ ] ~~Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec~~
