### PR TITLE
perf(consensus): Make the proposer run setProposal immediately

### DIFF
--- a/types/part_set.go
+++ b/types/part_set.go
@@ -297,11 +297,13 @@ func (ps *PartSet) AddPart(part *Part) (bool, error) {
 
 	// The proof should be compatible with the number of parts.
 	if part.Proof.Total != int64(ps.total) {
+		fmt.Println("incorrect total", part.Proof.Total, ps.total)
 		return false, ErrPartSetInvalidProof
 	}
 
 	// Check hash proof
 	if part.Proof.Verify(ps.Hash(), part.Bytes) != nil {
+		fmt.Println("incorrect hash", part.Proof, ps.Hash(), part.Bytes)
 		return false, ErrPartSetInvalidProof
 	}
 


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

Component of #3130 . This PR makes the proposer, upon building a block, directly update its local Proposal setting, rather than going through the internal message queue. This is progressing towards the goal, of minimizing the time between "proposer has locally built a block", and "proposer is ready to gossip block parts".



---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
