### PR TITLE
test(e2e): Improve e2e app test with tx TTL

### DIFF
--- a/abci/example/kvstore/code.go
+++ b/abci/example/kvstore/code.go
@@ -7,4 +7,5 @@ const (
 	CodeTypeInvalidTxFormat uint32 = 2
 	CodeTypeUnauthorized    uint32 = 3
 	CodeTypeExecuted        uint32 = 5
+	CodeTypeExpired         uint32 = 5
 )

--- a/test/e2e/app/app.go
+++ b/test/e2e/app/app.go
@@ -39,6 +39,7 @@ const (
 	suffixVoteExtHeight string = "VoteExtensionsHeight"
 	suffixPbtsHeight    string = "PbtsHeight"
 	suffixInitialHeight string = "InitialHeight"
+	txTTL               int64  = 5
 )
 
 // Application is an ABCI application for use by end-to-end tests. It is a
@@ -52,6 +53,8 @@ type Application struct {
 	cfg             *Config
 	restoreSnapshot *abci.Snapshot
 	restoreChunks   [][]byte
+	// It's OK not to persist this, as it is not part of the state machine
+	seenTxs map[cmttypes.TxKey]int64
 }
 
 // Config allows for the setting of high level parameters for running the e2e Application
@@ -158,6 +161,7 @@ func NewApplication(cfg *Config) (*Application, error) {
 		state:     state,
 		snapshots: snapshots,
 		cfg:       cfg,
+		seenTxs:   make(map[cmttypes.TxKey]int64),
 	}, nil
 }
 
@@ -268,6 +272,24 @@ func (app *Application) CheckTx(_ context.Context, req *abci.CheckTxRequest) (*a
 		}, nil
 	}
 
+	hash := cmttypes.Tx(req.Tx).Key()
+	stHeight, _ := app.state.Info()
+	height := int64(stHeight)
+	if txHeight, ok := app.seenTxs[hash]; ok {
+		if height < txHeight {
+			panic(fmt.Sprintf("txHeight is less than current height; txHeight %v, height %v", txHeight, height))
+		}
+		if height > txHeight+txTTL {
+			delete(app.seenTxs, hash)
+			return &abci.CheckTxResponse{
+				Code: kvstore.CodeTypeExpired,
+				Log:  fmt.Sprintf("transaction expired; seen height %v, current height %v", txHeight, height),
+			}, nil
+		}
+	} else {
+		app.seenTxs[hash] = height
+	}
+
 	if app.cfg.CheckTxDelay != 0 {
 		time.Sleep(app.cfg.CheckTxDelay)
 	}
@@ -294,6 +316,8 @@ func (app *Application) FinalizeBlock(_ context.Context, req *abci.FinalizeBlock
 			panic(fmt.Errorf("detected a transaction with key %q; this key is reserved and should have been filtered out", prefixReservedKey))
 		}
 		app.state.Set(key, value)
+
+		delete(app.seenTxs, cmttypes.Tx(tx).Key())
 
 		txs[i] = &abci.ExecTxResult{Code: kvstore.CodeTypeOK}
 	}


### PR DESCRIPTION
This modified version of the e2e app test improves the test to prevent txs getting stuck in the mempool

#### PR checklist

- [X] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [X] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
