### PR TITLE
perf: Micro optimization to save one allocation per packet

### DIFF
--- a/.changelog/unreleased/improvements/3019-reduce-allocations-in-packet-reads.md
+++ b/.changelog/unreleased/improvements/3019-reduce-allocations-in-packet-reads.md
@@ -1,0 +1,3 @@
+- [`protoio`] Remove one allocation and new object call from `ReadMsg`,
+  leading to a 4% p2p message reading performance gain.
+  ([\#3018](https://github.com/cometbft/cometbft/issues/3018)

--- a/libs/protoio/io.go
+++ b/libs/protoio/io.go
@@ -98,3 +98,7 @@ func (r *byteReader) ReadByte() (byte, error) {
 	}
 	return r.buf[0], nil
 }
+
+func (r *byteReader) resetBytesRead() {
+	r.bytesRead = 0
+}


### PR DESCRIPTION
This PR is a slight optimization to save one allocation per packet. We have much more worthwhile performance improvements to pursue, just driveby noticed it as I was reading through the code. (Though I am surprised this did add up to 1 second in total -- 4% of the processing time) 

This re-uses the byte reader's allocation across all ReadMsg's. There is no concurrenct access possible under safe usage (also implied by the reader)

This is the cause of the 1s time on the far right: 
![image](https://github.com/cometbft/cometbft/assets/6440154/d6c6bfaa-d287-4355-b094-9bdcbc6379c8)


---

#### PR checklist

- [x] Tests written/updated - covered by existing tests
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
