### PR TITLE
refactor(state): reuse method `proposalIsTimely`

### DIFF
--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -2711,9 +2711,7 @@ func repairWalFile(src, dst string) error {
 
 func (cs *State) calculateProposalTimestampDifferenceMetric() {
 	if cs.Proposal != nil && cs.Proposal.POLRound == -1 {
-		sp := cs.state.ConsensusParams.Synchrony.InRound(cs.Proposal.Round)
-
-		isTimely := cs.Proposal.IsTimely(cs.ProposalReceiveTime, sp)
+		isTimely := cs.proposalIsTimely()
 		cs.metrics.ProposalTimestampDifference.
 			With("is_timely", strconv.FormatBool(isTimely)).
 			Observe(cs.ProposalReceiveTime.Sub(cs.Proposal.Timestamp).Seconds())


### PR DESCRIPTION
Small refactor to simplify the calls to "is timely"

---

#### PR checklist

- [ ] Tests written/updated
- [ ] ~~Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)~~
- [ ] ~~Updated relevant documentation (`docs/` or `spec/`) and code comments~~
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
