### PR TITLE
perf(libs/json): Lower heap overhead of JSON encoding

### DIFF
--- a/.changelog/unreleased/improvements/2846-speedup-json-encoding.md
+++ b/.changelog/unreleased/improvements/2846-speedup-json-encoding.md
@@ -1,0 +1,2 @@
+- `[libs/json]` Lower the memory overhead of JSON encoding by using JSON encoders internally
+  ([\#2846](https://github.com/cometbft/cometbft/pull/2846)).

--- a/libs/json/encoder.go
+++ b/libs/json/encoder.go
@@ -238,7 +238,7 @@ func encodeReflectInterface(w *bytes.Buffer, rv reflect.Value) error {
 }
 
 func encodeStdlib(w *bytes.Buffer, v any) error {
-	// Stream the output of the JSON marshalling directly into the buffer.
+	// Stream the output of the JSON marshaling directly into the buffer.
 	// The stdlib encoder will write a newline, so we must truncate it,
 	// which is why we pass in a bytes.Buffer throughout, not io.Writer.
 	enc := json.NewEncoder(w)

--- a/libs/json/encoder.go
+++ b/libs/json/encoder.go
@@ -42,7 +42,7 @@ func MarshalIndent(v any, prefix, indent string) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func encode(w io.Writer, v any) error {
+func encode(w *bytes.Buffer, v any) error {
 	// Bare nil values can't be reflected, so we must handle them here.
 	if v == nil {
 		return writeStr(w, "null")
@@ -60,7 +60,7 @@ func encode(w io.Writer, v any) error {
 	return encodeReflect(w, rv)
 }
 
-func encodeReflect(w io.Writer, rv reflect.Value) error {
+func encodeReflect(w *bytes.Buffer, rv reflect.Value) error {
 	if !rv.IsValid() {
 		return errors.New("invalid reflect value")
 	}
@@ -115,7 +115,7 @@ func encodeReflect(w io.Writer, rv reflect.Value) error {
 	}
 }
 
-func encodeReflectList(w io.Writer, rv reflect.Value) error {
+func encodeReflectList(w *bytes.Buffer, rv reflect.Value) error {
 	// Emit nil slices as null.
 	if rv.Kind() == reflect.Slice && rv.IsNil() {
 		return writeStr(w, "null")
@@ -150,7 +150,7 @@ func encodeReflectList(w io.Writer, rv reflect.Value) error {
 	return writeStr(w, "]")
 }
 
-func encodeReflectMap(w io.Writer, rv reflect.Value) error {
+func encodeReflectMap(w *bytes.Buffer, rv reflect.Value) error {
 	if rv.Type().Key().Kind() != reflect.String {
 		return errors.New("map key must be string")
 	}
@@ -181,7 +181,7 @@ func encodeReflectMap(w io.Writer, rv reflect.Value) error {
 	return writeStr(w, "}")
 }
 
-func encodeReflectStruct(w io.Writer, rv reflect.Value) error {
+func encodeReflectStruct(w *bytes.Buffer, rv reflect.Value) error {
 	sInfo := makeStructInfo(rv.Type())
 	if err := writeStr(w, "{"); err != nil {
 		return err
@@ -212,7 +212,7 @@ func encodeReflectStruct(w io.Writer, rv reflect.Value) error {
 	return writeStr(w, "}")
 }
 
-func encodeReflectInterface(w io.Writer, rv reflect.Value) error {
+func encodeReflectInterface(w *bytes.Buffer, rv reflect.Value) error {
 	// Get concrete value and dereference pointers.
 	for rv.Kind() == reflect.Ptr || rv.Kind() == reflect.Interface {
 		if rv.IsNil() {
@@ -237,14 +237,17 @@ func encodeReflectInterface(w io.Writer, rv reflect.Value) error {
 	return writeStr(w, "}")
 }
 
-func encodeStdlib(w io.Writer, v any) error {
-	// Doesn't stream the output because that adds a newline, as per:
-	// https://golang.org/pkg/encoding/json/#Encoder.Encode
-	blob, err := json.Marshal(v)
+func encodeStdlib(w *bytes.Buffer, v any) error {
+	// Stream the output of the JSON marshalling directly into the buffer.
+	// The stdlib encoder will write a newline, so we must truncate it,
+	// which is why we pass in a bytes.Buffer throughout, not io.Writer.
+	enc := json.NewEncoder(w)
+	err := enc.Encode(v)
 	if err != nil {
 		return err
 	}
-	_, err = w.Write(blob)
+	// Remove the last byte from the buffer
+	w.Truncate(w.Len() - 1)
 	return err
 }
 

--- a/libs/json/encoder_test.go
+++ b/libs/json/encoder_test.go
@@ -111,7 +111,7 @@ func BenchmarkJsonMarshalStruct(b *testing.B) {
 	car := &Car{Wheels: 4}
 	boat := Boat{Sail: true}
 	for i := 0; i < b.N; i++ {
-		json.Marshal(Struct{
+		_, _ = json.Marshal(Struct{
 			Bool: true, Float64: 3.14, Int32: 32, Int64: 64, Int64Ptr: &i64,
 			String: "foo", StringPtrPtr: &sPtr, Bytes: []byte{1, 2, 3},
 			Time: ti, Car: car, Boat: boat, Vehicles: []Vehicle{car, boat},

--- a/libs/json/encoder_test.go
+++ b/libs/json/encoder_test.go
@@ -102,3 +102,20 @@ func TestMarshal(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkJsonMarshalStruct(b *testing.B) {
+	s := "string"
+	sPtr := &s
+	i64 := int64(64)
+	ti := time.Date(2020, 6, 2, 18, 5, 13, 4346374, time.FixedZone("UTC+2", 2*60*60))
+	car := &Car{Wheels: 4}
+	boat := Boat{Sail: true}
+	for i := 0; i < b.N; i++ {
+		json.Marshal(Struct{
+			Bool: true, Float64: 3.14, Int32: 32, Int64: 64, Int64Ptr: &i64,
+			String: "foo", StringPtrPtr: &sPtr, Bytes: []byte{1, 2, 3},
+			Time: ti, Car: car, Boat: boat, Vehicles: []Vehicle{car, boat},
+			Child: &Struct{Bool: false, String: "child"}, private: "private",
+		})
+	}
+}


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

Many RPC methods require JSON marshalled responses. We saw this taking a notable amount of heap allocation in query serving full nodes. This PR removes some extra heap allocations that were being done. We avoided using the more efficient encoder.Encode before, because it added a newline. This PR changes the function signature for these private methods to be using *bytes.Buffer, and then uses the in-buffer methods (rather than a second copy). We then just truncate the final byte after each such call, which does not waste any allocations.

I added a benchmark for the most complex test case. 

OLD:
```
BenchmarkJsonMarshalStruct-12              78992             15542 ns/op            4487 B/op        191 allocs/op
```
New:
```
BenchmarkJsonMarshalStruct-12              93346             11132 ns/op            3245 B/op         58 allocs/op
```

Roughly a 3-4x reduction in the number of allocations, and 20% speedup.

#### PR checklist

- [x] Tests written/updated - Existing tests cover this
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
