### PR TITLE
perf(blockstore)!: Cache more in blockstore, which speedsup the gossip routines

### DIFF
--- a/.changelog/unreleased/improvements/3342-improve-blockstore-caches.md
+++ b/.changelog/unreleased/improvements/3342-improve-blockstore-caches.md
@@ -1,0 +1,3 @@
+- `[blockstore]` Use LRU caches for LoadBlockPart. Make the LoadBlockPart and LoadBlockCommit APIs 
+    return mutative copies, that the caller is expected to not modify. This saves on memory copying.
+  ([\#3342](https://github.com/cometbft/cometbft/issues/3342))

--- a/store/store.go
+++ b/store/store.go
@@ -530,14 +530,17 @@ func (bs *BlockStore) PruneBlocks(height int64, state sm.State) (uint64, int64, 
 			if err := batch.Delete(bs.dbKeyLayout.CalcBlockCommitKey(h)); err != nil {
 				return 0, -1, err
 			}
+			bs.blockCommitCache.Remove(h)
 		}
 		if err := batch.Delete(bs.dbKeyLayout.CalcSeenCommitKey(h)); err != nil {
 			return 0, -1, err
 		}
+		bs.seenCommitCache.Remove(h)
 		for p := 0; p < int(meta.BlockID.PartSetHeader.Total); p++ {
 			if err := batch.Delete(bs.dbKeyLayout.CalcBlockPartKey(h, p)); err != nil {
 				return 0, -1, err
 			}
+			bs.blockPartCache.Remove(blockPartIndex{h, p})
 		}
 		pruned++
 


### PR DESCRIPTION
We speedup the gossip routines by using caches for LoadBlockPart, and making LoadBlockCommit no longer call Clone, as the caller does read-only operations to it.

This is a followup to https://github.com/cometbft/cometbft/pull/3003

This results in a net performance improvement, based on a 2hr sync on latest osmosis release, of:
- 20% less RAM allocated over program lifetime. (76GB no longer allocated, 380 GB alloc total)
- 50% speedup to gossipDataRoutine
- ~10% speedup to gossipVotesRoutine
- 1% less overall system CPU usage. (If GC proportional to bytes allocated, then 5% less)

I have checked that every usage of `LoadBlockPart` and `LoadBlockCommit` do not modify the return value, so returning this underlying cache copy is safe for the current codebase

I used an `!` in the title, since this is technically API breaking, even though all current usages are safe.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
