### PR TITLE
refactor(mempool): Add `Iterator` to replace `TxsFront` and `TxsWaitChan` methods

### DIFF
--- a/.changelog/unreleased/deprecations/3303-mempool-deprecate-txsfront-txswaitchan.md
+++ b/.changelog/unreleased/deprecations/3303-mempool-deprecate-txsfront-txswaitchan.md
@@ -1,0 +1,2 @@
+- `[mempool]` Mark methods `TxsFront` and `TxsWaitChan` in `CListMempool` as deprecated. They should
+  be replaced by the new `CListIterator` ([\#3303](https://github.com/cometbft/cometbft/pull/3303)).

--- a/.changelog/unreleased/improvements/3303-mempool-iterator.md
+++ b/.changelog/unreleased/improvements/3303-mempool-iterator.md
@@ -1,0 +1,3 @@
+- `[mempool]` New `Entry` and `Iterator` interfaces. New `CListIterator` data struct to iterate on
+  the mempool's CList instead of methods `TxsFront` and `TxsWaitChan`
+  ([\#3303](https://github.com/cometbft/cometbft/pull/3303)).

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -785,7 +785,9 @@ func (rc *recheck) consideredFull() bool {
 	return rc.recheckFull.Load()
 }
 
-// CListIterator implements an Iterator that traverses the CList sequentially.
+// CListIterator implements an Iterator that traverses the CList sequentially. When the current
+// entry is removed from the mempool, the iterator starts from the beginning of the CList. When it
+// reaches the end, it waits until a new entry is appended.
 type CListIterator struct {
 	txs    *clist.CList    // to wait on and retrieve the first entry
 	cursor *clist.CElement // pointer to the current entry in the list

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -220,7 +220,7 @@ func (mem *CListMempool) Flush() {
 //
 // Safe for concurrent use by multiple goroutines.
 //
-// Deprecated: Use Iterator instead.
+// Deprecated: Use CListIterator instead.
 func (mem *CListMempool) TxsFront() *clist.CElement {
 	return mem.txs.Front()
 }
@@ -231,7 +231,7 @@ func (mem *CListMempool) TxsFront() *clist.CElement {
 //
 // Safe for concurrent use by multiple goroutines.
 //
-// Deprecated: Use Iterator instead.
+// Deprecated: Use CListIterator instead.
 func (mem *CListMempool) TxsWaitChan() <-chan struct{} {
 	return mem.txs.WaitChan()
 }

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -219,6 +219,8 @@ func (mem *CListMempool) Flush() {
 // FIXME: leaking implementation details!
 //
 // Safe for concurrent use by multiple goroutines.
+//
+// Deprecated: Use Iterator instead.
 func (mem *CListMempool) TxsFront() *clist.CElement {
 	return mem.txs.Front()
 }
@@ -228,6 +230,8 @@ func (mem *CListMempool) TxsFront() *clist.CElement {
 // element)
 //
 // Safe for concurrent use by multiple goroutines.
+//
+// Deprecated: Use Iterator instead.
 func (mem *CListMempool) TxsWaitChan() <-chan struct{} {
 	return mem.txs.WaitChan()
 }

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -799,8 +799,8 @@ func (mem *CListMempool) NewIterator() Iterator {
 	}
 }
 
-// WaitNextCh returns a channel to wait for the next available entry. The
-// channel will be closed once the entry is added to the channel.
+// WaitNextCh returns a channel to wait for the next available entry. The channel will be closed
+// once the entry is added to the channel or when reaching the end of the list.
 func (iter *CListIterator) WaitNextCh() <-chan Entry {
 	ch := make(chan Entry)
 	// Spawn goroutine that waits for the next entry, saves it locally, and puts it in the channel.
@@ -815,6 +815,7 @@ func (iter *CListIterator) WaitNextCh() <-chan Entry {
 			<-iter.cursor.NextWaitChan()
 			iter.cursor = iter.cursor.Next()
 		}
+		// Check if we reached the end of the list (CElement.Next returned nil).
 		if iter.cursor != nil {
 			ch <- iter.cursor.Value.(Entry)
 		}

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -800,7 +800,7 @@ func (mem *CListMempool) NewIterator() Iterator {
 }
 
 // WaitNextCh returns a channel to wait for the next available entry. The
-// channel will be closed once the entry is sent.
+// channel will be closed once the entry is added to the channel.
 func (iter *CListIterator) WaitNextCh() <-chan Entry {
 	ch := make(chan Entry)
 	// Spawn goroutine that waits for the next entry, saves it locally, and puts it in the channel.

--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -146,10 +146,11 @@ func TestReapMaxBytesMaxGas(t *testing.T) {
 
 	// Ensure gas calculation behaves as expected
 	checkTxs(t, mp, 1)
-	tx0 := mp.TxsFront().Value.(*mempoolTx)
-	require.Equal(t, tx0.gasWanted, int64(1), "transactions gas was set incorrectly")
+	iter := mp.NewIterator()
+	tx0 := <-iter.WaitNextCh()
+	require.Equal(t, tx0.GasWanted(), int64(1), "transactions gas was set incorrectly")
 	// ensure each tx is 20 bytes long
-	require.Len(t, tx0.tx, 20, "Tx is longer than 20 bytes")
+	require.Len(t, tx0.Tx(), 20, "Tx is longer than 20 bytes")
 	mp.Flush()
 
 	// each table driven test creates numTxsToCreate txs with checkTx, and at the end clears all remaining txs.

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -148,3 +148,25 @@ func PostCheckMaxGas(maxGas int64) PostCheckFunc {
 
 // TxKey is the fixed length array key used as an index.
 type TxKey [sha256.Size]byte
+
+// An entry in the mempool.
+type Entry interface {
+	// Tx returns the transaction stored in the entry.
+	Tx() types.Tx
+
+	// Height returns the height of the latest block at the moment the entry was created.
+	Height() int64
+
+	// GasWanted returns the amount of gas required by the transaction.
+	GasWanted() int64
+
+	// IsSender returns whether we received the transaction from the given peer ID.
+	IsSender(peerID p2p.ID) bool
+}
+
+// An iterator is used to iterate through the mempool entries.
+// Multiple iterators should be allowed to run concurrently.
+type Iterator interface {
+	// WaitTxAvailableCh returns a channel on which to wait for the next available entry.
+	WaitNextCh() <-chan Entry
+}

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -167,6 +167,6 @@ type Entry interface {
 // An iterator is used to iterate through the mempool entries.
 // Multiple iterators should be allowed to run concurrently.
 type Iterator interface {
-	// WaitTxAvailableCh returns a channel on which to wait for the next available entry.
+	// WaitNextCh returns a channel on which to wait for the next available entry.
 	WaitNextCh() <-chan Entry
 }

--- a/mempool/mempoolTx.go
+++ b/mempool/mempoolTx.go
@@ -19,12 +19,19 @@ type mempoolTx struct {
 	senders sync.Map
 }
 
-// Height returns the height for this transaction.
+func (memTx *mempoolTx) Tx() types.Tx {
+	return memTx.tx
+}
+
 func (memTx *mempoolTx) Height() int64 {
 	return atomic.LoadInt64(&memTx.height)
 }
 
-func (memTx *mempoolTx) isSender(peerID p2p.ID) bool {
+func (memTx *mempoolTx) GasWanted() int64 {
+	return memTx.gasWanted
+}
+
+func (memTx *mempoolTx) IsSender(peerID p2p.ID) bool {
 	_, ok := memTx.senders.Load(peerID)
 	return ok
 }


### PR DESCRIPTION
Closes #3303 

This PR adds:
- the `Entry` interface, implemented by the existing `mempoolTx` data type, 
- the `Iterator` interface, with one method `WaitNextCh() <-chan Entry`.

On the routine that sends transactions to a peer, we can now use an `Iterator` to select the next mempool entry to send, instead of the methods `TxsFront` and `TxsWaitChan` in `CListMempool`. These two methods leak implementation details about the CList and are now marked as deprecated. Now all the logic needed to wait for and pick the next available entry is implemented in `CListMempool.WaitNextCh`.

---

#### PR checklist

- [X] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
