### PR TITLE
test(p2p/pex): fix TestConnectionSpeedForPeerReceivedFromSeed flacky test

### DIFF
--- a/p2p/pex/pex_reactor_test.go
+++ b/p2p/pex/pex_reactor_test.go
@@ -302,7 +302,7 @@ func TestConnectionSpeedForPeerReceivedFromSeed(t *testing.T) {
 	assertPeersWithTimeout(t, []*p2p.Switch{node}, 3*time.Second, 1)
 
 	// 5. Check that the node connects to the peers reported by the seed node
-	assertPeersWithTimeout(t, []*p2p.Switch{node}, 3*time.Second, cfg.MaxNumOutboundPeers)
+	assertPeersWithTimeout(t, []*p2p.Switch{node}, 10*time.Second, cfg.MaxNumOutboundPeers)
 
 	// 6. Assert that the configured maximum number of inbound/outbound peers
 	// are respected, see https://github.com/cometbft/cometbft/issues/486


### PR DESCRIPTION
Follow-up from #3568, as the same test is still flaky.

Trying now with 10s timeout for the connections to happen.

---

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
