### PR TITLE
spec: Add missing Feature Params information in ABCI spec and some other clean-up

### DIFF
--- a/spec/abci/abci++_app_requirements.md
+++ b/spec/abci/abci++_app_requirements.md
@@ -704,7 +704,7 @@ Must have `PbtsEnableHeight > [Current height]`
 
 This parameter is either 0 or a positive height at which vote extensions
 become mandatory. If the value is zero (which is the default), vote
-extensions are not required. Otherwise, at all heights greater than the
+extensions are not expected. Otherwise, at all heights greater than the
 configured height `H` vote extensions must be present (even if empty).
 When the configured height `H` is reached, `PrepareProposal` will not
 include vote extensions yet, but `ExtendVote` and `VerifyVoteExtension` will

--- a/spec/abci/abci++_app_requirements.md
+++ b/spec/abci/abci++_app_requirements.md
@@ -694,7 +694,7 @@ algorithm will be used to produce and validate block timestamps. Prior to
 this height, or when this height is set to 0, the legacy BFT Time
 algorithm is used to produce and validate timestamps.
 
-PBTS cannot be disabled once it's enabled.
+PBTS cannot be disabled once it is enabled.
 
 Cannot be set to heights lower or equal to the current blockchain height.
 


### PR DESCRIPTION
close: #901 

- Added missing information about the consensus Feature Params `vote_extensions_enable_height` and `pbts_enable_height`.
- Verified that the `List of Parameters` matches what is defined in `api/cometbft/types/v1/params.pb.go` file
- Cleaned up some old information that was hidden and not relevant and could cause rendering issues on the docs website.
- Removed the section for ABCI Params (deprecated).

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [X] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
