### PR TITLE
perf(mempool): get peer state once on broadcast routine

### DIFF
--- a/.changelog/unreleased/improvements/3430-mempool-get-peer-state-once.md
+++ b/.changelog/unreleased/improvements/3430-mempool-get-peer-state-once.md
@@ -1,0 +1,3 @@
+- `[mempool]` In the broadcast routine, get the pointer to the peer's state once, before starting to
+  iterate through the list of transactions.
+  ([\#3430](https://github.com/cometbft/cometbft/pull/3430))

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -203,6 +203,22 @@ func (memR *Reactor) broadcastTxRoutine(peer p2p.Peer) {
 		}
 	}
 
+	var peerState PeerState
+	// Wait until the peer's state is ready. We initialize it in the consensus reactor, but when we
+	// add the peer in Switch, the order in which we call reactors#AddPeer is different every time
+	// due to us using a map. Sometimes other reactors will be initialized before the consensus
+	// reactor. We should wait a few milliseconds and retry. We assume the pointer to the state is
+	// set once and never unset.
+	for {
+		if ps, ok := peer.Get(types.PeerStateKey).(PeerState); ok {
+			peerState = ps
+			break
+		}
+		// Peer does not have a state yet.
+		time.Sleep(PeerCatchupSleepIntervalMS * time.Millisecond)
+		continue
+	}
+
 	for {
 		// In case of both next.NextWaitChan() and peer.Quit() are variable at the same time
 		if !memR.IsRunning() || !peer.IsRunning() {
@@ -223,18 +239,6 @@ func (memR *Reactor) broadcastTxRoutine(peer p2p.Peer) {
 			case <-memR.Quit():
 				return
 			}
-		}
-
-		// Make sure the peer is up to date.
-		peerState, ok := peer.Get(types.PeerStateKey).(PeerState)
-		if !ok {
-			// Peer does not have a state yet. We set it in the consensus reactor, but
-			// when we add peer in Switch, the order we call reactors#AddPeer is
-			// different every time due to us using a map. Sometimes other reactors
-			// will be initialized before the consensus reactor. We should wait a few
-			// milliseconds and retry.
-			time.Sleep(PeerCatchupSleepIntervalMS * time.Millisecond)
-			continue
 		}
 
 		// If we suspect that the peer is lagging behind, at least by more than

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -216,7 +216,6 @@ func (memR *Reactor) broadcastTxRoutine(peer p2p.Peer) {
 		}
 		// Peer does not have a state yet.
 		time.Sleep(PeerCatchupSleepIntervalMS * time.Millisecond)
-		continue
 	}
 
 	for {


### PR DESCRIPTION
In each broadcast routine, before sending a transaction, we read the peer's state so we can compare the height of the transaction against the peer's height. So, for each transaction we want to send, we call `peer.Get(types.PeerStateKey).(PeerState)` that reads the (pointer to the) peer's state. This PR makes this call once, before starting the loop through the list of transactions. This is possible because `PeerState` is set once (on the consensus reactor) and never unset.

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [X] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
