### PR TITLE
feat(mempool): add error ErrRecheckFull

### DIFF
--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -431,16 +431,17 @@ func (mem *CListMempool) RemoveTxByKey(txKey types.TxKey) error {
 func (mem *CListMempool) isFull(txSize int) error {
 	memSize := mem.Size()
 	txsBytes := mem.SizeBytes()
-	recheckFull := mem.recheck.consideredFull()
-
-	if memSize >= mem.config.Size || uint64(txSize)+uint64(txsBytes) > uint64(mem.config.MaxTxsBytes) || recheckFull {
+	if memSize >= mem.config.Size || uint64(txSize)+uint64(txsBytes) > uint64(mem.config.MaxTxsBytes) {
 		return ErrMempoolIsFull{
 			NumTxs:      memSize,
 			MaxTxs:      mem.config.Size,
 			TxsBytes:    txsBytes,
 			MaxTxsBytes: mem.config.MaxTxsBytes,
-			RecheckFull: recheckFull,
 		}
+	}
+
+	if mem.recheck.consideredFull() {
+		return ErrRecheckFull
 	}
 
 	return nil

--- a/mempool/errors.go
+++ b/mempool/errors.go
@@ -11,6 +11,10 @@ var ErrTxNotFound = errors.New("transaction not found in mempool")
 // ErrTxInCache is returned to the client if we saw tx earlier.
 var ErrTxInCache = errors.New("tx already exists in cache")
 
+// ErrRecheckFull is returned when checking if the mempool is full and
+// rechecking is still in progress after a new block was committed.
+var ErrRecheckFull = errors.New("mempool is still rechecking after a new committed block, so it is considered as full")
+
 // ErrTxTooLarge defines an error when a transaction is too big to be sent in a
 // message to other peers.
 type ErrTxTooLarge struct {


### PR DESCRIPTION
Complements #3314

This PR adds a new error with a more clear error message when checking if the mempool is full while rechecking is in progress after a new block was committed.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
