### PR TITLE
fix(indexer): Ineffective or missing break statements in kv package.

### DIFF
--- a/.changelog/unreleased/bug-fixes/3544-indexer-break-statement.md
+++ b/.changelog/unreleased/bug-fixes/3544-indexer-break-statement.md
@@ -1,3 +1,3 @@
-- `[indexer]` Fixed ineffective selec break statements; they now
+- `[indexer]` Fixed ineffective select break statements; they now
   point to their enclosing for loop label to exit
   ([\#3544](https://github.com/cometbft/cometbft/issues/3544))

--- a/.changelog/unreleased/bug-fixes/3544-indexer-break-statement.md
+++ b/.changelog/unreleased/bug-fixes/3544-indexer-break-statement.md
@@ -1,0 +1,3 @@
+- `[indexer]` Fixed ineffective selec break statements; they now
+  point to their enclosing for loop label to exit
+  ([\#3544](https://github.com/cometbft/cometbft/issues/3544))

--- a/state/indexer/block/kv/kv.go
+++ b/state/indexer/block/kv/kv.go
@@ -491,7 +491,7 @@ LOOP:
 
 		select {
 		case <-ctx.Done():
-
+			break LOOP
 		default:
 		}
 	}

--- a/state/indexer/block/kv/kv.go
+++ b/state/indexer/block/kv/kv.go
@@ -513,6 +513,7 @@ LOOP:
 
 	// Remove/reduce matches in filteredHashes that were not found in this
 	// match (tmpHashes).
+FOR_LOOP:
 	for k, v := range filteredHeights {
 		tmpHeight := tmpHeights[k]
 
@@ -523,7 +524,7 @@ LOOP:
 
 			select {
 			case <-ctx.Done():
-
+				break FOR_LOOP
 			default:
 			}
 		}
@@ -608,6 +609,7 @@ func (idx *BlockerIndexer) match(
 		}
 		defer it.Close()
 
+	LOOP_EXISTS:
 		for ; it.Valid(); it.Next() {
 			keyHeight, err := parseHeightFromEventKey(it.Key())
 			if err != nil {
@@ -627,7 +629,7 @@ func (idx *BlockerIndexer) match(
 
 			select {
 			case <-ctx.Done():
-				break
+				break LOOP_EXISTS
 
 			default:
 			}
@@ -649,6 +651,7 @@ func (idx *BlockerIndexer) match(
 		}
 		defer it.Close()
 
+	LOOP_CONTAINS:
 		for ; it.Valid(); it.Next() {
 			eventValue, err := parseValueFromEventKey(it.Key())
 			if err != nil {
@@ -674,7 +677,7 @@ func (idx *BlockerIndexer) match(
 
 			select {
 			case <-ctx.Done():
-				break
+				break LOOP_CONTAINS
 
 			default:
 			}


### PR DESCRIPTION
Closes #3544.

### Changes
- Adds missing `for` loop labels in the kv indexer 
- Previously ineffective `break` statements now point to their enclosing `for` loop labels to exit upon reception on the `ctx.Done()` channel.

---

#### PR checklist

~- [ ] Tests written/updated~
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
~- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments~
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
