### PR TITLE
perf(consensus): align calls to `ValidateBlock`, `ProcessProposal` and `isTimely`

### DIFF
--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1427,7 +1427,7 @@ func (cs *State) defaultDoPrevote(height int64, round int32) {
 					return
 				}
 
-				if cs.Proposal.POLRound == -1 && !cs.proposalIsTimely() {
+				if !cs.proposalIsTimely() {
 					lowerBound, upperBound := cs.timelyProposalMargins()
 					// TODO: use Warn level once available.
 					logger.Info("prevote step: Proposal is not timely; prevoting nil",
@@ -1440,12 +1440,10 @@ func (cs *State) defaultDoPrevote(height int64, round int32) {
 					return
 				}
 
-				if cs.Proposal.POLRound == -1 {
-					logger.Debug("prevote step: Proposal is timely",
-						"timestamp", cs.Proposal.Timestamp.Format(time.RFC3339Nano),
-						"receive_time", cs.ProposalReceiveTime.Format(time.RFC3339Nano),
-						"timestamp_difference", cs.ProposalReceiveTime.Sub(cs.Proposal.Timestamp))
-				}
+				logger.Debug("prevote step: Proposal is timely",
+					"timestamp", cs.Proposal.Timestamp.Format(time.RFC3339Nano),
+					"receive_time", cs.ProposalReceiveTime.Format(time.RFC3339Nano),
+					"timestamp_difference", cs.ProposalReceiveTime.Sub(cs.Proposal.Timestamp))
 			}
 
 			// Validate proposal block, from consensus' perspective

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1384,36 +1384,6 @@ func (cs *State) defaultDoPrevote(height int64, round int32) {
 		return
 	}
 
-	// Timestamp validation using Proposed-Based TimeStamp (PBTS) algorithm.
-	// See: https://github.com/cometbft/cometbft/blob/main/spec/consensus/proposer-based-timestamp/
-	if cs.isPBTSEnabled(height) {
-		if !cs.Proposal.Timestamp.Equal(cs.ProposalBlock.Header.Time) {
-			logger.Debug("prevote step: proposal timestamp not equal; prevoting nil")
-			cs.signAddVote(types.PrevoteType, nil, types.PartSetHeader{}, nil)
-			return
-		}
-
-		if cs.Proposal.POLRound == -1 && !cs.proposalIsTimely() {
-			lowerBound, upperBound := cs.timelyProposalMargins()
-			// TODO: use Warn level once available.
-			logger.Info("prevote step: Proposal is not timely; prevoting nil",
-				"timestamp", cs.Proposal.Timestamp.Format(time.RFC3339Nano),
-				"receive_time", cs.ProposalReceiveTime.Format(time.RFC3339Nano),
-				"timestamp_difference", cs.ProposalReceiveTime.Sub(cs.Proposal.Timestamp),
-				"lower_bound", lowerBound,
-				"upper_bound", upperBound)
-			cs.signAddVote(types.PrevoteType, nil, types.PartSetHeader{}, nil)
-			return
-		}
-
-		if cs.Proposal.POLRound == -1 {
-			logger.Debug("prevote step: Proposal is timely",
-				"timestamp", cs.Proposal.Timestamp.Format(time.RFC3339Nano),
-				"receive_time", cs.ProposalReceiveTime.Format(time.RFC3339Nano),
-				"timestamp_difference", cs.ProposalReceiveTime.Sub(cs.Proposal.Timestamp))
-		}
-	}
-
 	/*
 		22: upon <PROPOSAL, h_p, round_p, v, −1> from proposer(h_p, round_p) while step_p = propose do
 		23: if valid(v) && (lockedRound_p = −1 || lockedValue_p = v) then
@@ -1446,6 +1416,36 @@ func (cs *State) defaultDoPrevote(height int64, round int32) {
 				logger.Debug("prevote step: ProposalBlock matches our valid block; prevoting the proposal")
 				cs.signAddVote(types.PrevoteType, cs.ProposalBlock.Hash(), cs.ProposalBlockParts.Header(), nil)
 				return
+			}
+
+			// Timestamp validation using Proposed-Based TimeStamp (PBTS) algorithm.
+			// See: https://github.com/cometbft/cometbft/blob/main/spec/consensus/proposer-based-timestamp/
+			if cs.isPBTSEnabled(height) {
+				if !cs.Proposal.Timestamp.Equal(cs.ProposalBlock.Header.Time) {
+					logger.Debug("prevote step: proposal timestamp not equal; prevoting nil")
+					cs.signAddVote(types.PrevoteType, nil, types.PartSetHeader{}, nil)
+					return
+				}
+
+				if cs.Proposal.POLRound == -1 && !cs.proposalIsTimely() {
+					lowerBound, upperBound := cs.timelyProposalMargins()
+					// TODO: use Warn level once available.
+					logger.Info("prevote step: Proposal is not timely; prevoting nil",
+						"timestamp", cs.Proposal.Timestamp.Format(time.RFC3339Nano),
+						"receive_time", cs.ProposalReceiveTime.Format(time.RFC3339Nano),
+						"timestamp_difference", cs.ProposalReceiveTime.Sub(cs.Proposal.Timestamp),
+						"lower_bound", lowerBound,
+						"upper_bound", upperBound)
+					cs.signAddVote(types.PrevoteType, nil, types.PartSetHeader{}, nil)
+					return
+				}
+
+				if cs.Proposal.POLRound == -1 {
+					logger.Debug("prevote step: Proposal is timely",
+						"timestamp", cs.Proposal.Timestamp.Format(time.RFC3339Nano),
+						"receive_time", cs.ProposalReceiveTime.Format(time.RFC3339Nano),
+						"timestamp_difference", cs.ProposalReceiveTime.Sub(cs.Proposal.Timestamp))
+				}
 			}
 
 			// Validate proposal block, from consensus' perspective

--- a/state/execution.go
+++ b/state/execution.go
@@ -41,9 +41,6 @@ type BlockExecutor struct {
 	mempool mempool.Mempool
 	evpool  EvidencePool
 
-	// 1-element cache of validated blocks
-	lastValidatedBlock *types.Block
-
 	logger log.Logger
 
 	metrics *Metrics
@@ -197,11 +194,9 @@ func (blockExec *BlockExecutor) ProcessProposal(
 // Validation does not mutate state, but does require historical information from the stateDB,
 // ie. to verify evidence from a validator at an old height.
 func (blockExec *BlockExecutor) ValidateBlock(state State, block *types.Block) error {
-	if !blockExec.lastValidatedBlock.HashesTo(block.Hash()) {
-		if err := validateBlock(state, block); err != nil {
-			return err
-		}
-		blockExec.lastValidatedBlock = block
+	err := validateBlock(state, block)
+	if err != nil {
+		return err
 	}
 	return blockExec.evpool.CheckEvidence(block.Evidence.Evidence)
 }


### PR DESCRIPTION
~~This change is an implementation of the alignment of `ValidateBlock` to `ProcessProposal` explained [here](https://github.com/cometbft/cometbft/issues/2854#issuecomment-2088261899).~~

We need to:

* Check if that helps, perf-wise
* Carefully make we're not compromising algorithm's correctness

EDIT:

In the end, we are implementing this as agreed [here](https://github.com/cometbft/cometbft/issues/2854#issuecomment-2107159921)

EDIT2:

This PR will just deal with alignment of `ValidateBlock`, `ProcessProposal` and `isTimely` (so it's no longer closing #2854)

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
