### PR TITLE
perf(p2p/channel): Speedup NewDelimitedWriter

### DIFF
--- a/.changelog/unreleased/improvements/2949-reduce-protoio-writer-creation-time.md
+++ b/.changelog/unreleased/improvements/2949-reduce-protoio-writer-creation-time.md
@@ -1,0 +1,2 @@
+- `[p2p/channel]` Speedup `ProtoIO` writer creation time, and thereby speedup channel writing by 5%.
+  ([\#2949](https://github.com/cometbft/cometbft/pull/2949))

--- a/internal/protoio/writer.go
+++ b/internal/protoio/writer.go
@@ -42,7 +42,7 @@ import (
 // equivalent to the gogoproto NewDelimitedWriter, except WriteMsg() also returns the
 // number of bytes written, which is necessary in the p2p package.
 func NewDelimitedWriter(w io.Writer) WriteCloser {
-	return &varintWriter{w, make([]byte, binary.MaxVarintLen64), nil}
+	return &varintWriter{w, nil, nil}
 }
 
 type varintWriter struct {
@@ -69,6 +69,9 @@ func (w *varintWriter) WriteMsg(msg proto.Message) (int, error) {
 	}
 
 	// fallback
+	if w.lenBuf == nil {
+		w.lenBuf = make([]byte, binary.MaxVarintLen64)
+	}
 	data, err := proto.Marshal(msg)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Speeds up 5% of the non-IO time overhead from `channel.WritePacketMsgTo`. The CPU time overhead in this function is quite significant, CPU time is more than 3 times the syscall time for writing to the net buffer. Working on a github issue for more substantial refactor / time eliminations, but this 3s is easy enough.

We don't even use this codepath, so this make slice is entirely wasted. However we should do things that reduce this overhead further.

![image](https://github.com/cometbft/cometbft/assets/6440154/e02e45bf-d6ff-4e11-9983-e81ca1102dc8)

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
