### PR TITLE
build(deps): Bump github.com/cometbft/cometbft-db from 0.11.0 to 0.12.0

### DIFF
--- a/.changelog/unreleased/breaking-changes/2775-deprecate-boltdb-cleveldb.md
+++ b/.changelog/unreleased/breaking-changes/2775-deprecate-boltdb-cleveldb.md
@@ -1,0 +1,2 @@
+- [`config`] deprecate boltdb and cleveldb. If you're using either of those,
+  please reach out ([\#2775](https://github.com/cometbft/cometbft/pull/2775))

--- a/config/config.go
+++ b/config/config.go
@@ -207,9 +207,11 @@ type BaseConfig struct {
 	//   - stable
 	//   - pure go
 	// * cleveldb (uses levigo wrapper)
+	//   - DEPRECATED
 	//   - requires gcc
 	//   - use cleveldb build tag (go build -tags cleveldb)
 	// * boltdb (uses etcd's fork of bolt - github.com/etcd-io/bbolt)
+	//   - DEPRECATED
 	//   - EXPERIMENTAL
 	//   - stable
 	//   - use boltdb build tag (go build -tags boltdb)

--- a/config/toml.go
+++ b/config/toml.go
@@ -95,9 +95,11 @@ moniker = "{{ .BaseConfig.Moniker }}"
 #   - stable
 #   - pure go
 # * cleveldb (uses levigo wrapper)
+#   - DEPRECATED
 #   - requires gcc
 #   - use cleveldb build tag (go build -tags cleveldb)
 # * boltdb (uses etcd's fork of bolt - github.com/etcd-io/bbolt)
+#   - DEPRECATED
 #   - EXPERIMENTAL
 #   - stable
 #   - use boltdb build tag (go build -tags boltdb)

--- a/docs/references/config/config.toml.md
+++ b/docs/references/config/config.toml.md
@@ -128,6 +128,8 @@ The CometBFT team tests rely on the GoLevelDB implementation. All other implemen
 a CometBFT perspective. The supported databases are part of the [cometbft-db](https://github.com/cometbft/cometbft-db) library
 that CometBFT uses as a common database interface to various databases.
 
+`boltdb` and `cleveldb` are deprecated and will be removed in a future release.
+
 ### db_dir
 The directory path where the database is stored.
 ```toml
@@ -351,7 +353,7 @@ filter_peers = false
 | **Possible values** | `false` |
 |                     | `true`  |
 
-When this setting is `true`, the ABCI application has to implement a query that will allow 
+When this setting is `true`, the ABCI application has to implement a query that will allow
 the connection to be kept of or dropped.
 
 This feature will likely be deprecated.
@@ -1458,7 +1460,7 @@ Time to spend discovering snapshots before initiating a restore.
 discovery_time = "15s"
 ```
 
-If `discovery_time` is &gt; 0 and  &lt; 5 seconds, its value will be overridden to 5 seconds. 
+If `discovery_time` is &gt; 0 and  &lt; 5 seconds, its value will be overridden to 5 seconds.
 
 If `discovery_time` is zero, the node will not wait for replies once it has broadcast the "snapshot request" message to its peers. If no snapshot data is received, state sync will fail without retrying.
 

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2
 	github.com/btcsuite/btcd/btcutil v1.1.5
-	github.com/cometbft/cometbft-db v0.11.1-0.20240407063702-fa37a805b0b4
+	github.com/cometbft/cometbft-db v0.12.0
 	github.com/cometbft/cometbft-load-test v0.1.0
 	github.com/cometbft/cometbft/api v1.0.0-alpha.2
 	github.com/cosmos/crypto v0.0.0-20240309083813-82ed2537802e

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,8 @@ github.com/cockroachdb/redact v1.1.5 h1:u1PMllDkdFfPWaNGMyLD1+so+aq3uUItthCFqzwP
 github.com/cockroachdb/redact v1.1.5/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 h1:zuQyyAKVxetITBuuhv3BI9cMrmStnpT18zmgmTxunpo=
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06/go.mod h1:7nc4anLGjupUW/PeY5qiNYsdNXj7zopG+eqsS7To5IQ=
-github.com/cometbft/cometbft-db v0.11.1-0.20240407063702-fa37a805b0b4 h1:bDDaSa4ahRNmaxEoyzrRNvLJ2fmklWLavFzs750ZZHY=
-github.com/cometbft/cometbft-db v0.11.1-0.20240407063702-fa37a805b0b4/go.mod h1:KnCEOGvUNAhvxKqGYYl4pr3D0JcP6Muld9lSeY/wmGg=
+github.com/cometbft/cometbft-db v0.12.0 h1:v77/z0VyfSU7k682IzZeZPFZrQAKiQwkqGN0QzAjMi0=
+github.com/cometbft/cometbft-db v0.12.0/go.mod h1:aX2NbCrjNVd2ZajYxt1BsiFf/Z+TQ2MN0VxdicheYuw=
 github.com/cometbft/cometbft-load-test v0.1.0 h1:Axw5oVXlQqZLVUHVxmULSfEtpEuaUMmoeM560hvBAmw=
 github.com/cometbft/cometbft-load-test v0.1.0/go.mod h1:QEXKZ2L5SH1gEw6DRSKYpd3nDCWrzIejaHxwYdgKtkc=
 github.com/cometbft/cometbft/api v1.0.0-alpha.2 h1:pw6k48EnA/FjxBP2/gCyDGnSdCNjB5yPFd2du/9rNoE=

--- a/node/node.go
+++ b/node/node.go
@@ -281,6 +281,10 @@ func NewNode(ctx context.Context,
 	logger log.Logger,
 	options ...Option,
 ) (*Node, error) {
+	if config.BaseConfig.DBBackend == "boltdb" || config.BaseConfig.DBBackend == "cleveldb" {
+		logger.Info("WARNING: BoltDB and GoLevelDB are deprecated and will be removed in a future release. Please switch to a different backend.")
+	}
+
 	blockStoreDB, stateDB, err := initDBs(config, dbProvider)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
`v0.12.0` deprecates `boltdb` and `cleveldb`. Once merged to v1, both will be removed. If you're using one of those, please get in touch.

---

#### PR checklist

- [ ] ~~Tests written/updated~~
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] ~~Updated relevant documentation (`docs/` or `spec/`) and code comments~~
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
