### PR TITLE
perf: Minor speedup to consenus metrics MarkLateVote

### DIFF
--- a/.changelog/unreleased/improvements/3017-speedup-consensus-metrics.md
+++ b/.changelog/unreleased/improvements/3017-speedup-consensus-metrics.md
@@ -1,0 +1,2 @@
+- [`consensus`] Improve performance of consensus metrics by lowering string operations
+  ([\#3017](https://github.com/cometbft/cometbft/issues/3017)

--- a/internal/consensus/metrics.go
+++ b/internal/consensus/metrics.go
@@ -160,7 +160,7 @@ func (m *Metrics) MarkVoteExtensionReceived(accepted bool) {
 
 func (m *Metrics) MarkVoteReceived(vt types.SignedMsgType, power, totalPower int64) {
 	p := float64(power) / float64(totalPower)
-	n := strings.ToLower(strings.TrimPrefix(vt.String(), "SIGNED_MSG_TYPE_"))
+	n := types.SignedMsgTypeToShortString(vt)
 	m.RoundVotingPowerPercent.With("vote_type", n).Add(p)
 }
 
@@ -169,17 +169,15 @@ func (m *Metrics) MarkRound(r int32, st time.Time) {
 	roundTime := cmttime.Since(st).Seconds()
 	m.RoundDurationSeconds.Observe(roundTime)
 
-	pvt := types.PrevoteType
-	pvn := strings.ToLower(strings.TrimPrefix(pvt.String(), "SIGNED_MSG_TYPE_"))
+	pvn := types.SignedMsgTypeToShortString(types.PrevoteType)
 	m.RoundVotingPowerPercent.With("vote_type", pvn).Set(0)
 
-	pct := types.PrecommitType
-	pcn := strings.ToLower(strings.TrimPrefix(pct.String(), "SIGNED_MSG_TYPE_"))
+	pcn := types.SignedMsgTypeToShortString(types.PrecommitType)
 	m.RoundVotingPowerPercent.With("vote_type", pcn).Set(0)
 }
 
 func (m *Metrics) MarkLateVote(vt types.SignedMsgType) {
-	n := strings.ToLower(strings.TrimPrefix(vt.String(), "SIGNED_MSG_TYPE_"))
+	n := types.SignedMsgTypeToShortString(vt)
 	m.LateVotes.With("vote_type", n).Add(1)
 }
 

--- a/types/signed_msg_type.go
+++ b/types/signed_msg_type.go
@@ -20,3 +20,18 @@ func IsVoteTypeValid(t SignedMsgType) bool {
 		return false
 	}
 }
+
+var signedMsgTypeToShortName = map[SignedMsgType]string{
+	UnknownType:   "unknown",
+	PrevoteType:   "prevote",
+	PrecommitType: "precommit",
+	ProposalType:  "proposal",
+}
+
+// Returns a short lowercase descriptor for a signed message type.
+func SignedMsgTypeToShortString(t SignedMsgType) string {
+	if shortName, ok := signedMsgTypeToShortName[t]; ok {
+		return shortName
+	}
+	return "unknown"
+}


### PR DESCRIPTION
Minor speedup to metrics MarkLateVote.

I saw the excess string allocation calls, so made a quick PR to remove it. This saves between .18s-25s from the consensus mutex across this one hour block sync. (Likely not at all consensus critical) It also appears in receiving votes

![image](https://github.com/cometbft/cometbft/assets/6440154/61875b0d-b419-4900-a74c-76c65087bca4)

(Saves ToLower(), .String(), .TrimPrefix() and newObject calls. The new call has comparable complexity to .String())

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
