### PR TITLE
perf(p2p/conn): Remove a minint call that was appearing in write packet delays

### DIFF
--- a/.changelog/unreleased/improvements/2952-lower-next-packet-msg-time.md
+++ b/.changelog/unreleased/improvements/2952-lower-next-packet-msg-time.md
@@ -1,0 +1,2 @@
+- `[p2p/conn]` Minor speedup (3%) to connection.WritePacketMsgTo, by removing MinInt calls.
+  ([\#2952](https://github.com/cometbft/cometbft/pull/2952))

--- a/p2p/conn/connection.go
+++ b/p2p/conn/connection.go
@@ -22,7 +22,6 @@ import (
 	cmtsync "github.com/cometbft/cometbft/internal/sync"
 	"github.com/cometbft/cometbft/internal/timer"
 	"github.com/cometbft/cometbft/libs/log"
-	cmtmath "github.com/cometbft/cometbft/libs/math"
 )
 
 const (
@@ -835,14 +834,15 @@ func (ch *Channel) isSendPending() bool {
 func (ch *Channel) nextPacketMsg() tmp2p.PacketMsg {
 	packet := tmp2p.PacketMsg{ChannelID: int32(ch.desc.ID)}
 	maxSize := ch.maxPacketMsgPayloadSize
-	packet.Data = ch.sending[:cmtmath.MinInt(maxSize, len(ch.sending))]
 	if len(ch.sending) <= maxSize {
+		packet.Data = ch.sending
 		packet.EOF = true
 		ch.sending = nil
 		atomic.AddInt32(&ch.sendQueueSize, -1) // decrement sendQueueSize
 	} else {
+		packet.Data = ch.sending[:maxSize]
 		packet.EOF = false
-		ch.sending = ch.sending[cmtmath.MinInt(maxSize, len(ch.sending)):]
+		ch.sending = ch.sending[maxSize:]
 	}
 	return packet
 }


### PR DESCRIPTION
Somehow this minint call is appearing in CPU profiles. Its too large of an appearance to be declared as noise, but I really don't get why its there. Must be some weird system effect I don't get. (perhaps due to being the result of a function call for a slice index? idk)

This PR just removes the function call, since its not needed, as we already branch on the if statement.

Profile showing it:
![image](https://github.com/cometbft/cometbft/assets/6440154/a12c8918-e4ce-4a3d-bad4-5ae678988f94)

Contributes a 3% improvement to #2951 

---

#### PR checklist

- [x] Tests written/updated - fully compatible with what already exists
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
