### PR TITLE
perf(p2p): Delete expensive debug log already slated for deletion

### DIFF
--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -311,15 +311,6 @@ func (p *peer) hasChannel(chID byte) bool {
 			return true
 		}
 	}
-	// NOTE: probably will want to remove this
-	// but could be helpful while the feature is new
-	p.Logger.Debug(
-		"Unknown channel for peer",
-		"channel",
-		chID,
-		"channels",
-		p.channels,
-	)
 	return false
 }
 


### PR DESCRIPTION
Delete an expensive debug log that has already been slated for deletion. On the osmosis fork (with many other debug logs removed), this debug log ended up taking 1.5% of all CPU time when we had many large blocks. (All from outbound gossip curiously enough) This caused 12GB of total memory allocation over an hour in that benchmark (out of 180GB total. With other optimizations in PR's / merged, would have been 12GB / 120GB total)

I am just making a PR to delete it, since it already had a code comment indicating we should delete it later. (Rather than waiting for #2989 

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
