### PR TITLE
fix(rpc): fix nil pointer error in `/tx` and `/tx_search`

### DIFF
--- a/.changelog/unreleased/bug-fixes/3352-nil-pointer-tx-search.md
+++ b/.changelog/unreleased/bug-fixes/3352-nil-pointer-tx-search.md
@@ -1,0 +1,2 @@
+- `[rpc]` Fix nil pointer error in `/tx` and `/tx_search` when block is
+  absent ([\#3352](https://github.com/cometbft/cometbft/issues/3352))

--- a/rpc/core/tx.go
+++ b/rpc/core/tx.go
@@ -36,7 +36,9 @@ func (env *Environment) Tx(_ *rpctypes.Context, hash []byte, prove bool) (*ctype
 	var proof types.TxProof
 	if prove {
 		block, _ := env.BlockStore.LoadBlock(r.Height)
-		proof = block.Data.Txs.Proof(int(r.Index))
+		if block != nil {
+			proof = block.Data.Txs.Proof(int(r.Index))
+		}
 	}
 
 	return &ctypes.ResultTx{
@@ -101,7 +103,9 @@ func (env *Environment) TxSearch(
 		var proof types.TxProof
 		if prove {
 			block, _ := env.BlockStore.LoadBlock(r.Height)
-			proof = block.Data.Txs.Proof(int(r.Index))
+			if block != nil {
+				proof = block.Data.Txs.Proof(int(r.Index))
+			}
 		}
 
 		apiResults = append(apiResults, &ctypes.ResultTx{


### PR DESCRIPTION
when block is absent
Closes #3352

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] ~~Tests written/updated~~
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] ~~Updated relevant documentation (`docs/` or `spec/`) and code comments~~
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
