### PR TITLE
perf: Make mempool recheck state only use an atomic for num rechecked txs

### DIFF
--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -618,7 +618,7 @@ func (mem *CListMempool) recheckTxs() {
 	// because this function has the lock (via Update and Lock).
 	for e := mem.txs.Front(); e != nil; e = e.Next() {
 		tx := e.Value.(*mempoolTx).tx
-		mem.recheck.numTxsToRecheck += 1
+		mem.recheck.numTxsToRecheck++
 
 		// Send a CheckTx request to the app. If we're using a sync client, the resCbRecheck
 		// callback will be called right after receiving the response.

--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -922,7 +922,7 @@ func TestMempoolAsyncRecheckTxReturnError(t *testing.T) {
 	require.NotNil(t, mp.recheck.end)
 	require.Equal(t, mp.recheck.end, mp.txs.Back())
 	require.Equal(t, len(txs)-1, mp.Size()) // one invalid tx was removed
-	require.Equal(t, int32(2), mp.recheck.numPendingTxs.Load())
+	require.Equal(t, int32(2), mp.recheck.numTxsToRecheck-mp.recheck.numRecheckedTxs.Load())
 
 	mockClient.AssertExpectations(t)
 }
@@ -956,7 +956,7 @@ func TestMempoolRecheckRace(t *testing.T) {
 	// should not result in a data race on the variable recheck.cursor.
 	_, err = mp.CheckTx(txs[:1][0])
 	require.Equal(t, err, ErrTxInCache)
-	require.Zero(t, mp.recheck.numPendingTxs.Load())
+	require.Equal(t, mp.recheck.numTxsToRecheck, mp.recheck.numRecheckedTxs.Load())
 }
 
 // Test adding transactions while a concurrent routine reaps txs and updates the mempool, simulating


### PR DESCRIPTION
This PR makes the mempool recheck only use an atomic instruction for the number of succesfully rechecked txs, not the "unbalanced" number of txs rechecked.

There are two reasons for this:
- As part of #2925 , I want to make an alternate information communication channel between Reap and Update. Recheck will maintain variables for rechecked # txs, # gas, # bytes. If Reap is called, and recheck is active, it will setup a channel fpr 
- This is technically a minor speedup, by making the initiating thread not use atomics, only the callbacks.

---

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog) - omitted since its new to this version / very minor, and about to be edited more in a subsequent PR
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
