### PR TITLE
perf(consensus): Make the block proposer bypass internalMsgQueue for updating itself

### DIFF
--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -835,13 +835,7 @@ func (cs *State) receiveRoutine(maxSteps int) {
 			cs.handleMsg(mi)
 
 		case mi = <-cs.internalMsgQueue:
-			err := cs.wal.WriteSync(mi) // NOTE: fsync
-			if err != nil {
-				panic(fmt.Sprintf(
-					"failed to write %v msg to consensus WAL due to %v; check your file system and restart the node",
-					mi, err,
-				))
-			}
+			cs.mustWriteWalSync(mi)
 
 			if _, ok := mi.Msg.(*VoteMessage); ok {
 				// we actually want to simulate failing during
@@ -867,6 +861,16 @@ func (cs *State) receiveRoutine(maxSteps int) {
 			onExit(cs)
 			return
 		}
+	}
+}
+
+func (cs *State) mustWriteWalSync(mi msgInfo) {
+	err := cs.wal.WriteSync(mi) // NOTE: fsync
+	if err != nil {
+		panic(fmt.Sprintf(
+			"failed to write %v msg to consensus WAL due to %v; check your file system and restart the node",
+			mi, err,
+		))
 	}
 }
 
@@ -1251,12 +1255,18 @@ func (cs *State) defaultDecideProposal(height int64, round int32) {
 		proposal.Signature = p.Signature
 
 		// send proposal and block parts on internal msg queue
-		cs.sendInternalMessage(msgInfo{&ProposalMessage{proposal}, "", cmttime.Now()})
+		mi := msgInfo{&ProposalMessage{proposal}, "", cmttime.Now()}
+		cs.mustWriteWalSync(mi) // TODO: Reconsider if we need this WAL write
+		cs.setProposal(proposal, mi.ReceiveTime)
 
 		for i := 0; i < int(blockParts.Total()); i++ {
 			part := blockParts.GetPart(i)
-			cs.sendInternalMessage(msgInfo{&BlockPartMessage{cs.Height, cs.Round, part}, "", time.Time{}})
+			mi := msgInfo{&BlockPartMessage{cs.Height, cs.Round, part}, "", time.Time{}}
+			cs.mustWriteWalSync(mi) // TODO: Reconsider if we need this WAL write, definitely does not need to be sync
+			// TODO: Make a new method "addAllBlockParts" for use here.
+			cs.addProposalBlockPart(mi.Msg.(*BlockPartMessage), "")
 		}
+		cs.handleCompleteProposal(cs.Height)
 
 		cs.Logger.Debug("signed proposal", "height", height, "round", round, "proposal", proposal)
 	} else if !cs.replayMode {


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

Closes #3130.

This PR makes the proposer, upon building a block, directly update its block part state, rather than going through the internal message queue. This has a number of benefits:
- Any blocked gossip routine, when unblocked, will directly sample from all block parts (cc @evanforbes)
- Gossip routines will only get unblocked once all block parts are added
- We do not further delay block gossip on incoming votes / other data from peers

In subsequent PRs, we can absolutely lower the overheads here. (E.g. we surely don't need all these WAL writes, or at minimum not them all as sync. We don't have to unmarshal the block, which for big blocks, seems like it can get to 3 ms, etc.)

I'm not sure if this needs any test updates. Potential failure modes here:
- We have a longer hold on the consensus mutex than before. (But this feels like it should be tested separately)
- We fail during proposal, but this PR handles the WAL exactly the same as we used to, so I don't think any issue would arise / should be covered by existing tests.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
