### PR TITLE
fix(e2e): add TTL for txs in kvstore to remove txs stuck in mempool

### DIFF
--- a/abci/example/kvstore/code.go
+++ b/abci/example/kvstore/code.go
@@ -7,4 +7,5 @@ const (
 	CodeTypeInvalidTxFormat uint32 = 2
 	CodeTypeUnauthorized    uint32 = 3
 	CodeTypeExecuted        uint32 = 5
+	CodeTypeExpired         uint32 = 5
 )

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -155,7 +155,7 @@ func (memR *Reactor) Receive(e p2p.Envelope) {
 			_, err := memR.mempool.CheckTx(tx, e.Src.ID())
 			if errors.Is(err, ErrTxInCache) {
 				memR.Logger.Debug("Tx already exists in cache", "tx", tx.Hash())
-			} else {
+			} else if err != nil {
 				memR.Logger.Info("Could not check tx", "tx", tx.Hash(), "err", err)
 			}
 		}

--- a/test/e2e/tests/app_test.go
+++ b/test/e2e/tests/app_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	cmtbytes "github.com/cometbft/cometbft/libs/bytes"
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 	"github.com/cometbft/cometbft/types"
 )
@@ -86,10 +87,13 @@ func TestApp_Tx(t *testing.T) {
 		value := hex.EncodeToString(bz)
 		tx := types.Tx(fmt.Sprintf("%v=%v", key, value))
 
-		_, err = client.BroadcastTxSync(ctx, tx)
+		res, err := client.BroadcastTxSync(ctx, tx)
 		require.NoError(t, err)
+		require.NotNil(t, res)
+		require.Zero(t, res.Code)
 
 		hash := tx.Hash()
+		require.Equal(t, res.Hash, cmtbytes.HexBytes(hash))
 		waitTime := 30 * time.Second
 		require.Eventuallyf(t, func() bool {
 			txResp, err := client.Tx(ctx, hash, false)


### PR DESCRIPTION
The e2e test `TestApp_Tx` is sometimes failing on testnets with full nodes doing state sync. This is the scenario:
- Node A starts with state sync, receives a snapshot at height H, switches to consensus mode, and enables the mempool.
- Then node A receives from a peer a transaction that was included in a block at height lower than H. This transaction will get stuck in the mempool forever. 
- The reason is that in e2e transactions are always valid, so it cannot be removed from the mempool during rechecking. It can only be removed when committing a block that includes the transaction. But the transaction was already committed at height H before node A started.

This fix implements a TTL in the app side as a weak form of replay protection. Real applications should implement replay protections so they shouldn't have this problem.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
