### PR TITLE
test: avoid already subscribed error in benchmarkNClientsOneQuery

### DIFF
--- a/libs/pubsub/pubsub_test.go
+++ b/libs/pubsub/pubsub_test.go
@@ -420,7 +420,7 @@ func benchmarkNClients(b *testing.B, n int) {
 	for i := 0; i < n; i++ {
 		subscription, err := s.Subscribe(
 			ctx,
-			clientID,
+			fmt.Sprintf("%s-%d", clientID, i+1),
 			query.MustCompile(fmt.Sprintf("abci.Account.Owner = 'Ivan' AND abci.Invoices.Number = %d", i)),
 		)
 		if err != nil {
@@ -464,7 +464,7 @@ func benchmarkNClientsOneQuery(b *testing.B, n int) {
 	ctx := context.Background()
 	q := query.MustCompile("abci.Account.Owner = 'Ivan' AND abci.Invoices.Number = 1")
 	for i := 0; i < n; i++ {
-		subscription, err := s.Subscribe(ctx, clientID, q)
+		subscription, err := s.Subscribe(ctx, fmt.Sprintf("%s-%d", clientID, i+1), q)
 		if err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
