### PR TITLE
perf(internal/bits): Speedup extended commit.BitArray()

### DIFF
--- a/.changelog/unreleased/improvements/2959-speedup-initialized-bitarray-construction.md
+++ b/.changelog/unreleased/improvements/2959-speedup-initialized-bitarray-construction.md
@@ -1,0 +1,2 @@
+- `[internal/bits]` 10x speedup creating initialized bitArrays, which speedsup extendedCommit.BitArray(). This is used in consensus vote gossip.
+  ([\#2959](https://github.com/cometbft/cometbft/pull/2841)).

--- a/internal/bits/bit_array.go
+++ b/internal/bits/bit_array.go
@@ -39,14 +39,17 @@ func NewBitArrayFromFn(bits int, fn func(int) bool) *BitArray {
 	if bits <= 0 {
 		return nil
 	}
-	ba := &BitArray{
+	bA := &BitArray{
 		Bits:  bits,
 		Elems: make([]uint64, (bits+63)/64),
 	}
 	for i := 0; i < bits; i++ {
-		ba.setIndex(i, fn(i))
+		v := fn(i)
+		if v {
+			bA.Elems[i/64] |= (uint64(1) << uint(i%64))
+		}
 	}
-	return ba
+	return bA
 }
 
 // Size returns the number of bits in the bitarray.

--- a/internal/bits/bit_array.go
+++ b/internal/bits/bit_array.go
@@ -32,6 +32,23 @@ func NewBitArray(bits int) *BitArray {
 	}
 }
 
+// NewBitArrayFromFn returns a new bit array.
+// It returns nil if the number of bits is zero.
+// It initializes the `i`th bit to the value of `fn(i)`.
+func NewBitArrayFromFn(bits int, fn func(int) bool) *BitArray {
+	if bits <= 0 {
+		return nil
+	}
+	ba := &BitArray{
+		Bits:  bits,
+		Elems: make([]uint64, (bits+63)/64),
+	}
+	for i := 0; i < bits; i++ {
+		ba.setIndex(i, fn(i))
+	}
+	return ba
+}
+
 // Size returns the number of bits in the bitarray.
 func (bA *BitArray) Size() int {
 	if bA == nil {

--- a/internal/bits/bit_array_test.go
+++ b/internal/bits/bit_array_test.go
@@ -21,17 +21,10 @@ var (
 
 func randBitArray(bits int) *BitArray {
 	src := cmtrand.Bytes((bits + 7) / 8)
-	bA := NewBitArray(bits)
-	for i := 0; i < len(src); i++ {
-		for j := 0; j < 8; j++ {
-			if i*8+j >= bits {
-				return bA
-			}
-			setBit := src[i]&(1<<uint(j)) > 0
-			bA.SetIndex(i*8+j, setBit)
-		}
+	srcIndexToBit := func(i int) bool {
+		return src[i/8]&(1<<uint(i%8)) > 0
 	}
-	return bA
+	return NewBitArrayFromFn(bits, srcIndexToBit)
 }
 
 func TestAnd(t *testing.T) {
@@ -59,7 +52,7 @@ func TestAnd(t *testing.T) {
 }
 
 func TestOr(t *testing.T) {
-	bA1 := randBitArray(51)
+	bA1 := randBitArray(57)
 	bA2 := randBitArray(31)
 	bA3 := bA1.Or(bA2)
 
@@ -68,7 +61,7 @@ func TestOr(t *testing.T) {
 	require.Equal(t, bA1.Or(nil), bA1)
 	require.Equal(t, bNil.Or(nil), (*BitArray)(nil))
 
-	if bA3.Bits != 51 {
+	if bA3.Bits != 57 {
 		t.Error("Expected max bits")
 	}
 	if len(bA3.Elems) != len(bA1.Elems) {
@@ -79,6 +72,10 @@ func TestOr(t *testing.T) {
 		if bA3.GetIndex(i) != expected {
 			t.Error("Wrong bit from bA3", i, bA1.GetIndex(i), bA2.GetIndex(i), bA3.GetIndex(i))
 		}
+	}
+	if bA3.getNumTrueIndices() == 0 {
+		t.Error("Expected at least one true bit. " +
+			"This has a false positive rate that is less than 1 in 2^70 (sextillion)")
 	}
 }
 

--- a/internal/bits/bit_array_test.go
+++ b/internal/bits/bit_array_test.go
@@ -75,7 +75,7 @@ func TestOr(t *testing.T) {
 	}
 	if bA3.getNumTrueIndices() == 0 {
 		t.Error("Expected at least one true bit. " +
-			"This has a false positive rate that is less than 1 in 2^70 (sextillion)")
+			"This has a false positive rate that is less than 1 in 2^80 (cryptographically improbable)")
 	}
 }
 

--- a/internal/bits/bit_array_test.go
+++ b/internal/bits/bit_array_test.go
@@ -75,7 +75,7 @@ func TestOr(t *testing.T) {
 	}
 	if bA3.getNumTrueIndices() == 0 {
 		t.Error("Expected at least one true bit. " +
-			"This has a false positive rate that is less than 1 in 2^80 (cryptographically improbable)")
+			"This has a false positive rate that is less than 1 in 2^80 (cryptographically improbable).")
 	}
 }
 

--- a/types/block.go
+++ b/types/block.go
@@ -1207,12 +1207,12 @@ func (ec *ExtendedCommit) Size() int {
 // Implements VoteSetReader.
 func (ec *ExtendedCommit) BitArray() *bits.BitArray {
 	if ec.bitArray == nil {
-		ec.bitArray = bits.NewBitArray(len(ec.ExtendedSignatures))
-		for i, extCommitSig := range ec.ExtendedSignatures {
+		initialBitFn := func(i int) bool {
 			// TODO: need to check the BlockID otherwise we could be counting conflicts,
 			//       not just the one with +2/3 !
-			ec.bitArray.SetIndex(i, extCommitSig.BlockIDFlag != BlockIDFlagAbsent)
+			return ec.ExtendedSignatures[i].BlockIDFlag != BlockIDFlagAbsent
 		}
+		ec.bitArray = bits.NewBitArrayFromFn(len(ec.ExtendedSignatures), initialBitFn)
 	}
 	return ec.bitArray
 }


### PR DESCRIPTION
Speedup ExtendedCommit.BitArray() by making a direct constructor that does not go through mutexes. I expect this to be a 10x performance improvement. (It also removes the duffcopies and reduces setIndex proportion of time here)

This removes this time (which is mostly coming from mutex calls): 
![image](https://github.com/cometbft/cometbft/assets/6440154/da11d57d-6bea-40ea-a0fa-9209ea3e22f8)

Later on we should instead make an API that lets us randomly sample from a bit array with no bit array copying needed. (But that makes the interface messier) 

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
