### PR TITLE
fix(cmd): align `p2p.external_address` argument when set the node P2P external address

### DIFF
--- a/.changelog/unreleased/bug-fixes/3497-fix-p2p-external-address.md
+++ b/.changelog/unreleased/bug-fixes/3497-fix-p2p-external-address.md
@@ -1,2 +1,2 @@
-- `[cli]` Align `p2p.external_address` argument to set the node P2P external address.
-  ([\#3497](https://github.com/cometbft/cometbft/pull/3497))
+- `[cmd]` Align `p2p.external_address` argument to set the node P2P external address.
+  ([\#3460](https://github.com/cometbft/cometbft/issues/3460))

--- a/.changelog/unreleased/bug-fixes/3497-fix-p2p-external-address.md
+++ b/.changelog/unreleased/bug-fixes/3497-fix-p2p-external-address.md
@@ -1,0 +1,2 @@
+- `[cli]` Align `p2p.external_address` argument to set the node P2P external address.
+  ([\#3497](https://github.com/cometbft/cometbft/pull/3497))

--- a/cmd/cometbft/commands/run_node.go
+++ b/cmd/cometbft/commands/run_node.go
@@ -52,7 +52,7 @@ func AddNodeFlags(cmd *cobra.Command) {
 		"p2p.laddr",
 		config.P2P.ListenAddress,
 		"node listen address. (0.0.0.0:0 means any interface, any port)")
-	cmd.Flags().String("p2p.external-address", config.P2P.ExternalAddress, "ip:port address to advertise to peers for them to dial")
+	cmd.Flags().String("p2p.external_address", config.P2P.ExternalAddress, "ip:port address to advertise to peers for them to dial")
 	cmd.Flags().String("p2p.seeds", config.P2P.Seeds, "comma-delimited ID@host:port seed nodes")
 	cmd.Flags().String("p2p.persistent_peers", config.P2P.PersistentPeers, "comma-delimited ID@host:port persistent peers")
 	cmd.Flags().String("p2p.unconditional_peer_ids",


### PR DESCRIPTION
Closes https://github.com/cometbft/cometbft/issues/3460

for more info, https://github.com/cometbft/cometbft/blob/0cc1b6504c51d481ded95d431900a064533ad9b3/config/config.go#L757

---

#### PR checklist

- [ ] ~~Tests written/updated~~
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] ~~Updated relevant documentation (`docs/` or `spec/`) and code comments~~
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
