### PR TITLE
spec: Rename ABCI++ in the spec

### DIFF
--- a/spec/abci/README.md
+++ b/spec/abci/README.md
@@ -1,39 +1,39 @@
 ---
 order: 1
 parent:
-  title: ABCI++
+  title: ABCI 2.0
   order: 3
 ---
 
-# ABCI++
+# ABCI 2.0
 
 ## Introduction
 
-ABCI++ is a major evolution of ABCI (**A**pplication **B**lock**c**hain **I**nterface).
-Like its predecessor, ABCI++ is the interface between CometBFT (a state-machine
+ABCI 2.0 is a major evolution of ABCI (**A**pplication **B**lock**c**hain **I**nterface).
+Like its predecessor, ABCI is the interface between CometBFT (a state-machine
 replication engine) and the actual state machine being replicated (i.e., the Application).
 The API consists of a set of _methods_, each with a corresponding `Request` and `Response`
 message type.
 
 The methods are always initiated by CometBFT. The Application implements its logic
-for handling all ABCI++ methods.
+for handling all ABCI methods.
 Thus, CometBFT always sends the `*Request` messages and receives the `*Response` messages
 in return.
 
-All ABCI++ messages and methods are defined in [protocol buffers](https://github.com/cometbft/cometbft/blob/main/proto/cometbft/abci/v1/types.proto).
+All ABCI messages and methods are defined in [protocol buffers](https://github.com/cometbft/cometbft/blob/main/proto/cometbft/abci/v1/types.proto).
 This allows CometBFT to run with applications written in many programming languages.
 
 This specification is split as follows:
 
 - [Overview and basic concepts](./abci++_basic_concepts.md) - interface's overview and concepts
   needed to understand other parts of this specification.
-- [Methods](./abci++_methods.md) - complete details on all ABCI++ methods
+- [Methods](./abci++_methods.md) - complete details on all ABCI methods
   and message types.
 - [Requirements for the Application](./abci++_app_requirements.md) - formal requirements
   on the Application's logic to ensure CometBFT properties such as liveness. These requirements define what
   CometBFT expects from the Application; second part on managing ABCI application state and related topics.
 - [CometBFT's expected behavior](./abci++_comet_expected_behavior.md) - specification of
-  how the different ABCI++ methods may be called by CometBFT. This explains what the Application
+  how the different ABCI methods may be called by CometBFT. This explains what the Application
   is to expect from CometBFT.
 - [Example scenarios](./abci++_example_scenarios.md) - specific scenarios showing why the Application needs to account
 for any CometBFT's behaviour prescribed by the specification.

--- a/spec/abci/abci++_app_requirements.md
+++ b/spec/abci/abci++_app_requirements.md
@@ -15,7 +15,7 @@ title: Requirements for the Application
             - [FinalizeBlock](#finalizeblock)
             - [Commit](#commit)
             - [Candidate States](#candidate-states)
-        - [States and ABCI++ Connections](#states-and-abci-connections)
+        - [States and ABCI Connections](#states-and-abci-connections)
             - [Consensus Connection](#consensus-connection)
             - [Mempool Connection](#mempool-connection)
                 - [Replay Protection](#replay-protection)
@@ -250,7 +250,7 @@ In contrast, the value of *b* MUST be the same across all processes.
 
 ### Connection State
 
-CometBFT maintains four concurrent ABCI++ connections, namely
+CometBFT maintains four concurrent ABCI connections, namely
 [Consensus Connection](#consensus-connection),
 [Mempool Connection](#mempool-connection),
 [Info/Query Connection](#infoquery-connection), and
@@ -260,7 +260,7 @@ the state for each connection, which are synchronized upon `Commit` calls.
 
 #### Concurrency
 
-In principle, each of the four ABCI++ connections operates concurrently with one
+In principle, each of the four ABCI connections operates concurrently with one
 another. This means applications need to ensure access to state is
 thread safe. Both the
 [default in-process ABCI client](https://github.com/cometbft/cometbft/blob/main/abci/client/local_client.go#L13)
@@ -273,20 +273,6 @@ ABCI messages from all connections are received in sequence, one at a
 time.
 
 The existence of this global mutex means Go application developers can get thread safety for application state by routing all reads and writes through the ABCI system. Thus it may be unsafe to expose application state directly to an RPC interface, and unless explicit measures are taken, all queries should be routed through the ABCI Query method.
-
-<!--
-This is no longer the case starting from v0.36.0: the global locks have been removed and it is
-up to the Application to synchronize access to its state when handling
-ABCI++ methods on all connections.
- -->
-
-<!--
- TODO CHeck with Sergio whether this is still the case
- -->
-<!--
-Nevertheless, as all ABCI calls are now synchronous, ABCI messages using the same connection are
-still received in sequence.
- -->
 
 #### FinalizeBlock
 
@@ -363,7 +349,7 @@ to bound memory usage. As a general rule, the Application should be ready to dis
 before `FinalizeBlock`, even if one of them might end up corresponding to the
 decided block and thus have to be reexecuted upon `FinalizeBlock`.
 
-### States and ABCI++ Connections
+### States and ABCI Connections
 
 #### Consensus Connection
 
@@ -404,7 +390,7 @@ Since the transaction cannot be guaranteed to be checked against the exact same 
 will be executed as part of a (potential) decided block, `CheckTx` shouldn't check *everything*
 that affects the transaction's validity, in particular those checks whose validity may depend on
 transaction ordering. `CheckTx` is weak because a Byzantine node need not care about `CheckTx`;
-it can propose a block full of invalid transactions if it wants. The mechanism ABCI++ has
+it can propose a block full of invalid transactions if it wants. The mechanism ABCI has
 in place for dealing with such behavior is `ProcessProposal`.
 
 ##### Replay Protection

--- a/spec/abci/abci++_basic_concepts.md
+++ b/spec/abci/abci++_basic_concepts.md
@@ -6,7 +6,7 @@ title: Overview and basic concepts
 ## Outline
 
 - [Overview and basic concepts](#overview-and-basic-concepts)
-    - [ABCI++ vs. ABCI](#abci-vs-abci)
+    - [ABCI 2.0 vs. ABCI](#abci-vs-abci)
     - [Method overview](#method-overview)
         - [Consensus/block execution methods](#consensusblock-execution-methods)
         - [Mempool methods](#mempool-methods)
@@ -372,7 +372,7 @@ irrefutable proof of malicious behavior by a network participant. It is the resp
 CometBFT to detect such malicious behavior. When malicious behavior is detected, CometBFT
 will gossip evidences of misbehavior to other nodes and commit the evidences to
 the chain once they are verified by a subset of validators. These evidences will then be
-passed on to the Application through ABCI++. It is the responsibility of the
+passed on to the Application through ABCI. It is the responsibility of the
 Application to handle evidence of misbehavior and exercise punishment.
 
 There are two forms of evidence: Duplicate Vote and Light Client Attack. More

--- a/spec/abci/abci++_client_server.md
+++ b/spec/abci/abci++_client_server.md
@@ -8,7 +8,7 @@ title: Client and Server
 This section is for those looking to implement their own ABCI Server, perhaps in
 a new programming language.
 
-You are expected to have read all previous sections of ABCI++ specification, namely
+You are expected to have read all previous sections of ABCI specification, namely
 [Basic Concepts](./abci%2B%2B_basic_concepts.md),
 [Methods](./abci%2B%2B_methods.md),
 [Application Requirements](./abci%2B%2B_app_requirements.md), and
@@ -24,12 +24,6 @@ or custom protobuf types.
 
 For more details on protobuf, see the [documentation](https://developers.google.com/protocol-buffers/docs/overview).
 
-<!--
-As of v0.36 requests are synchronous. For each of ABCI++'s four connections (see
-[Connections](./abci%2B%2B_app_requirements.md)), when CometBFT issues a request to the
-Application, it will wait for the response before continuing execution. As a side effect,
-requests and responses are ordered for each connection, but not necessarily across connections.
--->
 ## Server Implementations
 
 To use ABCI in your programming language of choice, there must be an ABCI

--- a/spec/abci/abci++_example_scenarios.md
+++ b/spec/abci/abci++_example_scenarios.md
@@ -1,6 +1,6 @@
 ---
 order: 6
-title: ABCI++ extra
+title: ABCI extra
 ---
 # Introduction
 
@@ -10,8 +10,8 @@ However, the grammar specified in the same section is more general and covers mo
 that an Application designer needs to account for.
 
 In this section, we give more information about these possible scenarios. We focus on methods
-introduced by ABCI++: `PrepareProposal` and `ProcessProposal`. Specifically, we concentrate
-on the part of the grammar presented below.  
+introduced by ABCI 1.0: `PrepareProposal` and `ProcessProposal`. Specifically, we concentrate
+on the part of the grammar presented below.
 
 ```abnf
 consensus-height    = *consensus-round finalize-block commit
@@ -161,4 +161,4 @@ $validValue$ and $lockedValue$ and sends $Precommit$ message. All correct proces
 rounds $0 <= r' <= r$ and that due to network asynchrony or Byzantine proposer, it does not receive the
 proposal before $timeoutPropose$ expires. As a result, it will enter round $r$ without calling
 `PrepareProposal` and `ProcessProposal` before it, and as shown in Round $r$ of [Scenario 3](#scenario-3) it
-will decide in this round. Again without calling any of these two calls.  
+will decide in this round. Again without calling any of these two calls.

--- a/spec/abci/abci++_methods.md
+++ b/spec/abci/abci++_methods.md
@@ -367,10 +367,6 @@ title: Methods
       `FinalizeBlockResponse`.
     * CometBFT does NOT provide any additional validity checks (such as checking for duplicate
       transactions).
-      <!--
-      As a sanity check, CometBFT will check the returned parameters for validity if the Application modified them.
-      In particular, `PrepareProposalResponse.txs` will be deemed invalid if there are duplicate transactions in the list.
-       -->
     * If CometBFT fails to validate the `PrepareProposalResponse`, CometBFT will assume the
       Application is faulty and crash.
     * The implementation of `PrepareProposal` MAY be non-deterministic.
@@ -797,7 +793,7 @@ Most of the data structures used in ABCI are shared [common data structures](../
     `Metadata`). Chunks may be retrieved from all nodes that have the same snapshot.
     * When sent across the network, a snapshot message can be at most 4 MB.
 
-## Data types introduced or modified in ABCI++
+## Data types introduced or modified in ABCI 2.0
 
 ### VoteInfo
 

--- a/spec/p2p/reactor-api/reactor.md
+++ b/spec/p2p/reactor-api/reactor.md
@@ -69,7 +69,7 @@ peer-error      = %s"log(Stopping peer for error)"
 The grammar is written in case-sensitive Augmented Backus–Naur form (ABNF,
 specified in [IETF RFC 7405](https://datatracker.ietf.org/doc/html/rfc7405)).
 It is inspired on the grammar produced to specify the interaction of CometBFT
-with an ABCI++ application, available [here](../../abci/abci%2B%2B_comet_expected_behavior.md).
+with an ABCI application, available [here](../../abci/abci%2B%2B_comet_expected_behavior.md).
 
 ## Registration
 


### PR DESCRIPTION
close: #2707 

- Renames ABCI++ to the appropriate name:
  - Related to `PrepareProposal` or `ProcessProposal` => `ABCI 1.0`
  - Related to `FinalizeBlock` or `vote extensions` => `ABCI 2.0`
  - Anything else => `ABCI` 
  
> NOTE: Filenames were not renamed if they have `abci++` in their name. These would be a major breaking change to external sites (e.g. Cosmos SDK docs) pointing to CometBFT website and since we don't support redirects in our docs website, it doesn't make sense to rename this files.  

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [X] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [X] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
