### PR TITLE
refactor(mempool)!: remove PreUpdate from Mempool interface and move its logic to Lock

### DIFF
--- a/.changelog/unreleased/breaking-changes/3363-remove-mempool-preupdate.md
+++ b/.changelog/unreleased/breaking-changes/3363-remove-mempool-preupdate.md
@@ -1,0 +1,4 @@
+- `[mempool]` Revert adding the method `PreUpdate()` to the `Mempool` interface, recently introduced
+  in the previous patch release. Its logic is now moved into the `Lock` method. With this change,
+  the `Mempool` interface is the same as before the previous patch.
+  ([\#3363](https://github.com/cometbft/cometbft/pull/3363))

--- a/blocksync/reactor_test.go
+++ b/blocksync/reactor_test.go
@@ -86,7 +86,6 @@ func newReactor(
 	mp := &mpmocks.Mempool{}
 	mp.On("Lock").Return()
 	mp.On("Unlock").Return()
-	mp.On("PreUpdate").Return()
 	mp.On("FlushAppConn", mock.Anything).Return(nil)
 	mp.On("Update",
 		mock.Anything,

--- a/consensus/replay_stubs.go
+++ b/consensus/replay_stubs.go
@@ -17,7 +17,6 @@ var _ mempl.Mempool = emptyMempool{}
 
 func (emptyMempool) Lock()            {}
 func (emptyMempool) Unlock()          {}
-func (emptyMempool) PreUpdate()       {}
 func (emptyMempool) Size() int        { return 0 }
 func (emptyMempool) SizeBytes() int64 { return 0 }
 func (emptyMempool) CheckTx(_ types.Tx, _ func(*abci.Response), _ mempl.TxInfo) error {

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -53,6 +53,8 @@ type Mempool interface {
 
 	// Lock locks the mempool. The consensus must be able to hold lock to safely
 	// update.
+	// Before acquiring the lock, it signals the mempool that a new update is coming.
+	// If the mempool is still rechecking at this point, it should be considered full.
 	Lock()
 
 	// Unlock unlocks the mempool.

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -58,10 +58,6 @@ type Mempool interface {
 	// Unlock unlocks the mempool.
 	Unlock()
 
-	// PreUpdate signals that a new update is coming, before acquiring the mempool lock.
-	// If the mempool is still rechecking at this point, it should be considered full.
-	PreUpdate()
-
 	// Update informs the mempool that the given txs were committed and can be
 	// discarded.
 	//

--- a/mempool/mocks/mempool.go
+++ b/mempool/mocks/mempool.go
@@ -59,11 +59,6 @@ func (_m *Mempool) Lock() {
 	_m.Called()
 }
 
-// PreUpdate provides a mock function with given fields:
-func (_m *Mempool) PreUpdate() {
-	_m.Called()
-}
-
 // ReapMaxBytesMaxGas provides a mock function with given fields: maxBytes, maxGas
 func (_m *Mempool) ReapMaxBytesMaxGas(maxBytes int64, maxGas int64) types.Txs {
 	ret := _m.Called(maxBytes, maxGas)

--- a/mempool/nop_mempool.go
+++ b/mempool/nop_mempool.go
@@ -40,8 +40,6 @@ func (*NopMempool) Lock() {}
 // Unlock does nothing.
 func (*NopMempool) Unlock() {}
 
-func (*NopMempool) PreUpdate() {}
-
 // Update does nothing.
 func (*NopMempool) Update(
 	int64,

--- a/mempool/v0/clist_mempool.go
+++ b/mempool/v0/clist_mempool.go
@@ -134,21 +134,19 @@ func WithMetrics(metrics *mempool.Metrics) CListMempoolOption {
 
 // Safe for concurrent use by multiple goroutines.
 func (mem *CListMempool) Lock() {
+	// Prepare for Update by setting recheckFull
+	rechecking := mem.isRechecking.Load()
+	recheckFull := mem.recheckFull.Swap(rechecking)
+	if rechecking != recheckFull {
+		mem.logger.Debug("the state of recheckFull has flipped")
+	}
+
 	mem.updateMtx.Lock()
 }
 
 // Safe for concurrent use by multiple goroutines.
 func (mem *CListMempool) Unlock() {
 	mem.updateMtx.Unlock()
-}
-
-// Safe for concurrent use by multiple goroutines.
-func (mem *CListMempool) PreUpdate() {
-	rechecking := mem.isRechecking.Load()
-	recheckFull := mem.recheckFull.Swap(rechecking)
-	if rechecking != recheckFull {
-		mem.logger.Debug("the state of recheckFull has flipped")
-	}
 }
 
 // Safe for concurrent use by multiple goroutines.

--- a/mempool/v0/reactor_test.go
+++ b/mempool/v0/reactor_test.go
@@ -96,7 +96,6 @@ func TestReactorConcurrency(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
-			reactors[0].mempool.PreUpdate()
 			reactors[0].mempool.Lock()
 			defer reactors[0].mempool.Unlock()
 
@@ -114,7 +113,6 @@ func TestReactorConcurrency(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
-			reactors[1].mempool.PreUpdate()
 			reactors[1].mempool.Lock()
 			defer reactors[1].mempool.Unlock()
 			err := reactors[1].mempool.Update(1, []types.Tx{}, make([]*abci.ResponseDeliverTx, 0), nil, nil)

--- a/mempool/v1/mempool.go
+++ b/mempool/v1/mempool.go
@@ -117,9 +117,6 @@ func (txmp *TxMempool) Lock() { txmp.mtx.Lock() }
 // Unlock releases a write-lock on the mempool.
 func (txmp *TxMempool) Unlock() { txmp.mtx.Unlock() }
 
-// PreUpdate does nothing on the v1 mempool
-func (txmp *TxMempool) PreUpdate() {}
-
 // Size returns the number of valid transactions in the mempool. It is
 // thread-safe.
 func (txmp *TxMempool) Size() int { return txmp.txs.Len() }

--- a/state/execution.go
+++ b/state/execution.go
@@ -285,7 +285,6 @@ func (blockExec *BlockExecutor) Commit(
 	block *types.Block,
 	deliverTxResponses []*abci.ResponseDeliverTx,
 ) ([]byte, int64, error) {
-	blockExec.mempool.PreUpdate()
 	blockExec.mempool.Lock()
 	defer blockExec.mempool.Unlock()
 

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -50,7 +50,6 @@ func TestApplyBlock(t *testing.T) {
 	mp := &mpmocks.Mempool{}
 	mp.On("Lock").Return()
 	mp.On("Unlock").Return()
-	mp.On("PreUpdate").Return()
 	mp.On("FlushAppConn", mock.Anything).Return(nil)
 	mp.On("Update",
 		mock.Anything,
@@ -223,7 +222,6 @@ func TestBeginBlockByzantineValidators(t *testing.T) {
 	mp := &mpmocks.Mempool{}
 	mp.On("Lock").Return()
 	mp.On("Unlock").Return()
-	mp.On("PreUpdate").Return()
 	mp.On("FlushAppConn", mock.Anything).Return(nil)
 	mp.On("Update",
 		mock.Anything,
@@ -480,7 +478,6 @@ func TestEndBlockValidatorUpdates(t *testing.T) {
 	mp := &mpmocks.Mempool{}
 	mp.On("Lock").Return()
 	mp.On("Unlock").Return()
-	mp.On("PreUpdate").Return()
 	mp.On("FlushAppConn", mock.Anything).Return(nil)
 	mp.On("Update",
 		mock.Anything,
@@ -607,7 +604,6 @@ func TestEmptyPrepareProposal(t *testing.T) {
 	mp := &mpmocks.Mempool{}
 	mp.On("Lock").Return()
 	mp.On("Unlock").Return()
-	mp.On("PreUpdate").Return()
 	mp.On("FlushAppConn", mock.Anything).Return(nil)
 	mp.On("Update",
 		mock.Anything,

--- a/state/validation_test.go
+++ b/state/validation_test.go
@@ -35,7 +35,6 @@ func TestValidateBlockHeader(t *testing.T) {
 	mp := &mpmocks.Mempool{}
 	mp.On("Lock").Return()
 	mp.On("Unlock").Return()
-	mp.On("PreUpdate").Return()
 	mp.On("FlushAppConn", mock.Anything).Return(nil)
 	mp.On("Update",
 		mock.Anything,
@@ -121,7 +120,6 @@ func TestValidateBlockCommit(t *testing.T) {
 	mp := &mpmocks.Mempool{}
 	mp.On("Lock").Return()
 	mp.On("Unlock").Return()
-	mp.On("PreUpdate").Return()
 	mp.On("FlushAppConn", mock.Anything).Return(nil)
 	mp.On("Update",
 		mock.Anything,
@@ -261,7 +259,6 @@ func TestValidateBlockEvidence(t *testing.T) {
 	mp := &mpmocks.Mempool{}
 	mp.On("Lock").Return()
 	mp.On("Unlock").Return()
-	mp.On("PreUpdate").Return()
 	mp.On("FlushAppConn", mock.Anything).Return(nil)
 	mp.On("Update",
 		mock.Anything,


### PR DESCRIPTION
Complements #3361 

This PR partially reverts the backport of https://github.com/cometbft/cometbft/pull/3314 into the recently released v0.37.7. With this change the Mempool interface is the same as in previous versions.

The reason is that we do not want to break the public API. We still keep in the code the feature that https://github.com/cometbft/cometbft/pull/3314 introduced by moving it inside the existing Lock method. We also keep the RecheckFull bool field that we added to ErrMempoolIsFull.

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
