### PR TITLE
fix: remove comment about default value (#2867)

### DIFF
--- a/rpc/jsonrpc/server/http_server.go
+++ b/rpc/jsonrpc/server/http_server.go
@@ -292,7 +292,8 @@ func PreChecksHandler(next http.Handler, config *Config) http.Handler {
 		r.Body = http.MaxBytesReader(w, r.Body, config.MaxBodyBytes)
 
 		// if maxBatchSize is 0 then don't constraint the limit of requests per batch
-		// the default value is 0, and it cannot be negative because of the config validation
+		// It cannot be negative because the config.toml validation requires it to be
+		// greater than or equal to 0
 		if config.MaxRequestBatchSize > 0 {
 			var requests []types.RPCRequest
 			var responses []types.RPCResponse


### PR DESCRIPTION
Related to #2867 

Quick fix for a comment in the code added about a default value for a config parameter. 

During backport to `v0.38.x`,  @melekes made a suggestion that the default value in a comment was inaccurate. Instead of updating the default value in the comment, I've decided to remove the comment about the default value. 

In my opinion, we should not have default value for config parameters in comments if it's clear specified in the configuration docs what are the default and possible values. Realized that having the default values in comments is not beneficial and updating in the comment might be a not as straightforward as changing it in code/config.


#### PR checklist

- [ ] ~~Tests written/updated~~
- [ ] ~~Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)~~
- [X] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [X] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
