### PR TITLE
fix(e2e): reproduction an fixing of missing evidence in `e2e` nightlies 

### DIFF
--- a/.github/workflows/e2e-manual-multiversion.yml
+++ b/.github/workflows/e2e-manual-multiversion.yml
@@ -34,12 +34,12 @@ jobs:
         # based on the current branch as compared to the latest version.
         run: ./build/generator -g 5 -m "latest:1,local:2" -d networks/nightly/ -p
 
-      - name: Run ${{ matrix.p2p }} p2p testnets
+      - name: Run p2p testnets (${{ matrix.group }})
         if: matrix.group != 5
         working-directory: test/e2e
         run: ./run-multiple.sh networks/nightly/*-group${{ matrix.group }}-*.toml
 
-      - name: Run ${{ matrix.p2p }} p2p regression testnets
+      - name: Run p2p testnets (regression)
         if: matrix.group == 5
         working-directory: test/e2e
         run: ./run-multiple.sh networks_regressions/*.toml

--- a/.github/workflows/e2e-manual-multiversion.yml
+++ b/.github/workflows/e2e-manual-multiversion.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: ['00', '01', '02', '03', '04']
+        group: ['00', '01', '02', '03', '04', '05']
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -27,6 +27,7 @@ jobs:
         run: make -j2 docker generator runner tests
 
       - name: Generate testnets
+        if: matrix.group != 5
         working-directory: test/e2e
         # When changing -g, also change the matrix groups above
         # Generate multi-version tests with double the quantity of E2E nodes
@@ -34,5 +35,11 @@ jobs:
         run: ./build/generator -g 5 -m "latest:1,local:2" -d networks/nightly/ -p
 
       - name: Run ${{ matrix.p2p }} p2p testnets
+        if: matrix.group != 5
         working-directory: test/e2e
         run: ./run-multiple.sh networks/nightly/*-group${{ matrix.group }}-*.toml
+
+      - name: Run ${{ matrix.p2p }} p2p regression testnets
+        if: matrix.group == 5
+        working-directory: test/e2e
+        run: ./run-multiple.sh networks_regressions/*.toml

--- a/.github/workflows/e2e-manual.yml
+++ b/.github/workflows/e2e-manual.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: ['00', '01', '02', '03', '04']
+        group: ['00', '01', '02', '03', '04', '05']
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -27,10 +27,17 @@ jobs:
         run: make -j2 docker generator runner tests
 
       - name: Generate testnets
+        if: matrix.group != 5
         working-directory: test/e2e
         # When changing -g, also change the matrix groups above
         run: ./build/generator -g 5 -d networks/nightly/ -p
 
-      - name: Run ${{ matrix.p2p }} p2p testnets
+      - name: Run p2p testnets (${{ matrix.group }})
+        if: matrix.group != 5
         working-directory: test/e2e
         run: ./run-multiple.sh networks/nightly/*-group${{ matrix.group }}-*.toml
+
+      - name: Run p2p testnets (regression)
+        if: matrix.group == 5
+        working-directory: test/e2e
+        run: ./run-multiple.sh networks_regressions/*.toml

--- a/.github/workflows/e2e-nightly-1x.yml
+++ b/.github/workflows/e2e-nightly-1x.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: ['00', '01', '02', '03', "04"]
+        group: ['00', '01', '02', '03', '04', '05']
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -38,13 +38,20 @@ jobs:
         run: make -j2 docker generator runner tests
 
       - name: Generate testnets
+        if: matrix.group != 5
         working-directory: test/e2e
         # When changing -g, also change the matrix groups above
         run: ./build/generator -g 5 -d networks/nightly/ -p
 
-      - name: Run ${{ matrix.p2p }} p2p testnets
+      - name: Run p2p testnets (${{ matrix.group }})
+        if: matrix.group != 5
         working-directory: test/e2e
         run: ./run-multiple.sh networks/nightly/*-group${{ matrix.group }}-*.toml
+
+      - name: Run p2p testnets (regression)
+        if: matrix.group == 5
+        working-directory: test/e2e
+        run: ./run-multiple.sh networks_regressions/*.toml
 
     outputs:
       git-branch: ${{ steps.git-info.outputs.branch }}

--- a/.github/workflows/e2e-nightly-38x.yml
+++ b/.github/workflows/e2e-nightly-38x.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: ['00', '01', '02', '03', "04"]
+        group: ['00', '01', '02', '03', '04', '05']
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -38,13 +38,20 @@ jobs:
         run: make -j2 docker generator runner tests
 
       - name: Generate testnets
+        if: matrix.group != 5
         working-directory: test/e2e
         # When changing -g, also change the matrix groups above
         run: ./build/generator -g 5 -d networks/nightly/ -p
 
-      - name: Run ${{ matrix.p2p }} p2p testnets
+      - name: Run p2p testnets (${{ matrix.group }})
+        if: matrix.group != 5
         working-directory: test/e2e
         run: ./run-multiple.sh networks/nightly/*-group${{ matrix.group }}-*.toml
+
+      - name: Run p2p testnets (regression)
+        if: matrix.group == 5
+        working-directory: test/e2e
+        run: ./run-multiple.sh networks_regressions/*.toml
 
     outputs:
       git-branch: ${{ steps.git-info.outputs.branch }}

--- a/.github/workflows/e2e-nightly-main.yml
+++ b/.github/workflows/e2e-nightly-main.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: ['00', '01', '02', '03', "04"]
+        group: ['00', '01', '02', '03', '04', '05']
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -32,13 +32,20 @@ jobs:
         run: make -j2 docker generator runner tests
 
       - name: Generate testnets
+        if: matrix.group != 5
         working-directory: test/e2e
         # When changing -g, also change the matrix groups above
         run: ./build/generator -g 5 -d networks/nightly/ -p
 
-      - name: Run ${{ matrix.p2p }} p2p testnets
+      - name: Run p2p testnets (${{ matrix.group }})
+        if: matrix.group != 5
         working-directory: test/e2e
         run: ./run-multiple.sh networks/nightly/*-group${{ matrix.group }}-*.toml
+
+      - name: Run p2p testnets (regression)
+        if: matrix.group == 5
+        working-directory: test/e2e
+        run: ./run-multiple.sh networks_regressions/*.toml
 
   e2e-nightly-fail:
     needs: e2e-nightly-test

--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -49,7 +49,7 @@ var (
 		4 * int(e2e.EvidenceAgeHeight),
 	}
 	nodeEnableCompanionPruning = uniformChoice{true, false}
-	evidence                   = uniformChoice{0, 1, 10}
+	evidence                   = uniformChoice{0, 1, 10, 20, 200}
 	abciDelays                 = uniformChoice{"none", "small", "large"}
 	nodePerturbations          = probSetChoice{
 		"disconnect": 0.1,

--- a/test/e2e/networks/ci.toml
+++ b/test/e2e/networks/ci.toml
@@ -1,102 +1,16 @@
-# This testnet is run by CI, and attempts to cover a broad range of
-# functionality with a single network.
-
-ipv6 = true
-initial_height = 1000
-vote_extensions_update_height = 1004
-vote_extensions_enable_height = 1007
-pbts_update_height = 1006
-pbts_enable_height = 1009
-evidence = 5
-initial_state = { initial01 = "a", initial02 = "b", initial03 = "c" }
-prepare_proposal_delay = "100ms"
-process_proposal_delay = "100ms"
-check_tx_delay = "0ms"
-# The most common case (e.g. Cosmos SDK-based chains).
-abci_protocol = "builtin"
+evidence = 120
 prometheus = true
-peer_gossip_intraloop_sleep_duration = "50ms"
-abci_tests_enabled = true
+pbts_enable_height = 1
 
 [validators]
-validator01 = 100
+  validator01 = 33
+  validator02 = 67
 
-[validator_update.0]
-validator01 = 10
-validator02 = 20
-validator03 = 30
-validator04 = 40
+[node]
+  [node.validator01]
+    mode = "validator"
+    persistent_peers = ["validator02"]
+    clock_skew = "40s"
+  [node.validator02]
+    mode = "validator"
 
-[validator_update.1010]
-validator05 = 50
-
-# validator03 gets killed and validator05 has lots of perturbations, so weight them low.
-[validator_update.1020]
-validator01 = 100
-validator02 = 100
-validator03 = 50
-validator04 = 100
-validator05 = 50
-
-[node.seed01]
-mode = "seed"
-perturb = ["restart"]
-
-[node.validator01]
-seeds = ["seed01"]
-snapshot_interval = 5
-perturb = ["disconnect"]
-clock_skew = "20s"
-
-[node.validator02]
-seeds = ["seed01"]
-database = "pebbledb"
-privval_protocol = "tcp"
-persist_interval = 0
-perturb = ["restart"]
-
-[node.validator03]
-seeds = ["seed01"]
-database = "badgerdb"
-privval_protocol = "unix"
-persist_interval = 3
-retain_blocks = 10
-enable_companion_pruning = true
-perturb = ["kill"]
-
-[node.validator04]
-persistent_peers = ["validator01"]
-database = "rocksdb"
-perturb = ["pause"]
-
-[node.validator05]
-start_at = 1005 # Becomes part of the validator set at 1010
-persistent_peers = ["validator01", "full01"]
-database = "rocksdb"
-privval_protocol = "tcp"
-perturb = ["kill", "pause", "disconnect", "restart"]
-
-[node.full01]
-start_at = 1010
-mode = "full"
-persistent_peers = ["validator01", "validator02", "validator03", "validator04", "validator05"]
-retain_blocks = 10
-enable_companion_pruning = true
-perturb = ["restart"]
-
-[node.full02]
-start_at = 1015
-mode = "full"
-state_sync = true
-seeds = ["seed01"]
-perturb = ["restart"]
-
-[node.light01]
-mode= "light"
-start_at= 1005
-persistent_peers = ["validator01", "validator02", "validator03"]
-
-[node.light02]
-mode= "light"
-start_at= 1015
-persistent_peers = ["validator04", "full01", "validator05"]

--- a/test/e2e/networks/ci.toml
+++ b/test/e2e/networks/ci.toml
@@ -60,7 +60,7 @@ seeds = ["seed01"]
 database = "badgerdb"
 privval_protocol = "unix"
 persist_interval = 3
-retain_blocks = 10
+retain_blocks = 20
 enable_companion_pruning = true
 perturb = ["kill"]
 
@@ -80,7 +80,7 @@ perturb = ["kill", "pause", "disconnect", "restart"]
 start_at = 1010
 mode = "full"
 persistent_peers = ["validator01", "validator02", "validator03", "validator04", "validator05"]
-retain_blocks = 10
+retain_blocks = 20
 enable_companion_pruning = true
 perturb = ["restart"]
 

--- a/test/e2e/networks/ci.toml
+++ b/test/e2e/networks/ci.toml
@@ -1,16 +1,102 @@
-evidence = 120
+# This testnet is run by CI, and attempts to cover a broad range of
+# functionality with a single network.
+
+ipv6 = true
+initial_height = 1000
+vote_extensions_update_height = 1004
+vote_extensions_enable_height = 1007
+pbts_update_height = 1006
+pbts_enable_height = 1009
+evidence = 5
+initial_state = { initial01 = "a", initial02 = "b", initial03 = "c" }
+prepare_proposal_delay = "100ms"
+process_proposal_delay = "100ms"
+check_tx_delay = "0ms"
+# The most common case (e.g. Cosmos SDK-based chains).
+abci_protocol = "builtin"
 prometheus = true
-pbts_enable_height = 1
+peer_gossip_intraloop_sleep_duration = "50ms"
+abci_tests_enabled = true
 
 [validators]
-  validator01 = 33
-  validator02 = 67
+validator01 = 100
 
-[node]
-  [node.validator01]
-    mode = "validator"
-    persistent_peers = ["validator02"]
-    clock_skew = "40s"
-  [node.validator02]
-    mode = "validator"
+[validator_update.0]
+validator01 = 10
+validator02 = 20
+validator03 = 30
+validator04 = 40
 
+[validator_update.1010]
+validator05 = 50
+
+# validator03 gets killed and validator05 has lots of perturbations, so weight them low.
+[validator_update.1020]
+validator01 = 100
+validator02 = 100
+validator03 = 50
+validator04 = 100
+validator05 = 50
+
+[node.seed01]
+mode = "seed"
+perturb = ["restart"]
+
+[node.validator01]
+seeds = ["seed01"]
+snapshot_interval = 5
+perturb = ["disconnect"]
+clock_skew = "20s"
+
+[node.validator02]
+seeds = ["seed01"]
+database = "pebbledb"
+privval_protocol = "tcp"
+persist_interval = 0
+perturb = ["restart"]
+
+[node.validator03]
+seeds = ["seed01"]
+database = "badgerdb"
+privval_protocol = "unix"
+persist_interval = 3
+retain_blocks = 10
+enable_companion_pruning = true
+perturb = ["kill"]
+
+[node.validator04]
+persistent_peers = ["validator01"]
+database = "rocksdb"
+perturb = ["pause"]
+
+[node.validator05]
+start_at = 1005 # Becomes part of the validator set at 1010
+persistent_peers = ["validator01", "full01"]
+database = "rocksdb"
+privval_protocol = "tcp"
+perturb = ["kill", "pause", "disconnect", "restart"]
+
+[node.full01]
+start_at = 1010
+mode = "full"
+persistent_peers = ["validator01", "validator02", "validator03", "validator04", "validator05"]
+retain_blocks = 10
+enable_companion_pruning = true
+perturb = ["restart"]
+
+[node.full02]
+start_at = 1015
+mode = "full"
+state_sync = true
+seeds = ["seed01"]
+perturb = ["restart"]
+
+[node.light01]
+mode= "light"
+start_at= 1005
+persistent_peers = ["validator01", "validator02", "validator03"]
+
+[node.light02]
+mode= "light"
+start_at= 1015
+persistent_peers = ["validator04", "full01", "validator05"]

--- a/test/e2e/networks_regressions/evidence_fail.toml
+++ b/test/e2e/networks_regressions/evidence_fail.toml
@@ -1,0 +1,16 @@
+evidence = 120
+prometheus = true
+pbts_enable_height = 1
+
+[validators]
+  validator01 = 33
+  validator02 = 67
+
+[node]
+  [node.validator01]
+    mode = "validator"
+    persistent_peers = ["validator02"]
+    clock_skew = "40s"
+  [node.validator02]
+    mode = "validator"
+

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -66,8 +66,8 @@ const (
 	PerturbationRestart    Perturbation = "restart"
 	PerturbationUpgrade    Perturbation = "upgrade"
 
-	EvidenceAgeHeight int64         = 7
-	EvidenceAgeTime   time.Duration = 500 * time.Millisecond
+	EvidenceAgeHeight int64         = 14
+	EvidenceAgeTime   time.Duration = 1500 * time.Millisecond
 )
 
 // Testnet represents a single testnet.

--- a/test/e2e/runner/evidence.go
+++ b/test/e2e/runner/evidence.go
@@ -123,6 +123,7 @@ func InjectEvidence(ctx context.Context, r *rand.Rand, testnet *e2e.Testnet, amo
 			}
 			return err
 		}
+		time.Sleep(5 * time.Second / time.Duration(amount))
 	}
 
 	// wait for the node to reach the height above the forged height so that


### PR DESCRIPTION
Closes #3233 

This PR is is to be interpreted commit by commit.

* Commit 1: Changes in `e2e runner to repro the problem (these changes will stay).
* Commit 2. Making the problem repro appear in this PR (look at the ❌ next to commit 2 below, and check the `e2e` logs)
* Commit 3: Fix. (look at the ✅ next to commit 3 below)
* Commit 4: Revert commit 2
* Commit 5: Adapt nightlies to start running all regression manifests in (newly introduced) `test/e2e/networks_regressions` directory. Also, adapt manifest generator to create testnets with more evidences.
* Further commits: fix e2e infra

The reproduction consists in coming up with a testnet where some evidences can be delayed in their transit to the next validator, long enough to become invalid (too old). The delay is achieved by having a validator with skewed clock, in such a way that every time it proposes (untimely proposal) other peers shut down their p2p connection with that validator. The validator having the skewed clock is the one receiving all evidences.

The root cause is that, in `e2e`, the max age of evidence is too restrictive (500ms in time, and 7 heights in terms blocks). So, if the gossiping of transactions is delayed, some of them are too old when they arrive to the first validator that can propose them.

The fix consists in relaxing the max age of evidences in `e2e`: 1500ms, or 14 heights.

Without the fix, the e2e run fails almost every time. With the fix, I haven't been able to repro it after multiple attempts.

---

#### PR checklist

- [x] Tests written/updated
- ~~[ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)~~
- ~~[ ] Updated relevant documentation (`docs/` or `spec/`) and code comments~~
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
