### PR TITLE
test(e2e): add option to the 'runner logs' command to output logs separately

### DIFF
--- a/.changelog/unreleased/improvements/3353-e2e-runner-split-logs.md
+++ b/.changelog/unreleased/improvements/3353-e2e-runner-split-logs.md
@@ -1,0 +1,2 @@
+- `[e2e]` add option to the 'runner logs' command to output logs separately.
+  ([\#3353](https://github.com/cometbft/cometbft/pull/3353))

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -129,7 +129,7 @@ The test runner has the following stages, which can also be executed explicitly 
 
 Auxiliary commands:
 
-* `logs`: outputs all node logs.
+* `logs`: outputs all node logs (specify `--split` to output individual logs).
 
 * `tail`: tails (follows) node logs until canceled.
 

--- a/test/e2e/runner/main.go
+++ b/test/e2e/runner/main.go
@@ -287,11 +287,10 @@ func NewCLI() *CLI {
 	var splitLogs bool
 	logCmd := &cobra.Command{
 		Use:   "logs",
-		Short: "Shows the testnet logs",
+		Short: "Shows the testnet logs. Use `--split` to split logs into separate files",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			splitLogs, _ = cmd.Flags().GetBool("split")
 			if splitLogs {
-				fmt.Println("Output separate logs for each node")
 				for _, node := range cli.testnet.Nodes {
 					fmt.Println("Log for", node.Name)
 					err := docker.ExecComposeVerbose(context.Background(), cli.testnet.Dir, "logs", node.Name)
@@ -301,7 +300,6 @@ func NewCLI() *CLI {
 				}
 				return nil
 			}
-			fmt.Println("Output combined log for all nodes")
 			return docker.ExecComposeVerbose(context.Background(), cli.testnet.Dir, "logs")
 		},
 	}


### PR DESCRIPTION
When conducting end-to-end testing, it can be difficult to effectively analyze or visualize the output of docker logs when all the containers are merged into a single log file.

To address this issue, I have introduced a new parameter (`--split`) to the runner `logs` command. When this parameter is used, the command will output the log for each container separately.

Having separate logs makes it much easier to troubleshoot individual containers, particularly when the log output is extensive and detailed. This feature boosts efficiency by simplifying the process of identifying the root cause of failures.

Usage:
```sh
 ./build/runner logs -f ./networks/simple.toml --split
```
#### PR checklist

- [ ] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
