### PR TITLE
fix(blocksync)!: don't block in blocksync if our voting power is blocking the chain

### DIFF
--- a/.changelog/unreleased/bug-fixes/3406-blocksync-dont-stall-if-blocking-chain.md
+++ b/.changelog/unreleased/bug-fixes/3406-blocksync-dont-stall-if-blocking-chain.md
@@ -1,0 +1,3 @@
+- `[blocksync]` Do not stay in blocksync if the local node's voting power
+  is big enough to block the chain while not online
+  ([\#3406](https://github.com/cometbft/cometbft/pull/3406))

--- a/.changelog/unreleased/bug-fixes/3406-blocksync-dont-stall-if-blocking-chain.md
+++ b/.changelog/unreleased/bug-fixes/3406-blocksync-dont-stall-if-blocking-chain.md
@@ -1,3 +1,3 @@
-- `[blocksync]` Do not stay in blocksync if the local node's voting power
-  is big enough to block the chain while not online
+- `[blocksync]` Do not stay in blocksync if the node's validator voting power
+  is high enough to block the chain while it is not online
   ([\#3406](https://github.com/cometbft/cometbft/pull/3406))

--- a/internal/blocksync/pool.go
+++ b/internal/blocksync/pool.go
@@ -7,13 +7,11 @@ import (
 	"sort"
 	"time"
 
-	"github.com/cometbft/cometbft/crypto"
 	flow "github.com/cometbft/cometbft/internal/flowrate"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/libs/service"
 	cmtsync "github.com/cometbft/cometbft/libs/sync"
 	"github.com/cometbft/cometbft/p2p"
-	sm "github.com/cometbft/cometbft/state"
 	"github.com/cometbft/cometbft/types"
 )
 
@@ -177,16 +175,6 @@ func (pool *BlockPool) removeTimedoutPeers() {
 	}
 
 	pool.sortPeers()
-}
-
-func weBlockTheChain(state sm.State, myAddr crypto.Address) bool {
-	_, val := state.Validators.GetByAddress(myAddr)
-	if val == nil {
-		return false
-	}
-	total := state.Validators.TotalVotingPower()
-	power := val.VotingPower
-	return power > total*2/3
 }
 
 // IsCaughtUp returns true if this node is caught up, false - otherwise.

--- a/internal/blocksync/pool.go
+++ b/internal/blocksync/pool.go
@@ -191,13 +191,9 @@ func weBlockTheChain(state sm.State, myAddr crypto.Address) bool {
 
 // IsCaughtUp returns true if this node is caught up, false - otherwise.
 // TODO: relax conditions, prevent abuse.
-func (pool *BlockPool) IsCaughtUp(state sm.State, myAddr crypto.Address) (isCaughtUp bool, height, maxPeerHeight int64) {
+func (pool *BlockPool) IsCaughtUp() (isCaughtUp bool, height, maxPeerHeight int64) {
 	pool.mtx.Lock()
 	defer pool.mtx.Unlock()
-
-	if weBlockTheChain(state, myAddr) {
-		return true, pool.height, pool.maxPeerHeight
-	}
 
 	// Need at least 1 peer to be considered caught up.
 	if len(pool.peers) == 0 {

--- a/internal/blocksync/reactor.go
+++ b/internal/blocksync/reactor.go
@@ -512,7 +512,7 @@ func (bcR *Reactor) localNodeBlocksTheChain(state sm.State) bool {
 		return false
 	}
 	total := state.Validators.TotalVotingPower()
-	return val.VotingPower > total*2/3
+	return val.VotingPower >= total/3
 }
 
 func (bcR *Reactor) isCaughtUp(state sm.State, blocksSynced uint64, stateSynced bool) bool {

--- a/internal/blocksync/reactor.go
+++ b/internal/blocksync/reactor.go
@@ -512,8 +512,7 @@ func (bcR *Reactor) localNodeBlocksTheChain(state sm.State) bool {
 		return false
 	}
 	total := state.Validators.TotalVotingPower()
-	power := val.VotingPower
-	return power > total*2/3
+	return val.VotingPower > total*2/3
 }
 
 func (bcR *Reactor) isCaughtUp(state sm.State, blocksSynced uint64, stateSynced bool) bool {

--- a/internal/blocksync/reactor.go
+++ b/internal/blocksync/reactor.go
@@ -62,7 +62,7 @@ type Reactor struct {
 	store         sm.BlockStore
 	pool          *BlockPool
 	blockSync     bool
-	myAddr        crypto.Address
+	localAddr     crypto.Address
 	poolRoutineWg sync.WaitGroup
 
 	requestsCh <-chan BlockRequest
@@ -75,7 +75,7 @@ type Reactor struct {
 
 // NewReactor returns new reactor instance.
 func NewReactor(state sm.State, blockExec *sm.BlockExecutor, store *store.BlockStore,
-	blockSync bool, myAddr crypto.Address, metrics *Metrics, offlineStateSyncHeight int64,
+	blockSync bool, localAddr crypto.Address, metrics *Metrics, offlineStateSyncHeight int64,
 ) *Reactor {
 	storeHeight := store.Height()
 	if storeHeight == 0 {
@@ -111,7 +111,7 @@ func NewReactor(state sm.State, blockExec *sm.BlockExecutor, store *store.BlockS
 		store:        store,
 		pool:         pool,
 		blockSync:    blockSync,
-		myAddr:       myAddr,
+		localAddr:    localAddr,
 		requestsCh:   requestsCh,
 		errorsCh:     errorsCh,
 		metrics:      metrics,
@@ -507,7 +507,7 @@ func (bcR *Reactor) isMissingExtension(state sm.State, blocksSynced uint64) bool
 }
 
 func (bcR *Reactor) localNodeBlocksTheChain(state sm.State) bool {
-	_, val := state.Validators.GetByAddress(bcR.myAddr)
+	_, val := state.Validators.GetByAddress(bcR.localAddr)
 	if val == nil {
 		return false
 	}

--- a/internal/blocksync/reactor.go
+++ b/internal/blocksync/reactor.go
@@ -408,7 +408,7 @@ FOR_LOOP:
 			blocksSynced++
 
 			if blocksSynced%100 == 0 {
-				_, height, maxPeerHeight := bcR.pool.IsCaughtUp(state, bcR.myAddr)
+				_, height, maxPeerHeight := bcR.pool.IsCaughtUp()
 				lastRate = 0.9*lastRate + 0.1*(100/time.Since(lastHundred).Seconds())
 				bcR.Logger.Info("Block Sync Rate", "height", height, "max_peer_height", maxPeerHeight, "blocks/s", lastRate)
 				lastHundred = time.Now()
@@ -507,7 +507,7 @@ func (bcR *Reactor) isMissingExtension(state sm.State, blocksSynced uint64) bool
 }
 
 func (bcR *Reactor) isCaughtUp(state sm.State, blocksSynced uint64, stateSynced bool) bool {
-	if isCaughtUp, height, _ := bcR.pool.IsCaughtUp(state, bcR.myAddr); isCaughtUp {
+	if isCaughtUp, height, _ := bcR.pool.IsCaughtUp(); isCaughtUp || weBlockTheChain(state, bcR.myAddr) {
 		bcR.Logger.Info("Time to switch to consensus mode!", "height", height)
 		if err := bcR.pool.Stop(); err != nil {
 			bcR.Logger.Error("Error stopping pool", "err", err)

--- a/internal/blocksync/reactor_test.go
+++ b/internal/blocksync/reactor_test.go
@@ -105,7 +105,7 @@ func newReactor(
 	// Make the Reactor itself.
 	// NOTE we have to create and commit the blocks first because
 	// pool.height is determined from the store.
-	fastSync := true
+	blockSync := true
 	db := dbm.NewMemDB()
 	stateStore = sm.NewStore(db, sm.StoreOptions{
 		DiscardABCIResponses: false,
@@ -119,6 +119,13 @@ func newReactor(
 	// The commit we are building for the current height.
 	seenExtCommit := &types.ExtendedCommit{}
 
+	pubKey, err := privVals[0].GetPubKey()
+	if err != nil {
+		panic(err)
+	}
+	addr := pubKey.Address()
+	idx, _ := state.Validators.GetByAddress(addr)
+
 	// let's add some blocks in
 	for blockHeight := int64(1); blockHeight <= maxBlockHeight; blockHeight++ {
 		lastExtCommit := seenExtCommit.Clone()
@@ -130,12 +137,6 @@ func newReactor(
 		blockID := types.BlockID{Hash: thisBlock.Hash(), PartSetHeader: thisParts.Header()}
 
 		// Simulate a commit for the current height
-		pubKey, err := privVals[0].GetPubKey()
-		if err != nil {
-			panic(err)
-		}
-		addr := pubKey.Address()
-		idx, _ := state.Validators.GetByAddress(addr)
 		vote, err := types.MakeVote(
 			privVals[0],
 			thisBlock.Header.ChainID,
@@ -164,7 +165,7 @@ func newReactor(
 		blockStore.SaveBlockWithExtendedCommit(thisBlock, thisParts, seenExtCommit)
 	}
 
-	bcReactor := NewReactor(state.Copy(), blockExec, blockStore, fastSync, NopMetrics(), 0)
+	bcReactor := NewReactor(state.Copy(), blockExec, blockStore, blockSync, addr, NopMetrics(), 0)
 	bcReactor.SetLogger(logger.With("module", "blocksync"))
 
 	return ReactorPair{bcReactor, proxyApp}

--- a/internal/blocksync/reactor_test.go
+++ b/internal/blocksync/reactor_test.go
@@ -165,7 +165,7 @@ func newReactor(
 		blockStore.SaveBlockWithExtendedCommit(thisBlock, thisParts, seenExtCommit)
 	}
 
-	// As the tests only support one validator in the valSet, we pass a different address to bypass the `localNodeBlocksTheChain` check
+	// As the tests only support one validator in the valSet, we pass a different address to bypass the `localNodeBlocksTheChain` check. Namely, the tested node is not an active validator.
 	bcReactor := NewReactor(state.Copy(), blockExec, blockStore, blockSync, []byte("anotherAddress"), NopMetrics(), 0)
 	bcReactor.SetLogger(logger.With("module", "blocksync"))
 

--- a/internal/blocksync/reactor_test.go
+++ b/internal/blocksync/reactor_test.go
@@ -165,7 +165,7 @@ func newReactor(
 		blockStore.SaveBlockWithExtendedCommit(thisBlock, thisParts, seenExtCommit)
 	}
 
-	// As the tests only support one validator in the valSet, we pass a different address to disable the `weBlockTheChain` check
+	// As the tests only support one validator in the valSet, we pass a different address to bypass the `localNodeBlocksTheChain` check
 	bcReactor := NewReactor(state.Copy(), blockExec, blockStore, blockSync, []byte("anotherAddress"), NopMetrics(), 0)
 	bcReactor.SetLogger(logger.With("module", "blocksync"))
 

--- a/internal/blocksync/reactor_test.go
+++ b/internal/blocksync/reactor_test.go
@@ -165,7 +165,8 @@ func newReactor(
 		blockStore.SaveBlockWithExtendedCommit(thisBlock, thisParts, seenExtCommit)
 	}
 
-	bcReactor := NewReactor(state.Copy(), blockExec, blockStore, blockSync, addr, NopMetrics(), 0)
+	// As the tests only support one validator in the valSet, we pass a different address to disable the `weBlockTheChain` check
+	bcReactor := NewReactor(state.Copy(), blockExec, blockStore, blockSync, []byte("anotherAddress"), NopMetrics(), 0)
 	bcReactor.SetLogger(logger.With("module", "blocksync"))
 
 	return ReactorPair{bcReactor, proxyApp}

--- a/node/node.go
+++ b/node/node.go
@@ -429,7 +429,8 @@ func NewNode(ctx context.Context,
 
 	consensusReactor, consensusState := createConsensusReactor(
 		config, state, blockExec, blockStore, mempool, evidencePool,
-		privValidator, csMetrics, waitSync, eventBus, consensusLogger, offlineStateSyncHeight,
+		privValidator, csMetrics, waitSync, eventBus, consensusLogger,
+		offlineStateSyncHeight,
 	)
 
 	err = stateStore.SetOfflineStateSyncHeight(0)

--- a/node/node.go
+++ b/node/node.go
@@ -350,10 +350,10 @@ func NewNode(ctx context.Context,
 	if err != nil {
 		return nil, ErrGetPubKey{Err: err}
 	}
-	myAddr := pubKey.Address()
+	localAddr := pubKey.Address()
 
 	// Determine whether we should attempt state sync.
-	stateSync := config.StateSync.Enable && !onlyValidatorIsUs(state, myAddr)
+	stateSync := config.StateSync.Enable && !onlyValidatorIsUs(state, localAddr)
 	if stateSync && state.LastBlockHeight > 0 {
 		logger.Info("Found local state with non-zero height, skipping state sync")
 		stateSync = false
@@ -378,7 +378,7 @@ func NewNode(ctx context.Context,
 
 	// Determine whether we should do block sync. This must happen after the handshake, since the
 	// app may modify the validator set, specifying ourself as the only validator.
-	blockSync := !onlyValidatorIsUs(state, myAddr)
+	blockSync := !onlyValidatorIsUs(state, localAddr)
 	waitSync := stateSync || blockSync
 
 	logNodeStartupInfo(state, pubKey, logger, consensusLogger)
@@ -423,7 +423,7 @@ func NewNode(ctx context.Context,
 		}
 	}
 	// Don't start block sync if we're doing a state sync first.
-	bcReactor, err := createBlocksyncReactor(config, state, blockExec, blockStore, blockSync && !stateSync, myAddr, logger, bsMetrics, offlineStateSyncHeight)
+	bcReactor, err := createBlocksyncReactor(config, state, blockExec, blockStore, blockSync && !stateSync, localAddr, logger, bsMetrics, offlineStateSyncHeight)
 	if err != nil {
 		return nil, ErrCreateBlockSyncReactor{Err: err}
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -430,8 +430,7 @@ func NewNode(ctx context.Context,
 
 	consensusReactor, consensusState := createConsensusReactor(
 		config, state, blockExec, blockStore, mempool, evidencePool,
-		privValidator, csMetrics, waitSync, eventBus, consensusLogger,
-		offlineStateSyncHeight,
+		privValidator, csMetrics, waitSync, eventBus, consensusLogger, offlineStateSyncHeight,
 	)
 
 	err = stateStore.SetOfflineStateSyncHeight(0)

--- a/node/node.go
+++ b/node/node.go
@@ -350,9 +350,10 @@ func NewNode(ctx context.Context,
 	if err != nil {
 		return nil, ErrGetPubKey{Err: err}
 	}
+	myAddr := pubKey.Address()
 
 	// Determine whether we should attempt state sync.
-	stateSync := config.StateSync.Enable && !onlyValidatorIsUs(state, pubKey)
+	stateSync := config.StateSync.Enable && !onlyValidatorIsUs(state, myAddr)
 	if stateSync && state.LastBlockHeight > 0 {
 		logger.Info("Found local state with non-zero height, skipping state sync")
 		stateSync = false
@@ -377,7 +378,7 @@ func NewNode(ctx context.Context,
 
 	// Determine whether we should do block sync. This must happen after the handshake, since the
 	// app may modify the validator set, specifying ourself as the only validator.
-	blockSync := !onlyValidatorIsUs(state, pubKey)
+	blockSync := !onlyValidatorIsUs(state, myAddr)
 	waitSync := stateSync || blockSync
 
 	logNodeStartupInfo(state, pubKey, logger, consensusLogger)
@@ -422,7 +423,7 @@ func NewNode(ctx context.Context,
 		}
 	}
 	// Don't start block sync if we're doing a state sync first.
-	bcReactor, err := createBlocksyncReactor(config, state, blockExec, blockStore, blockSync && !stateSync, logger, bsMetrics, offlineStateSyncHeight)
+	bcReactor, err := createBlocksyncReactor(config, state, blockExec, blockStore, blockSync && !stateSync, myAddr, logger, bsMetrics, offlineStateSyncHeight)
 	if err != nil {
 		return nil, ErrCreateBlockSyncReactor{Err: err}
 	}

--- a/node/setup.go
+++ b/node/setup.go
@@ -233,12 +233,12 @@ func logNodeStartupInfo(state sm.State, pubKey crypto.PubKey, logger, consensusL
 	}
 }
 
-func onlyValidatorIsUs(state sm.State, myAddr crypto.Address) bool {
+func onlyValidatorIsUs(state sm.State, localAddr crypto.Address) bool {
 	if state.Validators.Size() > 1 {
 		return false
 	}
 	valAddr, _ := state.Validators.GetByIndex(0)
-	return bytes.Equal(myAddr, valAddr)
+	return bytes.Equal(localAddr, valAddr)
 }
 
 // createMempoolAndMempoolReactor creates a mempool and a mempool reactor based on the config.
@@ -305,14 +305,14 @@ func createBlocksyncReactor(config *cfg.Config,
 	blockExec *sm.BlockExecutor,
 	blockStore *store.BlockStore,
 	blockSync bool,
-	myAddr crypto.Address,
+	localAddr crypto.Address,
 	logger log.Logger,
 	metrics *blocksync.Metrics,
 	offlineStateSyncHeight int64,
 ) (bcReactor p2p.Reactor, err error) {
 	switch config.BlockSync.Version {
 	case "v0":
-		bcReactor = blocksync.NewReactor(state.Copy(), blockExec, blockStore, blockSync, myAddr, metrics, offlineStateSyncHeight)
+		bcReactor = blocksync.NewReactor(state.Copy(), blockExec, blockStore, blockSync, localAddr, metrics, offlineStateSyncHeight)
 	case "v1", "v2":
 		return nil, fmt.Errorf("block sync version %s has been deprecated. Please use v0", config.BlockSync.Version)
 	default:

--- a/node/setup.go
+++ b/node/setup.go
@@ -233,12 +233,12 @@ func logNodeStartupInfo(state sm.State, pubKey crypto.PubKey, logger, consensusL
 	}
 }
 
-func onlyValidatorIsUs(state sm.State, pubKey crypto.PubKey) bool {
+func onlyValidatorIsUs(state sm.State, myAddr crypto.Address) bool {
 	if state.Validators.Size() > 1 {
 		return false
 	}
-	addr, _ := state.Validators.GetByIndex(0)
-	return bytes.Equal(pubKey.Address(), addr)
+	valAddr, _ := state.Validators.GetByIndex(0)
+	return bytes.Equal(myAddr, valAddr)
 }
 
 // createMempoolAndMempoolReactor creates a mempool and a mempool reactor based on the config.
@@ -305,13 +305,14 @@ func createBlocksyncReactor(config *cfg.Config,
 	blockExec *sm.BlockExecutor,
 	blockStore *store.BlockStore,
 	blockSync bool,
+	myAddr crypto.Address,
 	logger log.Logger,
 	metrics *blocksync.Metrics,
 	offlineStateSyncHeight int64,
 ) (bcReactor p2p.Reactor, err error) {
 	switch config.BlockSync.Version {
 	case "v0":
-		bcReactor = blocksync.NewReactor(state.Copy(), blockExec, blockStore, blockSync, metrics, offlineStateSyncHeight)
+		bcReactor = blocksync.NewReactor(state.Copy(), blockExec, blockStore, blockSync, myAddr, metrics, offlineStateSyncHeight)
 	case "v1", "v2":
 		return nil, fmt.Errorf("block sync version %s has been deprecated. Please use v0", config.BlockSync.Version)
 	default:

--- a/test/e2e/networks_regressions/blocksync_blocked.toml
+++ b/test/e2e/networks_regressions/blocksync_blocked.toml
@@ -1,0 +1,11 @@
+vote_extensions_enable_height = 1
+pbts_enable_height = 1
+
+[validators]
+validator01 = 67
+validator02 = 33
+
+[node.validator01]
+
+[node.validator02]
+start_at = 5


### PR DESCRIPTION
Partially addresses #3415

The a node has no peers, blocksync gets stuck without switching to consesnus, because it needs info from other peers to have an idea of maximum height.

However, there is an edge case (mainly when testing) where a validator might have >2/3 of the voting power and other validators are not started. In this case, we know we are blocking the chain, so we don't need to stay in blockchain if the only condition is that we don't have peers.

Moreover, in order to block a chain, 1/3 of the voting power is enough, so the reasoning of this fix is the following:

* _I am a node and I am starting... shall I run blocksync?_
* _Well, looks like I have 1/3 of the voting power (or more) at my current height... so there's no way the chain could advance in my absence... so I don't need to blocksync"_

Explanation of commits:

* Commit 1: `e2e` testbed reproducing the issue
* Commit 2: commit with a trivial change to trigger `e2e` tests. Check the error: ❌ next to the commit hash (3fb1057)
* Commit 3: Tentative fix. Although there is a  ❌ next to the commit hash (16a46ea), if you click on it, you'll see that `e2e` are passing now.
* Commit 4: revert commit2
* Commit 5: Move the check for "local node is blocking the chain" outside the pool, as suggested by @cason 
* Commit 6: Fixed unit tests

All further commits: addressing other comments and tidying up the code

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- ~[ ] Updated relevant documentation (`docs/` or `spec/`) and code comments~
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
