### PR TITLE
fix(mempool): Move senders back from reactor to clist_mempool entries

### DIFF
--- a/.changelog/unreleased/breaking-changes/1010-mempool-interface.md
+++ b/.changelog/unreleased/breaking-changes/1010-mempool-interface.md
@@ -1,4 +1,0 @@
-`[mempool]` Change the signature of `CheckTx` in the `Mempool` interface to
-`CheckTx(tx types.Tx) (*abcicli.ReqRes, error)`. Also, add new method
-`SetTxRemovedCallback`.
-([\#1010](https://github.com/cometbft/cometbft/issues/1010))

--- a/abci/client/client.go
+++ b/abci/client/client.go
@@ -36,6 +36,11 @@ type Client interface {
 	// with the exception of `CheckTxAsync` which we maintain
 	// for the v0 mempool. We should explore refactoring the
 	// mempool to remove this vestige behavior.
+	//
+	// SetResponseCallback is not actually used anymore. It was used only by the mempool on CheckTx
+	// requests. Now the callback for processing the response is set on the ReqRes returned by
+	// CheckTxAsync. This is more flexible as it allows to pass other tx information such as the
+	// sender.
 	SetResponseCallback(cb Callback)
 	CheckTxAsync(ctx context.Context, req *types.CheckTxRequest) (*ReqRes, error)
 }

--- a/abci/client/grpc_client.go
+++ b/abci/client/grpc_client.go
@@ -30,7 +30,7 @@ type grpcClient struct {
 	mtx   sync.Mutex
 	addr  string
 	err   error
-	resCb func(*types.Request, *types.Response) // listens to all callbacks
+	resCb Callback // listens to all callbacks
 }
 
 func NewGRPCClient(addr string, mustConnect bool) Client {

--- a/abci/client/local_client.go
+++ b/abci/client/local_client.go
@@ -61,7 +61,9 @@ func (app *localClient) CheckTxAsync(ctx context.Context, req *types.CheckTxRequ
 }
 
 func (app *localClient) callback(req *types.Request, res *types.Response) *ReqRes {
-	app.Callback(req, res)
+	if app.Callback != nil {
+		app.Callback(req, res)
+	}
 	rr := newLocalReqRes(req, res)
 	rr.callbackInvoked = true
 	return rr

--- a/abci/client/socket_client.go
+++ b/abci/client/socket_client.go
@@ -40,8 +40,8 @@ type socketClient struct {
 
 	mtx     sync.Mutex
 	err     error
-	reqSent *list.List                            // list of requests sent, waiting for response
-	resCb   func(*types.Request, *types.Response) // called on all requests, if set.
+	reqSent *list.List // list of requests sent, waiting for response
+	resCb   Callback   // called on all requests, if set.
 }
 
 var _ Client = (*socketClient)(nil)

--- a/abci/client/unsync_local_client.go
+++ b/abci/client/unsync_local_client.go
@@ -55,7 +55,9 @@ func (app *unsyncLocalClient) CheckTxAsync(ctx context.Context, req *types.Check
 }
 
 func (app *unsyncLocalClient) callback(req *types.Request, res *types.Response) *ReqRes {
-	app.Callback(req, res)
+	if app.Callback != nil {
+		app.Callback(req, res)
+	}
 	rr := newLocalReqRes(req, res)
 	rr.callbackInvoked = true
 	return rr

--- a/docs/references/architecture/adr-105-refactor-mempool-senders.md
+++ b/docs/references/architecture/adr-105-refactor-mempool-senders.md
@@ -5,10 +5,11 @@
 - 2023-07-19: Choose callbacks option and mark as accepted (@hvanz)
 - 2023-07-10: Add callback alternative (@hvanz)
 - 2023-06-26: Initial draft (@hvanz)
+- 2024-05-22: Reverted (@hvanz)
 
 ## Status
 
-Accepted
+Reverted
 
 ## Context
 

--- a/internal/consensus/mempool_test.go
+++ b/internal/consensus/mempool_test.go
@@ -111,9 +111,8 @@ func deliverTxsRange(t *testing.T, cs *State, end int) {
 	start := 0
 	// Deliver some txs.
 	for i := start; i < end; i++ {
-		reqRes, err := assertMempool(cs.txNotifier).CheckTx(kvstore.NewTx(strconv.Itoa(i), "true"))
+		err := assertMempool(cs.txNotifier).CheckTx(kvstore.NewTx(strconv.Itoa(i), "true"), nil, mempl.TxInfo{})
 		require.NoError(t, err)
-		require.False(t, reqRes.Response.GetCheckTx().IsErr())
 	}
 }
 
@@ -168,16 +167,17 @@ func TestMempoolRmBadTx(t *testing.T) {
 		// CheckTx should not err, but the app should return a bad abci code
 		// and the tx should get removed from the pool
 		invalidTx := []byte("invalidTx")
-		reqRes, err := assertMempool(cs.txNotifier).CheckTx(invalidTx)
+		err := assertMempool(cs.txNotifier).CheckTx(invalidTx, func(r *abci.CheckTxResponse) {
+			if r.Code != kvstore.CodeTypeInvalidTxFormat {
+				t.Errorf("expected checktx to return invalid format, got %v", r)
+				return
+			}
+			checkTxRespCh <- struct{}{}
+		}, mempl.TxInfo{})
 		if err != nil {
 			t.Errorf("error after CheckTx: %v", err)
 			return
 		}
-		if reqRes.Response.GetCheckTx().Code != kvstore.CodeTypeInvalidTxFormat {
-			t.Errorf("expected checktx to return invalid format, got %v", reqRes.Response)
-			return
-		}
-		checkTxRespCh <- struct{}{}
 
 		// check for the tx
 		for {

--- a/internal/consensus/reactor_test.go
+++ b/internal/consensus/reactor_test.go
@@ -232,11 +232,10 @@ func TestReactorCreatesBlockWhenEmptyBlocksFalse(t *testing.T) {
 	defer stopConsensusNet(log.TestingLogger(), reactors, eventBuses)
 
 	// send a tx
-	reqRes, err := assertMempool(css[3].txNotifier).CheckTx(kvstore.NewTxFromID(1))
-	if err != nil {
-		t.Error(err)
-	}
-	require.False(t, reqRes.Response.GetCheckTx().IsErr())
+	err := assertMempool(css[3].txNotifier).CheckTx(kvstore.NewTxFromID(1), func(resp *abci.CheckTxResponse) {
+		require.False(t, resp.IsErr())
+	}, mempl.TxInfo{})
+	require.Error(t, err)
 
 	// wait till everyone makes the first new block
 	timeoutWaitGroup(n, func(j int) {
@@ -664,9 +663,8 @@ func waitForAndValidateBlock(
 
 		// optionally add transactions for the next block
 		for _, tx := range txs {
-			reqRes, err := assertMempool(css[j].txNotifier).CheckTx(tx)
+			err := assertMempool(css[j].txNotifier).CheckTx(tx, nil, mempl.TxInfo{})
 			require.NoError(t, err)
-			require.False(t, reqRes.Response.GetCheckTx().IsErr())
 		}
 	})
 }

--- a/internal/consensus/replay_stubs.go
+++ b/internal/consensus/replay_stubs.go
@@ -3,7 +3,6 @@ package consensus
 import (
 	"context"
 
-	abcicli "github.com/cometbft/cometbft/abci/client"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/internal/clist"
 	mempl "github.com/cometbft/cometbft/mempool"
@@ -21,8 +20,8 @@ func (emptyMempool) Lock()            {}
 func (emptyMempool) Unlock()          {}
 func (emptyMempool) Size() int        { return 0 }
 func (emptyMempool) SizeBytes() int64 { return 0 }
-func (emptyMempool) CheckTx(types.Tx) (*abcicli.ReqRes, error) {
-	return nil, nil
+func (emptyMempool) CheckTx(types.Tx, func(*abci.CheckTxResponse), mempl.TxInfo) error {
+	return nil
 }
 
 func (emptyMempool) RemoveTxByKey(types.TxKey) error {
@@ -40,13 +39,12 @@ func (emptyMempool) Update(
 ) error {
 	return nil
 }
-func (emptyMempool) Flush()                                 {}
-func (emptyMempool) FlushAppConn() error                    { return nil }
-func (emptyMempool) TxsAvailable() <-chan struct{}          { return make(chan struct{}) }
-func (emptyMempool) EnableTxsAvailable()                    {}
-func (emptyMempool) SetTxRemovedCallback(func(types.TxKey)) {}
-func (emptyMempool) TxsBytes() int64                        { return 0 }
-func (emptyMempool) InMempool(types.TxKey) bool             { return false }
+func (emptyMempool) Flush()                        {}
+func (emptyMempool) FlushAppConn() error           { return nil }
+func (emptyMempool) TxsAvailable() <-chan struct{} { return make(chan struct{}) }
+func (emptyMempool) EnableTxsAvailable()           {}
+func (emptyMempool) TxsBytes() int64               { return 0 }
+func (emptyMempool) InMempool(types.TxKey) bool    { return false }
 
 func (emptyMempool) TxsFront() *clist.CElement    { return nil }
 func (emptyMempool) TxsWaitChan() <-chan struct{} { return nil }

--- a/internal/consensus/replay_test.go
+++ b/internal/consensus/replay_test.go
@@ -27,7 +27,7 @@ import (
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
 	"github.com/cometbft/cometbft/internal/test"
 	"github.com/cometbft/cometbft/libs/log"
-	"github.com/cometbft/cometbft/mempool"
+	mempl "github.com/cometbft/cometbft/mempool"
 	"github.com/cometbft/cometbft/privval"
 	"github.com/cometbft/cometbft/proxy"
 	sm "github.com/cometbft/cometbft/state"
@@ -117,13 +117,12 @@ func sendTxs(ctx context.Context, cs *State) {
 			return
 		default:
 			tx := kvstore.NewTxFromID(i)
-			reqRes, err := assertMempool(cs.txNotifier).CheckTx(tx)
-			if err != nil {
+			if err := assertMempool(cs.txNotifier).CheckTx(tx, func(resp *abci.CheckTxResponse) {
+				if resp.Code != 0 {
+					panic(fmt.Sprintf("Unexpected code: %d, log: %s", resp.Code, resp.Log))
+				}
+			}, mempl.TxInfo{}); err != nil {
 				panic(err)
-			}
-			resp := reqRes.Response.GetCheckTx()
-			if resp.Code != 0 {
-				panic(fmt.Sprintf("Unexpected code: %d, log: %s", resp.Code, resp.Log))
 			}
 			i++
 		}
@@ -366,7 +365,7 @@ func setupChainWithChangingValidators(t *testing.T, name string, nBlocks int) (*
 	newValidatorPubKey1, err := css[nVals].privValidator.GetPubKey()
 	require.NoError(t, err)
 	newValidatorTx1 := updateValTx(newValidatorPubKey1, testMinPower)
-	_, err = assertMempool(css[0].txNotifier).CheckTx(newValidatorTx1)
+	err = assertMempool(css[0].txNotifier).CheckTx(newValidatorTx1, nil, mempl.TxInfo{})
 	require.NoError(t, err)
 
 	propBlock, propBlockParts, blockID := createProposalBlock(t, css[0]) // changeProposer(t, cs1, v2)
@@ -388,7 +387,7 @@ func setupChainWithChangingValidators(t *testing.T, name string, nBlocks int) (*
 	updateValidatorPubKey1, err := css[nVals].privValidator.GetPubKey()
 	require.NoError(t, err)
 	updateValidatorTx1 := updateValTx(updateValidatorPubKey1, 25)
-	_, err = assertMempool(css[0].txNotifier).CheckTx(updateValidatorTx1)
+	err = assertMempool(css[0].txNotifier).CheckTx(updateValidatorTx1, nil, mempl.TxInfo{})
 	require.NoError(t, err)
 
 	propBlock, propBlockParts, blockID = createProposalBlock(t, css[0]) // changeProposer(t, cs1, v2)
@@ -410,12 +409,12 @@ func setupChainWithChangingValidators(t *testing.T, name string, nBlocks int) (*
 	newValidatorPubKey2, err := css[nVals+1].privValidator.GetPubKey()
 	require.NoError(t, err)
 	newValidatorTx2 := updateValTx(newValidatorPubKey2, testMinPower)
-	_, err = assertMempool(css[0].txNotifier).CheckTx(newValidatorTx2)
+	err = assertMempool(css[0].txNotifier).CheckTx(newValidatorTx2, nil, mempl.TxInfo{})
 	require.NoError(t, err)
 	newValidatorPubKey3, err := css[nVals+2].privValidator.GetPubKey()
 	require.NoError(t, err)
 	newValidatorTx3 := updateValTx(newValidatorPubKey3, testMinPower)
-	_, err = assertMempool(css[0].txNotifier).CheckTx(newValidatorTx3)
+	err = assertMempool(css[0].txNotifier).CheckTx(newValidatorTx3, nil, mempl.TxInfo{})
 	require.NoError(t, err)
 
 	propBlock, propBlockParts, blockID = createProposalBlock(t, css[0]) // changeProposer(t, cs1, v2)
@@ -451,7 +450,7 @@ func setupChainWithChangingValidators(t *testing.T, name string, nBlocks int) (*
 	ensureNewProposal(proposalCh, height, round)
 
 	removeValidatorTx2 := updateValTx(newValidatorPubKey2, 0)
-	_, err = assertMempool(css[0].txNotifier).CheckTx(removeValidatorTx2)
+	err = assertMempool(css[0].txNotifier).CheckTx(removeValidatorTx2, nil, mempl.TxInfo{})
 	require.NoError(t, err)
 
 	rs = css[0].GetRoundState()
@@ -487,7 +486,7 @@ func setupChainWithChangingValidators(t *testing.T, name string, nBlocks int) (*
 	height++
 	incrementHeight(vss...)
 	removeValidatorTx3 := updateValTx(newValidatorPubKey3, 0)
-	_, err = assertMempool(css[0].txNotifier).CheckTx(removeValidatorTx3)
+	err = assertMempool(css[0].txNotifier).CheckTx(removeValidatorTx3, nil, mempl.TxInfo{})
 	require.NoError(t, err)
 
 	propBlock, propBlockParts, blockID = createProposalBlock(t, css[0]) // changeProposer(t, cs1, v2)
@@ -731,7 +730,7 @@ func testHandshakeReplay(t *testing.T, config *cfg.Config, nBlocks int, mode uin
 	}
 }
 
-func applyBlock(t *testing.T, stateStore sm.Store, mempool mempool.Mempool, evpool sm.EvidencePool, st sm.State, blk *types.Block, proxyApp proxy.AppConns, bs sm.BlockStore) sm.State {
+func applyBlock(t *testing.T, stateStore sm.Store, mempool mempl.Mempool, evpool sm.EvidencePool, st sm.State, blk *types.Block, proxyApp proxy.AppConns, bs sm.BlockStore) sm.State {
 	t.Helper()
 	testPartSize := types.BlockPartSizeBytes
 	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyApp.Consensus(), mempool, evpool, bs)
@@ -744,7 +743,7 @@ func applyBlock(t *testing.T, stateStore sm.Store, mempool mempool.Mempool, evpo
 	return newState
 }
 
-func buildAppStateFromChain(t *testing.T, proxyApp proxy.AppConns, stateStore sm.Store, mempool mempool.Mempool, evpool sm.EvidencePool,
+func buildAppStateFromChain(t *testing.T, proxyApp proxy.AppConns, stateStore sm.Store, mempool mempl.Mempool, evpool sm.EvidencePool,
 	state sm.State, chain []*types.Block, nBlocks int, mode uint, bs sm.BlockStore,
 ) {
 	t.Helper()
@@ -793,7 +792,7 @@ func buildTMStateFromChain(
 	t *testing.T,
 	config *cfg.Config,
 	stateStore sm.Store,
-	mempool mempool.Mempool,
+	mempool mempl.Mempool,
 	evpool sm.EvidencePool,
 	state sm.State,
 	chain []*types.Block,

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/libs/protoio"
 	cmtpubsub "github.com/cometbft/cometbft/libs/pubsub"
+	mempl "github.com/cometbft/cometbft/mempool"
 	p2pmock "github.com/cometbft/cometbft/p2p/mock"
 	"github.com/cometbft/cometbft/types"
 )
@@ -1518,9 +1519,8 @@ func TestStateLock_POLSafety1(t *testing.T) {
 
 	// add a tx to the mempool
 	tx := kvstore.NewRandomTx(22)
-	reqRes, err := assertMempool(cs1.txNotifier).CheckTx(tx)
+	err = assertMempool(cs1.txNotifier).CheckTx(tx, nil, mempl.TxInfo{})
 	require.NoError(t, err)
-	require.False(t, reqRes.Response.GetCheckTx().IsErr())
 
 	// start the machine
 	startTestRound(cs1, cs1.Height, round)
@@ -1615,9 +1615,8 @@ func TestStateLock_POLSafety2(t *testing.T) {
 
 	// add a tx to the mempool
 	tx := kvstore.NewRandomTx(22)
-	reqRes, err := assertMempool(cs1.txNotifier).CheckTx(tx)
+	err = assertMempool(cs1.txNotifier).CheckTx(tx, nil, mempl.TxInfo{})
 	require.NoError(t, err)
-	require.False(t, reqRes.Response.GetCheckTx().IsErr())
 
 	// start the machine
 	startTestRound(cs1, cs1.Height, round)

--- a/mempool/bench_test.go
+++ b/mempool/bench_test.go
@@ -27,7 +27,7 @@ func BenchmarkReap(b *testing.B) {
 	size := 10000
 	for i := 0; i < size; i++ {
 		tx := kvstore.NewTxFromID(i)
-		if _, err := mp.CheckTx(tx); err != nil {
+		if err := mp.CheckTx(tx, nil, TxInfo{}); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -51,7 +51,7 @@ func BenchmarkCheckTx(b *testing.B) {
 		tx := kvstore.NewTxFromID(i)
 		b.StartTimer()
 
-		if _, err := mp.CheckTx(tx); err != nil {
+		if err := mp.CheckTx(tx, nil, TxInfo{}); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -74,7 +74,7 @@ func BenchmarkParallelCheckTx(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			tx := kvstore.NewTxFromID(int(next()))
-			if _, err := mp.CheckTx(tx); err != nil {
+			if err := mp.CheckTx(tx, nil, TxInfo{}); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -90,15 +90,15 @@ func BenchmarkCheckDuplicateTx(b *testing.B) {
 	mp.config.Size = 2
 
 	tx := kvstore.NewTxFromID(1)
-	if _, err := mp.CheckTx(tx); err != nil {
+	if err := mp.CheckTx(tx, nil, TxInfo{}); err != nil {
 		b.Fatal(err)
 	}
-	e := mp.FlushAppConn()
-	require.NotErrorIs(b, nil, e)
+	err := mp.FlushAppConn()
+	require.NotErrorIs(b, nil, err)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if _, err := mp.CheckTx(tx); err == nil {
+		if err := mp.CheckTx(tx, nil, TxInfo{}); err == nil {
 			b.Fatal("tx should be duplicate")
 		}
 	}
@@ -128,11 +128,11 @@ func BenchmarkUpdateRemoteClient(b *testing.B) {
 	for i := 1; i <= b.N; i++ {
 		tx := kvstore.NewTxFromID(i)
 
-		_, e := mp.CheckTx(tx)
-		require.NoError(b, e)
+		err := mp.CheckTx(tx, nil, TxInfo{})
+		require.NoError(b, err)
 
-		e = mp.FlushAppConn()
-		require.NoError(b, e)
+		err = mp.FlushAppConn()
+		require.NoError(b, err)
 
 		require.Equal(b, 1, mp.Size())
 

--- a/mempool/cache_test.go
+++ b/mempool/cache_test.go
@@ -64,9 +64,8 @@ func TestCacheAfterUpdate(t *testing.T) {
 	for tcIndex, tc := range tests {
 		for i := 0; i < tc.numTxsToCreate; i++ {
 			tx := kvstore.NewTx(strconv.Itoa(i), "value")
-			reqRes, err := mp.CheckTx(tx)
+			err := mp.CheckTx(tx, func(resp *abci.CheckTxResponse) { require.False(t, resp.IsErr()) }, TxInfo{})
 			require.NoError(t, err)
-			require.False(t, reqRes.Response.GetCheckTx().IsErr())
 		}
 
 		updateTxs := []types.Tx{}
@@ -79,10 +78,7 @@ func TestCacheAfterUpdate(t *testing.T) {
 
 		for _, v := range tc.reAddIndices {
 			tx := kvstore.NewTx(strconv.Itoa(v), "value")
-			reqRes, err := mp.CheckTx(tx)
-			if err == nil {
-				require.False(t, reqRes.Response.GetCheckTx().IsErr())
-			}
+			_ = mp.CheckTx(tx, func(resp *abci.CheckTxResponse) { require.False(t, resp.IsErr()) }, TxInfo{})
 		}
 
 		cache := mp.cache.(*LRUTxCache)

--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -105,7 +105,7 @@ func ensureFire(t *testing.T, ch <-chan struct{}, timeoutMS int) {
 func callCheckTx(t *testing.T, mp Mempool, txs types.Txs) {
 	t.Helper()
 	for i, tx := range txs {
-		if _, err := mp.CheckTx(tx); err != nil {
+		if err := mp.CheckTx(tx, nil, TxInfo{}); err != nil {
 			// Skip invalid txs.
 			// TestMempoolFilters will fail otherwise. It asserts a number of txs
 			// returned.
@@ -233,7 +233,7 @@ func TestMempoolUpdate(t *testing.T) {
 		tx1 := kvstore.NewTxFromID(1)
 		err := mp.Update(1, []types.Tx{tx1}, abciResponses(1, abci.CodeTypeOK), nil, nil)
 		require.NoError(t, err)
-		_, err = mp.CheckTx(tx1)
+		err = mp.CheckTx(tx1, nil, TxInfo{})
 		if assert.Error(t, err) { //nolint:testifylint // require.Error doesn't work with the conditional here
 			assert.Equal(t, ErrTxInCache, err)
 		}
@@ -242,7 +242,7 @@ func TestMempoolUpdate(t *testing.T) {
 	// 2. Removes valid txs from the mempool
 	{
 		tx2 := kvstore.NewTxFromID(2)
-		_, err := mp.CheckTx(tx2)
+		err := mp.CheckTx(tx2, nil, TxInfo{})
 		require.NoError(t, err)
 		err = mp.Update(1, []types.Tx{tx2}, abciResponses(1, abci.CodeTypeOK), nil, nil)
 		require.NoError(t, err)
@@ -252,13 +252,13 @@ func TestMempoolUpdate(t *testing.T) {
 	// 3. Removes invalid transactions from the cache and the mempool (if present)
 	{
 		tx3 := kvstore.NewTxFromID(3)
-		_, err := mp.CheckTx(tx3)
+		err := mp.CheckTx(tx3, nil, TxInfo{})
 		require.NoError(t, err)
 		err = mp.Update(1, []types.Tx{tx3}, abciResponses(1, 1), nil, nil)
 		require.NoError(t, err)
 		assert.Zero(t, mp.Size())
 
-		_, err = mp.CheckTx(tx3)
+		err = mp.CheckTx(tx3, nil, TxInfo{})
 		require.NoError(t, err)
 	}
 }
@@ -266,30 +266,27 @@ func TestMempoolUpdate(t *testing.T) {
 // Test dropping CheckTx requests when rechecking transactions. It mocks an asynchronous connection
 // to the app.
 func TestMempoolUpdateDoesNotPanicWhenApplicationMissedTx(t *testing.T) {
-	var callback abciclient.Callback
 	mockClient := new(abciclimocks.Client)
 	mockClient.On("Start").Return(nil)
 	mockClient.On("SetLogger", mock.Anything)
 	mockClient.On("Error").Return(nil).Times(4)
-	mockClient.On("SetResponseCallback", mock.MatchedBy(func(cb abciclient.Callback) bool { callback = cb; return true }))
-	mockClient.On("CheckTxAsync", mock.Anything, mock.Anything).Return(nil, nil)
-	mockClient.On("Flush", mock.Anything).Return(nil)
 
 	mp, cleanup := newMempoolWithAppMock(mockClient)
 	defer cleanup()
 
+	// Disable rechecking to simulate it manually later.
+	mp.config.Recheck = false
+
 	// Add 4 transactions to the mempool by calling the mempool's `CheckTx` on each of them.
 	txs := []types.Tx{[]byte{0x01}, []byte{0x02}, []byte{0x03}, []byte{0x04}}
 	for _, tx := range txs {
-		_, err := mp.CheckTx(tx)
-		require.NoError(t, err)
-	}
-	require.Zero(t, mp.Size())
-
-	// Invoke CheckTx callbacks asynchronously.
-	for _, tx := range txs {
 		reqRes := newReqRes(tx, abci.CodeTypeOK, abci.CHECK_TX_TYPE_CHECK)
-		callback(reqRes.Request, reqRes.Response)
+		mockClient.On("CheckTxAsync", mock.Anything, mock.Anything).Return(reqRes, nil).Once()
+		err := mp.CheckTx(tx, nil, TxInfo{})
+		require.NoError(t, err)
+
+		// ensure that the callback that the mempool sets on the ReqRes is run.
+		reqRes.InvokeCallback()
 	}
 	require.Len(t, txs, mp.Size())
 	require.True(t, mp.recheck.done())
@@ -299,17 +296,17 @@ func TestMempoolUpdateDoesNotPanicWhenApplicationMissedTx(t *testing.T) {
 	err := mp.Update(0, []types.Tx{txs[0]}, abciResponses(1, abci.CodeTypeOK), nil, nil)
 	require.NoError(t, err)
 
-	// The mempool has now sent its requests off to the client to be rechecked
-	// and is waiting for the corresponding callbacks to be called.
+	// The mempool now should have sent its requests off to the client to be rechecked
+	// and should be waiting for the corresponding callbacks to be called.
 	// We now call the mempool-supplied callback on the first and third transaction.
 	// This simulates the client dropping the second request.
 	// Previous versions of this code panicked when the ABCI application missed
 	// a recheck-tx request.
 	reqRes := newReqRes(txs[1], abci.CodeTypeOK, abci.CHECK_TX_TYPE_RECHECK)
-	callback(reqRes.Request, reqRes.Response)
+	reqRes.SetCallback(mp.handleRecheckTxResponse(txs[1]))
 
 	reqRes = newReqRes(txs[3], abci.CodeTypeOK, abci.CHECK_TX_TYPE_RECHECK)
-	callback(reqRes.Request, reqRes.Response)
+	reqRes.SetCallback(mp.handleRecheckTxResponse(txs[3]))
 
 	mockClient.AssertExpectations(t)
 }
@@ -330,7 +327,7 @@ func TestMempool_KeepInvalidTxsInCache(t *testing.T) {
 		b := make([]byte, 8)
 		binary.BigEndian.PutUint64(b, 1)
 
-		_, err := mp.CheckTx(b)
+		err := mp.CheckTx(b, nil, TxInfo{})
 		require.NoError(t, err)
 
 		// simulate new block
@@ -343,13 +340,13 @@ func TestMempool_KeepInvalidTxsInCache(t *testing.T) {
 		require.NoError(t, err)
 
 		// a must be added to the cache
-		_, err = mp.CheckTx(a)
+		err = mp.CheckTx(a, nil, TxInfo{})
 		if assert.Error(t, err) { //nolint:testifylint // require.Error doesn't work with the conditional here
 			assert.Equal(t, ErrTxInCache, err)
 		}
 
 		// b must remain in the cache
-		_, err = mp.CheckTx(b)
+		err = mp.CheckTx(b, nil, TxInfo{})
 		if assert.Error(t, err) { //nolint:testifylint // require.Error doesn't work with the conditional here
 			assert.Equal(t, ErrTxInCache, err)
 		}
@@ -363,7 +360,7 @@ func TestMempool_KeepInvalidTxsInCache(t *testing.T) {
 		// remove a from the cache to test (2)
 		mp.cache.Remove(a)
 
-		_, err := mp.CheckTx(a)
+		err := mp.CheckTx(a, nil, TxInfo{})
 		require.NoError(t, err)
 	}
 }
@@ -429,7 +426,7 @@ func TestSerialReap(t *testing.T) {
 		// Deliver some txs.
 		for i := start; i < end; i++ {
 			txBytes := kvstore.NewTx(strconv.Itoa(i), "true")
-			_, err := mp.CheckTx(txBytes)
+			err := mp.CheckTx(txBytes, nil, TxInfo{})
 			_, cached := cacheMap[string(txBytes)]
 			if cached {
 				require.Error(t, err, "expected error for cached tx")
@@ -439,7 +436,7 @@ func TestSerialReap(t *testing.T) {
 			cacheMap[string(txBytes)] = struct{}{}
 
 			// Duplicates are cached and should return error
-			_, err = mp.CheckTx(txBytes)
+			err = mp.CheckTx(txBytes, nil, TxInfo{})
 			require.Error(t, err, "Expected error after CheckTx on duplicated tx")
 		}
 	}
@@ -550,7 +547,7 @@ func TestMempool_CheckTxChecksTxSize(t *testing.T) {
 
 		tx := cmtrand.Bytes(testCase.len)
 
-		_, err := mempl.CheckTx(tx)
+		err := mempl.CheckTx(tx, nil, TxInfo{})
 		bv := gogotypes.BytesValue{Value: tx}
 		bz, err2 := bv.Marshal()
 		require.NoError(t, err2)
@@ -582,7 +579,7 @@ func TestMempoolTxsBytes(t *testing.T) {
 
 	// 2. len(tx) after CheckTx
 	tx1 := kvstore.NewRandomTx(10)
-	_, err := mp.CheckTx(tx1)
+	err := mp.CheckTx(tx1, nil, TxInfo{})
 	require.NoError(t, err)
 	assert.EqualValues(t, 10, mp.SizeBytes())
 
@@ -593,7 +590,7 @@ func TestMempoolTxsBytes(t *testing.T) {
 
 	// 4. zero after Flush
 	tx2 := kvstore.NewRandomTx(20)
-	_, err = mp.CheckTx(tx2)
+	err = mp.CheckTx(tx2, nil, TxInfo{})
 	require.NoError(t, err)
 	assert.EqualValues(t, 20, mp.SizeBytes())
 
@@ -602,11 +599,11 @@ func TestMempoolTxsBytes(t *testing.T) {
 
 	// 5. ErrMempoolIsFull is returned when/if MaxTxsBytes limit is reached.
 	tx3 := kvstore.NewRandomTx(100)
-	_, err = mp.CheckTx(tx3)
+	err = mp.CheckTx(tx3, nil, TxInfo{})
 	require.NoError(t, err)
 
 	tx4 := kvstore.NewRandomTx(10)
-	_, err = mp.CheckTx(tx4)
+	err = mp.CheckTx(tx4, nil, TxInfo{})
 	if assert.Error(t, err) { //nolint:testifylint // require.Error doesn't work with the conditional here
 		assert.IsType(t, ErrMempoolIsFull{}, err)
 	}
@@ -620,7 +617,7 @@ func TestMempoolTxsBytes(t *testing.T) {
 
 	txBytes := kvstore.NewRandomTx(10)
 
-	_, err = mp.CheckTx(txBytes)
+	err = mp.CheckTx(txBytes, nil, TxInfo{})
 	require.NoError(t, err)
 	assert.EqualValues(t, 10, mp.SizeBytes())
 
@@ -648,7 +645,7 @@ func TestMempoolTxsBytes(t *testing.T) {
 	assert.EqualValues(t, 10, mp.SizeBytes())
 
 	// 7. Test RemoveTxByKey function
-	_, err = mp.CheckTx(tx1)
+	err = mp.CheckTx(tx1, nil, TxInfo{})
 	require.NoError(t, err)
 	assert.EqualValues(t, 20, mp.SizeBytes())
 	require.Error(t, mp.RemoveTxByKey(types.Tx([]byte{0x07}).Key()))
@@ -663,14 +660,14 @@ func TestMempoolNoCacheOverflow(t *testing.T) {
 
 	// add tx0
 	tx0 := kvstore.NewTxFromID(0)
-	_, err := mp.CheckTx(tx0)
+	err := mp.CheckTx(tx0, nil, TxInfo{})
 	require.NoError(t, err)
 	err = mp.FlushAppConn()
 	require.NoError(t, err)
 
 	// saturate the cache to remove tx0
 	for i := 1; i <= mp.config.CacheSize; i++ {
-		_, err = mp.CheckTx(kvstore.NewTxFromID(i))
+		err = mp.CheckTx(kvstore.NewTxFromID(i), nil, TxInfo{})
 		require.NoError(t, err)
 	}
 	err = mp.FlushAppConn()
@@ -678,7 +675,7 @@ func TestMempoolNoCacheOverflow(t *testing.T) {
 	assert.False(t, mp.cache.Has(kvstore.NewTxFromID(0)))
 
 	// add again tx0
-	_, err = mp.CheckTx(tx0)
+	err = mp.CheckTx(tx0, nil, TxInfo{})
 	require.NoError(t, err)
 	err = mp.FlushAppConn()
 	require.NoError(t, err)
@@ -713,7 +710,7 @@ func TestMempoolRemoteAppConcurrency(t *testing.T) {
 		tx := txs[txNum]
 
 		// this will err with ErrTxInCache many times ...
-		mp.CheckTx(tx) //nolint: errcheck // will error
+		mp.CheckTx(tx, nil, TxInfo{}) //nolint: errcheck // will error
 	}
 
 	require.NoError(t, mp.FlushAppConn())
@@ -736,7 +733,11 @@ func TestMempoolConcurrentUpdateAndReceiveCheckTxResponse(t *testing.T) {
 		go func(h int) {
 			defer wg.Done()
 
-			err := mp.Update(int64(h), []types.Tx{tx}, abciResponses(1, abci.CodeTypeOK), nil, nil)
+			mp.Lock()
+			err := mp.FlushAppConn()
+			require.NoError(t, err)
+			err = mp.Update(int64(h), []types.Tx{tx}, abciResponses(1, abci.CodeTypeOK), nil, nil)
+			mp.Unlock()
 			require.NoError(t, err)
 			require.Equal(t, int64(h), mp.height.Load(), "height mismatch")
 		}(h)
@@ -745,7 +746,8 @@ func TestMempoolConcurrentUpdateAndReceiveCheckTxResponse(t *testing.T) {
 			defer wg.Done()
 
 			tx := kvstore.NewTxFromID(h)
-			mp.resCbFirstTime(tx, &abci.CheckTxResponse{Code: abci.CodeTypeOK})
+			err := mp.CheckTx(tx, nil, TxInfo{})
+			require.NoError(t, err)
 			require.Equal(t, h, mp.Size(), "pool size mismatch")
 		}(h)
 
@@ -767,14 +769,16 @@ func TestMempoolNotifyTxsAvailable(t *testing.T) {
 
 	// Adding a new valid tx to the pool will notify a tx is available
 	tx := kvstore.NewTxFromID(1)
-	mp.resCbFirstTime(tx, &abci.CheckTxResponse{Code: abci.CodeTypeOK})
+	res := abci.ToCheckTxResponse(&abci.CheckTxResponse{Code: abci.CodeTypeOK})
+	mp.handleCheckTxResponse(tx, nil, TxInfo{})(res)
 	require.Equal(t, 1, mp.Size(), "pool size mismatch")
 	require.True(t, mp.notifiedTxsAvailable.Load())
 	require.Len(t, mp.TxsAvailable(), 1)
 	<-mp.TxsAvailable()
 
 	// Receiving CheckTx response for a tx already in the pool should not notify of available txs
-	mp.resCbFirstTime(tx, &abci.CheckTxResponse{Code: abci.CodeTypeOK})
+	res = abci.ToCheckTxResponse(&abci.CheckTxResponse{Code: abci.CodeTypeOK})
+	mp.handleCheckTxResponse(tx, nil, TxInfo{})(res)
 	require.Equal(t, 1, mp.Size())
 	require.True(t, mp.notifiedTxsAvailable.Load())
 	require.Empty(t, mp.TxsAvailable())
@@ -791,7 +795,6 @@ func TestMempoolSyncCheckTxReturnError(t *testing.T) {
 	mockClient := new(abciclimocks.Client)
 	mockClient.On("Start").Return(nil)
 	mockClient.On("SetLogger", mock.Anything)
-	mockClient.On("SetResponseCallback", mock.Anything)
 
 	mp, cleanup := newMempoolWithAppMock(mockClient)
 	defer cleanup()
@@ -806,43 +809,37 @@ func TestMempoolSyncCheckTxReturnError(t *testing.T) {
 			t.Errorf("CheckTx did not panic")
 		}
 	}()
-	_, err := mp.CheckTx(tx)
+	err := mp.CheckTx(tx, nil, TxInfo{})
 	require.NoError(t, err)
 }
 
 // Test that rechecking panics when a CheckTx request fails, when using a sync ABCI client.
 func TestMempoolSyncRecheckTxReturnError(t *testing.T) {
-	var callback abciclient.Callback
 	mockClient := new(abciclimocks.Client)
 	mockClient.On("Start").Return(nil)
 	mockClient.On("SetLogger", mock.Anything)
-	mockClient.On("SetResponseCallback", mock.MatchedBy(func(cb abciclient.Callback) bool { callback = cb; return true }))
+	mockClient.On("Error").Return(nil)
 
 	mp, cleanup := newMempoolWithAppMock(mockClient)
 	defer cleanup()
 
-	// First we add a two transactions to the mempool.
+	// First we add two transactions to the mempool.
 	txs := []types.Tx{[]byte{0x01}, []byte{0x02}}
 	for _, tx := range txs {
-		// Mock a sync client, which will call the callback just after the response from the app.
-		mockClient.On("CheckTxAsync", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-			req := args.Get(1).(*abci.CheckTxRequest)
-			reqRes := newReqRes(req.Tx, abci.CodeTypeOK, abci.CHECK_TX_TYPE_CHECK)
-			callback(reqRes.Request, reqRes.Response)
-		}).Return(nil, nil).Once()
-		mockClient.On("Error").Return(nil)
-
-		_, err := mp.CheckTx(tx)
+		reqRes := newReqRes(tx, abci.CodeTypeOK, abci.CHECK_TX_TYPE_CHECK)
+		mockClient.On("CheckTxAsync", mock.Anything, mock.Anything).Return(reqRes, nil).Once()
+		err := mp.CheckTx(tx, nil, TxInfo{})
 		require.NoError(t, err)
+
+		// ensure that the callback that the mempool sets on the ReqRes is run.
+		reqRes.InvokeCallback()
 	}
 	require.Len(t, txs, mp.Size())
 
 	// The first tx is valid when rechecking and the client will call the callback right after the
 	// response from the app and before returning.
-	mockClient.On("CheckTxAsync", mock.Anything, mock.Anything).Run(func(_ mock.Arguments) {
-		reqRes := newReqRes(txs[0], abci.CodeTypeOK, abci.CHECK_TX_TYPE_RECHECK)
-		callback(reqRes.Request, reqRes.Response)
-	}).Return(nil, nil).Once()
+	reqRes := newReqRes(txs[0], abci.CodeTypeOK, abci.CHECK_TX_TYPE_RECHECK)
+	mockClient.On("CheckTxAsync", mock.Anything, mock.Anything).Return(reqRes, nil).Once()
 
 	// On the second CheckTx request, the app returns an error.
 	mockClient.On("CheckTxAsync", mock.Anything, mock.Anything).Return(nil, errors.New("")).Once()
@@ -859,38 +856,27 @@ func TestMempoolSyncRecheckTxReturnError(t *testing.T) {
 // Test that rechecking finishes correctly when a CheckTx response never arrives, when using an
 // async ABCI client.
 func TestMempoolAsyncRecheckTxReturnError(t *testing.T) {
-	var callback abciclient.Callback
 	mockClient := new(abciclimocks.Client)
 	mockClient.On("Start").Return(nil)
 	mockClient.On("SetLogger", mock.Anything)
 	mockClient.On("Error").Return(nil).Times(4)
-	mockClient.On("SetResponseCallback", mock.MatchedBy(func(cb abciclient.Callback) bool { callback = cb; return true }))
 
 	mp, cleanup := newMempoolWithAppMock(mockClient)
 	defer cleanup()
 
-	// Mocking the async client will just send the request and not call the callback, which we do
-	// manually later. The first 4 times CheckTxAsync is called are for adding the transactions to
-	// the mempool.
-	mockClient.On("CheckTxAsync", mock.Anything, mock.Anything).Return(nil, nil).Times(4)
+	mp.config.RecheckTimeout = 100 * time.Millisecond
 
 	// Add 4 txs to the mempool.
 	txs := []types.Tx{[]byte{0x01}, []byte{0x02}, []byte{0x03}, []byte{0x04}}
 	for _, tx := range txs {
-		_, err := mp.CheckTx(tx)
-		require.NoError(t, err)
-	}
-
-	// There are still no replies from the app.
-	require.Zero(t, mp.Size())
-
-	// Invoke CheckTx callbacks asynchronously.
-	for _, tx := range txs {
 		reqRes := newReqRes(tx, abci.CodeTypeOK, abci.CHECK_TX_TYPE_CHECK)
-		callback(reqRes.Request, reqRes.Response)
-	}
+		mockClient.On("CheckTxAsync", mock.Anything, mock.Anything).Return(reqRes, nil).Once()
+		err := mp.CheckTx(tx, nil, TxInfo{})
+		require.NoError(t, err)
 
-	// The 4 txs are added to the mempool.
+		// ensure that the callback that the mempool sets on the ReqRes is run.
+		reqRes.InvokeCallback()
+	}
 	require.Len(t, txs, mp.Size())
 
 	// Check that recheck has not started.
@@ -899,20 +885,24 @@ func TestMempoolAsyncRecheckTxReturnError(t *testing.T) {
 	require.Nil(t, mp.recheck.end)
 	mockClient.AssertExpectations(t)
 
-	// One call to CheckTxAsync per tx, for rechecking.
-	mockClient.On("CheckTxAsync", mock.Anything, mock.Anything).Return(nil, nil).Times(4)
+	// For rechecking, there will be one call to CheckTxAsync per tx.
+	// The app will reply to the second and fourth requests later than the allowed recheck duration.
+	rr1 := newReqRes(txs[0], abci.CodeTypeOK, abci.CHECK_TX_TYPE_RECHECK)
+	mockClient.On("CheckTxAsync", mock.Anything, mock.Anything).Return(rr1, nil).Once()
+	rr2 := newReqRes(txs[1], abci.CodeTypeOK, abci.CHECK_TX_TYPE_RECHECK)
+	mockClient.On("CheckTxAsync", mock.Anything, mock.Anything).Return(rr2, nil).Once().After(mp.config.RecheckTimeout * 10)
+	rr3 := newReqRes(txs[2], 1, abci.CHECK_TX_TYPE_RECHECK) // invalid tx
+	mockClient.On("CheckTxAsync", mock.Anything, mock.Anything).Return(rr3, nil).Once()
+	rr4 := newReqRes(txs[3], abci.CodeTypeOK, abci.CHECK_TX_TYPE_RECHECK)
+	mockClient.On("CheckTxAsync", mock.Anything, mock.Anything).Return(rr4, nil).Once().After(mp.config.RecheckTimeout * 10)
 
-	// On the async client, the callbacks are executed when flushing the connection. The app replies
+	// On the async client, the callbacks are invoked when flushing the connection. The app replies
 	// to the request for the first tx (valid) and for the third tx (invalid), so the callback is
 	// invoked twice. The app does not reply to the requests for the second and fourth txs, so the
 	// callback is not invoked on these two cases.
 	mockClient.On("Flush", mock.Anything).Run(func(_ mock.Arguments) {
-		// First tx is valid.
-		reqRes1 := newReqRes(txs[0], abci.CodeTypeOK, abci.CHECK_TX_TYPE_RECHECK)
-		callback(reqRes1.Request, reqRes1.Response)
-		// Third tx is invalid.
-		reqRes2 := newReqRes(txs[2], 1, abci.CHECK_TX_TYPE_RECHECK)
-		callback(reqRes2.Request, reqRes2.Response)
+		rr1.InvokeCallback()
+		rr3.InvokeCallback()
 	}).Return(nil)
 
 	// mp.recheck.done() should be true only before and after calling recheckTxs.
@@ -936,7 +926,7 @@ func TestMempoolRecheckRace(t *testing.T) {
 	var err error
 	txs := newUniqueTxs(10)
 	for _, tx := range txs {
-		_, err = mp.CheckTx(tx)
+		err = mp.CheckTx(tx, nil, TxInfo{})
 		require.NoError(t, err)
 	}
 
@@ -954,7 +944,7 @@ func TestMempoolRecheckRace(t *testing.T) {
 
 	// Add again the same transaction that was updated. Recheck has finished so adding this tx
 	// should not result in a data race on the variable recheck.cursor.
-	_, err = mp.CheckTx(txs[:1][0])
+	err = mp.CheckTx(txs[:1][0], nil, TxInfo{})
 	require.Equal(t, err, ErrTxInCache)
 	require.Zero(t, mp.recheck.numPendingTxs.Load())
 }
@@ -991,7 +981,7 @@ func TestMempoolConcurrentCheckTxAndUpdate(t *testing.T) {
 
 	// Concurrently, add transactions (one per height).
 	for h := 1; h <= maxHeight; h++ {
-		_, err := mp.CheckTx(kvstore.NewTxFromID(h))
+		err := mp.CheckTx(kvstore.NewTxFromID(h), nil, TxInfo{})
 		require.NoError(t, err)
 	}
 

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -4,8 +4,8 @@ import (
 	"crypto/sha256"
 	"fmt"
 
-	abcicli "github.com/cometbft/cometbft/abci/client"
 	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/cometbft/cometbft/p2p"
 	"github.com/cometbft/cometbft/types"
 )
 
@@ -25,7 +25,7 @@ const (
 type Mempool interface {
 	// CheckTx executes a new transaction against the application to determine
 	// its validity and whether it should be added to the mempool.
-	CheckTx(tx types.Tx) (*abcicli.ReqRes, error)
+	CheckTx(tx types.Tx, externalCb func(*abci.CheckTxResponse), txInfo TxInfo) error
 
 	// RemoveTxByKey removes a transaction, identified by its key,
 	// from the mempool.
@@ -86,10 +86,6 @@ type Mempool interface {
 	// trigger once every height when transactions are available.
 	EnableTxsAvailable()
 
-	// Set a callback function to be called when a transaction is removed from
-	// the mempool.
-	SetTxRemovedCallback(cb func(types.TxKey))
-
 	// Size returns the number of transactions in the mempool.
 	Size() int
 
@@ -143,3 +139,9 @@ func PostCheckMaxGas(maxGas int64) PostCheckFunc {
 
 // TxKey is the fixed length array key used as an index.
 type TxKey [sha256.Size]byte
+
+// TxInfo is a parameter passed to CheckTx when attempting to add a new tx to the mempool.
+type TxInfo struct {
+	// sender is the peer that sent the transaction to this node.
+	sender p2p.ID
+}

--- a/mempool/mempoolTx.go
+++ b/mempool/mempoolTx.go
@@ -1,8 +1,10 @@
 package mempool
 
 import (
+	"sync"
 	"sync/atomic"
 
+	"github.com/cometbft/cometbft/p2p"
 	"github.com/cometbft/cometbft/types"
 )
 
@@ -11,9 +13,29 @@ type mempoolTx struct {
 	height    int64    // height that this tx had been validated in
 	gasWanted int64    // amount of gas this tx states it will require
 	tx        types.Tx // validated by the application
+
+	// ids of peers who've sent us this tx (as a map for quick lookups).
+	// senders: PeerID -> bool
+	senders sync.Map
 }
 
 // Height returns the height for this transaction.
 func (memTx *mempoolTx) Height() int64 {
 	return atomic.LoadInt64(&memTx.height)
+}
+
+func (memTx *mempoolTx) isSender(peerID p2p.ID) bool {
+	_, ok := memTx.senders.Load(peerID)
+	return ok
+}
+
+// Add the peer ID to the list of senders. Return true if it exists already in the list.
+func (memTx *mempoolTx) addSender(peerID p2p.ID) bool {
+	if peerID == "" {
+		return false
+	}
+	if _, loaded := memTx.senders.LoadOrStore(peerID, struct{}{}); loaded {
+		return true
+	}
+	return false
 }

--- a/mempool/mocks/mempool.go
+++ b/mempool/mocks/mempool.go
@@ -3,9 +3,7 @@
 package mocks
 
 import (
-	abcicli "github.com/cometbft/cometbft/abci/client"
 	mempool "github.com/cometbft/cometbft/mempool"
-
 	mock "github.com/stretchr/testify/mock"
 
 	types "github.com/cometbft/cometbft/types"
@@ -18,34 +16,22 @@ type Mempool struct {
 	mock.Mock
 }
 
-// CheckTx provides a mock function with given fields: tx
-func (_m *Mempool) CheckTx(tx types.Tx) (*abcicli.ReqRes, error) {
-	ret := _m.Called(tx)
+// CheckTx provides a mock function with given fields: tx, callback, txInfo
+func (_m *Mempool) CheckTx(tx types.Tx, callback func(*v1.CheckTxResponse), txInfo mempool.TxInfo) error {
+	ret := _m.Called(tx, callback, txInfo)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CheckTx")
 	}
 
-	var r0 *abcicli.ReqRes
-	var r1 error
-	if rf, ok := ret.Get(0).(func(types.Tx) (*abcicli.ReqRes, error)); ok {
-		return rf(tx)
-	}
-	if rf, ok := ret.Get(0).(func(types.Tx) *abcicli.ReqRes); ok {
-		r0 = rf(tx)
+	var r0 error
+	if rf, ok := ret.Get(0).(func(types.Tx, func(*v1.CheckTxResponse), mempool.TxInfo) error); ok {
+		r0 = rf(tx, callback, txInfo)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*abcicli.ReqRes)
-		}
+		r0 = ret.Error(0)
 	}
 
-	if rf, ok := ret.Get(1).(func(types.Tx) error); ok {
-		r1 = rf(tx)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 
 // EnableTxsAvailable provides a mock function with given fields:
@@ -137,11 +123,6 @@ func (_m *Mempool) RemoveTxByKey(txKey types.TxKey) error {
 	}
 
 	return r0
-}
-
-// SetTxRemovedCallback provides a mock function with given fields: cb
-func (_m *Mempool) SetTxRemovedCallback(cb func(types.TxKey)) {
-	_m.Called(cb)
 }
 
 // Size provides a mock function with given fields:

--- a/mempool/nop_mempool.go
+++ b/mempool/nop_mempool.go
@@ -3,7 +3,6 @@ package mempool
 import (
 	"errors"
 
-	abcicli "github.com/cometbft/cometbft/abci/client"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/libs/service"
 	"github.com/cometbft/cometbft/p2p"
@@ -22,8 +21,8 @@ var errNotAllowed = errors.New("not allowed with `nop` mempool")
 var _ Mempool = &NopMempool{}
 
 // CheckTx always returns an error.
-func (*NopMempool) CheckTx(types.Tx) (*abcicli.ReqRes, error) {
-	return nil, errNotAllowed
+func (*NopMempool) CheckTx(types.Tx, func(*abci.CheckTxResponse), TxInfo) error {
+	return errNotAllowed
 }
 
 // RemoveTxByKey always returns an error.
@@ -65,9 +64,6 @@ func (*NopMempool) TxsAvailable() <-chan struct{} {
 
 // EnableTxsAvailable does nothing.
 func (*NopMempool) EnableTxsAvailable() {}
-
-// SetTxRemovedCallback does nothing.
-func (*NopMempool) SetTxRemovedCallback(func(txKey types.TxKey)) {}
 
 // Size always returns 0.
 func (*NopMempool) Size() int { return 0 }

--- a/mempool/nop_mempool_test.go
+++ b/mempool/nop_mempool_test.go
@@ -17,7 +17,7 @@ func TestNopMempool_Basic(t *testing.T) {
 	assert.Equal(t, 0, mem.Size())
 	assert.Equal(t, int64(0), mem.SizeBytes())
 
-	_, err := mem.CheckTx(tx)
+	err := mem.CheckTx(tx, nil, TxInfo{})
 	assert.Equal(t, errNotAllowed, err)
 
 	err = mem.RemoveTxByKey(tx.Key())

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -9,12 +9,10 @@ import (
 
 	"golang.org/x/sync/semaphore"
 
-	abci "github.com/cometbft/cometbft/abci/types"
 	protomem "github.com/cometbft/cometbft/api/cometbft/mempool/v1"
 	cfg "github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/internal/clist"
 	"github.com/cometbft/cometbft/libs/log"
-	cmtsync "github.com/cometbft/cometbft/libs/sync"
 	"github.com/cometbft/cometbft/p2p"
 	"github.com/cometbft/cometbft/types"
 )
@@ -30,13 +28,6 @@ type Reactor struct {
 	waitSync   atomic.Bool
 	waitSyncCh chan struct{} // for signaling when to start receiving and sending txs
 
-	// `txSenders` maps every received transaction to the set of peer IDs that
-	// have sent the transaction to this node. Sender IDs are used during
-	// transaction propagation to avoid sending a transaction to a peer that
-	// already has it.
-	txSenders    map[types.TxKey]map[p2p.ID]bool
-	txSendersMtx cmtsync.Mutex
-
 	// Semaphores to keep track of how many connections to peers are active for broadcasting
 	// transactions. Each semaphore has a capacity that puts an upper bound on the number of
 	// connections for different groups of peers.
@@ -47,17 +38,15 @@ type Reactor struct {
 // NewReactor returns a new Reactor with the given config and mempool.
 func NewReactor(config *cfg.MempoolConfig, mempool *CListMempool, waitSync bool) *Reactor {
 	memR := &Reactor{
-		config:    config,
-		mempool:   mempool,
-		waitSync:  atomic.Bool{},
-		txSenders: make(map[types.TxKey]map[p2p.ID]bool),
+		config:   config,
+		mempool:  mempool,
+		waitSync: atomic.Bool{},
 	}
 	memR.BaseReactor = *p2p.NewBaseReactor("Mempool", memR)
 	if waitSync {
 		memR.waitSync.Store(true)
 		memR.waitSyncCh = make(chan struct{})
 	}
-	memR.mempool.SetTxRemovedCallback(func(txKey types.TxKey) { memR.removeSenders(txKey) })
 	memR.activePersistentPeersSemaphore = semaphore.NewWeighted(int64(memR.config.ExperimentalMaxGossipConnectionsToPersistentPeers))
 	memR.activeNonPersistentPeersSemaphore = semaphore.NewWeighted(int64(memR.config.ExperimentalMaxGossipConnectionsToNonPersistentPeers))
 
@@ -163,24 +152,12 @@ func (memR *Reactor) Receive(e p2p.Envelope) {
 
 		for _, txBytes := range protoTxs {
 			tx := types.Tx(txBytes)
-			reqRes, err := memR.mempool.CheckTx(tx)
+			err := memR.mempool.CheckTx(tx, nil, TxInfo{sender: e.Src.ID()})
 			switch {
 			case errors.Is(err, ErrTxInCache):
 				memR.Logger.Debug("Tx already exists in cache", "tx", tx.Hash())
-			case err != nil:
-				memR.Logger.Info("Could not check tx", "tx", tx.Hash(), "err", err)
 			default:
-				// Record the sender only when the transaction is valid and, as
-				// a consequence, added to the mempool. Senders are stored until
-				// the transaction is removed from the mempool. Note that it's
-				// possible a tx is still in the cache but no longer in the
-				// mempool. For example, after committing a block, txs are
-				// removed from mempool but not the cache.
-				reqRes.SetCallback(func(res *abci.Response) {
-					if res.GetCheckTx().Code == abci.CodeTypeOK {
-						memR.addSender(tx.Key(), e.Src.ID())
-					}
-				})
+				memR.Logger.Info("Could not check tx", "tx", tx.Hash(), "err", err)
 			}
 		}
 	default:
@@ -276,7 +253,7 @@ func (memR *Reactor) broadcastTxRoutine(peer p2p.Peer) {
 		// NOTE: Transaction batching was disabled due to
 		// https://github.com/tendermint/tendermint/issues/5796
 
-		if !memR.isSender(memTx.tx.Key(), peer.ID()) {
+		if !memTx.isSender(peer.ID()) {
 			success := peer.Send(p2p.Envelope{
 				ChannelID: MempoolChannel,
 				Message:   &protomem.Txs{Txs: [][]byte{memTx.tx}},
@@ -296,33 +273,5 @@ func (memR *Reactor) broadcastTxRoutine(peer p2p.Peer) {
 		case <-memR.Quit():
 			return
 		}
-	}
-}
-
-func (memR *Reactor) isSender(txKey types.TxKey, peerID p2p.ID) bool {
-	memR.txSendersMtx.Lock()
-	defer memR.txSendersMtx.Unlock()
-
-	sendersSet, ok := memR.txSenders[txKey]
-	return ok && sendersSet[peerID]
-}
-
-func (memR *Reactor) addSender(txKey types.TxKey, senderID p2p.ID) {
-	memR.txSendersMtx.Lock()
-	defer memR.txSendersMtx.Unlock()
-
-	if sendersSet, ok := memR.txSenders[txKey]; ok {
-		sendersSet[senderID] = true
-		return
-	}
-	memR.txSenders[txKey] = map[p2p.ID]bool{senderID: true}
-}
-
-func (memR *Reactor) removeSenders(txKey types.TxKey) {
-	memR.txSendersMtx.Lock()
-	defer memR.txSendersMtx.Unlock()
-
-	if memR.txSenders != nil {
-		delete(memR.txSenders, txKey)
 	}
 }

--- a/mempool/reactor_test.go
+++ b/mempool/reactor_test.go
@@ -145,8 +145,7 @@ func TestReactorNoBroadcastToSender(t *testing.T) {
 	// the second peer sends all the transactions to the first peer
 	secondNodeID := reactors[1].Switch.NodeInfo().ID()
 	for _, tx := range txs {
-		reactors[0].addSender(tx.Key(), secondNodeID)
-		_, err := reactors[0].mempool.CheckTx(tx)
+		err := reactors[0].mempool.CheckTx(tx, nil, TxInfo{sender: secondNodeID})
 		require.NoError(t, err)
 	}
 
@@ -175,9 +174,8 @@ func TestReactor_MaxTxBytes(t *testing.T) {
 	// Broadcast a tx, which has the max size
 	// => ensure it's received by the second reactor.
 	tx1 := kvstore.NewRandomTx(config.Mempool.MaxTxBytes)
-	reqRes, err := reactors[0].mempool.CheckTx(tx1)
+	err := reactors[0].mempool.CheckTx(tx1, nil, TxInfo{})
 	require.NoError(t, err)
-	require.False(t, reqRes.Response.GetCheckTx().IsErr())
 	waitForReactors(t, []types.Tx{tx1}, reactors, checkTxsInOrder)
 
 	reactors[0].mempool.Flush()
@@ -186,9 +184,8 @@ func TestReactor_MaxTxBytes(t *testing.T) {
 	// Broadcast a tx, which is beyond the max size
 	// => ensure it's not sent
 	tx2 := kvstore.NewRandomTx(config.Mempool.MaxTxBytes + 1)
-	reqRes, err = reactors[0].mempool.CheckTx(tx2)
+	err = reactors[0].mempool.CheckTx(tx2, nil, TxInfo{})
 	require.Error(t, err)
-	require.Nil(t, reqRes)
 }
 
 func TestBroadcastTxForPeerStopsWhenPeerStops(t *testing.T) {
@@ -235,104 +232,6 @@ func TestBroadcastTxForPeerStopsWhenReactorStops(t *testing.T) {
 	leaktest.CheckTimeout(t, 10*time.Second)()
 }
 
-func TestReactorTxSendersLocal(t *testing.T) {
-	config := cfg.TestConfig()
-	const n = 1
-	reactors, _ := makeAndConnectReactors(config, n)
-	defer func() {
-		for _, r := range reactors {
-			if err := r.Stop(); err != nil {
-				require.NoError(t, err)
-			}
-		}
-	}()
-	reactor := reactors[0]
-
-	tx1 := kvstore.NewTxFromID(1)
-	tx2 := kvstore.NewTxFromID(2)
-	require.False(t, reactor.isSender(types.Tx(tx1).Key(), "peer1"))
-
-	reactor.addSender(types.Tx(tx1).Key(), "peer1")
-	reactor.addSender(types.Tx(tx1).Key(), "peer2")
-	reactor.addSender(types.Tx(tx2).Key(), "peer1")
-	require.True(t, reactor.isSender(types.Tx(tx1).Key(), "peer1"))
-	require.True(t, reactor.isSender(types.Tx(tx1).Key(), "peer2"))
-	require.True(t, reactor.isSender(types.Tx(tx2).Key(), "peer1"))
-
-	reactor.removeSenders(types.Tx(tx1).Key())
-	require.False(t, reactor.isSender(types.Tx(tx1).Key(), "peer1"))
-	require.False(t, reactor.isSender(types.Tx(tx1).Key(), "peer2"))
-	require.True(t, reactor.isSender(types.Tx(tx2).Key(), "peer1"))
-}
-
-// Test that:
-// - If a transaction came from a peer AND if the transaction is added to the
-// mempool, it must have a non-empty list of senders in the reactor.
-// - If a transaction is removed from the mempool, it must also be removed from
-// the list of senders in the reactor.
-func TestReactorTxSendersMultiNode(t *testing.T) {
-	config := cfg.TestConfig()
-	config.Mempool.Size = 1000
-	config.Mempool.CacheSize = 1000
-	const n = 3
-	reactors, _ := makeAndConnectReactors(config, n)
-	defer func() {
-		for _, r := range reactors {
-			if err := r.Stop(); err != nil {
-				require.NoError(t, err)
-			}
-		}
-	}()
-	for _, r := range reactors {
-		for _, peer := range r.Switch.Peers().Copy() {
-			peer.Set(types.PeerStateKey, peerState{1})
-		}
-	}
-	firstReactor := reactors[0]
-
-	numTxs := config.Mempool.Size
-	txs := newUniqueTxs(numTxs)
-
-	// Initially, there are no transactions (and no senders).
-	for _, r := range reactors {
-		require.Zero(t, len(r.txSenders))
-	}
-
-	// Add transactions to the first reactor.
-	callCheckTx(t, firstReactor.mempool, txs)
-
-	// Wait for all txs to be in the mempool of each reactor.
-	waitForReactors(t, txs, reactors, checkTxsInMempool)
-	for i, r := range reactors {
-		checkTxsInMempoolAndSenders(t, r, txs, i)
-	}
-
-	// Split the transactions in three groups of different sizes.
-	splitIndex := numTxs / 6
-	validTxs := txs[:splitIndex]                 // will be used to update the mempool, as valid txs
-	invalidTxs := txs[splitIndex : 3*splitIndex] // will be used to update the mempool, as invalid txs
-	ignoredTxs := txs[3*splitIndex:]             // will remain in the mempool
-
-	// Update the mempools with a list of valid and invalid transactions.
-	for i, r := range reactors {
-		updateMempool(t, r.mempool, validTxs, invalidTxs)
-
-		// Txs included in a block should have been removed from the mempool and
-		// have no senders.
-		for _, tx := range append(validTxs, invalidTxs...) {
-			require.False(t, r.mempool.InMempool(tx.Key()))
-			_, hasSenders := r.txSenders[tx.Key()]
-			require.False(t, hasSenders)
-		}
-
-		// Ignored txs should still be in the mempool.
-		checkTxsInMempoolAndSenders(t, r, ignoredTxs, i)
-	}
-
-	// The first reactor should not receive transactions from other peers.
-	require.Zero(t, len(firstReactor.txSenders))
-}
-
 // Finding a solution for guaranteeing FIFO ordering is not easy; it would
 // require changes at the p2p level. The order of messages is just best-effort,
 // but this is not documented anywhere. If this is well understood and
@@ -361,7 +260,7 @@ func TestMempoolFIFOWithParallelCheckTx(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		go func() {
 			for _, tx := range txs {
-				mp.CheckTx(tx) //nolint:errcheck
+				_ = mp.CheckTx(tx, nil, TxInfo{})
 			}
 		}()
 	}
@@ -512,33 +411,6 @@ func TestMempoolReactorMaxActiveOutboundConnectionsStar(t *testing.T) {
 	}
 }
 
-// Check that the mempool has exactly the given list of txs and, if it's not the
-// first reactor (reactorIndex == 0), then each tx has a non-empty list of senders.
-func checkTxsInMempoolAndSenders(t *testing.T, r *Reactor, txs types.Txs, reactorIndex int) {
-	t.Helper()
-	r.txSendersMtx.Lock()
-	defer r.txSendersMtx.Unlock()
-
-	require.Len(t, txs, r.mempool.Size())
-	if reactorIndex == 0 {
-		require.Zero(t, len(r.txSenders))
-	} else {
-		require.Equal(t, len(txs), len(r.txSenders))
-	}
-
-	// Each transaction is in the mempool and, if it's not the first reactor, it
-	// has a non-empty list of senders.
-	for _, tx := range txs {
-		assert.True(t, r.mempool.InMempool(tx.Key()))
-		senders, hasSenders := r.txSenders[tx.Key()]
-		if reactorIndex == 0 {
-			require.False(t, hasSenders)
-		} else {
-			require.True(t, hasSenders && len(senders) > 0)
-		}
-	}
-}
-
 // mempoolLogger is a TestingLogger which uses a different
 // color for each validator ("validator" key must exist).
 func mempoolLogger() log.Logger {
@@ -659,21 +531,6 @@ func checkTxsInOrder(t *testing.T, txs types.Txs, reactor *Reactor, reactorIndex
 		assert.Equalf(t, tx, reapedTxs[i],
 			"txs at index %d on reactor %d don't match: %v vs %v", i, reactorIndex, tx, reapedTxs[i])
 	}
-}
-
-func updateMempool(t *testing.T, mp Mempool, validTxs types.Txs, invalidTxs types.Txs) {
-	t.Helper()
-	allTxs := append(validTxs, invalidTxs...)
-
-	validTxResponses := abciResponses(len(validTxs), abci.CodeTypeOK)
-	invalidTxResponses := abciResponses(len(invalidTxs), 1)
-	allResponses := append(validTxResponses, invalidTxResponses...)
-
-	mp.Lock()
-	err := mp.Update(1, allTxs, allResponses, nil, nil)
-	mp.Unlock()
-
-	require.NoError(t, err)
 }
 
 // ensure no txs on reactor after some timeout.

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -328,7 +328,7 @@ func TestCreateProposalBlock(t *testing.T) {
 	txLength := 100
 	for i := 0; i <= int(maxBytes)/txLength; i++ {
 		tx := cmtrand.Bytes(txLength)
-		_, err := mempool.CheckTx(tx)
+		err := mempool.CheckTx(tx, nil, mempl.TxInfo{})
 		require.NoError(t, err)
 	}
 
@@ -406,7 +406,7 @@ func TestMaxProposalBlockSize(t *testing.T) {
 	// fill the mempool with one txs just below the maximum size
 	txLength := int(types.MaxDataBytesNoEvidence(maxBytes, 1))
 	tx := cmtrand.Bytes(txLength - 4) // to account for the varint
-	_, err = mempool.CheckTx(tx)
+	err = mempool.CheckTx(tx, nil, mempl.TxInfo{})
 	require.NoError(t, err)
 
 	blockExec := sm.NewBlockExecutor(

--- a/rpc/client/rpc_test.go
+++ b/rpc/client/rpc_test.go
@@ -18,6 +18,7 @@ import (
 	cmtjson "github.com/cometbft/cometbft/libs/json"
 	"github.com/cometbft/cometbft/libs/log"
 	cmtmath "github.com/cometbft/cometbft/libs/math"
+	mempl "github.com/cometbft/cometbft/mempool"
 	"github.com/cometbft/cometbft/rpc/client"
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 	rpclocal "github.com/cometbft/cometbft/rpc/client/local"
@@ -373,9 +374,8 @@ func TestUnconfirmedTxs(t *testing.T) {
 
 	ch := make(chan *abci.CheckTxResponse, 1)
 	mempool := node.Mempool()
-	reqRes, err := mempool.CheckTx(tx)
+	err := mempool.CheckTx(tx, func(resp *abci.CheckTxResponse) { ch <- resp }, mempl.TxInfo{})
 	require.NoError(t, err)
-	ch <- reqRes.Response.GetCheckTx()
 
 	// wait for tx to arrive in mempoool.
 	select {
@@ -404,9 +404,8 @@ func TestNumUnconfirmedTxs(t *testing.T) {
 
 	ch := make(chan *abci.CheckTxResponse, 1)
 	mempool := node.Mempool()
-	reqRes, err := mempool.CheckTx(tx)
+	err := mempool.CheckTx(tx, func(resp *abci.CheckTxResponse) { ch <- resp }, mempl.TxInfo{})
 	require.NoError(t, err)
-	ch <- reqRes.Response.GetCheckTx()
 
 	// wait for tx to arrive in mempoool.
 	select {

--- a/test/fuzz/mempool/checktx.go
+++ b/test/fuzz/mempool/checktx.go
@@ -24,7 +24,7 @@ func init() {
 }
 
 func Fuzz(data []byte) int {
-	_, err := mempool.CheckTx(data)
+	err := mempool.CheckTx(data, nil, mempl.TxInfo{})
 	if err != nil {
 		return 0
 	}

--- a/test/fuzz/tests/mempool_test.go
+++ b/test/fuzz/tests/mempool_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/cometbft/cometbft/abci/example/kvstore"
 	"github.com/cometbft/cometbft/config"
 	cmtsync "github.com/cometbft/cometbft/libs/sync"
-	"github.com/cometbft/cometbft/mempool"
+	mempl "github.com/cometbft/cometbft/mempool"
 )
 
 func FuzzMempool(f *testing.F) {
@@ -24,9 +24,9 @@ func FuzzMempool(f *testing.F) {
 	cfg := config.DefaultMempoolConfig()
 	cfg.Broadcast = false
 
-	mp := mempool.NewCListMempool(cfg, conn, 0)
+	mp := mempl.NewCListMempool(cfg, conn, 0)
 
 	f.Fuzz(func(_ *testing.T, data []byte) {
-		_, _ = mp.CheckTx(data)
+		_ = mp.CheckTx(data, nil, mempl.TxInfo{})
 	})
 }


### PR DESCRIPTION
Close #3084 

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
