### PR TITLE
docs(mempool): added network consistency properties and Priority Mempool

### DIFF
--- a/docs/references/architecture/adr-113-mempool-lanes.md
+++ b/docs/references/architecture/adr-113-mempool-lanes.md
@@ -151,13 +151,12 @@ to be useful and predictable for the whole appchain network.
 These properties are expressed in terms of consistency of the information, configuration and behaviour
 across nodes in the network.
 
-:parking: _Property_ **Consistent transaction classes**: For any transaction `tx`,
-and any two correct nodes $p$ and $q$ that receive `tx` for the first time,
-$p$ and $q$ MUST have the same set of transaction classes and their relative priority and configuration,
-as long as `tx` has not been included in a block.
+> TODO: Define "for the first time" here: receveived from RPC, peer, or `Update`
+> (try to define it an as modular a way as possible)
 
-> TODO: Do we really need to require that the `tx` hasn't been decided? Isn't it adding complexity for nothing?
-> Besides, it break modularity, as we use a consensus concept in the mempool.
+:parking: _Property_ **Consistent transaction classes**: For any transaction `tx`,
+and any two correct nodes $p$ and $q$ that receive `tx` *for the first time*,
+$p$ and $q$ MUST have the same set of transaction classes and their relative priority and configuration.
 
 The property is only required to hold for on-the-fly transactions:
 if a node receives a (late) transaction that has already been decided, this property does not enforce anything.
@@ -166,9 +165,8 @@ Notice that, if this property does not hold, it is not possible to guarantee any
 such as transaction latency as defined above.
 
 :parking: _Property_ **Consistent transaction classification**: For any transaction `tx`
-and any two correct nodes $p$ and $q$ that receive `tx` for the first time,
-$p$'s application MUST classify `tx` into the same transaction class as $q$'s application,
-as long as `tx` has not been included in a block.
+and any two correct nodes $p$ and $q$ that receive `tx` *for the first time*,
+$p$'s application MUST classify `tx` into the same transaction class as $q$'s application.
 
 This property only makes sense when the previous property (_consistent transaction classes_) defined above holds.
 Even if we ensure consistent transaction classes, if this property does not hold, a given transaction
@@ -179,6 +177,8 @@ Additionally, it is important to note that these two properties also constrain t
 classes and transaction classification logic can evolve in an existing implementation.
 If either transaction classes or classification logic are not modified in a coordinated manner in a working system,
 there will be at least a period where the these two properties may not hold for all transactions.
+
+> TODO: Need to find somewhere in the text to say: "ReCheckTx" doesn't classify, it's mempool information is disregarded"
 
 ## Alternative Approaches
 

--- a/docs/references/architecture/adr-113-mempool-lanes.md
+++ b/docs/references/architecture/adr-113-mempool-lanes.md
@@ -7,6 +7,7 @@
 - 2024-04-17: Discussions (@sergio-mena @hvanz)
 - 2024-04-18: Preliminary structure (@hvanz)
 - 2024-05-01: Add Context and Properties (@hvanz)
+- 2024-05-21: Add more Properties + priority mempool (@sergio-mena)
 
 ## Status
 
@@ -37,7 +38,7 @@ The goal of this document is thus to propose a mechanism enabling the mempool to
 transactions by *classes*, for processing and dissemination, directly impacting block creation and transaction latency. In
 IP networking terminology, this is known as Quality of Service (QoS). By providing certain QoS
 guarantees, developers will be able to more easily estimate when transactions will be disseminated, processed and
-included in a block. 
+included in a block.
 
 In practical terms, we envision an implementation of the transaction class abstraction as *mempool
 lanes*. The application will be allowed to split the mempool transaction space into a hierarchy of
@@ -45,7 +46,8 @@ lanes, with each lane operating as an independent mempool. At the same time, all
 coordinated to ensure the delivery of the desired levels of QoS.
 
 Note that improving the dissemination protocol to reduce bandwidth and/or latency is a separate
-concern and falls outside the scope of this proposal. Likewise, graceful degradation under high load is an orthogonal problem to transaction classification, although the latter may help improve the former. 
+concern and falls outside the scope of this proposal. Likewise, graceful degradation under high load
+is an orthogonal problem to transaction classification, although the latter may help improve the former.
 
 ## Properties
 
@@ -53,7 +55,7 @@ Before jumping into the design of the proposal, we define more formally the prop
 the current implementation of the mempool. Then we state what properties the new mempool should
 offer to guarantee the desired QoS.
 
-The following definition is common to all properties. 
+The following definition is common to all properties.
 
 :memo: _Definition_: Given any two different transactions `tx1` and `tx2`, we say that `tx1` is
 *processed and disseminated before* `tx2` in a given node, when:

--- a/docs/references/architecture/adr-113-mempool-lanes.md
+++ b/docs/references/architecture/adr-113-mempool-lanes.md
@@ -106,6 +106,8 @@ Therefore all classes can be ordered by priority.
 
 Given these definitions, we want the proposed QoS mechanism to offer the following property:
 
+#### Basic properties
+
 :parking: _Property_ **Priorities between classes**: Transactions belonging to a certain class will
 be processed and disseminated before transactions belonging to another class with lower priority.
 
@@ -140,6 +142,43 @@ the mempool, regardless of their classes, will have a *partial order*.
 
 This means that some pairs of
 transactions are comparable and, thus, have and order, while others not.
+
+#### Network-wide consistency
+
+The properties presented so far may be interpreted as per-node properties.
+However, we need to define some network-wide properties in order for a mempool QoS implementation
+to be useful and predictable for the whole appchain network.
+These properties are expressed in terms of consistency of the information, configuration and behaviour
+across nodes in the network.
+
+:parking: _Property_ **Consistent transaction classes**: For any transaction `tx`,
+and any two correct nodes $p$ and $q$ that receive `tx` for the first time,
+$p$ and $q$ MUST have the same the set of transaction classes and their relative priority and configuration,
+as long as `tx` has not been included in a block.
+
+> TODO: Do we really need to require that the `tx` hasn't been decided? Isn't it adding complexity for nothing?
+> Besides, it break modularity, as we use a consensus concept in the mempool.
+
+The property is only required to hold for on-the-fly transactions:
+if a node receives a (late) transaction that has already been decided, this property does not enforce anything.
+The same goes for duplicate transactions.
+Notice that, if this property does not hold, it is not possible to guarantee any property across the network,
+such as transaction latency as defined above.
+
+:parking: _Property_ **Consistent transaction classification**: For any transaction `tx`
+and any two correct nodes $p$ and $q$ that receive `tx` for the first time,
+$p$'s application MUST classify `tx` into the same transaction class as $q$'s application,
+as long as `tx` has not been included in a block.
+
+This property only makes sense when the previous property (_consistent transaction classes_) defined above holds.
+Even if we ensure consistent transaction classes, if this property does not hold, a given transaction
+may not receive the same classification across the network and it will thus be impossible to reason
+about any network-wide guarantees we want to provide that transaction with.
+
+Additionally, it is important to note that these two properties also constrain the way transaction
+classes and transaction classification logic can evolve in an existing implementation.
+If either transaction classes or classification logic are not modified in a coordinated manner in a working system,
+there will be at least a period where the these two properties may not hold for all transactions.
 
 ## Alternative Approaches
 

--- a/docs/references/architecture/adr-113-mempool-lanes.md
+++ b/docs/references/architecture/adr-113-mempool-lanes.md
@@ -153,7 +153,7 @@ across nodes in the network.
 
 :parking: _Property_ **Consistent transaction classes**: For any transaction `tx`,
 and any two correct nodes $p$ and $q$ that receive `tx` for the first time,
-$p$ and $q$ MUST have the same the set of transaction classes and their relative priority and configuration,
+$p$ and $q$ MUST have the same set of transaction classes and their relative priority and configuration,
 as long as `tx` has not been included in a block.
 
 > TODO: Do we really need to require that the `tx` hasn't been decided? Isn't it adding complexity for nothing?

--- a/docs/references/architecture/adr-113-mempool-lanes.md
+++ b/docs/references/architecture/adr-113-mempool-lanes.md
@@ -151,8 +151,8 @@ to be useful and predictable for the whole appchain network.
 These properties are expressed in terms of consistency of the information, configuration and behaviour
 across nodes in the network.
 
-> TODO: Define "for the first time" here: receveived from RPC, peer, or `Update`
-> (try to define it an as modular a way as possible)
+> TODO: Define "for the first time" here: received from RPC, peer, or `Update`
+> (try to define it in as modular a way as possible)
 
 :parking: _Property_ **Consistent transaction classes**: For any transaction `tx`,
 and any two correct nodes $p$ and $q$ that receive `tx` *for the first time*,
@@ -178,7 +178,7 @@ classes and transaction classification logic can evolve in an existing implement
 If either transaction classes or classification logic are not modified in a coordinated manner in a working system,
 there will be at least a period where the these two properties may not hold for all transactions.
 
-> TODO: Need to find somewhere in the text to say: "ReCheckTx" doesn't classify, it's mempool information is disregarded"
+> TODO: Need to find somewhere in the text to say: "ReCheckTx" doesn't classify, its mempool information is disregarded"
 
 ## Alternative Approaches
 


### PR DESCRIPTION
Partially addresses #3110

Added subsection "Priority mempool" in "Alternative approaces" section.

I also added extra properties in the previous section: those properties are one of the core points in our current discussions with our users, and I wanted to relate it to the priority mempool.

---

#### PR checklist

- ~~[ ] Tests written/updated~~
- ~~[ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)~~
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
