### PR TITLE
perf: log debug only if it is enabled to avoid heap allocations

### DIFF
--- a/internal/blocksync/reactor.go
+++ b/internal/blocksync/reactor.go
@@ -250,7 +250,9 @@ func (bcR *Reactor) Receive(e p2p.Envelope) {
 		return
 	}
 
-	bcR.Logger.Debug("Receive", "e.Src", e.Src, "chID", e.ChannelID, "msg", e.Message)
+	if bcR.Logger.DebugOn() {
+		bcR.Logger.Debug("Receive", "e.Src", e.Src, "chID", e.ChannelID, "msg", e.Message)
+	}
 
 	switch msg := e.Message.(type) {
 	case *bcproto.BlockRequest:
@@ -291,7 +293,9 @@ func (bcR *Reactor) Receive(e p2p.Envelope) {
 		// Got a peer status. Unverified.
 		bcR.pool.SetPeerRange(e.Src.ID(), msg.Base, msg.Height)
 	case *bcproto.NoBlockResponse:
-		bcR.Logger.Debug("Peer does not have requested block", "peer", e.Src, "height", msg.Height)
+		if bcR.Logger.DebugOn() {
+			bcR.Logger.Debug("Peer does not have requested block", "peer", e.Src, "height", msg.Height)
+		}
 		bcR.pool.RedoRequestFrom(msg.Height, e.Src.ID())
 	default:
 		bcR.Logger.Error(fmt.Sprintf("Unknown message type %v", reflect.TypeOf(msg)))
@@ -330,7 +334,9 @@ FOR_LOOP:
 		select {
 		case <-switchToConsensusTicker.C:
 			outbound, inbound, _ := bcR.Switch.NumPeers()
-			bcR.Logger.Debug("Consensus ticker", "outbound", outbound, "inbound", inbound, "lastHeight", state.LastBlockHeight)
+			if bcR.Logger.DebugOn() {
+				bcR.Logger.Debug("Consensus ticker", "outbound", outbound, "inbound", inbound, "lastHeight", state.LastBlockHeight)
+			}
 
 			if !initialCommitHasExtensions {
 				// If require extensions, but since we don't have them yet, then we cannot switch to consensus yet.
@@ -439,7 +445,9 @@ func (bcR *Reactor) handleBlockRequest(request BlockRequest) {
 		Message:   &bcproto.BlockRequest{Height: request.Height},
 	})
 	if !queued {
-		bcR.Logger.Debug("Send queue is full, drop block request", "peer", peer.ID(), "height", request.Height)
+		if bcR.Logger.DebugOn() {
+			bcR.Logger.Debug("Send queue is full, drop block request", "peer", peer.ID(), "height", request.Height)
+		}
 	}
 }
 

--- a/libs/log/filter.go
+++ b/libs/log/filter.go
@@ -54,6 +54,10 @@ func (l *filter) Debug(msg string, keyvals ...any) {
 	l.next.Debug(msg, keyvals...)
 }
 
+func (l *filter) DebugOn() bool {
+	return l.allowed&levelDebug != 0
+}
+
 func (l *filter) Error(msg string, keyvals ...any) {
 	levelAllowed := l.allowed&levelError != 0
 	if !levelAllowed {

--- a/libs/log/logger.go
+++ b/libs/log/logger.go
@@ -13,6 +13,7 @@ type Logger interface {
 	Error(msg string, keyvals ...any)
 
 	With(keyvals ...any) Logger
+	DebugOn() bool
 }
 
 // NewSyncWriter returns a new writer that is safe for concurrent use by

--- a/libs/log/nop_logger.go
+++ b/libs/log/nop_logger.go
@@ -15,3 +15,5 @@ func (nopLogger) Error(string, ...any) {}
 func (l *nopLogger) With(...any) Logger {
 	return l
 }
+
+func (*nopLogger) DebugOn() bool { return false }

--- a/libs/log/tm_logger.go
+++ b/libs/log/tm_logger.go
@@ -84,3 +84,7 @@ func (l *tmLogger) Error(msg string, keyvals ...any) {
 func (l *tmLogger) With(keyvals ...any) Logger {
 	return &tmLogger{kitlog.With(l.srcLogger, keyvals...)}
 }
+
+func (*tmLogger) DebugOn() bool {
+	return false // TODO implement logic to check if debug mode is on
+}

--- a/libs/log/tracing_logger.go
+++ b/libs/log/tracing_logger.go
@@ -44,6 +44,8 @@ func (l *tracingLogger) With(keyvals ...any) Logger {
 	return &tracingLogger{next: l.next.With(formatErrors(keyvals)...)}
 }
 
+func (*tracingLogger) DebugOn() bool { return false }
+
 func formatErrors(keyvals []any) []any {
 	newKeyvals := make([]any, len(keyvals))
 	copy(newKeyvals, keyvals)

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -147,11 +147,15 @@ func (memR *Reactor) AddPeer(peer p2p.Peer) {
 // Receive implements Reactor.
 // It adds any received transactions to the mempool.
 func (memR *Reactor) Receive(e p2p.Envelope) {
-	memR.Logger.Debug("Receive", "src", e.Src, "chId", e.ChannelID, "msg", e.Message)
+	if memR.Logger.DebugOn() {
+		memR.Logger.Debug("Receive", "src", e.Src, "chId", e.ChannelID, "msg", e.Message)
+	}
 	switch msg := e.Message.(type) {
 	case *protomem.Txs:
 		if memR.WaitSync() {
-			memR.Logger.Debug("Ignored message received while syncing", "msg", msg)
+			if memR.Logger.DebugOn() {
+				memR.Logger.Debug("Ignored message received while syncing", "msg", msg)
+			}
 			return
 		}
 
@@ -166,7 +170,9 @@ func (memR *Reactor) Receive(e p2p.Envelope) {
 			reqRes, err := memR.mempool.CheckTx(tx)
 			switch {
 			case errors.Is(err, ErrTxInCache):
-				memR.Logger.Debug("Tx already exists in cache", "tx", tx.Hash())
+				if memR.Logger.DebugOn() {
+					memR.Logger.Debug("Tx already exists in cache", "tx", tx.Hash())
+				}
 			case err != nil:
 				memR.Logger.Info("Could not check tx", "tx", tx.Hash(), "err", err)
 			default:


### PR DESCRIPTION
close: #2847 

**NOTE**: Please **don't** merge this yet. This is an experimental WIP so @ValarDragon can do some testing for performance profiling. Depending on the outcome of these changes we then can decide to merge it or not. But it would still need a bit of work in the logging library.


#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
