### PR TITLE
fix(types): Add missing JSON tags to `DuplicateVoteEvidence` and `LightClientAttackEvidence` types

### DIFF
--- a/.changelog/unreleased/bug-fixes/3528-evidence-missing-json-tags.md
+++ b/.changelog/unreleased/bug-fixes/3528-evidence-missing-json-tags.md
@@ -1,0 +1,2 @@
+- `[types]` Added missing JSON tags to `DuplicateVoteEvidence` and `LightClientAttackEvidence`
+  types ([\#3528](https://github.com/cometbft/cometbft/issues/3528))

--- a/.changelog/unreleased/bug-fixes/3543-evidence-missing-json-tags.md
+++ b/.changelog/unreleased/bug-fixes/3543-evidence-missing-json-tags.md
@@ -1,2 +1,0 @@
-- Added missing JSON tags to DuplicateVoteEvidence and LightClientAttackEvidence
-  types ([\#3543](https://github.com/cometbft/cometbft/pull/3543))

--- a/.changelog/unreleased/bug-fixes/3543-evidence-missing-json-tags.md
+++ b/.changelog/unreleased/bug-fixes/3543-evidence-missing-json-tags.md
@@ -1,0 +1,2 @@
+- Added missing JSON tags to DuplicateVoteEvidence and LightClientAttackEvidence
+  types ([\#3543](https://github.com/cometbft/cometbft/pull/3543))

--- a/types/evidence.go
+++ b/types/evidence.go
@@ -38,9 +38,9 @@ type DuplicateVoteEvidence struct {
 	VoteB *Vote `json:"vote_b"`
 
 	// abci specific information
-	TotalVotingPower int64
-	ValidatorPower   int64
-	Timestamp        time.Time
+	TotalVotingPower int64     `json:"total_voting_power"`
+	ValidatorPower   int64     `json:"validator_power"`
+	Timestamp        time.Time `json:"timestamp"`
 }
 
 var _ Evidence = &DuplicateVoteEvidence{}

--- a/types/evidence.go
+++ b/types/evidence.go
@@ -211,7 +211,7 @@ type LightClientAttackEvidence struct {
 	ConflictingBlock *LightBlock `json:"conflicting_block"`
 	CommonHeight     int64       `json:"common_height"`
 
-	// abci specific information
+	// ABCI specific information
 
 	// validators in the validator set that misbehaved in creating the conflicting
 	// block

--- a/types/evidence.go
+++ b/types/evidence.go
@@ -208,13 +208,20 @@ func DuplicateVoteEvidenceFromProto(pb *cmtproto.DuplicateVoteEvidence) (*Duplic
 // and Amnesia. These attacks are exhaustive. You can find a more detailed overview of this at
 // cometbft/docs/architecture/tendermint-core/adr-047-handling-evidence-from-light-client.md.
 type LightClientAttackEvidence struct {
-	ConflictingBlock *LightBlock
-	CommonHeight     int64
+	ConflictingBlock *LightBlock `json:"conflicting_block"`
+	CommonHeight     int64       `json:"common_height"`
 
 	// abci specific information
-	ByzantineValidators []*Validator // validators in the validator set that misbehaved in creating the conflicting block
-	TotalVotingPower    int64        // total voting power of the validator set at the common height
-	Timestamp           time.Time    // timestamp of the block at the common height
+
+	// validators in the validator set that misbehaved in creating the conflicting
+	// block
+	ByzantineValidators []*Validator `json:"byzantine_validators"`
+
+	// total voting power of the validator set at the common height
+	TotalVotingPower int64 `json:"total_voting_power"`
+
+	// timestamp of the block at the common height
+	Timestamp time.Time `json:"timestamp"`
 }
 
 var _ Evidence = &LightClientAttackEvidence{}

--- a/types/evidence_test.go
+++ b/types/evidence_test.go
@@ -309,7 +309,7 @@ func TestEvidenceProto(t *testing.T) {
 	}
 }
 
-// Test that the new JSON tags are picked up correctly, see issue #3528
+// Test that the new JSON tags are picked up correctly, see issue #3528.
 func TestDuplicateVoteEvidenceJSON(t *testing.T) {
 	var evidence DuplicateVoteEvidence
 	js, err := cmtjson.Marshal(evidence)

--- a/types/evidence_test.go
+++ b/types/evidence_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/crypto/tmhash"
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
+	cmtjson "github.com/cometbft/cometbft/libs/json"
 	cmttime "github.com/cometbft/cometbft/types/time"
 	"github.com/cometbft/cometbft/version"
 )
@@ -306,4 +307,24 @@ func TestEvidenceProto(t *testing.T) {
 			require.Equal(t, tt.evidence, evi, tt.testName)
 		})
 	}
+}
+
+// Test that the new JSON tags are picked up correctly, see issue #3528
+func TestDuplicateVoteEvidenceJSON(t *testing.T) {
+	var evidence DuplicateVoteEvidence
+	js, err := cmtjson.Marshal(evidence)
+	require.NoError(t, err)
+
+	wantJSON := `{"type":"tendermint/DuplicateVoteEvidence","value":{"vote_a":null,"vote_b":null,"total_voting_power":"0","validator_power":"0","timestamp":"0001-01-01T00:00:00Z"}}`
+	assert.Equal(t, wantJSON, string(js))
+}
+
+// Test that the new JSON tags are picked up correctly, see issue #3528.
+func TestLightClientAttackEvidenceJSON(t *testing.T) {
+	var evidence LightClientAttackEvidence
+	js, err := cmtjson.Marshal(evidence)
+	require.NoError(t, err)
+
+	wantJSON := `{"type":"tendermint/LightClientAttackEvidence","value":{"conflicting_block":null,"common_height":"0","byzantine_validators":null,"total_voting_power":"0","timestamp":"0001-01-01T00:00:00Z"}}`
+	assert.Equal(t, wantJSON, string(js))
 }


### PR DESCRIPTION
Closes #3528 

### Changes
Added missing JSON tags to `DuplicateVoteEvidence` and `LightClientAttackEvidence` types.

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
~- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments~
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
