### PR TITLE
chore: use sized array

### DIFF
--- a/node/setup.go
+++ b/node/setup.go
@@ -673,6 +673,9 @@ func splitAndTrimEmpty(s, sep, cutset string) []string {
 	return nonEmptyStrings
 }
 
+// sizedByteArray converts a byte slice to a fixed-size byte array of length 32.
+// If the input byte slice is shorter than 32 bytes, it will be padded with zero bytes.
+// If the input byte slice is longer than 32 bytes, it will be truncated to 32 bytes.
 func sizedByteArray(bz []byte) [32]byte {
 	b := [32]byte{}
 	copy(b[:], bz)

--- a/node/setup.go
+++ b/node/setup.go
@@ -46,7 +46,7 @@ const readHeaderTimeout = 10 * time.Second
 // SHA256 checksum.
 type ChecksummedGenesisDoc struct {
 	GenesisDoc     *types.GenesisDoc
-	Sha256Checksum []byte
+	Sha256Checksum [32]byte
 }
 
 // GenesisDocProvider returns a GenesisDoc together with its SHA256 checksum.


### PR DESCRIPTION
Since the checksum is assumed to be sha256 you might as well set the size in the struct. 

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
