### PR TITLE
perf(p2p): Make ingesting packets not block on channel unmarshal or channel receive logic

### DIFF
--- a/p2p/conn/connection.go
+++ b/p2p/conn/connection.go
@@ -336,7 +336,7 @@ func (c *MConnection) flush() {
 }
 
 // Catch panics, usually caused by remote disconnects.
-func (c *MConnection) _recover() {
+func (c *MConnection) PanicRecover() {
 	if r := recover(); r != nil {
 		c.Logger.Error("MConnection panicked", "err", r, "stack", string(debug.Stack()))
 		c.stopForError(fmt.Errorf("recovered from panic: %v", r))
@@ -427,7 +427,7 @@ func (c *MConnection) CanSend(chID byte) bool {
 
 // sendRoutine polls for packets to send from channels.
 func (c *MConnection) sendRoutine() {
-	defer c._recover()
+	defer c.PanicRecover()
 
 	protoWriter := protoio.NewDelimitedWriter(c.bufConnWriter)
 
@@ -581,7 +581,7 @@ func (c *MConnection) sendPacketMsgOnChannel(w protoio.Writer, sendChannel *Chan
 // Blocks depending on how the connection is throttled.
 // Otherwise, it never blocks.
 func (c *MConnection) recvRoutine() {
-	defer c._recover()
+	defer c.PanicRecover()
 
 	protoReader := protoio.NewDelimitedReader(c.bufConnReader, c._maxPacketMsgSize)
 

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -217,6 +217,9 @@ func (p *peer) OnStart() error {
 // NOTE: it is not safe to call this method more than once.
 func (p *peer) FlushStop() {
 	p.mconn.FlushStop() // stop everything and close the conn
+	for i := 0; i < len(p.channels); i++ {
+		p.recvListenersQuitChan <- struct{}{}
+	}
 }
 
 // OnStop implements BaseService.

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -213,13 +213,11 @@ func (p *peer) OnStart() error {
 
 // FlushStop mimics OnStop but additionally ensures that all successful
 // .Send() calls will get flushed before closing the connection.
+// Correct API usage requires FlushStop to terminate, and then OnStop getting called.
 //
 // NOTE: it is not safe to call this method more than once.
 func (p *peer) FlushStop() {
 	p.mconn.FlushStop() // stop everything and close the conn
-	for i := 0; i < len(p.channels); i++ {
-		p.recvListenersQuitChan <- struct{}{}
-	}
 }
 
 // OnStop implements BaseService.
@@ -230,6 +228,7 @@ func (p *peer) OnStop() {
 	for i := 0; i < len(p.channels); i++ {
 		p.recvListenersQuitChan <- struct{}{}
 	}
+	close(p.recvListenersQuitChan)
 }
 
 // ---------------------------------------------------

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -199,7 +199,6 @@ func (p *peer) OnStart() error {
 		return err
 	}
 
-	defer p.mconn.PanicRecover()
 	p.recvListenersQuitChan = make(chan struct{}, len(p.channels))
 	p.setupRecvListeners()
 
@@ -473,6 +472,7 @@ func (p *peer) setupChannelProcessors(
 // Processes incoming packets for this channel. This should be ran in a go-routine.
 // when it hits an error, it panics, which is safe as it must be caught by a conn.PanicRecover.
 func channelProcessor(p *peer, reactor Reactor, chID byte, msgType proto.Message, channel chan []byte) {
+	defer p.mconn.PanicRecover()
 	for {
 		select {
 		case msgBytes := <-channel:

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -411,6 +411,9 @@ func createMConnection(
 	channelProcessorsStarted := false
 
 	onReceive := func(chID byte, msgBytes []byte) {
+		// TODO: Consider sync.Pool for this, upon examining benchmarks
+		chanBytes := make([]byte, len(msgBytes))
+		copy(chanBytes, msgBytes)
 		// should never happen, it means we received a packet before createMConnection returned.
 		// This would imply that at minimum NewMConnectionWithConfig also did mConn.OnStart()
 		if !channelProcessorsStarted {
@@ -422,7 +425,7 @@ func createMConnection(
 		if !ok {
 			panic(fmt.Sprintf("Unknown channel %X", chID))
 		}
-		channel <- msgBytes
+		channel <- chanBytes
 	}
 
 	mconn := cmtconn.NewMConnectionWithConfig(


### PR DESCRIPTION
Handles a significant part of #3199

This separates out the entire left hand side of into its own goroutine that won't block further reading:
![image](https://github.com/cometbft/cometbft/assets/6440154/bb6b6c1c-338e-47ce-a52f-fc7a02a33207)

That is unblocking us from reading/ingesting packets 73% of the CPU time on a very light period of Osmosis traffic, and likely far more real-time as much of this is mutex blocked! (Separate PR's will improve I/O usage, and other non-I/O terms)

We guarantee that every channel receives packets in-order from a peer.

Furthermore this will allow concurrency across channels for getting their own packets unmarshalled and sent to respective reactors. (Meaning a mempool tx gossip will now not block on a consensus packet receive, unless the per-channel unmarshal/recv buffer is full. Right now its parameterized to be low, but @evan-forbes has a PR that composes with this, for adding a buffer into every reactor, that should fix this from being remotely likely)

To me, I think the main questions for this PR being merged are:
- Are we fine w/ my API change of: `mconn._recover` to `mconn.PanicRecover` (publicly exporting it)? I do like where I ended up putting the panic recover. 
- Is it fine to put "setup channels fn" as a field element in peer? 
- Do we want any new behavior tested? I'll test this on mainnet osmosis. Due to matching the panic recovery path the old code, I don't think theres concern over that being handled differently.
- Any other tests we think are missing? Nothing comes to mind

I'll get this tested on mainnet osmosis soon, to help build confidence :)

---

#### PR checklist

- [ ] Tests written/updated - Some of the behavior here appears to never have been tested, so I we could introduce a test for sending an undecodable packet on a channel that does exist.
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
