### PR TITLE
feat(p2p): pre-allocate static labels used to produce metrics

### DIFF
--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -46,10 +46,14 @@ type metricsLabelCache struct {
 	chIDLabelNames    map[byte]string
 }
 
+// AddChID pre-allocates the metric label for a chID.
+// Labels are populated by the switch, before the p2p layer is started.
 func (m *metricsLabelCache) AddChID(chID byte) {
 	m.chIDLabelNames[chID] = fmt.Sprintf("%#x", chID)
 }
 
+// ChIDToMetricLabel returns the metric label for a chID.
+// No need for synchronization, as labels, once populated, never change.
 func (m *metricsLabelCache) ChIDToMetricLabel(chID byte) string {
 	return m.chIDLabelNames[chID]
 }

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -43,6 +43,15 @@ type Metrics struct {
 type metricsLabelCache struct {
 	mtx               *sync.RWMutex
 	messageLabelNames map[reflect.Type]string
+	chIDLabelNames    map[byte]string
+}
+
+func (m *metricsLabelCache) AddChID(chID byte) {
+	m.chIDLabelNames[chID] = fmt.Sprintf("%#x", chID)
+}
+
+func (m *metricsLabelCache) ChIDToMetricLabel(chID byte) string {
+	return m.chIDLabelNames[chID]
 }
 
 // ValueToMetricLabel is a method that is used to produce a prometheus label value of the golang
@@ -72,5 +81,6 @@ func newMetricsLabelCache() *metricsLabelCache {
 	return &metricsLabelCache{
 		mtx:               &sync.RWMutex{},
 		messageLabelNames: map[reflect.Type]string{},
+		chIDLabelNames:    map[byte]string{},
 	}
 }

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -46,9 +46,9 @@ type metricsLabelCache struct {
 	chIDLabelNames    map[byte]string
 }
 
-// AddChID pre-allocates the metric label for a chID.
+// RegisterChID pre-allocates the metric label for a chID.
 // Labels are populated by the switch, before the p2p layer is started.
-func (m *metricsLabelCache) AddChID(chID byte) {
+func (m *metricsLabelCache) RegisterChID(chID byte) {
 	m.chIDLabelNames[chID] = fmt.Sprintf("%#x", chID)
 }
 

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -271,6 +271,7 @@ func (p *peer) send(chID byte, msg proto.Message, sendFunc func(byte, []byte) bo
 	} else if !p.hasChannel(chID) {
 		return false
 	}
+	metricLabelValue := p.mlc.ValueToMetricLabel(msg)
 	if w, ok := msg.(types.Wrapper); ok {
 		msg = w.Wrap()
 	}
@@ -285,7 +286,7 @@ func (p *peer) send(chID byte, msg proto.Message, sendFunc func(byte, []byte) bo
 			With("peer_id", string(p.ID()), "chID", p.mlc.ChIDToMetricLabel(chID)).
 			Add(float64(len(msgBytes)))
 		p.metrics.MessageSendBytesTotal.
-			With("message_type", p.mlc.ValueToMetricLabel(msg)).
+			With("message_type", metricLabelValue).
 			Add(float64(len(msgBytes)))
 	}
 	return res

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -271,7 +271,6 @@ func (p *peer) send(chID byte, msg proto.Message, sendFunc func(byte, []byte) bo
 	} else if !p.hasChannel(chID) {
 		return false
 	}
-	metricLabelValue := p.mlc.ValueToMetricLabel(msg)
 	if w, ok := msg.(types.Wrapper); ok {
 		msg = w.Wrap()
 	}
@@ -285,7 +284,9 @@ func (p *peer) send(chID byte, msg proto.Message, sendFunc func(byte, []byte) bo
 		p.metrics.PeerSendBytesTotal.
 			With("peer_id", string(p.ID()), "chID", p.mlc.ChIDToMetricLabel(chID)).
 			Add(float64(len(msgBytes)))
-		p.metrics.MessageSendBytesTotal.With("message_type", metricLabelValue).Add(float64(len(msgBytes)))
+		p.metrics.MessageSendBytesTotal.
+			With("message_type", p.mlc.ValueToMetricLabel(msg)).
+			Add(float64(len(msgBytes)))
 	}
 	return res
 }
@@ -421,7 +422,9 @@ func createMConnection(
 		p.metrics.PeerReceiveBytesTotal.
 			With("peer_id", string(p.ID()), "chID", p.mlc.ChIDToMetricLabel(chID)).
 			Add(float64(len(msgBytes)))
-		p.metrics.MessageReceiveBytesTotal.With("message_type", p.mlc.ValueToMetricLabel(msg)).Add(float64(len(msgBytes)))
+		p.metrics.MessageReceiveBytesTotal.
+			With("message_type", p.mlc.ValueToMetricLabel(msg)).
+			Add(float64(len(msgBytes)))
 		reactor.Receive(Envelope{
 			ChannelID: chID,
 			Src:       p,

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -401,6 +401,12 @@ func createMConnection(
 	onPeerError func(Peer, any),
 	config cmtconn.MConnConfig,
 ) *cmtconn.MConnection {
+	// Pre-allocate channel ID labels
+	labelsByChID := make(map[byte]string)
+	for chID := range reactorsByCh {
+		labelsByChID[chID] = fmt.Sprintf("%#x", chID)
+	}
+
 	onReceive := func(chID byte, msgBytes []byte) {
 		reactor := reactorsByCh[chID]
 		if reactor == nil {
@@ -416,7 +422,7 @@ func createMConnection(
 		}
 		labels := []string{
 			"peer_id", string(p.ID()),
-			"chID", fmt.Sprintf("%#x", chID),
+			"chID", labelsByChID[chID],
 		}
 		if w, ok := msg.(types.Unwrapper); ok {
 			msg, err = w.Unwrap()

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -413,6 +413,7 @@ func createMConnection(
 		if err != nil {
 			panic(fmt.Sprintf("unmarshaling message: %v into type: %s", err, reflect.TypeOf(mt)))
 		}
+		metricLabelValue := p.mlc.ValueToMetricLabel(msg)
 		if w, ok := msg.(types.Unwrapper); ok {
 			msg, err = w.Unwrap()
 			if err != nil {
@@ -423,7 +424,7 @@ func createMConnection(
 			With("peer_id", string(p.ID()), "chID", p.mlc.ChIDToMetricLabel(chID)).
 			Add(float64(len(msgBytes)))
 		p.metrics.MessageReceiveBytesTotal.
-			With("message_type", p.mlc.ValueToMetricLabel(msg)).
+			With("message_type", metricLabelValue).
 			Add(float64(len(msgBytes)))
 		reactor.Receive(Envelope{
 			ChannelID: chID,

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -406,6 +406,7 @@ func createMConnection(
 	for chID := range reactorsByCh {
 		labelsByChID[chID] = fmt.Sprintf("%#x", chID)
 	}
+	peerID := string(p.ID())
 
 	onReceive := func(chID byte, msgBytes []byte) {
 		reactor := reactorsByCh[chID]
@@ -427,7 +428,7 @@ func createMConnection(
 			}
 		}
 		p.metrics.PeerReceiveBytesTotal.
-			With("peer_id", string(p.ID()), "chID", labelsByChID[chID]).
+			With("peer_id", peerID, "chID", labelsByChID[chID]).
 			Add(float64(len(msgBytes)))
 		p.metrics.MessageReceiveBytesTotal.With("message_type", p.mlc.ValueToMetricLabel(msg)).Add(float64(len(msgBytes)))
 		reactor.Receive(Envelope{

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -173,7 +173,7 @@ func (sw *Switch) AddReactor(name string, reactor Reactor) Reactor {
 		sw.chDescs = append(sw.chDescs, chDesc)
 		sw.reactorsByCh[chID] = reactor
 		sw.msgTypeByChID[chID] = chDesc.MessageType
-		sw.mlc.AddChID(chID)
+		sw.mlc.RegisterChID(chID)
 	}
 	sw.reactors[name] = reactor
 	reactor.SetSwitch(sw)

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -173,6 +173,7 @@ func (sw *Switch) AddReactor(name string, reactor Reactor) Reactor {
 		sw.chDescs = append(sw.chDescs, chDesc)
 		sw.reactorsByCh[chID] = reactor
 		sw.msgTypeByChID[chID] = chDesc.MessageType
+		sw.mlc.AddChID(chID)
 	}
 	sw.reactors[name] = reactor
 	reactor.SetSwitch(sw)


### PR DESCRIPTION
Addresses #2840.

The same approach taken for the `send()` method is also adopted for the `onReceive()` method. 

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
