### PR TITLE
docs: Add front matter to ABCI 2.0 tutorial

### DIFF
--- a/docs/tutorials/forum-application/1.abci-intro.md
+++ b/docs/tutorials/forum-application/1.abci-intro.md
@@ -1,3 +1,7 @@
+---
+order: 1
+---
+
 # Introduction to ABCI 2.0
 
 `ABCI 2.0` is an updated version of the ABCI (Application Blockchain Interface) from CometBFT. For more details, check the [specification document](https://docs.cometbft.com/v1.0/spec/abci/).

--- a/docs/tutorials/forum-application/2.intro-forumApp.md
+++ b/docs/tutorials/forum-application/2.intro-forumApp.md
@@ -1,10 +1,6 @@
-# Forum Application
-
-In this tutorial, we will build a Forum application using [ABCI 2.0](https://docs.cometbft.com/v1.0/spec/abci/).
-A Forum is an application where people can discuss topics by posting messages and responding to each other.
-
-We will demonstrate the use of `ABCI 2.0` methods like - `CheckTx`, `PrepareProposal`, `ProcessProposal`, `FinalizeBlock`,
-`ExtendVote` and `VerifyVoteExtension`
+---
+order: 2
+---
 
 ## What does the application do?
 

--- a/docs/tutorials/forum-application/2.intro-forumApp.md
+++ b/docs/tutorials/forum-application/2.intro-forumApp.md
@@ -2,7 +2,7 @@
 order: 2
 ---
 
-## What does the application do?
+## How the Application Works
 
 For the sake of simplicity, we will not be developing a fully functioning Forum Application. In our tutorial, we will focus
 on `sender` and `messages` and the censorship of ill-behaved forum users.

--- a/docs/tutorials/forum-application/3.send-message.md
+++ b/docs/tutorials/forum-application/3.send-message.md
@@ -1,4 +1,8 @@
-# Send Message
+---
+order: 3
+---
+
+# Sending Messages
 
 **In this section you will learn how a user can send a message on the Forum Application.**
 

--- a/docs/tutorials/forum-application/4.query-message.md
+++ b/docs/tutorials/forum-application/4.query-message.md
@@ -1,4 +1,8 @@
-# Query Message
+---
+order: 4
+---
+
+# Querying Messages
 
 **In this section you will learn how users query messages on the forum application.**
 

--- a/docs/tutorials/forum-application/5.model.md
+++ b/docs/tutorials/forum-application/5.model.md
@@ -1,4 +1,8 @@
-# Supported functions
+---
+order: 5
+---
+
+# Defining model types
 
 **In this section you will learn how a user, messages and db are defined in the Forum Application.**
 

--- a/docs/tutorials/forum-application/6.main.md
+++ b/docs/tutorials/forum-application/6.main.md
@@ -1,4 +1,8 @@
-# Main function
+---
+order: 6
+---
+
+# Running a node
 
 **The main function in the `forum.go` file is responsible for running the Forum Application blockchain.**
 

--- a/docs/tutorials/forum-application/7.vote-extension.md
+++ b/docs/tutorials/forum-application/7.vote-extension.md
@@ -1,3 +1,7 @@
+---
+order: 7
+---
+
 # Vote Extensions
 
 **In this section you will learn how a node can `ExtendVote` and `VerifyVote` on the forum application.**

--- a/docs/tutorials/forum-application/8.app.md
+++ b/docs/tutorials/forum-application/8.app.md
@@ -1,4 +1,8 @@
-# App.go
+---
+order: 8
+---
+
+# Application code
 
 *In this section you will find the code for entire `app.go` file.*
 

--- a/docs/tutorials/forum-application/9.run-app.md
+++ b/docs/tutorials/forum-application/9.run-app.md
@@ -1,4 +1,8 @@
-# Run Application
+---
+order: 9
+---
+
+# Running the Application
 
 In previous sections you learned about different ABCI 2.0 methods and how they are used.
 

--- a/docs/tutorials/forum-application/README.md
+++ b/docs/tutorials/forum-application/README.md
@@ -1,0 +1,16 @@
+---
+order: 1
+parent:
+  title: Forum Application Tutorial
+  order: 3
+---
+
+# ABCI 2.0 Forum Application Tutorial
+
+In this tutorial, we will build a Forum application using [ABCI 2.0](https://docs.cometbft.com/v1.0/spec/abci/).
+A Forum is an application where people can discuss topics by posting messages and responding to each other.
+
+We will demonstrate the use of `ABCI 2.0` methods like - `CheckTx`, `PrepareProposal`, `ProcessProposal`, `FinalizeBlock`,
+`ExtendVote` and `VerifyVoteExtension`
+
+Follow the [tutorial](1.abci-intro.md) in order to create a forum application using ABCI 2.0 methods.

--- a/docs/tutorials/go-built-in.md
+++ b/docs/tutorials/go-built-in.md
@@ -1,5 +1,5 @@
 ---
-order: 2
+order: 3
 ---
 
 # Creating a built-in application in Go

--- a/docs/tutorials/go.md
+++ b/docs/tutorials/go.md
@@ -1,5 +1,5 @@
 ---
-order: 1
+order: 4
 ---
 
 # Creating an application in Go

--- a/docs/tutorials/install.md
+++ b/docs/tutorials/install.md
@@ -1,5 +1,5 @@
 ---
-order: 3
+order: 1
 ---
 
 # Install CometBFT


### PR DESCRIPTION
Close: #3508 

Tested locally and left hand navigation displays properly with this fix.

![tutorial_navigation](https://github.com/user-attachments/assets/5a02c1ce-44c8-411a-89a2-a6f2bca77c38)

#### PR checklist

- [ ] ~~Tests written/updated~~
- [ ] ~~Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)~~
- [X] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [X] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
