### PR TITLE
perf(consensus): Fix some peer messages taking write locks on the cs mtx

### DIFF
--- a/.changelog/unreleased/improvements/3159-fix-taking-wlocks-instead-of-rlocks.md
+++ b/.changelog/unreleased/improvements/3159-fix-taking-wlocks-instead-of-rlocks.md
@@ -1,0 +1,2 @@
+- [`consensus`] Fix some reactor messages taking write locks instead of read locks.
+  ([\#3159](https://github.com/cometbft/cometbft/issues/3159)

--- a/internal/consensus/reactor.go
+++ b/internal/consensus/reactor.go
@@ -267,9 +267,9 @@ func (conR *Reactor) Receive(e p2p.Envelope) {
 	case StateChannel:
 		switch msg := msg.(type) {
 		case *NewRoundStepMessage:
-			conR.conS.mtx.Lock()
+			conR.conS.mtx.RLock()
 			initialHeight := conR.conS.state.InitialHeight
-			conR.conS.mtx.Unlock()
+			conR.conS.mtx.RUnlock()
 			if err = msg.ValidateHeight(initialHeight); err != nil {
 				conR.Logger.Error("Peer sent us invalid msg", "peer", e.Src, "msg", msg, "err", err)
 				conR.Switch.StopPeerForError(e.Src, err)
@@ -284,9 +284,9 @@ func (conR *Reactor) Receive(e p2p.Envelope) {
 			ps.ApplyHasProposalBlockPartMessage(msg)
 		case *VoteSetMaj23Message:
 			cs := conR.conS
-			cs.mtx.Lock()
+			cs.mtx.RLock()
 			height, votes := cs.Height, cs.Votes
-			cs.mtx.Unlock()
+			cs.mtx.RUnlock()
 			if height != msg.Height {
 				return
 			}
@@ -373,9 +373,9 @@ func (conR *Reactor) Receive(e p2p.Envelope) {
 		switch msg := msg.(type) {
 		case *VoteSetBitsMessage:
 			cs := conR.conS
-			cs.mtx.Lock()
+			cs.mtx.RLock()
 			height, votes := cs.Height, cs.Votes
-			cs.mtx.Unlock()
+			cs.mtx.RUnlock()
 
 			if height == msg.Height {
 				var ourVotes *bits.BitArray


### PR DESCRIPTION
Some clear, read-only spots in receive routine took Write locks instead of read locks. Seems like a bug.

This PR fixes it.

---

#### PR checklist

- [x] Tests written/updated - N/A imo?
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
