### PR TITLE
test: allow the v1.x nightly to be manually triggered

### DIFF
--- a/.github/workflows/e2e-nightly-1x.yml
+++ b/.github/workflows/e2e-nightly-1x.yml
@@ -7,6 +7,7 @@ name: e2e-nightly-1x
 on:
   schedule:
     - cron: '0 2 * * *'
+  workflow_dispatch: # This allows the workflow to be manually triggered
 
 jobs:
   e2e-nightly-test:


### PR DESCRIPTION
In order to allow testing the nightly on `v1.x` without having to wait a full day

#### PR checklist

- [X] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
