### PR TITLE
feat(cmd): add support for all key types in gen-validator

### DIFF
--- a/.changelog/unreleased/improvements/1757-gen-validator.md
+++ b/.changelog/unreleased/improvements/1757-gen-validator.md
@@ -1,0 +1,3 @@
+- `[cmd]` Add support for all key types in `gen-validator` command. Use
+ `--key-type=` (or `-k`) to specify the key type (e.g., `-k secp256k1`).
+  ([\#1757](https://github.com/cometbft/cometbft/issues/1757))

--- a/cmd/cometbft/commands/gen_validator.go
+++ b/cmd/cometbft/commands/gen_validator.go
@@ -5,9 +5,16 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/cometbft/cometbft/crypto"
+	"github.com/cometbft/cometbft/crypto/bls12381"
+	"github.com/cometbft/cometbft/crypto/ed25519"
+	"github.com/cometbft/cometbft/crypto/secp256k1"
+	"github.com/cometbft/cometbft/crypto/sr25519"
 	cmtjson "github.com/cometbft/cometbft/libs/json"
 	"github.com/cometbft/cometbft/privval"
 )
+
+var keyType string
 
 // GenValidatorCmd allows the generation of a keypair for a
 // validator.
@@ -15,15 +22,36 @@ var GenValidatorCmd = &cobra.Command{
 	Use:     "gen-validator",
 	Aliases: []string{"gen_validator"},
 	Short:   "Generate new validator keypair",
-	Run:     genValidator,
+	Long:    `Generate new validator keypair using an optional key-type (default: "ed25519").`,
+	RunE:    genValidator,
 }
 
-func genValidator(*cobra.Command, []string) {
-	pv := privval.GenFilePV("", "")
+func init() {
+	GenValidatorCmd.Flags().StringVarP(&keyType, "key-type", "k", ed25519.KeyType, "private key type")
+}
+
+func genValidator(*cobra.Command, []string) error {
+	var pk crypto.PrivKey
+	switch keyType {
+	case secp256k1.KeyType:
+		pk = secp256k1.GenPrivKey()
+	case sr25519.KeyType:
+		pk = sr25519.GenPrivKey()
+	case bls12381.KeyType:
+		var err error
+		pk, err = bls12381.GenPrivKey()
+		if err != nil {
+			return fmt.Errorf("failed to generate BLS key: %w", err)
+		}
+	default:
+		pk = ed25519.GenPrivKey()
+	}
+	pv := privval.NewFilePV(pk, "", "")
 	jsbz, err := cmtjson.Marshal(pv)
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("failed to marshal private validator: %w", err)
 	}
 	fmt.Printf(`%v
 `, string(jsbz))
+	return nil
 }

--- a/privval/file.go
+++ b/privval/file.go
@@ -182,8 +182,7 @@ func NewFilePV(privKey crypto.PrivKey, keyFilePath, stateFilePath string) *FileP
 	}
 }
 
-// GenFilePV generates a new validator with randomly generated private key
-// and sets the filePaths, but does not call Save().
+// GenFilePV calls NewFilePV with a random ed25519 private key.
 func GenFilePV(keyFilePath, stateFilePath string) *FilePV {
 	return NewFilePV(ed25519.GenPrivKey(), keyFilePath, stateFilePath)
 }

--- a/spec/core/encoding.md
+++ b/spec/core/encoding.md
@@ -79,7 +79,7 @@ Decoding the RPC response for a secp256k1 pubkey:
 #     "value": "AkeI23hsiCXVTf2+k+hGJAj/tuXRlwNRHI/Iv2Cvj3LQ"
 # },
 
-$ echo AkeI23hsiCXVTf2+k+hGJAj/tuXRlwNRHI/Iv2Cvj3LQ | base64 -D | xxd -p -c 999
+$ echo AkeI23hsiCXVTf2+k+hGJAj/tuXRlwNRHI/Iv2Cvj3LQ | base64 -d | xxd -p -c 33
 024788db786c8825d54dfdbe93e8462408ffb6e5d19703511c8fc8bf60af8f72d0
 ```
 

--- a/spec/core/encoding.md
+++ b/spec/core/encoding.md
@@ -65,6 +65,31 @@ The address is the first 20-bytes of the SHA256 hash of the raw 32-byte public k
 address = SHA256(pubkey)[:20]
 ```
 
+The public key comprised of 32 bytes for one field element (the x-coordinate),
+plus one byte for the parity of the y-coordinate. The first byte depends is a
+0x02 byte if the y-coordinate is the lexicographically largest of the two
+associated with the x-coordinate. Otherwise the first byte is a 0x03. This
+prefix is followed with the x-coordinate.
+
+Decoding the RPC response for a secp256k1 pubkey:
+
+```sh
+# "pub_key": {
+#     "type": "tendermint/PubKeySecp256k1",
+#     "value": "AkeI23hsiCXVTf2+k+hGJAj/tuXRlwNRHI/Iv2Cvj3LQ"
+# },
+
+$ echo AkeI23hsiCXVTf2+k+hGJAj/tuXRlwNRHI/Iv2Cvj3LQ | base64 -D | xxd -p -c 999
+024788db786c8825d54dfdbe93e8462408ffb6e5d19703511c8fc8bf60af8f72d0
+```
+
+The first byte plus the two field elements:
+
+```
+02_4788db786c8825d54dfdbe93e8462408ffb6e5d19703511c8fc8bf60af8f72d0
+   4788db786c8825d54dfdbe93e8462408ffb6e5d19703511c8fc8bf60af8f72d0_c47efb012b928018e99e892cfbfa7e8535de85169682346d66676e47da261498
+```
+
 ## Other Common Types
 
 ### BitArray


### PR DESCRIPTION
also better document secp256k1 keys in spec/core/encoding.md

Closes #1757

---

#### PR checklist

- [ ] ~~Tests written/updated~~ (tested manually)
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
