### PR TITLE
perf(p2p): Change channel.recentlySent to be based on num_messages

### DIFF
--- a/.changelog/unreleased/improvements/2957-improve-channel-prioritization.md
+++ b/.changelog/unreleased/improvements/2957-improve-channel-prioritization.md
@@ -1,0 +1,3 @@
+- `[p2p]` Improve the prioritization of which channel to gossip from, by changing channel deprioritization
+  to be based on the number of messages in the channel, rather than the size of messages communicated on the channel.
+  ([\#2928](https://github.com/cometbft/cometbft/pull/2928))


### PR DESCRIPTION
Closes #2954 

This should make block part gossip not be bottom priority. (though more work is needed to make it match the prioritization expectation)

---

#### PR checklist

- [x] Tests written/updated - there is actually no tests here for prioritization, just eventual delivery tests. Should be easy to add tests after #2953 
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
