### PR TITLE
docs: update release doc to include Buf publish instructions

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -174,8 +174,8 @@ backport branch (see above). Otherwise:
    * `git push origin api/v2.0.0-rc1`
    * Notice the prefix `api/`, which denotes that the version refers to the `api` module.
 5. Prepare the versioning:
-   * Bump CometBFT version in  `version.go`
-   * Bump P2P and block protocol versions in  `version.go`, if necessary.
+   * Bump CometBFT version in `version.go`
+   * Bump P2P and block protocol versions in `version.go`, if necessary.
      Check the changelog for breaking changes in these components.
    * Bump ABCI protocol version in `version.go`, if necessary
 6. Open a PR with these changes against the backport branch.
@@ -188,6 +188,8 @@ backport branch (see above). Otherwise:
    `git push origin v2.0.0-rc1`
    Now the tag should be available on the repo's releases page.
 10. Future pre-releases will continue to be built off of this branch.
+11. [Publish the proto changes](#publish-protos-to-the-buf-schema-registry) to the `Buf` schema registry `comet/comet`
+repository (if necessary).
 
 ## Major release
 
@@ -226,6 +228,8 @@ Before performing these steps, be sure the
    * `git push origin v2.0.0`
 6. Make sure that `main` is updated with the latest `CHANGELOG.md`,
    `CHANGELOG_PENDING.md`, and `UPGRADING.md`.
+7. [Publish the proto changes](#publish-protos-to-the-buf-schema-registry) to the `Buf` schema registry `comet/comet`
+repository (if necessary).
 
 ## Minor and patch releases
 
@@ -270,6 +274,8 @@ To create a patch release:
 6. Create a pull request back to main with the CHANGELOG and version changes
    from the latest release.
    * Do not merge the backport branch into main.
+7. [Publish the proto changes](#publish-protos-to-the-buf-schema-registry) to the `Buf` schema registry `comet/comet`
+    repository (if necessary).
 
 After the release of `v1.0.0`, the backport branch is named `v1.x`. Any future minor or patch releases will be cut
 from the `v1.x` branch. There won't be a separate backport branch for minor releases, so there won't be a `v1.1.x` backport branch.
@@ -426,6 +432,45 @@ of 150 validators is configured to only possess a cumulative stake of 67% of the
 total stake. The remaining 33% of the stake is configured to belong to a
 validator that is never actually run in the test network. The network is run for
 multiple days, ensuring that it is able to produce blocks without issue.
+
+## Publish protos to the Buf schema registry
+
+For each release, if necessary, publish the proto changes to the `Buf` schema registry `comet/comet` repository.
+
+* Install the `buf` tool:
+    * If you don't have the `buf` tool installed on your machine, please refer to the [Buf docs](https://buf.build/docs/installation)
+      in order to learn how to install it.
+* Ensure you have access to `Buf` and that you can login and publish files:
+    * Go to [Buf schema registry](https://buf.build/)
+    * Click on `Sign in`. If you don't have an account, please create one.
+    * Once you sign in, click on your username (top right), and in the dropdown menu select `Organizations`.
+    * Ensure that you can see `cometbft` under Organizations and it shows `Writer` role on the right side.
+    * If you can't see `cometbft` or you don't see the `Writer` role, please reach out to one of the CometBFT team members who have
+      admin access in Buf for the `cometbft` organization so they can grant you the right permissions.
+    * If you see `cometbft` and have `Writer` role, login in Buf via terminal:
+        - `buf registry login`
+    * When prompted for the username, type it and hit enter. It will ask for a `token` next.
+    * Go back to the Buf website and click on your username, and select `Settings`.
+    * Click on `Create new token`, add a name and select an expiry date.
+    * Once the token is created, copy the token code from the website and paste it on the terminal and hit enter. You
+      should see a message saying `Credentials saved ...`
+* Publish the files:
+    * Checkout the new release that was tagged:
+        - `git checkout v2.0.0-rc1`
+    * Change to the proto directory:
+        - `cd proto`
+    * Lint the protos:
+        - `buf lint`
+    * Update the dependencies:
+        - `buf dep update`
+    * Build the files
+        - `buf build`
+    * Push the files to the registry. This will publish a commit to the Buf registry using the last
+      commit checksum from the release.
+        - `buf push --tag "$(git rev-parse HEAD)"`
+    * Go to the `Commits` section for the `cometbft/cometbft` repository and ensure that you
+      can see commit just [published there](https://buf.build/cometbft/cometbft/commits).
+    * All set, the Buf registry now hosts the [latest proto files](https://buf.build/cometbft/cometbft) in the `cometbft/cometbft` repository.
 
 [unclog]: https://github.com/informalsystems/unclog
 [unclog-release]: https://github.com/informalsystems/unclog#releasing-a-new-versions-change-set

--- a/proto/README.md
+++ b/proto/README.md
@@ -21,7 +21,8 @@ parts of [CometBFT]:
 
 The canonical Protobuf definitions live in the `proto` folder of the relevant
 release branch of CometBFT. These definitions are published to the [Buf
-registry][buf] for integrators' convenience.
+registry][buf] for integrators' convenience. For detailed instructions on how to publish
+the files to the Buf registry, please refer to the [RELEASES.md](../RELEASES.md) document.
 
 The Protobuf files are organized under two domains: `cometbft` and `tendermint`.
 The `cometbft.*` packages use version suffixes to let application developers


### PR DESCRIPTION
Close: #3388 

This PR adds detailed instructions to the `RELEASES.doc` related to the publishing of proto files to the Buf schema registry. 

#### PR checklist

~~- [ ] Tests written/updated~~
~~- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)~~
- [X] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [X] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
