### PR TITLE
fix(types): re-enable some vote extension-related sanity checks when signing a vote

### DIFF
--- a/types/vote.go
+++ b/types/vote.go
@@ -433,11 +433,19 @@ func SignAndCheckVote(
 		return false, &ErrVoteExtensionInvalid{ExtSignature: v.ExtensionSignature}
 	}
 
+	isNil := vote.BlockID.IsNil()
+	extSignature := (len(v.ExtensionSignature) > 0)
+
+	// Error if prevote contains an extension signature
+	if extSignature && (!isPrecommit || isNil) {
+		// Non-recoverable because the vote is malformed
+		return false, &ErrVoteExtensionInvalid{ExtSignature: v.ExtensionSignature}
+	}
+
 	vote.ExtensionSignature = nil
 	if extensionsEnabled {
-		isNil := vote.BlockID.IsNil()
-		extSignature := (len(v.ExtensionSignature) > 0)
-		if extSignature == (!isPrecommit || isNil) {
+		// Error if missing extension signature for non-nil Precommit
+		if !extSignature && isPrecommit && !isNil {
 			// Non-recoverable because the vote is malformed
 			return false, &ErrVoteExtensionInvalid{ExtSignature: v.ExtensionSignature}
 		}


### PR DESCRIPTION
When vote extensions are disabled, we still need to (sanity-)check that:

* Prevotes don't contain an extension signature
* `nil` precommits don't contain an extension signature

This PR is re-enabling those checks, in alignment with #3565 in `v0.38.x`

---

#### PR checklist

- ~[ ] Tests written/updated~
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- ~[ ] Updated relevant documentation (`docs/` or `spec/`) and code comments~
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
