### PR TITLE
perf(types): Make TM2PB.Validator's Address function use the validator object

### DIFF
--- a/.changelog/unreleased/improvements/3149-speedup-tm2pb-validator.md
+++ b/.changelog/unreleased/improvements/3149-speedup-tm2pb-validator.md
@@ -1,0 +1,2 @@
+- [`types`] Speedup tm2pb.Validator, by not re-hashing the public key
+  ([\#3149](https://github.com/cometbft/cometbft/issues/3149)

--- a/types/protobuf.go
+++ b/types/protobuf.go
@@ -39,7 +39,7 @@ func (tm2pb) Header(header *Header) cmtproto.Header {
 
 func (tm2pb) Validator(val *Validator) abci.Validator {
 	return abci.Validator{
-		Address: val.PubKey.Address(),
+		Address: val.Address,
 		Power:   val.VotingPower,
 	}
 }


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

Mild speedup, saw this coming up very slightly in benchmarks for `state.buildLastCommitInfo`. 
![image](https://github.com/cometbft/cometbft/assets/6440154/ad7c28e3-54e3-4e8e-b9f4-f32dd76be680)


---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
