### PR TITLE
fix(ci): run `make all` error 'No rule to make target 'check''

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,8 @@ ifeq (linux/riscv64,$(findstring linux/riscv64,$(TARGETPLATFORM)))
 	GOARCH=riscv64
 endif
 
-#? all: Run target check, build, test and install
-all: check build test install
+#? all: Run target build, test and install
+all: build test install
 .PHONY: all
 
 include tests.mk


### PR DESCRIPTION
Running `make all` would cause an error: `make: *** No rule to make target 'check', needed by 'all'.  Stop.`

The `check` target has already removed, let's delete it