### PR TITLE
fix(mempool/rpc): remove duplicate invokeCallback

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -158,12 +158,12 @@ cb(reqRes.Response.GetCheckTx())
 
 The `*abcicli.ReqRes` structure that `CheckTx` returns has a callback to 
 process the response already set (namely, the function `handleCheckTxResponse`).
-The callback can be invoked manually; for example:
+The callback will be invoked internally when the response is ready. We need only 
+to wait for it; for example:
 ```golang
 reqRes, err := CheckTx(tx, sender)
 // check `err` here
 reqRes.Wait()
-reqRes.InvokeCallback()
 ```
 
 ### Protobufs and Generated Go Code

--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -115,7 +115,7 @@ func callCheckTx(t *testing.T, mp Mempool, txs types.Txs) {
 			}
 			t.Fatalf("CheckTx failed: %v while checking #%d tx", err, i)
 		}
-		rr.InvokeCallback()
+		rr.Wait()
 	}
 }
 

--- a/rpc/core/mempool.go
+++ b/rpc/core/mempool.go
@@ -53,7 +53,6 @@ func (env *Environment) BroadcastTxSync(ctx *rpctypes.Context, tx types.Tx) (*ct
 		select {
 		case <-ctx.Context().Done():
 		default:
-			reqRes.InvokeCallback()
 			resCh <- reqRes.Response.GetCheckTx()
 		}
 	}()
@@ -117,7 +116,6 @@ func (env *Environment) BroadcastTxCommit(ctx *rpctypes.Context, tx types.Tx) (*
 		select {
 		case <-ctx.Context().Done():
 		default:
-			reqRes.InvokeCallback()
 			checkTxResCh <- reqRes.Response.GetCheckTx()
 		}
 	}()


### PR DESCRIPTION
On sync RPC endpoints `broadcast_tx_sync|commit`, it is wrong to call `reqRes.InvokeCallback()` because the callback was executed before. This PR removes these lines. 

The reason is that the callback was already executed, either inside the remote clients (socket or grpc) or when setting the callback on the local client.
- The socket client executes the callback explicitly [when receiving the response](https://github.com/cometbft/cometbft/blob/e731a3fdf9187fe07b2385463320669fcac569b6/abci/client/socket_client.go#L234C9-L234C15).
- The local client, on receiving the response, sets `reqRes.callbackInvoked = true`. Then it's the function `SetCallback` that actually executes the callback [outside of the client](https://github.com/cometbft/cometbft/blob/e731a3fdf9187fe07b2385463320669fcac569b6/mempool/clist_mempool.go#L287), when `CheckTxAsync` returns the reqRes object.


---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [X] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [X] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
