### PR TITLE
perf(consensus/state): Change finalizeCommit to use applyVerifiedBlock

### DIFF
--- a/.changelog/unreleased/improvements/2928-remove-redundant-verifyblock-call-in-finalize-commit.md
+++ b/.changelog/unreleased/improvements/2928-remove-redundant-verifyblock-call-in-finalize-commit.md
@@ -1,0 +1,2 @@
+- `[consensus/state]` Remove a redundant `VerifyBlock` call in `FinalizeCommit`
+  ([\#2928](https://github.com/cometbft/cometbft/pull/2928))

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1900,8 +1900,9 @@ func (cs *State) finalizeCommit(height int64) {
 	stateCopy := cs.state.Copy()
 
 	// Execute and commit the block, update and save the state, and update the mempool.
+	// We use apply verified block here because we have verified the block in this function already.
 	// NOTE The block.AppHash won't reflect these txs until the next block.
-	stateCopy, err := cs.blockExec.ApplyBlock(
+	stateCopy, err := cs.blockExec.ApplyVerifiedBlock(
 		stateCopy,
 		types.BlockID{
 			Hash:          block.Hash(),


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

Simplest component of #2854 

We already run ValidateBlock in finalizeCommit, so this PR removes one extra redundant call by using ApplyVerifiedBlock. (The other call is also redundant, but that likely requires a more complex caching strategy as noted in #2854 to remedy)

From my understanding of these benchmarks, at Osmosis 150 validators, this should be saving ~13ms of execution time per block. 

---

#### PR checklist

- [X] Tests written/updated - Theres no test to update, as its impossible to reach the difference in codepaths! 
- [X] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
