### PR TITLE
perf(txindex): Lower allocation overhead of txIndex matchRange

### DIFF
--- a/.changelog/unreleased/improvements/2839-tx_index-lower-heap-allocation.md
+++ b/.changelog/unreleased/improvements/2839-tx_index-lower-heap-allocation.md
@@ -1,0 +1,2 @@
+- `[state/indexer]` Lower the heap allocation of transaction searches
+  ([\#2839](https://github.com/cometbft/cometbft/pull/2839))


### PR DESCRIPTION
In Osmosis we see massive amounts of heap pressure/allocations coming from txIndex matchRange. (Screenshot below from ~1 hour of heap profiling)

![image](https://github.com/cometbft/cometbft/assets/6440154/bf2dfe89-56f0-4824-815b-c5822d20568b)

This PR is expected to fully compatibly drop this down by a factor of 3. It:
- Does not get Key() twice (160GB allocation saved)
- Uses no heap allocations for isTagKey (120GB saved)
- Does not string cast or do strings.Split in parsing the value (~400GB expected saved)
- Reuses the big.Int (24GB saved)

The remaining RAM overhead from .Key() needs a cometbft-db API change. The remaining RAM overhead from extracting the value can be saved with an unsafe call for casting the output to string with no heap allocation, but we can do that in a separate PR.

---

#### PR checklist

- [x] Tests written/updated - All existing tests still apply
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
