### PR TITLE
perf(p2p): Remove unnecessary atomic read

### DIFF
--- a/p2p/conn/connection.go
+++ b/p2p/conn/connection.go
@@ -512,7 +512,7 @@ func (c *MConnection) sendSomePacketMsgs() bool {
 	// Block until .sendMonitor says we can write.
 	// Once we're ready we send more than we asked for,
 	// but amortized it should even out.
-	c.sendMonitor.Limit(c._maxPacketMsgSize, atomic.LoadInt64(&c.config.SendRate), true)
+	c.sendMonitor.Limit(c._maxPacketMsgSize, c.config.SendRate, true)
 
 	// Now send some PacketMsgs.
 	for i := 0; i < numBatchPacketMsgs; i++ {


### PR DESCRIPTION
This PR is a driveby change. We were doing an atomic read here, but this is unnecessary. Nothing in the codebase modified this variable after instantiation.

Doesn't really feel changelog worthy, but I can add one if we want. Felt like a minor code nit