### PR TITLE
perf(event bus): Remove expensive Logger debug call in PublishEventTx

### DIFF
--- a/.changelog/unreleased/improvements/2911-remove-event-bus-debug-logs.md
+++ b/.changelog/unreleased/improvements/2911-remove-event-bus-debug-logs.md
@@ -1,0 +1,2 @@
+- `[event-bus]` Remove the debug logs in PublishEventTx, which were noticed production slowdowns.
+  ([\#2911](https://github.com/cometbft/cometbft/pull/2911))

--- a/types/event_bus.go
+++ b/types/event_bus.go
@@ -110,17 +110,15 @@ func (b *EventBus) Publish(eventType string, eventData TMEventData) error {
 // map of stringified events where each key is composed of the event
 // type and each of the event's attributes keys in the form of
 // "{event.Type}.{attribute.Key}" and the value is each attribute's value.
-func (*EventBus) validateAndStringifyEvents(events []types.Event, logger log.Logger) map[string][]string {
+func (*EventBus) validateAndStringifyEvents(events []types.Event) map[string][]string {
 	result := make(map[string][]string)
 	for _, event := range events {
 		if len(event.Type) == 0 {
-			logger.Debug("Got an event with an empty type (skipping)", "event", event)
 			continue
 		}
 
 		for _, attr := range event.Attributes {
 			if len(attr.Key) == 0 {
-				logger.Debug("Got an event attribute with an empty key(skipping)", "event", event)
 				continue
 			}
 
@@ -135,8 +133,7 @@ func (*EventBus) validateAndStringifyEvents(events []types.Event, logger log.Log
 func (b *EventBus) PublishEventNewBlock(data EventDataNewBlock) error {
 	// no explicit deadline for publishing events
 	ctx := context.Background()
-
-	events := b.validateAndStringifyEvents(data.ResultFinalizeBlock.Events, b.Logger.With("height", data.Block.Height))
+	events := b.validateAndStringifyEvents(data.ResultFinalizeBlock.Events)
 
 	// add predefined new block event
 	events[EventTypeKey] = append(events[EventTypeKey], EventNewBlock)
@@ -148,7 +145,7 @@ func (b *EventBus) PublishEventNewBlockEvents(data EventDataNewBlockEvents) erro
 	// no explicit deadline for publishing events
 	ctx := context.Background()
 
-	events := b.validateAndStringifyEvents(data.Events, b.Logger.With("height", data.Height))
+	events := b.validateAndStringifyEvents(data.Events)
 
 	// add predefined new block event
 	events[EventTypeKey] = append(events[EventTypeKey], EventNewBlockEvents)
@@ -179,7 +176,7 @@ func (b *EventBus) PublishEventTx(data EventDataTx) error {
 	// no explicit deadline for publishing events
 	ctx := context.Background()
 
-	events := b.validateAndStringifyEvents(data.Result.Events, b.Logger.With("tx", data.Tx))
+	events := b.validateAndStringifyEvents(data.Result.Events)
 
 	// add predefined compositeKeys
 	events[EventTypeKey] = append(events[EventTypeKey], EventTx)


### PR DESCRIPTION
Component of #2869 

This on its own is an expected 1% speedup to blocksync on osmosis mainnet right now.

I originally considered keeping the log lines but with only creating the logger cost if there is an error, but these are debug logs I've never seen. I think its better to just remove these debug logs directly, rather than worry about maintaining them. These aren't even that concerning scenarios I feel like, as more of the stack moves away from these. 


---

#### PR checklist

- [x] Tests written/updated - Covered by existing tests
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [X] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [X] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
