### PR TITLE
perf(blockstore): Add LRU caches to blockstore operations used in consensus

### DIFF
--- a/.changelog/unreleased/improvements/3003-use-lru-caches-in-blockstore.md
+++ b/.changelog/unreleased/improvements/3003-use-lru-caches-in-blockstore.md
@@ -1,0 +1,2 @@
+- [`blockstore`] Use LRU caches in blockstore, significiantly improving consensus gossip routine performance
+  ([\#3003](https://github.com/cometbft/cometbft/issues/3003)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -101,6 +101,7 @@ linters-settings:
           - github.com/gofrs/uuid
           - github.com/google
           - github.com/gorilla/websocket
+          - github.com/hashicorp/golang-lru/v2
           - github.com/lib/pq
           - github.com/libp2p/go-buffer-pool
           - github.com/Masterminds/semver/v3

--- a/go.mod
+++ b/go.mod
@@ -96,6 +96,7 @@ require (
 	github.com/google/flatbuffers v2.0.8+incompatible // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/gotestyourself/gotestyourself v2.2.0+incompatible // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/imdario/mergo v0.3.15 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -224,6 +224,8 @@ github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible h1:AQwinXlbQR2HvPjQZOmDhRqsv5mZf+Jb1RnSLxcqZcI=
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=

--- a/store/bench_test.go
+++ b/store/bench_test.go
@@ -13,7 +13,7 @@ import (
 // TestLoadBlockExtendedCommit tests loading the extended commit for a previously
 // saved block. The load method should return nil when only a commit was saved and
 // return the extended commit otherwise.
-func BenchmarkRepeatedLoadSeenCommit(b *testing.B) {
+func BenchmarkRepeatedLoadSeenCommitSameBlock(b *testing.B) {
 	state, bs, _, _, cleanup, _ := makeStateAndBlockStoreAndIndexers()
 	defer cleanup()
 	h := bs.Height() + 1

--- a/store/bench_test.go
+++ b/store/bench_test.go
@@ -1,0 +1,35 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/internal/test"
+	"github.com/cometbft/cometbft/types"
+	cmttime "github.com/cometbft/cometbft/types/time"
+)
+
+// TestLoadBlockExtendedCommit tests loading the extended commit for a previously
+// saved block. The load method should return nil when only a commit was saved and
+// return the extended commit otherwise.
+func BenchmarkRepeatedLoadSeenCommit(b *testing.B) {
+	state, bs, _, _, cleanup, _ := makeStateAndBlockStoreAndIndexers()
+	defer cleanup()
+	h := bs.Height() + 1
+	block := state.MakeBlock(h, test.MakeNTxs(h, 10), new(types.Commit), nil, state.Validators.GetProposer().Address)
+	seenCommit := makeTestExtCommitWithNumSigs(block.Header.Height, cmttime.Now(), 100).ToCommit()
+	ps, err := block.MakePartSet(types.BlockPartSizeBytes)
+	require.NoError(b, err)
+	bs.SaveBlock(block, ps, seenCommit)
+
+	// sanity check
+	res := bs.LoadSeenCommit(block.Height)
+	require.Equal(b, seenCommit, res)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		res := bs.LoadSeenCommit(block.Height)
+		require.NotNil(b, res)
+	}
+}

--- a/store/store.go
+++ b/store/store.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cosmos/gogoproto/proto"
 	"github.com/go-kit/kit/metrics"
+	lru "github.com/hashicorp/golang-lru/v2"
 
 	dbm "github.com/cometbft/cometbft-db"
 	cmtstore "github.com/cometbft/cometbft/api/cometbft/store/v1"
@@ -64,6 +65,10 @@ type BlockStore struct {
 	blocksDeleted      int64
 	compact            bool
 	compactionInterval int64
+
+	seenCommitCache          *lru.Cache[int64, *types.Commit]
+	blockCommitCache         *lru.Cache[int64, *types.Commit]
+	blockExtendedCommitCache *lru.Cache[int64, *types.ExtendedCommit]
 }
 
 type BlockStoreOption func(*BlockStore)
@@ -126,6 +131,7 @@ func NewBlockStore(db dbm.DB, options ...BlockStoreOption) *BlockStore {
 		db:      db,
 		metrics: NopMetrics(),
 	}
+	bStore.addCaches()
 
 	for _, option := range options {
 		option(bStore)
@@ -137,6 +143,23 @@ func NewBlockStore(db dbm.DB, options ...BlockStoreOption) *BlockStore {
 
 	addTimeSample(bStore.metrics.BlockStoreAccessDurationSeconds.With("method", "new_block_store"), start)()
 	return bStore
+}
+
+func (bs *BlockStore) addCaches() {
+	var err error
+	// err can only occur if the argument is non-positive, so is impossible in context.
+	bs.blockCommitCache, err = lru.New[int64, *types.Commit](100)
+	if err != nil {
+		panic(err)
+	}
+	bs.blockExtendedCommitCache, err = lru.New[int64, *types.ExtendedCommit](100)
+	if err != nil {
+		panic(err)
+	}
+	bs.seenCommitCache, err = lru.New[int64, *types.Commit](100)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func (bs *BlockStore) GetVersion() string {
@@ -329,6 +352,10 @@ func (bs *BlockStore) LoadBlockMetaByHash(hash []byte) *types.BlockMeta {
 // and it comes from the block.LastCommit for `height+1`.
 // If no commit is found for the given height, it returns nil.
 func (bs *BlockStore) LoadBlockCommit(height int64) *types.Commit {
+	comm, ok := bs.blockCommitCache.Get(height)
+	if ok {
+		return comm.Clone()
+	}
 	pbc := new(cmtproto.Commit)
 
 	start := time.Now()
@@ -351,13 +378,18 @@ func (bs *BlockStore) LoadBlockCommit(height int64) *types.Commit {
 	if err != nil {
 		panic(cmterrors.ErrMsgToProto{MessageName: "Commit", Err: err})
 	}
-	return commit
+	bs.blockCommitCache.Add(height, commit)
+	return commit.Clone()
 }
 
 // LoadExtendedCommit returns the ExtendedCommit for the given height.
 // The extended commit is not guaranteed to contain the same +2/3 precommits data
 // as the commit in the block.
 func (bs *BlockStore) LoadBlockExtendedCommit(height int64) *types.ExtendedCommit {
+	comm, ok := bs.blockExtendedCommitCache.Get(height)
+	if ok {
+		return comm.Clone()
+	}
 	pbec := new(cmtproto.ExtendedCommit)
 
 	start := time.Now()
@@ -380,13 +412,18 @@ func (bs *BlockStore) LoadBlockExtendedCommit(height int64) *types.ExtendedCommi
 	if err != nil {
 		panic(fmt.Errorf("converting extended commit: %w", err))
 	}
-	return extCommit
+	bs.blockExtendedCommitCache.Add(height, extCommit)
+	return extCommit.Clone()
 }
 
 // LoadSeenCommit returns the locally seen Commit for the given height.
 // This is useful when we've seen a commit, but there has not yet been
 // a new block at `height + 1` that includes this commit in its block.LastCommit.
 func (bs *BlockStore) LoadSeenCommit(height int64) *types.Commit {
+	comm, ok := bs.seenCommitCache.Get(height)
+	if ok {
+		return comm.Clone()
+	}
 	pbc := new(cmtproto.Commit)
 	start := time.Now()
 	bz, err := bs.db.Get(bs.dbKeyLayout.CalcSeenCommitKey(height))
@@ -409,7 +446,8 @@ func (bs *BlockStore) LoadSeenCommit(height int64) *types.Commit {
 	if err != nil {
 		panic(fmt.Errorf("converting seen commit: %w", err))
 	}
-	return commit
+	bs.seenCommitCache.Add(height, commit)
+	return commit.Clone()
 }
 
 // PruneBlocks removes block up to (but not including) a height. It returns the

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -34,15 +34,22 @@ import (
 // make an extended commit with a single vote containing just the height and a
 // timestamp.
 func makeTestExtCommit(height int64, timestamp time.Time) *types.ExtendedCommit {
-	extCommitSigs := []types.ExtendedCommitSig{{
-		CommitSig: types.CommitSig{
-			BlockIDFlag:      types.BlockIDFlagCommit,
-			ValidatorAddress: cmtrand.Bytes(crypto.AddressSize),
-			Timestamp:        timestamp,
-			Signature:        []byte("Signature"),
-		},
-		ExtensionSignature: []byte("ExtensionSignature"),
-	}}
+	return makeTestExtCommitWithNumSigs(height, timestamp, 1)
+}
+
+func makeTestExtCommitWithNumSigs(height int64, timestamp time.Time, numSigs int) *types.ExtendedCommit {
+	extCommitSigs := []types.ExtendedCommitSig{}
+	for i := 0; i < numSigs; i++ {
+		extCommitSigs = append(extCommitSigs, types.ExtendedCommitSig{
+			CommitSig: types.CommitSig{
+				BlockIDFlag:      types.BlockIDFlagCommit,
+				ValidatorAddress: cmtrand.Bytes(crypto.AddressSize),
+				Timestamp:        timestamp,
+				Signature:        cmtrand.Bytes(64),
+			},
+			ExtensionSignature: []byte("ExtensionSignature"),
+		})
+	}
 	return &types.ExtendedCommit{
 		Height: height,
 		BlockID: types.BlockID{

--- a/types/block.go
+++ b/types/block.go
@@ -857,6 +857,15 @@ type Commit struct {
 	hash cmtbytes.HexBytes
 }
 
+// Clone creates a deep copy of this commit.
+func (commit *Commit) Clone() *Commit {
+	sigs := make([]CommitSig, len(commit.Signatures))
+	copy(sigs, commit.Signatures)
+	commCopy := *commit
+	commCopy.Signatures = sigs
+	return &commCopy
+}
+
 // GetVote converts the CommitSig for the given valIdx to a Vote. Commits do
 // not contain vote extensions, so the vote extension and vote extension
 // signature will not be present in the returned vote.


### PR DESCRIPTION
Closes #2844

We are seeing that the blockstore loading operations get used in hot loops within gossip routines, and queryMaj23 routines. This PR reduces that overhead using an LRU cache.

The LRU cache does have a mutex on every get, but the time with the LRU cache is 9x faster than without (before even adding in DB overheads), due to the proto unmarshalling saved. We could imagine a setup where we avoided a lock there entirely. I don't think this is worth right now, since the new code is 9x faster, and these mostly appear in catchup code which should not be highly contended for across peers at the same time.

With the new benchmark I added:
OLD:
```
BenchmarkRepeatedLoadSeenCommit-12         24447             54691 ns/op           46495 B/op        319 allocs/op
```
NEW:
```
BenchmarkRepeatedLoadSeenCommit-12        224131              6401 ns/op            8320 B/op          2 allocs/op
```

It turns out these gossip routines don't need mutative copies, so we could optimize out the large allocation in the future if we want.

1 hour cpu profile that shows this appearing in prod: 
![image](https://github.com/cometbft/cometbft/assets/6440154/5a7e0f02-8385-4c01-aa6a-dba2a2bf376d)

The state machine execution time here for context is 92 seconds. So this is adding up in system load (and GC! The GC load is 52GB, the entire trace is 200GB, with other parts being optimized down from recent PRs)

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
