### PR TITLE
fix(metric): message type in metric `MessageReceiveBytesTotal` is wrong

### DIFF
--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -414,7 +414,6 @@ func createMConnection(
 		if err != nil {
 			panic(fmt.Sprintf("unmarshaling message: %v into type: %s", err, reflect.TypeOf(mt)))
 		}
-		metricLabelValue := p.mlc.ValueToMetricLabel(msg)
 		if w, ok := msg.(types.Unwrapper); ok {
 			msg, err = w.Unwrap()
 			if err != nil {
@@ -425,7 +424,7 @@ func createMConnection(
 			With("peer_id", string(p.ID()), "chID", p.mlc.ChIDToMetricLabel(chID)).
 			Add(float64(len(msgBytes)))
 		p.metrics.MessageReceiveBytesTotal.
-			With("message_type", metricLabelValue).
+			With("message_type", p.mlc.ValueToMetricLabel(msg)).
 			Add(float64(len(msgBytes)))
 		reactor.Receive(Envelope{
 			ChannelID: chID,


### PR DESCRIPTION
In the metric `MessageReceiveBytesTotal`, the only value produced in the `message_type` label is `v1_Message`. This is because we are reading the `msg` variable before the message is unwrapped. This bug was recently introduced in #2851.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
