### PR TITLE
test(e2e): reverting PR3211 since it is making e2e nightly to fail

### DIFF
--- a/.changelog/unreleased/improvements/3211-make-cs-reactor-no-longer-takes-cs-locks.md
+++ b/.changelog/unreleased/improvements/3211-make-cs-reactor-no-longer-takes-cs-locks.md
@@ -1,4 +1,0 @@
-- `[consensus]` Make the consensus reactor no longer have packets on receive take the consensus lock.
-Consensus will now update the reactor's view after every relevant change through the existing 
-synchronous event bus subscription.
-  ([\#3211](https://github.com/cometbft/cometbft/pull/3211))

--- a/internal/consensus/reactor.go
+++ b/internal/consensus/reactor.go
@@ -46,9 +46,8 @@ type Reactor struct {
 	waitSync atomic.Bool
 	eventBus *types.EventBus
 
-	rsMtx         cmtsync.RWMutex
-	rs            *cstypes.RoundState
-	initialHeight int64 // under rsMtx
+	rsMtx cmtsync.Mutex
+	rs    *cstypes.RoundState
 
 	Metrics *Metrics
 }
@@ -268,9 +267,9 @@ func (conR *Reactor) Receive(e p2p.Envelope) {
 	case StateChannel:
 		switch msg := msg.(type) {
 		case *NewRoundStepMessage:
-			conR.rsMtx.RLock()
-			initialHeight := conR.initialHeight
-			conR.rsMtx.RUnlock()
+			conR.conS.mtx.RLock()
+			initialHeight := conR.conS.state.InitialHeight
+			conR.conS.mtx.RUnlock()
 			if err = msg.ValidateHeight(initialHeight); err != nil {
 				conR.Logger.Error("Peer sent us invalid msg", "peer", e.Src, "msg", msg, "err", err)
 				conR.Switch.StopPeerForError(e.Src, err)
@@ -284,9 +283,10 @@ func (conR *Reactor) Receive(e p2p.Envelope) {
 		case *HasProposalBlockPartMessage:
 			ps.ApplyHasProposalBlockPartMessage(msg)
 		case *VoteSetMaj23Message:
-			conR.rsMtx.RLock()
-			height, votes := conR.rs.Height, conR.rs.Votes
-			conR.rsMtx.RUnlock()
+			cs := conR.conS
+			cs.mtx.RLock()
+			height, votes := cs.Height, cs.Votes
+			cs.mtx.RUnlock()
 			if height != msg.Height {
 				return
 			}
@@ -351,10 +351,9 @@ func (conR *Reactor) Receive(e p2p.Envelope) {
 		switch msg := msg.(type) {
 		case *VoteMessage:
 			cs := conR.conS
-
-			conR.rsMtx.RLock()
-			height, valSize, lastCommitSize := conR.rs.Height, conR.rs.Validators.Size(), conR.rs.LastCommit.Size()
-			conR.rsMtx.RUnlock()
+			cs.mtx.RLock()
+			height, valSize, lastCommitSize := cs.Height, cs.Validators.Size(), cs.LastCommit.Size()
+			cs.mtx.RUnlock()
 			ps.SetHasVoteFromPeer(msg.Vote, height, valSize, lastCommitSize)
 
 			cs.peerMsgQueue <- msgInfo{msg, e.Src.ID(), time.Time{}}
@@ -371,9 +370,10 @@ func (conR *Reactor) Receive(e p2p.Envelope) {
 		}
 		switch msg := msg.(type) {
 		case *VoteSetBitsMessage:
-			conR.rsMtx.RLock()
-			height, votes := conR.rs.Height, conR.rs.Votes
-			conR.rsMtx.RUnlock()
+			cs := conR.conS
+			cs.mtx.RLock()
+			height, votes := cs.Height, cs.Votes
+			cs.mtx.RUnlock()
 
 			if height == msg.Height {
 				var ourVotes *bits.BitArray
@@ -420,7 +420,6 @@ func (conR *Reactor) subscribeToBroadcastEvents() {
 	if err := conR.conS.evsw.AddListenerForEvent(subscriber, types.EventNewRoundStep,
 		func(data cmtevents.EventData) {
 			conR.broadcastNewRoundStepMessage(data.(*cstypes.RoundState))
-			conR.updateRoundStateNoCsLock()
 		}); err != nil {
 		conR.Logger.Error("Error adding listener for events (NewRoundStep)", "err", err)
 	}
@@ -435,7 +434,6 @@ func (conR *Reactor) subscribeToBroadcastEvents() {
 	if err := conR.conS.evsw.AddListenerForEvent(subscriber, types.EventVote,
 		func(data cmtevents.EventData) {
 			conR.broadcastHasVoteMessage(data.(*types.Vote))
-			conR.updateRoundStateNoCsLock()
 		}); err != nil {
 		conR.Logger.Error("Error adding listener for events (Vote)", "err", err)
 	}
@@ -443,7 +441,6 @@ func (conR *Reactor) subscribeToBroadcastEvents() {
 	if err := conR.conS.evsw.AddListenerForEvent(subscriber, types.EventProposalBlockPart,
 		func(data cmtevents.EventData) {
 			conR.broadcastHasProposalBlockPartMessage(data.(*BlockPartMessage))
-			conR.updateRoundStateNoCsLock()
 		}); err != nil {
 		conR.Logger.Error("Error adding listener for events (ProposalBlockPart)", "err", err)
 	}
@@ -567,14 +564,6 @@ func (conR *Reactor) updateRoundStateRoutine() {
 		conR.rs = rs
 		conR.rsMtx.Unlock()
 	}
-}
-
-func (conR *Reactor) updateRoundStateNoCsLock() {
-	rs := conR.conS.getRoundState()
-	conR.rsMtx.Lock()
-	conR.rs = rs
-	conR.initialHeight = conR.conS.state.InitialHeight
-	conR.rsMtx.Unlock()
 }
 
 func (conR *Reactor) getRoundState() *cstypes.RoundState {

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -248,18 +248,10 @@ func (cs *State) GetLastHeight() int64 {
 }
 
 // GetRoundState returns a shallow copy of the internal consensus state.
-// This function is thread-safe.
 func (cs *State) GetRoundState() *cstypes.RoundState {
 	cs.mtx.RLock()
-	rs := cs.getRoundState()
-	cs.mtx.RUnlock()
-	return rs
-}
-
-// getRoundState returns a shallow copy of the internal consensus state.
-// This function is not thread-safe. Use GetRoundState for the thread-safe version.
-func (cs *State) getRoundState() *cstypes.RoundState {
 	rs := cs.RoundState // copy
+	cs.mtx.RUnlock()
 	return &rs
 }
 


### PR DESCRIPTION
This PR reverts #3211 since it is making the e2e nightly to fail in reproducible ways. This PR was identified as the reason for the recent e2e nightly failure on `main` and doing a bi-sect test of all recent commits it was determined that this PR introduced a behavior that makes the tests to fail and indicate a bug or unknown behavior has been introduced. 

Even though we are reverting this logic for now, we'd be happy to consider it in the future again once more tests are performed and we can ensure it passes all tests.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
