### PR TITLE
fix(types): fix consensus failure

### DIFF
--- a/.changelog/unreleased/bug-fixes/2711-consensus-failure.md
+++ b/.changelog/unreleased/bug-fixes/2711-consensus-failure.md
@@ -1,0 +1,2 @@
+- [`types`] Fix consensus failure "non-recoverable error when signing vote"
+  when using tmkms ([\#]())

--- a/types/vote.go
+++ b/types/vote.go
@@ -428,15 +428,15 @@ func SignAndCheckVote(
 		return false, &ErrVoteExtensionInvalid{ExtSignature: v.ExtensionSignature}
 	}
 
-	isNil := vote.BlockID.IsZero()
-	extSignature := (len(v.ExtensionSignature) > 0)
-	if extSignature == (!isPrecommit || isNil) {
-		// Non-recoverable because the vote is malformed
-		return false, &ErrVoteExtensionInvalid{ExtSignature: v.ExtensionSignature}
-	}
-
+	// Check the extension signature only if extensions are enabled.
 	vote.ExtensionSignature = nil
 	if extensionsEnabled {
+		isNil := vote.BlockID.IsZero()
+		extSignature := (len(v.ExtensionSignature) > 0)
+		if extSignature == (!isPrecommit || isNil) {
+			// Non-recoverable because the vote is malformed
+			return false, &ErrVoteExtensionInvalid{ExtSignature: v.ExtensionSignature}
+		}
 		vote.ExtensionSignature = v.ExtensionSignature
 	}
 


### PR DESCRIPTION
"non-recoverable error when signing vote" when using tmkms Note it changes the previous behavior of always checking the extension signature.

```
2:59PM ERR CONSENSUS FAILURE!!! err="non-recoverable error when signing vote (15385390/1)" module=consensus stack="goroutine 139403 [running]:
runtime/debug.Stack()
    /opt/hostedtoolcache/go/1.21.8/x64/src/runtime/debug/stack.go:24 +0x5e
github.com/cometbft/cometbft/consensus.(*State).receiveRoutine.func2()
    /home/runner/go/pkg/mod/github.com/cometbft/cometbft@v0.38.5/consensus/state.go:800 +0x46
panic({0x2d03080?, 0xc0b5748830?})
    /opt/hostedtoolcache/go/1.21.8/x64/src/runtime/panic.go:914 +0x21f
github.com/cometbft/cometbft/consensus.(*State).signVote(0xc000aaca80, 0x2, {0xc03d3b9360, 0x20, 0x20}, {0xe0eb5c?, {0xc03d3b9380?, 0xc054dc92ec?, 0x3035160?}}, 0xc0aff57a40)
    /home/runner/go/pkg/mod/github.com/cometbft/cometbft@v0.38.5/consensus/state.go:2388 +0x639
github.com/cometbft/cometbft/consensus.(*State).signAddVote(0xc000aaca80, 0x1?, {0xc03d3b9360, 0x20, 0x20}, {0x1?, {0xc03d3b9380?, 0xc0fd083a60?, 0x20?}}, 0xc0aff57a40)
    /home/runner/go/pkg/mod/github.com/cometbft/cometbft@v0.38.5/consensus/state.go:2439 +0x212
github.com/cometbft/cometbft/consensus.(*State).enterPrecommit(0xc000aaca80, 0xeac32e, 0x1)
    /home/runner/go/pkg/mod/github.com/cometbft/cometbft@v0.38.5/consensus/state.go:1536 +0x1337
github.com/cometbft/cometbft/consensus.(*State).addVote(0xc000aaca80, 0xc1677dc270, {0xc00675e120, 0x28})
    /home/runner/go/pkg/mod/github.com/cometbft/cometbft@v0.38.5/consensus/state.go:2296 +0x186f
github.com/cometbft/cometbft/consensus.(*State).tryAddVote(0xc000aaca80, 0xc1677dc270, {0xc00675e120?, 0xc054dc9c08?})
    /home/runner/go/pkg/mod/github.com/cometbft/cometbft@v0.38.5/consensus/state.go:2056 +0x26
github.com/cometbft/cometbft/consensus.(*State).handleMsg(0xc000aaca80, {{0x3c0ebc0, 0xc0b4f8ebc8}, {0xc00675e120, 0x28}})
    /home/runner/go/pkg/mod/github.com/cometbft/cometbft@v0.38.5/consensus/state.go:928 +0x3ce
github.com/cometbft/cometbft/consensus.(*State).receiveRoutine(0xc000aaca80, 0x0)
    /home/runner/go/pkg/mod/github.com/cometbft/cometbft@v0.38.5/consensus/state.go:835 +0x3d1
created by github.com/cometbft/cometbft/consensus.(*State).OnStart in goroutine 334
    /home/runner/go/pkg/mod/github.com/cometbft/cometbft@v0.38.5/consensus/state.go:397 +0x10c"
2:59PM INF service stop impl=baseWAL module=consensus msg="Stopping baseWAL service" wal=/home/validator/.paloma/data/cs.wal/wal
2:59PM INF service stop impl=Group module=consensus msg="Stopping Group service" wal=/home/validator/.paloma/data/cs.wal/wal
```

Closes #2711

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
