### PR TITLE
perf(p2p): Only update send monitor once per batch packet msg send

### DIFF
--- a/.changelog/unreleased/improvements/3382-single-send-monitor-per-packet.md
+++ b/.changelog/unreleased/improvements/3382-single-send-monitor-per-packet.md
@@ -1,2 +1,2 @@
-- `p2p` perf(p2p): Only update send monitor once per batch packet msg send
+- `[p2p]` Only update send monitor once per batch packet msg send
   ([\#3382](https://github.com/cometbft/cometbft/pull/3382))

--- a/.changelog/unreleased/improvements/3382-single-send-monitor-per-packet.md
+++ b/.changelog/unreleased/improvements/3382-single-send-monitor-per-packet.md
@@ -1,2 +1,2 @@
-- `[p2p]` Only update send monitor once per batch packet msg send
+- `[p2p/conn]` Update send monitor, used for sending rate limiting, once per batch of packets sent
   ([\#3382](https://github.com/cometbft/cometbft/pull/3382))

--- a/.changelog/unreleased/improvements/3382-single-send-monitor-per-packet.md
+++ b/.changelog/unreleased/improvements/3382-single-send-monitor-per-packet.md
@@ -1,0 +1,2 @@
+- `p2p` perf(p2p): Only update send monitor once per batch packet msg send
+  ([\#3382](https://github.com/cometbft/cometbft/pull/3382))

--- a/p2p/conn/connection.go
+++ b/p2p/conn/connection.go
@@ -522,6 +522,11 @@ func (c *MConnection) sendSomePacketMsgs(w protoio.Writer) bool {
 func (c *MConnection) sendBatchPacketMsgs(w protoio.Writer, batchSize int) bool {
 	// Send a batch of PacketMsgs.
 	totalBytesWritten := 0
+	defer func() {
+		if totalBytesWritten > 0 {
+			c.sendMonitor.Update(totalBytesWritten)
+		}
+	}()
 	for i := 0; i < batchSize; i++ {
 		channel := selectChannelToGossipOn(c.channels)
 		// nothing to send across any channel.

--- a/p2p/conn/connection.go
+++ b/p2p/conn/connection.go
@@ -539,7 +539,6 @@ func (c *MConnection) sendBatchPacketMsgs(w protoio.Writer, batchSize int) bool 
 		}
 		totalBytesWritten += bytesWritten
 	}
-	c.sendMonitor.Update(totalBytesWritten)
 	return false
 }
 
@@ -579,7 +578,7 @@ func (c *MConnection) sendPacketMsgOnChannel(w protoio.Writer, sendChannel *Chan
 		c.stopForError(err)
 		return n, true
 	}
-	// TODO: Change this to only do one update for the entire bawtch.
+	// TODO: Change this to only add flush signals at the start and end of the batch.
 	c.flushTimer.Set()
 	return n, false
 }

--- a/p2p/conn/connection.go
+++ b/p2p/conn/connection.go
@@ -568,15 +568,15 @@ func selectChannelToGossipOn(channels []*Channel) *Channel {
 // returns (num_bytes_written, error_occurred).
 func (c *MConnection) sendPacketMsgOnChannel(w protoio.Writer, sendChannel *Channel) (int, bool) {
 	// Make & send a PacketMsg from this channel
-	_n, err := sendChannel.writePacketMsgTo(w)
+	n, err := sendChannel.writePacketMsgTo(w)
 	if err != nil {
 		c.Logger.Error("Failed to write PacketMsg", "err", err)
 		c.stopForError(err)
-		return _n, true
+		return n, true
 	}
 	// TODO: Change this to only do one update for the entire bawtch.
 	c.flushTimer.Set()
-	return _n, false
+	return n, false
 }
 
 // recvRoutine reads PacketMsgs and reconstructs the message using the channels' "recving" buffer.

--- a/p2p/conn/connection.go
+++ b/p2p/conn/connection.go
@@ -565,7 +565,7 @@ func selectChannelToGossipOn(channels []*Channel) *Channel {
 	return leastChannel
 }
 
-// returns (num_bytes_written, error_occurred)
+// returns (num_bytes_written, error_occurred).
 func (c *MConnection) sendPacketMsgOnChannel(w protoio.Writer, sendChannel *Channel) (int, bool) {
 	// Make & send a PacketMsg from this channel
 	_n, err := sendChannel.writePacketMsgTo(w)

--- a/p2p/conn/connection.go
+++ b/p2p/conn/connection.go
@@ -521,17 +521,20 @@ func (c *MConnection) sendSomePacketMsgs(w protoio.Writer) bool {
 // Returns true if messages from channels were exhausted.
 func (c *MConnection) sendBatchPacketMsgs(w protoio.Writer, batchSize int) bool {
 	// Send a batch of PacketMsgs.
+	totalBytesWritten := 0
 	for i := 0; i < batchSize; i++ {
 		channel := selectChannelToGossipOn(c.channels)
 		// nothing to send across any channel.
 		if channel == nil {
 			return true
 		}
-		err := c.sendPacketMsgOnChannel(w, channel)
+		bytesWritten, err := c.sendPacketMsgOnChannel(w, channel)
 		if err {
 			return true
 		}
+		totalBytesWritten += bytesWritten
 	}
+	c.sendMonitor.Update(totalBytesWritten)
 	return false
 }
 
@@ -562,18 +565,18 @@ func selectChannelToGossipOn(channels []*Channel) *Channel {
 	return leastChannel
 }
 
-func (c *MConnection) sendPacketMsgOnChannel(w protoio.Writer, sendChannel *Channel) bool {
+// returns (num_bytes_written, error_occurred)
+func (c *MConnection) sendPacketMsgOnChannel(w protoio.Writer, sendChannel *Channel) (int, bool) {
 	// Make & send a PacketMsg from this channel
 	_n, err := sendChannel.writePacketMsgTo(w)
 	if err != nil {
 		c.Logger.Error("Failed to write PacketMsg", "err", err)
 		c.stopForError(err)
-		return true
+		return _n, true
 	}
 	// TODO: Change this to only do one update for the entire bawtch.
-	c.sendMonitor.Update(_n)
 	c.flushTimer.Set()
-	return false
+	return _n, false
 }
 
 // recvRoutine reads PacketMsgs and reconstructs the message using the channels' "recving" buffer.


### PR DESCRIPTION
Small optimization to outbound packet gossip, I expect this to be a 1-2% speedup to outbound packet gossip as is right now. Will test on mainnet soon

This is safe as outbound packet gossip is single threaded per peer as is right now. Technically makes the send monitor marginally less real time, but this is irrelevant as the send monitor works on 20ms sliding windows anyway

---

#### PR checklist

- [ ] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
