### PR TITLE
perf(txindex): search optimization

### DIFF
--- a/.changelog/unreleased/improvements/3458-txindex-search-optimization.md
+++ b/.changelog/unreleased/improvements/3458-txindex-search-optimization.md
@@ -1,0 +1,2 @@
+- `[state/txindex]` search optimization
+  ([\#3458](https://github.com/cometbft/cometbft/pull/3458))

--- a/state/txindex/kv/kv.go
+++ b/state/txindex/kv/kv.go
@@ -434,9 +434,9 @@ func byHeightAsc(i, j *hashKey) bool {
 	hi := i.height
 	hj := j.height
 	if hi == hj {
-		return i.hash > j.hash
+		return i.hash < j.hash
 	}
-	return hi > hj
+	return hi < hj
 }
 
 // Search performs a search using the given query.

--- a/state/txindex/kv/kv.go
+++ b/state/txindex/kv/kv.go
@@ -27,9 +27,10 @@ import (
 )
 
 const (
-	tagKeySeparator     = "/"
-	tagKeySeparatorRune = '/'
-	eventSeqSeparator   = "$es$"
+	tagKeySeparator          = "/"
+	tagKeySeparatorRune      = '/'
+	eventSeqSeparator        = "$es$"
+	eventSeqSeperatorRuneAt0 = '$'
 )
 
 var (
@@ -406,6 +407,38 @@ func (txi *TxIndex) indexEvents(result *abci.TxResult, hash []byte, store dbm.Ba
 	return nil
 }
 
+type hashKey struct {
+	hash   string
+	height int64
+}
+
+type hashKeySorter struct {
+	keys []hashKey
+	by   func(t1, t2 *hashKey) bool
+}
+
+func (t *hashKeySorter) Less(i, j int) bool { return t.by(&t.keys[i], &t.keys[j]) }
+func (t *hashKeySorter) Len() int           { return len(t.keys) }
+func (t *hashKeySorter) Swap(i, j int)      { t.keys[i], t.keys[j] = t.keys[j], t.keys[i] }
+
+func byHeightDesc(i, j *hashKey) bool {
+	hi := i.height
+	hj := j.height
+	if hi == hj {
+		return i.hash > j.hash
+	}
+	return hi > hj
+}
+
+func byHeightAsc(i, j *hashKey) bool {
+	hi := i.height
+	hj := j.height
+	if hi == hj {
+		return i.hash > j.hash
+	}
+	return hi > hj
+}
+
 // Search performs a search using the given query.
 //
 // It breaks the query into conditions (like "tx.height > 5"). For each
@@ -515,26 +548,23 @@ func (txi *TxIndex) Search(ctx context.Context, q *query.Query, pagSettings txin
 	numResults := len(filteredHashes)
 
 	// Convert map keys to slice for deterministic ordering
-	hashKeys := make([]string, 0, numResults)
-	for k := range filteredHashes {
-		hashKeys = append(hashKeys, k)
+	hashKeys := make([]hashKey, 0, numResults)
+	for k, v := range filteredHashes {
+		hashKeys = append(hashKeys, hashKey{hash: k, height: v.Height})
+	}
+
+	var by func(i, j *hashKey) bool
+
+	if pagSettings.OrderDesc {
+		by = byHeightDesc
+	} else {
+		by = byHeightAsc
 	}
 
 	// Sort by height
-	sort.Slice(hashKeys, func(i, j int) bool {
-		hi := filteredHashes[hashKeys[i]].Height
-		hj := filteredHashes[hashKeys[j]].Height
-		if hi == hj {
-			// If heights are equal, sort lexicographically
-			if pagSettings.OrderDesc {
-				return hashKeys[i] > hashKeys[j]
-			}
-			return hashKeys[i] < hashKeys[j]
-		}
-		if pagSettings.OrderDesc {
-			return hi > hj
-		}
-		return hi < hj
+	sort.Sort(&hashKeySorter{
+		keys: hashKeys,
+		by:   by,
 	})
 
 	// If paginated, determine which hash keys to return
@@ -565,7 +595,7 @@ func (txi *TxIndex) Search(ctx context.Context, q *query.Query, pagSettings txin
 	resultMap := make(map[string]struct{})
 RESULTS_LOOP:
 	for _, hKey := range hashKeys {
-		h := filteredHashes[hKey].TxBytes
+		h := filteredHashes[hKey.hash].TxBytes
 		res, err := txi.Get(h)
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to get Tx{%X}: %w", h, err)
@@ -995,13 +1025,21 @@ func extractValueFromKey(key []byte) string {
 }
 
 func extractEventSeqFromKey(key []byte) string {
-	parts := strings.Split(string(key), tagKeySeparator)
+	endPos := bytes.LastIndexByte(key, tagKeySeparatorRune)
 
-	lastEl := parts[len(parts)-1]
-
-	if strings.Contains(lastEl, eventSeqSeparator) {
-		return strings.SplitN(lastEl, eventSeqSeparator, 2)[1]
+	if endPos == -1 {
+		return "0"
 	}
+
+	for ; endPos < len(key); endPos++ {
+		if key[endPos] == eventSeqSeperatorRuneAt0 && len(key)-endPos > 4 {
+			eventSeq := string(key[endPos:])
+			if eventSeq, ok := strings.CutPrefix(eventSeq, eventSeqSeparator); ok {
+				return eventSeq
+			}
+		}
+	}
+
 	return "0"
 }
 

--- a/state/txindex/kv/kv.go
+++ b/state/txindex/kv/kv.go
@@ -1032,7 +1032,7 @@ func extractEventSeqFromKey(key []byte) string {
 	}
 
 	for ; endPos < len(key); endPos++ {
-		if key[endPos] == eventSeqSeperatorRuneAt0 && len(key)-endPos > 4 {
+		if key[endPos] == eventSeqSeperatorRuneAt0 {
 			eventSeq := string(key[endPos:])
 			if eventSeq, ok := strings.CutPrefix(eventSeq, eventSeqSeparator); ok {
 				return eventSeq

--- a/state/txindex/kv/kv_bench_test.go
+++ b/state/txindex/kv/kv_bench_test.go
@@ -10,10 +10,50 @@ import (
 	dbm "github.com/cometbft/cometbft-db"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/libs/pubsub/query"
+	"github.com/cometbft/cometbft/state/txindex"
 	"github.com/cometbft/cometbft/types"
 )
 
-func BenchmarkTxSearch(b *testing.B) {
+func generateDummyTxs(b *testing.B, indexer *TxIndex, numHeights int, numTxs int) {
+	for h := 0; h < numHeights; h++ {
+		batch := txindex.NewBatch(int64(numTxs))
+
+		for i := 0; i < numTxs; i++ {
+			events := []abci.Event{
+				{
+					Type: "transfer",
+					Attributes: []abci.EventAttribute{
+						{Key: "address", Value: fmt.Sprintf("address_%d", (h*numTxs+i)%100), Index: true},
+						{Key: "amount", Value: "50", Index: true},
+					},
+				},
+			}
+
+			txBz := make([]byte, 8)
+			if _, err := rand.Read(txBz); err != nil {
+				b.Errorf("failed produce random bytes: %s", err)
+			}
+
+			if err := batch.Add(&abci.TxResult{
+				Height: int64(h),
+				Index:  uint32(i),
+				Tx:     types.Tx(string(txBz)),
+				Result: abci.ExecTxResult{
+					Data:   []byte{0},
+					Code:   abci.CodeTypeOK,
+					Log:    "",
+					Events: events,
+				},
+			}); err != nil {
+				b.Errorf("failed to index tx: %s", err)
+			}
+		}
+
+		indexer.AddBatch(batch)
+	}
+}
+
+func BenchmarkTxSearchDisk(b *testing.B) {
 	dbDir, err := os.MkdirTemp("", "benchmark_tx_search_test")
 	if err != nil {
 		b.Errorf("failed to create temporary directory: %s", err)
@@ -25,41 +65,27 @@ func BenchmarkTxSearch(b *testing.B) {
 	}
 
 	indexer := NewTxIndex(db)
-
-	for i := 0; i < 35000; i++ {
-		events := []abci.Event{
-			{
-				Type: "transfer",
-				Attributes: []abci.EventAttribute{
-					{Key: "address", Value: fmt.Sprintf("address_%d", i%100), Index: true},
-					{Key: "amount", Value: "50", Index: true},
-				},
-			},
-		}
-
-		txBz := make([]byte, 8)
-		if _, err := rand.Read(txBz); err != nil {
-			b.Errorf("failed produce random bytes: %s", err)
-		}
-
-		txResult := &abci.TxResult{
-			Height: int64(i),
-			Index:  0,
-			Tx:     types.Tx(string(txBz)),
-			Result: abci.ExecTxResult{
-				Data:   []byte{0},
-				Code:   abci.CodeTypeOK,
-				Log:    "",
-				Events: events,
-			},
-		}
-
-		if err := indexer.Index(txResult); err != nil {
-			b.Errorf("failed to index tx: %s", err)
-		}
-	}
+	generateDummyTxs(b, indexer, 1000, 20)
 
 	txQuery := query.MustCompile(`transfer.address = 'address_43' AND transfer.amount = 50`)
+
+	b.ResetTimer()
+
+	ctx := context.Background()
+
+	for i := 0; i < b.N; i++ {
+		if _, _, err := indexer.Search(ctx, txQuery, DefaultPagination); err != nil {
+			b.Errorf("failed to query for txs: %s", err)
+		}
+	}
+}
+
+func BenchmarkTxSearchBigResult(b *testing.B) {
+	db := dbm.NewMemDB()
+	indexer := NewTxIndex(db)
+	generateDummyTxs(b, indexer, 20000, 50)
+
+	txQuery := query.MustCompile(`transfer.amount = 50`)
 
 	b.ResetTimer()
 

--- a/state/txindex/kv/kv_bench_test.go
+++ b/state/txindex/kv/kv_bench_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func generateDummyTxs(b *testing.B, indexer *TxIndex, numHeights int, numTxs int) {
+	b.Helper()
 	for h := 0; h < numHeights; h++ {
 		batch := txindex.NewBatch(int64(numTxs))
 
@@ -49,7 +50,9 @@ func generateDummyTxs(b *testing.B, indexer *TxIndex, numHeights int, numTxs int
 			}
 		}
 
-		indexer.AddBatch(batch)
+		if err := indexer.AddBatch(batch); err != nil {
+			b.Errorf("failed to add batch: %s", err)
+		}
 	}
 }
 

--- a/state/txindex/kv/kv_test.go
+++ b/state/txindex/kv/kv_test.go
@@ -929,3 +929,29 @@ func setDiff(bigger [][]byte, smaller [][]byte) [][]byte {
 	}
 	return diff
 }
+
+func TestExtractEventSeqFromKey(t *testing.T) {
+	testCases := []struct {
+		str      string
+		expected string
+	}{
+		{
+			"0/0/0/1234$es$0",
+			"0",
+		},
+		{
+			"0/0/0/1234$es$1234",
+			"1234",
+		},
+		{
+			"0/0/0/1234",
+			"0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.expected, func(t *testing.T) {
+			assert.Equal(t, extractEventSeqFromKey([]byte(tc.str)), tc.expected)
+		})
+	}
+}


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->
This PR addresses several optimization points for TxIndex.Search:

1. Remove expensive map access from sorting function
2. Replace sort.Slice to sort.Sort with sorter approach
3. Reduce heap allocations from extractEventSeqFromKey

benchstat result:
```
goos: darwin
goarch: amd64
pkg: github.com/cometbft/cometbft/state/txindex/kv
cpu: Intel(R) Core(TM) i9-10910 CPU @ 3.60GHz
                     │   old.txt    │              new.txt               │
                     │    sec/op    │   sec/op     vs base               │
TxSearchBigResult-20   3236.1m ± 7%   945.9m ± 9%  -70.77% (p=0.002 n=6)

                     │   old.txt    │               new.txt               │
                     │     B/op     │     B/op      vs base               │
TxSearchBigResult-20   426.1Mi ± 0%   311.6Mi ± 0%  -26.86% (p=0.002 n=6)

                     │   old.txt   │              new.txt               │
                     │  allocs/op  │  allocs/op   vs base               │
TxSearchBigResult-20   4.040M ± 0%   2.040M ± 0%  -49.51% (p=0.002 n=6)
```

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
