### PR TITLE
feat(p2p): render `HasChannel(chID)` is a public `p2p.Peer` method

### DIFF
--- a/.changelog/unreleased/features/3472-p2p-has-channel-api.md
+++ b/.changelog/unreleased/features/3472-p2p-has-channel-api.md
@@ -1,0 +1,3 @@
+- `[p2p]` `HasChannel(chID)` method added to the `Peer` interface, used by
+  reactors to check whether a peer implements/supports a given channel.
+  ([#3472](https://github.com/cometbft/cometbft/issues/3472))

--- a/internal/consensus/reactor.go
+++ b/internal/consensus/reactor.go
@@ -589,6 +589,10 @@ func (conR *Reactor) getRoundState() *cstypes.RoundState {
 
 func (conR *Reactor) gossipDataRoutine(peer p2p.Peer, ps *PeerState) {
 	logger := conR.Logger.With("peer", peer)
+	if !peer.HasChannel(DataChannel) {
+		logger.Info("Peer does not implement DataChannel.")
+		return
+	}
 	rng := cmtrand.NewStdlibRand()
 
 OUTER_LOOP:
@@ -645,6 +649,10 @@ OUTER_LOOP:
 
 func (conR *Reactor) gossipVotesRoutine(peer p2p.Peer, ps *PeerState) {
 	logger := conR.Logger.With("peer", peer)
+	if !peer.HasChannel(VoteChannel) {
+		logger.Info("Peer does not implement VoteChannel.")
+		return
+	}
 	rng := cmtrand.NewStdlibRand()
 
 	// Simple hack to throttle logs upon sleep.

--- a/internal/evidence/reactor.go
+++ b/internal/evidence/reactor.go
@@ -64,7 +64,9 @@ func (*Reactor) GetChannels() []*p2p.ChannelDescriptor {
 
 // AddPeer implements Reactor.
 func (evR *Reactor) AddPeer(peer p2p.Peer) {
-	go evR.broadcastEvidenceRoutine(peer)
+	if peer.HasChannel(EvidenceChannel) {
+		go evR.broadcastEvidenceRoutine(peer)
+	}
 }
 
 // Receive implements Reactor.

--- a/internal/evidence/reactor_test.go
+++ b/internal/evidence/reactor_test.go
@@ -207,6 +207,7 @@ func TestReactorBroadcastEvidenceMemoryLeak(t *testing.T) {
 	// i.e. broadcastEvidenceRoutine finishes when peer is stopped
 	defer leaktest.CheckTimeout(t, 10*time.Second)()
 
+	p.On("HasChannel", evidence.EvidenceChannel).Maybe().Return(true)
 	p.On("Send", mock.MatchedBy(func(i any) bool {
 		e, ok := i.(p2p.Envelope)
 		return ok && e.ChannelID == evidence.EvidenceChannel

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -93,7 +93,7 @@ func (memR *Reactor) GetChannels() []*p2p.ChannelDescriptor {
 // AddPeer implements Reactor.
 // It starts a broadcast routine ensuring all txs are forwarded to the given peer.
 func (memR *Reactor) AddPeer(peer p2p.Peer) {
-	if memR.config.Broadcast {
+	if memR.config.Broadcast && peer.HasChannel(MempoolChannel) {
 		go func() {
 			// Always forward transactions to unconditional peers.
 			if !memR.Switch.IsPeerUnconditional(peer.ID()) {

--- a/p2p/mock/peer.go
+++ b/p2p/mock/peer.go
@@ -43,6 +43,7 @@ func NewPeer(ip net.IP) *Peer {
 }
 
 func (mp *Peer) FlushStop()               { mp.Stop() } //nolint:errcheck //ignore error
+func (*Peer) HasChannel(_ byte) bool      { return true }
 func (*Peer) TrySend(_ p2p.Envelope) bool { return true }
 func (*Peer) Send(_ p2p.Envelope) bool    { return true }
 func (mp *Peer) NodeInfo() p2p.NodeInfo {

--- a/p2p/mocks/peer.go
+++ b/p2p/mocks/peer.go
@@ -79,6 +79,24 @@ func (_m *Peer) GetRemovalFailed() bool {
 	return r0
 }
 
+// HasChannel provides a mock function with given fields: chID
+func (_m *Peer) HasChannel(chID byte) bool {
+	ret := _m.Called(chID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for HasChannel")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(byte) bool); ok {
+		r0 = rf(chID)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // ID provides a mock function with given fields:
 func (_m *Peer) ID() p2p.ID {
 	ret := _m.Called()

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -37,8 +37,9 @@ type Peer interface {
 	Status() cmtconn.ConnectionStatus
 	SocketAddr() *NetAddress // actual address of the socket
 
-	Send(e Envelope) bool
-	TrySend(e Envelope) bool
+	HasChannel(chID byte) bool // Does the peer implement this channel?
+	Send(e Envelope) bool      // Send a message to the peer, blocking version
+	TrySend(e Envelope) bool   // Send a message to the peer, non-blocking version
 
 	Set(key string, value any)
 	Get(key string) any
@@ -113,7 +114,7 @@ type peer struct {
 
 	// peer's node info and the channel it knows about
 	// channels = nodeInfo.Channels
-	// cached to avoid copying nodeInfo in hasChannel
+	// cached to avoid copying nodeInfo in HasChannel
 	nodeInfo NodeInfo
 	channels []byte
 
@@ -268,7 +269,7 @@ func (p *peer) TrySend(e Envelope) bool {
 func (p *peer) send(chID byte, msg proto.Message, sendFunc func(byte, []byte) bool) bool {
 	if !p.IsRunning() {
 		return false
-	} else if !p.hasChannel(chID) {
+	} else if !p.HasChannel(chID) {
 		return false
 	}
 	metricLabelValue := p.mlc.ValueToMetricLabel(msg)
@@ -303,9 +304,8 @@ func (p *peer) Set(key string, data any) {
 	p.Data.Set(key, data)
 }
 
-// hasChannel returns true if the peer reported
-// knowing about the given chID.
-func (p *peer) hasChannel(chID byte) bool {
+// HasChannel returns whether the peer reported implementing this channel.
+func (p *peer) HasChannel(chID byte) bool {
 	for _, ch := range p.channels {
 		if ch == chID {
 			return true

--- a/p2p/peer_set_test.go
+++ b/p2p/peer_set_test.go
@@ -19,6 +19,7 @@ type mockPeer struct {
 }
 
 func (mp *mockPeer) FlushStop()            { mp.Stop() } //nolint:errcheck // ignore error
+func (*mockPeer) HasChannel(byte) bool     { return true }
 func (*mockPeer) TrySend(Envelope) bool    { return true }
 func (*mockPeer) Send(Envelope) bool       { return true }
 func (*mockPeer) NodeInfo() NodeInfo       { return DefaultNodeInfo{} }

--- a/spec/p2p/reactor-api/p2p-api.md
+++ b/spec/p2p/reactor-api/p2p-api.md
@@ -182,15 +182,16 @@ From this point, reactors can use the methods of the new `Peer` instance.
 The table below summarizes the interaction of the standard reactors with
 connected peers, with the `Peer` methods used by them:
 
-| `Peer` API method                                     | consensus | block sync | state sync | mempool | evidence  | PEX   |
-|--------------------------------------------|-----------|------------|------------|---------|-----------|-------|
-| `ID() ID`                                  | x         | x          | x          | x       | x         | x     |
-| `IsRunning() bool`                         | x         |            |            | x       | x         |       |
-| `Quit() <-chan struct{}`                   |           |            |            | x       | x         |       |
-| `Get(string) interface{}`                  | x         |            |            | x       | x         |       |
-| `Set(string, interface{})`                 | x         |            |            |         |           |       |
-| `Send(Envelope) bool`                      | x         | x          | x          | x       | x         | x     |
-| `TrySend(Envelope) bool`                   | x         | x          |            |         |           |       |
+| `Peer` API method          | consensus | block sync | state sync | mempool | evidence | PEX |
+|----------------------------|-----------|------------|------------|---------|----------|-----|
+| `ID() ID`                  | x         | x          | x          | x       | x        | x   |
+| `IsRunning() bool`         | x         |            |            | x       | x        |     |
+| `Quit() <-chan struct{}`   |           |            |            | x       | x        |     |
+| `Get(string) interface{}`  | x         |            |            | x       | x        |     |
+| `Set(string, interface{})` | x         |            |            |         |          |     |
+| `HasChannel(byte) bool`    | x         |            |            | x       | x        |     |
+| `Send(Envelope) bool`      | x         | x          | x          | x       | x        | x   |
+| `TrySend(Envelope) bool`   | x         | x          |            |         |          |     |
 
 The above list is not exhaustive as it does not include all the `Peer` methods
 invoked by the PEX reactor, a special component that should be considered part
@@ -266,8 +267,10 @@ Finally, a `Peer` instance allows a reactor to send messages to companion
 reactors running at that peer.
 This is ultimately the goal of the switch when it provides `Peer` instances to
 the registered reactors.
-There are two methods for sending messages:
+There are two methods for sending messages, and one auxiliary method to check
+whether the peer supports a given channel:
 
+    func (p Peer) HasChannel(chID byte) bool
     func (p Peer) Send(e Envelope) bool
     func (p Peer) TrySend(e Envelope) bool
 
@@ -276,6 +279,9 @@ set as follows:
 
 - `ChannelID`: the channel the message should be sent through, which defines
   the reactor that will process the message;
+  - The auxiliary `HasChannel()` method allows testing whether the remote peer
+    implements a channel; if it does not, both message-sending methods will
+    immediately return `false`, as sending always fails.
 - `Src`: this field represents the source of an incoming message, which is
   irrelevant for outgoing messages;
 - `Message`: the actual message's payload, which is marshalled using protocol buffers.


### PR DESCRIPTION
Closes: #3472 

It also prevents reactors from starting routines intended to send messages to a peer that does not implement/support a given channel. Because all `Send()` or `TrySend()` calls from this routine will be useless, always returning `false` and possibly producing some busy-wait behavior (see https://github.com/cometbft/cometbft/issues/3414).

The changes are restricted to: mempool and evidence reactor, because they use a single channel and have a sending routine peer peer, and two of the consensus routines, for Data and Votes.

Block and State sync reactors have smarter ways to deal with unresponsive peers, so probably this check is not needed.

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
