### PR TITLE
fix(types): check for nil Valset.Proposer.PubKey + valid commit.BlockID to avoid crashes

### DIFF
--- a/types/validation.go
+++ b/types/validation.go
@@ -158,11 +158,20 @@ func verifyCommitLightTrustingInternal(
 	if vals == nil {
 		return errors.New("nil validator set")
 	}
+	proposer := vals.GetProposer()
+	if proposer == nil || proposer.PubKey == nil {
+		return errors.New("nil proposer.PubKey in validatorSet")
+	}
 	if trustLevel.Denominator == 0 {
 		return errors.New("trustLevel has zero Denominator")
 	}
 	if commit == nil {
 		return errors.New("nil commit")
+	}
+	// Validate that the BlockID is valid before doing any work.
+        // See https://github.com/cometbft/cometbft/issues/2627
+	if err := commit.BlockID.ValidateBasic(); err != nil {
+		return err
 	}
 
 	// safely calculate voting power needed.

--- a/types/validation_test.go
+++ b/types/validation_test.go
@@ -307,3 +307,20 @@ func TestValidatorSet_VerifyCommitLightTrustingErrorsOnOverflow(t *testing.T) {
 		assert.Contains(t, err.Error(), "int64 overflow")
 	}
 }
+
+// Verifies that we return an error and don't panic on a nil Proposer in the
+// validator set. Please see issue https://github.com/cometbft/cometbft/issues/2626
+func TestVerifyLightTrustingCrashingNilProposerInValSet(t *testing.T) {
+	vs := &ValidatorSet{
+		Validators: []*Validator{{}},
+	}
+	chainID := "chain_id"
+	commit := &Commit{
+		Signatures: []CommitSig{{}, {}},
+	}
+	frac := cmtmath.Fraction{Denominator: 1}
+
+	err := vs.VerifyCommitLightTrusting(chainID, commit, frac)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nil proposer.PubKey in validatorSet")
+}


### PR DESCRIPTION
This change adds validation to avoid runtime panics for when:
* ValidatorSet.GetProposer() returns nil or has a nil public key
* Commit.BlockID is invalid and just causes a crash

all conditions which can be simply checked for upfront and not later on after doing lots of work and cause sudden panics.

Fixes #2626
Fixes #2627
