### PR TITLE
Removes unneeded commands and copies the right entrypoint file.

### DIFF
--- a/test/e2e/docker/Dockerfile.debug
+++ b/test/e2e/docker/Dockerfile.debug
@@ -18,7 +18,7 @@ RUN go mod download
 # Build CometBFT and install into /usr/bin/cometbft
 COPY . .
 RUN echo $COMETBFT_BUILD_OPTION && make build && cp build/cometbft /usr/bin/cometbft
-COPY test/e2e/docker/entrypoint* /usr/bin/
+COPY test/e2e/docker/entrypoint-delve  /usr/bin/entrypoint-builtin
 RUN cd test/e2e && make node && cp build/node /usr/bin/app
 
 # Set up runtime directory. We don't use a separate runtime image since we need
@@ -29,6 +29,4 @@ ENV CMTHOME=/cometbft
 ENV GORACE "halt_on_error=1"
 
 EXPOSE 26656 26657 26660 6060 2345 2346
-ENTRYPOINT ["/usr/bin/entrypoint-delve"]
-CMD ["node"]
 STOPSIGNAL SIGTERM


### PR DESCRIPTION
The entry point file used is entrypoint-builtin, so there is no point in copying others or in specifying an entry point in this file.


---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
