### PR TITLE
chore: run e2e many times

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,9 +55,7 @@ jobs:
         working-directory: test/e2e
         # Run two make jobs in parallel, since we can't run steps in parallel.
         run: make -j2 docker runner
-        if: "env.GIT_DIFF != ''"
 
       - name: Run CI testnet
         working-directory: test/e2e
         run: ./run-multiple.sh networks/ci.toml
-        if: "env.GIT_DIFF != ''"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,7 +2,7 @@ name: e2e
 # Runs the CI end-to-end test network on all pushes to main or release branches
 # and every pull request, but only if any Go files have been changed.
 on:
-  workflow_dispatch:  # allow running workflow manually
+  workflow_dispatch: # allow running workflow manually
   pull_request:
   merge_group:
   push:
@@ -12,12 +12,37 @@ on:
 
 jobs:
   e2e-test:
+    strategy:
+      matrix:
+        repeat:
+          [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+          ]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: "1.21"
       - uses: actions/checkout@v4
       - uses: technote-space/get-diff-action@v6
         with:


### PR DESCRIPTION
Noticed that e2e tests are flaky.  This PR investigates and confirms the issue.

* #2618 



---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
