### PR TITLE
test(p2p/pex): fix `TestConnectionSpeedForPeerReceivedFromSeed` flacky test

### DIFF
--- a/p2p/pex/pex_reactor_test.go
+++ b/p2p/pex/pex_reactor_test.go
@@ -285,21 +285,18 @@ func TestConnectionSpeedForPeerReceivedFromSeed(t *testing.T) {
 		defer peer.Stop() //nolint:errcheck // ignore for tests
 
 		knownAddrs = append(knownAddrs, addr)
-		t.Log("Created peer", id, addr)
 	}
 
 	// 2. Create seed node which knows about the previous peers
 	seed := testCreateSeed(dir, id, knownAddrs, knownAddrs)
 	require.NoError(t, seed.Start())
 	defer seed.Stop() //nolint:errcheck // ignore for tests
-	t.Log("Created seed", id, seed.NetAddress())
 
 	// 3. Create a node with only seed configured.
 	id++
 	node := testCreatePeerWithSeed(dir, id, seed)
 	require.NoError(t, node.Start())
 	defer node.Stop() //nolint:errcheck // ignore for tests
-	t.Log("Created node", id, node.NetAddress())
 
 	// 4. Check that the node connects to seed immediately
 	assertPeersWithTimeout(t, []*p2p.Switch{node}, 3*time.Second, 1)

--- a/p2p/pex/pex_reactor_test.go
+++ b/p2p/pex/pex_reactor_test.go
@@ -305,7 +305,7 @@ func TestConnectionSpeedForPeerReceivedFromSeed(t *testing.T) {
 	assertPeersWithTimeout(t, []*p2p.Switch{node}, 3*time.Second, 1)
 
 	// 5. Check that the node connects to the peers reported by the seed node
-	assertPeersWithTimeout(t, []*p2p.Switch{node}, 1*time.Second, cfg.MaxNumOutboundPeers)
+	assertPeersWithTimeout(t, []*p2p.Switch{node}, 3*time.Second, cfg.MaxNumOutboundPeers)
 
 	// 6. Assert that the configured maximum number of inbound/outbound peers
 	// are respected, see https://github.com/cometbft/cometbft/issues/486


### PR DESCRIPTION
Increased the timeout from 1 to 3 seconds.

Almost never fails locally, but fails on the GitHub CI (e.g., https://github.com/cometbft/cometbft/actions/runs/10111986972/job/27965072382?pr=3411).

---

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
