### PR TITLE
feat(crypto)!: remove PubKey#Equals and PrivKey#Equals

### DIFF
--- a/.changelog/unreleased/breaking-changes/3606-crypto-equals.md
+++ b/.changelog/unreleased/breaking-changes/3606-crypto-equals.md
@@ -1,0 +1,2 @@
+- `[crypto]` Remove `PubKey#Equals` and `PrivKey#Equals`
+  ([\#3606](https://github.com/cometbft/cometbft/pull/3606))

--- a/crypto/bls12381/key.go
+++ b/crypto/bls12381/key.go
@@ -50,11 +50,6 @@ func (PrivKey) PubKey() crypto.PubKey {
 	panic("bls12_381 is disabled")
 }
 
-// Equals always panics.
-func (PrivKey) Equals(crypto.PrivKey) bool {
-	panic("bls12_381 is disabled")
-}
-
 // Type returns the key's type.
 func (PrivKey) Type() string {
 	return KeyType
@@ -97,9 +92,4 @@ func (PubKey) Bytes() []byte {
 // Type returns the key's type.
 func (PubKey) Type() string {
 	return KeyType
-}
-
-// Equals always panics.
-func (PubKey) Equals(crypto.PubKey) bool {
-	panic("bls12_381 is disabled")
 }

--- a/crypto/bls12381/key_bls12381.go
+++ b/crypto/bls12381/key_bls12381.go
@@ -3,7 +3,6 @@
 package bls12381
 
 import (
-	"bytes"
 	"crypto/sha256"
 
 	"github.com/cometbft/cometbft/crypto"
@@ -66,11 +65,6 @@ func (privKey PrivKey) PubKey() crypto.PubKey {
 	}
 
 	return PubKey(secretKey.PublicKey().Marshal())
-}
-
-// Equals returns true if two keys are equal and false otherwise.
-func (privKey PrivKey) Equals(other crypto.PrivKey) bool {
-	return privKey.Type() == other.Type() && bytes.Equal(privKey.Bytes(), other.Bytes())
 }
 
 // Type returns the type.
@@ -150,9 +144,4 @@ func (pubKey PubKey) Bytes() []byte {
 // Type returns the key's type.
 func (PubKey) Type() string {
 	return KeyType
-}
-
-// Equals returns true if the other's type is the same and their bytes are deeply equal.
-func (pubKey PubKey) Equals(other crypto.PubKey) bool {
-	return pubKey.Type() == other.Type() && bytes.Equal(pubKey.Bytes(), other.Bytes())
 }

--- a/crypto/bls12381/key_test.go
+++ b/crypto/bls12381/key_test.go
@@ -20,7 +20,7 @@ func TestNewPrivateKeyFromBytes(t *testing.T) {
 	privKey2, err := bls12381.NewPrivateKeyFromBytes(privKeyBytes)
 	require.NoError(t, err)
 
-	assert.True(t, privKey.Equals(privKey2))
+	assert.Equal(t, privKey, privKey2)
 
 	_, err = bls12381.NewPrivateKeyFromBytes(crypto.CRandBytes(31))
 	assert.Error(t, err)
@@ -40,7 +40,7 @@ func TestPrivKeyBytes(t *testing.T) {
 	privKey2, err := bls12381.NewPrivateKeyFromBytes(privKeyBytes)
 	require.NoError(t, err)
 
-	assert.True(t, privKey.Equals(privKey2))
+	assert.Equal(t, privKey, privKey2)
 }
 
 func TestPrivKeyPubKey(t *testing.T) {
@@ -48,16 +48,6 @@ func TestPrivKeyPubKey(t *testing.T) {
 	require.NoError(t, err)
 	pubKey := privKey.PubKey()
 	assert.NotNil(t, pubKey)
-}
-
-func TestPrivKeyEquals(t *testing.T) {
-	privKey, err := bls12381.GenPrivKey()
-	require.NoError(t, err)
-	privKey2, err := bls12381.GenPrivKey()
-	require.NoError(t, err)
-
-	assert.True(t, privKey.Equals(privKey))
-	assert.False(t, privKey.Equals(privKey2))
 }
 
 func TestPrivKeyType(t *testing.T) {
@@ -106,16 +96,6 @@ func TestPubKey(t *testing.T) {
 	require.NoError(t, err)
 	pubKey := privKey.PubKey()
 	assert.NotNil(t, pubKey)
-}
-
-func TestPubKeyEquals(t *testing.T) {
-	privKey, err := bls12381.GenPrivKey()
-	require.NoError(t, err)
-	pubKey := privKey.PubKey()
-	pubKey2 := privKey.PubKey()
-
-	assert.True(t, pubKey.Equals(pubKey))
-	assert.True(t, pubKey.Equals(pubKey2))
 }
 
 func TestPubKeyType(t *testing.T) {

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -23,7 +23,6 @@ type PubKey interface {
 	Address() Address
 	Bytes() []byte
 	VerifySignature(msg []byte, sig []byte) bool
-	Equals(other PubKey) bool
 	Type() string
 }
 
@@ -31,7 +30,6 @@ type PrivKey interface {
 	Bytes() []byte
 	Sign(msg []byte) ([]byte, error)
 	PubKey() PubKey
-	Equals(other PrivKey) bool
 	Type() string
 }
 

--- a/crypto/doc.go
+++ b/crypto/doc.go
@@ -12,7 +12,6 @@
 //		Bytes() []byte
 //		Sign(msg []byte) ([]byte, error)
 //		PubKey() PubKey
-//		Equals(other PrivKey) bool
 //		Type() string
 //	}
 //
@@ -30,7 +29,6 @@
 //		Address() Address
 //		Bytes() []byte
 //		VerifySignature(msg []byte, sig []byte) bool
-//		Equals(other PubKey) bool
 //		Type() string
 //	}
 package crypto

--- a/crypto/ed25519/ed25519.go
+++ b/crypto/ed25519/ed25519.go
@@ -1,9 +1,7 @@
 package ed25519
 
 import (
-	"bytes"
 	"crypto/sha256"
-	"crypto/subtle"
 	"errors"
 	"fmt"
 	"io"
@@ -118,16 +116,6 @@ func (privKey PrivKey) PubKey() crypto.PubKey {
 	return PubKey(pubkeyBytes)
 }
 
-// Equals - you probably don't need to use this.
-// Runs in constant time based on length of the keys.
-func (privKey PrivKey) Equals(other crypto.PrivKey) bool {
-	if otherEd, ok := other.(PrivKey); ok {
-		return subtle.ConstantTimeCompare(privKey[:], otherEd[:]) == 1
-	}
-
-	return false
-}
-
 func (PrivKey) Type() string {
 	return KeyType
 }
@@ -194,14 +182,6 @@ func (pubKey PubKey) String() string {
 
 func (PubKey) Type() string {
 	return KeyType
-}
-
-func (pubKey PubKey) Equals(other crypto.PubKey) bool {
-	if otherEd, ok := other.(PubKey); ok {
-		return bytes.Equal(pubKey[:], otherEd[:])
-	}
-
-	return false
 }
 
 // -------------------------------------

--- a/crypto/secp256k1/secp256k1.go
+++ b/crypto/secp256k1/secp256k1.go
@@ -1,9 +1,7 @@
 package secp256k1
 
 import (
-	"bytes"
 	"crypto/sha256"
-	"crypto/subtle"
 	"fmt"
 	"io"
 	"math/big"
@@ -48,15 +46,6 @@ func (privKey PrivKey) PubKey() crypto.PubKey {
 	pk := pubkeyObject.SerializeCompressed()
 
 	return PubKey(pk)
-}
-
-// Equals - you probably don't need to use this.
-// Runs in constant time based on length of the keys.
-func (privKey PrivKey) Equals(other crypto.PrivKey) bool {
-	if otherSecp, ok := other.(PrivKey); ok {
-		return subtle.ConstantTimeCompare(privKey[:], otherSecp[:]) == 1
-	}
-	return false
 }
 
 func (PrivKey) Type() string {
@@ -175,13 +164,6 @@ func (pubKey PubKey) Bytes() []byte {
 
 func (pubKey PubKey) String() string {
 	return fmt.Sprintf("PubKeySecp256k1{%X}", []byte(pubKey))
-}
-
-func (pubKey PubKey) Equals(other crypto.PubKey) bool {
-	if otherSecp, ok := other.(PubKey); ok {
-		return bytes.Equal(pubKey[:], otherSecp[:])
-	}
-	return false
 }
 
 func (PubKey) Type() string {

--- a/crypto/sr25519/privkey.go
+++ b/crypto/sr25519/privkey.go
@@ -80,15 +80,6 @@ func (privKey PrivKey) PubKey() crypto.PubKey {
 	return PubKey(b)
 }
 
-// Equals - you probably don't need to use this.
-// Runs in constant time based on length of the keys.
-func (privKey PrivKey) Equals(other crypto.PrivKey) bool {
-	if otherSr, ok := other.(PrivKey); ok {
-		return privKey.msk.Equal(&otherSr.msk)
-	}
-	return false
-}
-
 func (PrivKey) Type() string {
 	return KeyType
 }

--- a/crypto/sr25519/pubkey.go
+++ b/crypto/sr25519/pubkey.go
@@ -1,7 +1,6 @@
 package sr25519
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/oasisprotocol/curve25519-voi/primitives/sr25519"
@@ -34,16 +33,6 @@ func (pubKey PubKey) Address() crypto.Address {
 // Bytes returns the byte representation of the PubKey.
 func (pubKey PubKey) Bytes() []byte {
 	return []byte(pubKey)
-}
-
-// Equals - checks that two public keys are the same time
-// Runs in constant time based on length of the keys.
-func (pubKey PubKey) Equals(other crypto.PubKey) bool {
-	if otherSr, ok := other.(PubKey); ok {
-		return bytes.Equal(pubKey[:], otherSr[:])
-	}
-
-	return false
 }
 
 func (pubKey PubKey) VerifySignature(msg []byte, sigBytes []byte) bool {

--- a/internal/consensus/replay_test.go
+++ b/internal/consensus/replay_test.go
@@ -432,7 +432,7 @@ func setupChainWithChangingValidators(t *testing.T, name string, nBlocks int) (*
 			cssPubKey, err := css[cssIdx].privValidator.GetPubKey()
 			require.NoError(t, err)
 
-			if vsPubKey.Equals(cssPubKey) {
+			if vsPubKey.Type() == cssPubKey.Type() && bytes.Equal(vsPubKey.Bytes(), cssPubKey.Bytes()) {
 				return i
 			}
 		}

--- a/p2p/conn/secret_connection_test.go
+++ b/p2p/conn/secret_connection_test.go
@@ -2,6 +2,7 @@ package conn
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/hex"
 	"errors"
 	"flag"
@@ -51,7 +52,6 @@ type privKeyWithNilPubKey struct {
 func (pk privKeyWithNilPubKey) Bytes() []byte                   { return pk.orig.Bytes() }
 func (pk privKeyWithNilPubKey) Sign(msg []byte) ([]byte, error) { return pk.orig.Sign(msg) }
 func (privKeyWithNilPubKey) PubKey() crypto.PubKey              { return nil }
-func (pk privKeyWithNilPubKey) Equals(pk2 crypto.PrivKey) bool  { return pk.orig.Equals(pk2) }
 func (privKeyWithNilPubKey) Type() string                       { return "privKeyWithNilPubKey" }
 
 func TestSecretConnectionHandshake(t *testing.T) {
@@ -354,7 +354,7 @@ func makeSecretConnPair(tb testing.TB) (fooSecConn, barSecConn *SecretConnection
 				return nil, true, err
 			}
 			remotePubBytes := fooSecConn.RemotePubKey()
-			if !remotePubBytes.Equals(barPubKey) {
+			if !bytes.Equal(remotePubBytes.Bytes(), barPubKey.Bytes()) {
 				err = fmt.Errorf("unexpected fooSecConn.RemotePubKey.  Expected %v, got %v",
 					barPubKey, fooSecConn.RemotePubKey())
 				tb.Error(err)
@@ -369,7 +369,7 @@ func makeSecretConnPair(tb testing.TB) (fooSecConn, barSecConn *SecretConnection
 				return nil, true, err
 			}
 			remotePubBytes := barSecConn.RemotePubKey()
-			if !remotePubBytes.Equals(fooPubKey) {
+			if !bytes.Equal(remotePubBytes.Bytes(), fooPubKey.Bytes()) {
 				err = fmt.Errorf("unexpected barSecConn.RemotePubKey.  Expected %v, got %v",
 					fooPubKey, barSecConn.RemotePubKey())
 				tb.Error(err)

--- a/test/fuzz/tests/p2p_secretconnection_test.go
+++ b/test/fuzz/tests/p2p_secretconnection_test.go
@@ -99,7 +99,7 @@ func makeSecretConnPair() (fooSecConn, barSecConn *sc.SecretConnection) {
 				return nil, true, err
 			}
 			remotePubBytes := fooSecConn.RemotePubKey()
-			if !remotePubBytes.Equals(barPubKey) {
+			if !bytes.Equal(remotePubBytes.Bytes(), barPubKey.Bytes()) {
 				err = fmt.Errorf("unexpected fooSecConn.RemotePubKey.  Expected %v, got %v",
 					barPubKey, fooSecConn.RemotePubKey())
 				log.Print(err)
@@ -114,7 +114,7 @@ func makeSecretConnPair() (fooSecConn, barSecConn *sc.SecretConnection) {
 				return nil, true, err
 			}
 			remotePubBytes := barSecConn.RemotePubKey()
-			if !remotePubBytes.Equals(fooPubKey) {
+			if !bytes.Equal(remotePubBytes.Bytes(), fooPubKey.Bytes()) {
 				err = fmt.Errorf("unexpected barSecConn.RemotePubKey.  Expected %v, got %v",
 					fooPubKey, barSecConn.RemotePubKey())
 				log.Print(err)


### PR DESCRIPTION
a) it's unused
b) Cosmos SDK folks suggested to remove it in one of the issues 

Refs https://github.com/cometbft/cometbft/issues/2426

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
