### PR TITLE
perf(types): 3x speedup MakePartSet

### DIFF
--- a/.changelog/unreleased/improvements/3117-significantly-speedup-make-partset.md
+++ b/.changelog/unreleased/improvements/3117-significantly-speedup-make-partset.md
@@ -1,2 +1,2 @@
-- [`types`] Significantly speedup types.MakePartSet, which is used in creating a block proposal
+- [`types`] Significantly speedup types.MakePartSet and types.AddPart, which are used in creating a block proposal
   ([\#3117](https://github.com/cometbft/cometbft/issues/3117)

--- a/.changelog/unreleased/improvements/3117-significantly-speedup-make-partset.md
+++ b/.changelog/unreleased/improvements/3117-significantly-speedup-make-partset.md
@@ -1,0 +1,2 @@
+- [`types`] Significantly speedup types.MakePartSet, which is used in creating a block proposal
+  ([\#3117](https://github.com/cometbft/cometbft/issues/3117)

--- a/crypto/merkle/bench_test.go
+++ b/crypto/merkle/bench_test.go
@@ -40,3 +40,25 @@ func BenchmarkInnerHash(b *testing.B) {
 		b.Fatal("Benchmark did not run!")
 	}
 }
+
+// Benchmark the time it takes to hash a 64kb leaf, which is the size of
+// a block part.
+// This helps determine whether its worth parallelizing this hash for the propose.r
+func BenchmarkLeafHash64kb(b *testing.B) {
+	b.ReportAllocs()
+	leaf := make([]byte, 64*1024)
+	hash := sha256.New()
+
+	for i := 0; i < b.N; i++ {
+		leaf[0] = byte(i)
+		got := leafHashOpt(hash, leaf)
+		if g, w := len(got), sha256.Size; g != w {
+			b.Fatalf("size discrepancy: got %d, want %d", g, w)
+		}
+		sink = got
+	}
+
+	if sink == nil {
+		b.Fatal("Benchmark did not run!")
+	}
+}

--- a/crypto/merkle/bench_test.go
+++ b/crypto/merkle/bench_test.go
@@ -43,7 +43,7 @@ func BenchmarkInnerHash(b *testing.B) {
 
 // Benchmark the time it takes to hash a 64kb leaf, which is the size of
 // a block part.
-// This helps determine whether its worth parallelizing this hash for the propose.r
+// This helps determine whether its worth parallelizing this hash for the proposer.
 func BenchmarkLeafHash64kb(b *testing.B) {
 	b.ReportAllocs()
 	leaf := make([]byte, 64*1024)

--- a/crypto/merkle/proof_value.go
+++ b/crypto/merkle/proof_value.go
@@ -104,7 +104,7 @@ func (op ValueOp) Run(args [][]byte) ([][]byte, error) {
 		}
 	}
 
-	rootHash, err := op.Proof.computeRootHash()
+	rootHash, err := op.Proof.computeRootHash(tmhash.New())
 	if err != nil {
 		return nil, err
 	}

--- a/types/part_set.go
+++ b/types/part_set.go
@@ -180,7 +180,6 @@ func NewPartSetFromData(data []byte, partSize uint32) *PartSet {
 	total := (uint32(len(data)) + partSize - 1) / partSize
 	parts := make([]*Part, total)
 	partsBytes := make([][]byte, total)
-	partsBitArray := bits.NewBitArray(int(total))
 	for i := uint32(0); i < total; i++ {
 		part := &Part{
 			Index: i,
@@ -188,13 +187,13 @@ func NewPartSetFromData(data []byte, partSize uint32) *PartSet {
 		}
 		parts[i] = part
 		partsBytes[i] = part.Bytes
-		partsBitArray.SetIndex(int(i), true)
 	}
 	// Compute merkle proofs
 	root, proofs := merkle.ProofsFromByteSlices(partsBytes)
 	for i := uint32(0); i < total; i++ {
 		parts[i].Proof = *proofs[i]
 	}
+	partsBitArray := bits.NewBitArrayFromFn(int(total), func(int) bool { return true })
 	return &PartSet{
 		total:         total,
 		hash:          root,

--- a/types/part_set_test.go
+++ b/types/part_set_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"fmt"
 	"io"
 	"testing"
 
@@ -217,5 +218,21 @@ func TestPartProtoBuf(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tc.ps1, p, tc.msg)
 		}
+	}
+}
+
+func runBenchMakePartSet(b *testing.B, nParts int) {
+	data := cmtrand.Bytes(testPartSize * nParts)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		NewPartSetFromData(data, testPartSize)
+	}
+}
+
+func BenchmarkMakePartSet(b *testing.B) {
+	for i := 1; i <= 5; i++ {
+		b.Run(fmt.Sprintf("nParts=%d", i), func(b *testing.B) {
+			runBenchMakePartSet(b, i)
+		})
 	}
 }

--- a/types/part_set_test.go
+++ b/types/part_set_test.go
@@ -221,18 +221,14 @@ func TestPartProtoBuf(t *testing.T) {
 	}
 }
 
-func runBenchMakePartSet(b *testing.B, nParts int) {
-	data := cmtrand.Bytes(testPartSize * nParts)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		NewPartSetFromData(data, testPartSize)
-	}
-}
-
 func BenchmarkMakePartSet(b *testing.B) {
-	for i := 1; i <= 5; i++ {
-		b.Run(fmt.Sprintf("nParts=%d", i), func(b *testing.B) {
-			runBenchMakePartSet(b, i)
+	for nParts := 1; nParts <= 5; nParts++ {
+		b.Run(fmt.Sprintf("nParts=%d", nParts), func(b *testing.B) {
+			data := cmtrand.Bytes(testPartSize * nParts)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				NewPartSetFromData(data, testPartSize)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

This PR adds some benchmarks, and significantly speeds up types.MakePartSet, and Partset.AddPart. (Used by the block proposer, and every consensus instance) It does so by doing two things:
- Saving mutexes on the newly created bit array, by defaulting every value to True (rather than setting it in a loop that goes through a mutex)
- Uses the same hash object throughout, and avoids an extra copy of every leaf. (main speedup)

I do the same hash optimization for proof.Verify, which is used in the add block part codepath for both the proposer and every full node.

New:
```
BenchmarkMakePartSet/nParts=1-12         	   38616	     29817 ns/op	     568 B/op	      12 allocs/op
BenchmarkMakePartSet/nParts=2-12         	   19888	     59866 ns/op	    1000 B/op	      22 allocs/op
BenchmarkMakePartSet/nParts=3-12         	   12979	     95691 ns/op	    1528 B/op	      33 allocs/op
BenchmarkMakePartSet/nParts=4-12         	    8688	    128192 ns/op	    2024 B/op	      44 allocs/op
BenchmarkMakePartSet/nParts=5-12         	    7308	    155224 ns/op	    2888 B/op	      57 allocs/op
```

Old:
```
BenchmarkMakePartSet/nParts=1-12         	   16647	    106545 ns/op	   74169 B/op	      12 allocs/op
BenchmarkMakePartSet/nParts=2-12         	   10000	    106361 ns/op	  148329 B/op	      23 allocs/op
BenchmarkMakePartSet/nParts=3-12         	    6992	    337644 ns/op	  222587 B/op	      35 allocs/op
BenchmarkMakePartSet/nParts=4-12         	    3488	    480109 ns/op	  296811 B/op	      47 allocs/op
BenchmarkMakePartSet/nParts=5-12         	    2228	    557768 ns/op	  371404 B/op	      61 allocs/op
```

System wide, this is definitely not our issue (looks like roughly .1ms per blockpart), but still definitely useful time to remove

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
