### PR TITLE
deps: bump Go version from 1.20 to 1.21 in go.mod (v0.37.x)

### DIFF
--- a/.github/workflows/e2e-nightly-34x.yml
+++ b/.github/workflows/e2e-nightly-34x.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.18'
+          go-version: '1.21'
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/e2e-nightly-main.yml
+++ b/.github/workflows/e2e-nightly-main.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
 
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ looking for, see [our security policy](SECURITY.md).
 
 | CometBFT version | Requirement | Notes             |
 |------------------|-------------|-------------------|
-| v0.34.x          | Go version  | Go 1.19 or higher |
-| v0.37.x          | Go version  | Go 1.20 or higher |
-| main             | Go version  | Go 1.20 or higher |
+| v0.34.x          | Go version  | Go 1.21 or higher |
+| v0.37.x          | Go version  | Go 1.21 or higher |
+| main             | Go version  | Go 1.22 or higher |
 
 ### Install
 
@@ -168,7 +168,7 @@ maintains [cometbft.com](https://cometbft.com).
 [version-url]: https://github.com/cometbft/cometbft/releases/latest
 [api-badge]: https://camo.githubusercontent.com/915b7be44ada53c290eb157634330494ebe3e30a/68747470733a2f2f676f646f632e6f72672f6769746875622e636f6d2f676f6c616e672f6764646f3f7374617475732e737667
 [api-url]: https://pkg.go.dev/github.com/cometbft/cometbft
-[go-badge]: https://img.shields.io/badge/go-1.20-blue.svg
+[go-badge]: https://img.shields.io/badge/go-1.21-blue.svg
 [go-url]: https://github.com/moovweb/gvm
 [discord-badge]: https://img.shields.io/discord/669268347736686612.svg
 [discord-url]: https://discord.gg/cosmosnetwork

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,11 @@
 
 This guide provides instructions for upgrading to specific versions of CometBFT.
 
+## v0.37.6
+
+It is recommended that CometBFT be built with Go v1.21+ since v1.20 is no longer
+supported.
+
 ## v0.37.1
 
 For users explicitly making use of the Go APIs provided in the `crypto/merkle`

--- a/docs/guides/go-built-in.md
+++ b/docs/guides/go-built-in.md
@@ -47,7 +47,7 @@ Verify that you have the latest version of Go installed (refer to the [official 
 
 ```bash
 $ go version
-go version go1.20.1 darwin/amd64
+go version go1.21.9 darwin/amd64
 ```
 
 ## 1.2 Creating a new Go project
@@ -95,7 +95,7 @@ The go.mod file should look similar to:
 ```go
 module github.com/me/example
 
-go 1.20
+go 1.21
 
 require (
 	github.com/cometbft/cometbft v0.37.0

--- a/docs/guides/go.md
+++ b/docs/guides/go.md
@@ -46,7 +46,7 @@ Verify that you have the latest version of Go installed (refer to the [official 
 
 ```bash
 $ go version
-go version go1.20.1 darwin/amd64
+go version go1.21.9 darwin/amd64
 ```
 
 ## 1.2 Creating a new Go project
@@ -94,7 +94,7 @@ The go.mod file should look similar to:
 ```go
 module github.com/me/example
 
-go 1.20
+go 1.21
 
 require (
 	github.com/cometbft/cometbft v0.37.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cometbft/cometbft
 
-go 1.20
+go 1.21
 
 require (
 	github.com/BurntSushi/toml v1.2.1

--- a/scripts/proto-gen.sh
+++ b/scripts/proto-gen.sh
@@ -10,7 +10,7 @@ cd "$(git rev-parse --show-toplevel)"
 
 # Run inside Docker to install the correct versions of the required tools
 # without polluting the local system.
-docker run --rm -i -v "$PWD":/w --workdir=/w golang:1.20-alpine sh <<"EOF"
+docker run --rm -i -v "$PWD":/w --workdir=/w golang:1.21-alpine sh <<"EOF"
 apk add git make
 
 go install github.com/bufbuild/buf/cmd/buf

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15
+FROM golang:1.21
 
 # Grab deps (jq, hexdump, xxd, killall)
 RUN apt-get update && \


### PR DESCRIPTION
NOTE: v0.37 was tested with Go 1.21, but had Go 1.20 in `go.mod` file.