### PR TITLE
fix(rpc): Make websocket's log on success be in Debug, not info

### DIFF
--- a/.changelog/unreleased/improvements/2788-move-ws-info-log-to-debug
+++ b/.changelog/unreleased/improvements/2788-move-ws-info-log-to-debug
@@ -1,0 +1,1 @@
+Move the websockets info log for successful replies to debug.

--- a/rpc/jsonrpc/server/ws_handler.go
+++ b/rpc/jsonrpc/server/ws_handler.go
@@ -380,7 +380,7 @@ func (wsc *wsConnection) readRoutine() {
 			returns := rpcFunc.f.Call(args)
 
 			// TODO: Need to encode args/returns to string if we want to log them
-			wsc.Logger.Info("WSJSONRPC", "method", request.Method)
+			wsc.Logger.Debug("WSJSONRPC", "method", request.Method)
 
 			result, err := unreflectResult(returns)
 			if err != nil {


### PR DESCRIPTION
This log is extreme noise in our current setup for all RPC's. I moved to Debug, but should be deleted imo.

This logging of requests/responses should come at a higher proxy level IMO, or have the request + response written elsewhere asynchronously.

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
