### PR TITLE
fix(types): Genesis doc validation of validators Pubkey types.

### DIFF
--- a/.changelog/unreleased/bug-fixes/3525-3514-genesis-validation-pub-key.md
+++ b/.changelog/unreleased/bug-fixes/3525-3514-genesis-validation-pub-key.md
@@ -1,0 +1,3 @@
+- genesis doc validation verifies that all validators
+  use PubKey types supported by the chain to be started
+  ([\#3525](https://github.com/cometbft/cometbft/pull/3525))

--- a/.changelog/unreleased/bug-fixes/3525-3514-genesis-validation-pub-key.md
+++ b/.changelog/unreleased/bug-fixes/3525-3514-genesis-validation-pub-key.md
@@ -1,3 +1,3 @@
-- genesis doc validation verifies that all validators
+- `[types]` genesis doc validation verifies that all validators
   use PubKey types supported by the chain to be started
   ([\#3525](https://github.com/cometbft/cometbft/pull/3525))

--- a/types/genesis.go
+++ b/types/genesis.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"time"
 
 	"github.com/cometbft/cometbft/crypto"
@@ -86,6 +87,7 @@ func (genDoc *GenesisDoc) ValidateAndComplete() error {
 		return err
 	}
 
+	acceptedPubKeyTypes := genDoc.ConsensusParams.Validator.PubKeyTypes
 	for i, v := range genDoc.Validators {
 		if v.Power == 0 {
 			return fmt.Errorf("the genesis file cannot contain validators with no voting power: %v", v)
@@ -95,6 +97,11 @@ func (genDoc *GenesisDoc) ValidateAndComplete() error {
 		}
 		if len(v.Address) == 0 {
 			genDoc.Validators[i].Address = v.PubKey.Address()
+		}
+
+		if !slices.Contains(acceptedPubKeyTypes, v.PubKey.Type()) {
+			formatStr := "validator %v uses an unsupported pubkey type: %q"
+			return fmt.Errorf(formatStr, v, v.PubKey.Type())
 		}
 	}
 

--- a/types/genesis.go
+++ b/types/genesis.go
@@ -113,7 +113,7 @@ func GenesisDocFromJSON(jsonBlob []byte) (*GenesisDoc, error) {
 	genDoc := GenesisDoc{}
 	err := cmtjson.Unmarshal(jsonBlob, &genDoc)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid json for GenesisDoc: %s", err)
 	}
 
 	if err := genDoc.ValidateAndComplete(); err != nil {

--- a/types/genesis_test.go
+++ b/types/genesis_test.go
@@ -68,7 +68,6 @@ func TestGenesisBad(t *testing.T) {
 
 	for i, testCase := range testCases {
 		_, err := GenesisDocFromJSON(testCase)
-		t.Log(err)
 		formatStr := "test case %i: expected error for invalid genesis doc"
 		require.Error(t, err, formatStr, i)
 	}

--- a/types/genesis_test.go
+++ b/types/genesis_test.go
@@ -48,6 +48,28 @@ func TestGenesisBad(t *testing.T) {
 				`},"power":"10","name":""}` +
 				`]}`,
 		),
+		// unsupported validator pubkey type
+		[]byte(
+			`{
+				"genesis_time": "0001-01-01T00:00:00Z",
+				"chain_id": "test-chain-QDKdJr",
+				"initial_height": "1000",
+				"validators": [{
+					"pub_key":{"type":"tendermint/PubKeyEd25519","value":"AT/+aaL1eB0477Mud9JMm8Sh8BIvOYlPGC9KkIUmFaE="},
+					"power":"10",
+					"name":""
+				}],
+				"app_hash":"",
+				"app_state":{"account_owner": "Bob"},
+				"consensus_params": {
+					"synchrony":  {"precision": "1", "message_delay": "10"},
+					"validator": {"pub_key_types":["secp256k1"]},
+					"block": {"max_bytes": "100"},
+					"evidence": {"max_age_num_blocks": "100", "max_age_duration": "10"},
+					"feature": {"vote_extension_enable_height": "0", "pbts_enable_height": "0"}
+				}
+			}`,
+		),
 	}
 
 	for _, testCase := range testCases {

--- a/types/genesis_test.go
+++ b/types/genesis_test.go
@@ -51,6 +51,7 @@ func TestGenesisBad(t *testing.T) {
 		// unsupported validator pubkey type
 		[]byte(
 			`{
+				"chain_id": "test-chain-QDKdJr",
 				"validators": [{
 					"pub_key":{"type":"tendermint/PubKeyEd25519","value":"AT/+aaL1eB0477Mud9JMm8Sh8BIvOYlPGC9KkIUmFaE="},
 					"power":"10",
@@ -59,15 +60,17 @@ func TestGenesisBad(t *testing.T) {
 				"consensus_params": {
 					"validator": {"pub_key_types":["secp256k1"]},
 					"block": {"max_bytes": "100"},
-					"evidence": {"max_age_num_blocks": "100", "max_age_duration": "10"},
+					"evidence": {"max_age_num_blocks": "100", "max_age_duration": "10"}
 				}
 			}`,
 		),
 	}
 
-	for _, testCase := range testCases {
+	for i, testCase := range testCases {
 		_, err := GenesisDocFromJSON(testCase)
-		require.Error(t, err, "expected error for empty genDoc json")
+		t.Log(err)
+		formatStr := "test case %i: expected error for invalid genesis doc"
+		require.Error(t, err, formatStr, i)
 	}
 }
 

--- a/types/genesis_test.go
+++ b/types/genesis_test.go
@@ -51,22 +51,15 @@ func TestGenesisBad(t *testing.T) {
 		// unsupported validator pubkey type
 		[]byte(
 			`{
-				"genesis_time": "0001-01-01T00:00:00Z",
-				"chain_id": "test-chain-QDKdJr",
-				"initial_height": "1000",
 				"validators": [{
 					"pub_key":{"type":"tendermint/PubKeyEd25519","value":"AT/+aaL1eB0477Mud9JMm8Sh8BIvOYlPGC9KkIUmFaE="},
 					"power":"10",
 					"name":""
 				}],
-				"app_hash":"",
-				"app_state":{"account_owner": "Bob"},
 				"consensus_params": {
-					"synchrony":  {"precision": "1", "message_delay": "10"},
 					"validator": {"pub_key_types":["secp256k1"]},
 					"block": {"max_bytes": "100"},
 					"evidence": {"max_age_num_blocks": "100", "max_age_duration": "10"},
-					"feature": {"vote_extension_enable_height": "0", "pbts_enable_height": "0"}
 				}
 			}`,
 		),


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->
Closes #3514.

### Changes
- Added unit test demonstrating the problem.
- Added code in `ValidateAndComplete` that, for each validator in the genesis doc, checks if their `PubKey.Type()` is present in the accepted `PubKeyTypes` of the chain.

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
