### PR TITLE
chore: update cometbft-db dependency

### DIFF
--- a/.changelog/unreleased/dependencies/3661-bump-cometbft-db-version.md
+++ b/.changelog/unreleased/dependencies/3661-bump-cometbft-db-version.md
@@ -1,0 +1,2 @@
+- reinstate BoltDB and ClevelDB as backend DBs, bumped cometbft-db version to
+  v0.14.0 ([\#3661](https://github.com/cometbft/cometbft/pull/3661))

--- a/cmd/cometbft/commands/inspect.go
+++ b/cmd/cometbft/commands/inspect.go
@@ -36,8 +36,11 @@ func init() {
 		String("rpc.laddr",
 			config.RPC.ListenAddress, "RPC listenener address. Port required")
 	InspectCmd.Flags().
-		String("db-backend",
-			config.DBBackend, "database backend: goleveldb | rocksdb | badgerdb | pebbledb")
+		String(
+			"db-backend",
+			config.DBBackend,
+			"database backend: goleveldb | cleveldb | boltdb | rocksdb | badgerdb | pebbledb",
+		)
 	InspectCmd.Flags().
 		String("db-dir", config.DBPath, "database directory")
 }

--- a/cmd/cometbft/commands/run_node.go
+++ b/cmd/cometbft/commands/run_node.go
@@ -84,7 +84,7 @@ func AddNodeFlags(cmd *cobra.Command) {
 	cmd.Flags().String(
 		"db_backend",
 		config.DBBackend,
-		"database backend: goleveldb | rocksdb | badgerdb | pebbledb")
+		"database backend: goleveldb | cleveldb | boltdb | rocksdb | badgerdb | pebbledb")
 	cmd.Flags().String(
 		"db_dir",
 		config.DBPath,

--- a/common.mk
+++ b/common.mk
@@ -29,10 +29,21 @@ ifeq (clock_skew,$(findstring clock_skew,$(COMETBFT_BUILD_OPTIONS)))
   BUILD_TAGS += clock_skew
 endif
 
+# handle cleveldb
+ ifeq (cleveldb,$(findstring cleveldb,$(COMETBFT_BUILD_OPTIONS)))
+   CGO_ENABLED=1
+   BUILD_TAGS += cleveldb
+ endif
+
 # handle badgerdb
 ifeq (badgerdb,$(findstring badgerdb,$(COMETBFT_BUILD_OPTIONS)))
   BUILD_TAGS += badgerdb
 endif
+
+# handle boltdb
+ ifeq (boltdb,$(findstring boltdb,$(COMETBFT_BUILD_OPTIONS)))
+   BUILD_TAGS += boltdb
+ endif
 
 # handle rocksdb
 ifeq (rocksdb,$(findstring rocksdb,$(COMETBFT_BUILD_OPTIONS)))

--- a/config/config.go
+++ b/config/config.go
@@ -229,11 +229,20 @@ type BaseConfig struct {
 	// A custom human readable name for this node
 	Moniker string `mapstructure:"moniker"`
 
-	// Database backend: goleveldb | rocksdb | badgerdb | pebbledb
+	// Database backend: goleveldb | cleveldb | boltdb | rocksdb | pebbledb
 	// * goleveldb (github.com/syndtr/goleveldb)
 	//   - UNMAINTAINED
 	//   - stable
 	//   - pure go
+	// * cleveldb (uses levigo wrapper)
+	//   - DEPRECATED
+	//   - requires gcc
+	//   - use cleveldb build tag (go build -tags cleveldb)
+	// * boltdb (uses etcd's fork of bolt - github.com/etcd-io/bbolt)
+	//   - DEPRECATED
+	//   - EXPERIMENTAL
+	//   - stable
+	//   - use boltdb build tag (go build -tags boltdb)
 	// * rocksdb (uses github.com/linxGnu/grocksdb)
 	//   - EXPERIMENTAL
 	//   - requires gcc

--- a/config/config.toml.tpl
+++ b/config/config.toml.tpl
@@ -21,11 +21,20 @@ proxy_app = "{{ .BaseConfig.ProxyApp }}"
 # A custom human readable name for this node
 moniker = "{{ .BaseConfig.Moniker }}"
 
-# Database backend: goleveldb | rocksdb | badgerdb | pebbledb
+# Database backend: goleveldb | cleveldb | boltdb | rocksdb | badgerdb | pebbledb
 # * goleveldb (github.com/syndtr/goleveldb)
 #   - UNMAINTAINED
 #   - stable
 #   - pure go
+# * cleveldb (uses levigo wrapper)
+#   - DEPRECATED
+#   - requires gcc
+#   - use cleveldb build tag (go build -tags cleveldb)
+# * boltdb (uses etcd's fork of bolt - github.com/etcd-io/bbolt)
+#   - DEPRECATED
+#   - EXPERIMENTAL
+#   - stable
+#   - use boltdb build tag (go build -tags boltdb)
 # * rocksdb (uses github.com/linxGnu/grocksdb)
 #   - EXPERIMENTAL
 #   - requires gcc

--- a/docs/references/config/config.toml.md
+++ b/docs/references/config/config.toml.md
@@ -115,6 +115,8 @@ db_backend = "goleveldb"
 | Value type          | string        | dependencies  | GitHub                                           |
 |:--------------------|:--------------|:--------------|:-------------------------------------------------|
 | **Possible values** | `"goleveldb"` | pure Golang   | [goleveldb](https://github.com/syndtr/goleveldb) |
+|                     | `"cleveldb"`  | requires gcc  | [leveldb](https://github.com/google/leveldb)     |
+|                     | `"boltdb"`    | pure Golang   | [bbolt](https://github.com/etcd-io/bbolt)        |
 |                     | `"rocksdb"`   | requires gcc  | [grocksdb](https://github.com/linxGnu/grocksdb)  |
 |                     | `"badgerdb"`  | pure Golang   | [badger](https://github.com/dgraph-io/badger)    |
 |                     | `"pebbledb"`  | pure Golang   | [pebble](https://github.com/cockroachdb/pebble)  |
@@ -128,6 +130,8 @@ The RocksDB fork has API changes from the upstream RocksDB implementation. All o
 The CometBFT team tests rely on the GoLevelDB implementation. All other implementations are considered experimental from
 a CometBFT perspective. The supported databases are part of the [cometbft-db](https://github.com/cometbft/cometbft-db) library
 that CometBFT uses as a common database interface to various databases.
+
+**NOTE**: `boltdb` and `cleveldb` are deprecated and will be removed in a future release.
 
 ### db_dir
 The directory path where the database is stored.

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/btcsuite/btcd/btcec/v2 v2.3.3
 	github.com/btcsuite/btcd/btcutil v1.1.5
-	github.com/cometbft/cometbft-db v0.13.0
+	github.com/cometbft/cometbft-db v0.14.0
 	github.com/cometbft/cometbft-load-test v0.1.0
 	github.com/cometbft/cometbft/api v1.0.0-rc.1
 	github.com/cosmos/gogoproto v1.6.0

--- a/node/node.go
+++ b/node/node.go
@@ -317,6 +317,10 @@ func NewNodeWithCliParams(ctx context.Context,
 	cliParams CliParams,
 	options ...Option,
 ) (*Node, error) {
+	if config.BaseConfig.DBBackend == "boltdb" || config.BaseConfig.DBBackend == "cleveldb" {
+		logger.Info("WARNING: BoltDB and GoLevelDB are deprecated and will be removed in a future release. Please switch to a different backend.")
+	}
+
 	blockStoreDB, stateDB, err := initDBs(config, dbProvider)
 	if err != nil {
 		return nil, err

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -1,4 +1,4 @@
-COMETBFT_BUILD_OPTIONS += badgerdb,rocksdb,pebbledb,clock_skew,bls12381
+COMETBFT_BUILD_OPTIONS += badgerdb,boltdb,cleveldb,rocksdb,pebbledb,clock_skew,bls12381
 IMAGE_TAG=cometbft/e2e-node:local-version
 
 include ../../common.mk

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -1,7 +1,7 @@
 # We need to build in a Linux environment to support C libraries, e.g. RocksDB.
 # We use Debian instead of Alpine, so that we can use binary database packages
 # instead of spending time compiling them.
-FROM cometbft/cometbft-db-testing:v0.13.0
+FROM cometbft/cometbft-db-testing:v0.14.0
 
 RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
 

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -12,7 +12,7 @@ COPY test/e2e/pkg/latency/aws-latencies.csv /scripts/
 COPY test/e2e/pkg/latency/latency-setter.py /scripts/
 
 # Set up build directory /src/cometbft
-ENV COMETBFT_BUILD_OPTIONS=badgerdb,rocksdb,pebbledb,clock_skew,bls12381
+ENV COMETBFT_BUILD_OPTIONS badgerdb,boltdb,cleveldb,rocksdb,pebbledb,clock_skew,bls12381
 WORKDIR /src/cometbft
 
 # Fetch dependencies separately (for layer caching)

--- a/test/e2e/docker/Dockerfile.debug
+++ b/test/e2e/docker/Dockerfile.debug
@@ -1,7 +1,7 @@
 # We need to build in a Linux environment to support C libraries, e.g. RocksDB.
 # We use Debian instead of Alpine, so that we can use binary database packages
 # instead of spending time compiling them.
-FROM cometbft/cometbft-db-testing:v0.13.0
+FROM cometbft/cometbft-db-testing:v0.14.0
 
 RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
 RUN apt-get -qq install -y zsh vim >/dev/null

--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -37,7 +37,7 @@ var (
 	}
 
 	// The following specify randomly chosen values for testnet nodes.
-	nodeDatabases = uniformChoice{"goleveldb", "rocksdb", "badgerdb", "pebbledb"}
+	nodeDatabases = uniformChoice{"goleveldb", "cleveldb", "rocksdb", "boltdb", "badgerdb", "pebbledb"}
 	ipv6          = uniformChoice{false, true}
 	// FIXME: grpc disabled due to https://github.com/tendermint/tendermint/issues/5439
 	nodeABCIProtocols     = uniformChoice{"unix", "tcp", "builtin", "builtin_connsync"} // "grpc"

--- a/test/e2e/pkg/manifest.go
+++ b/test/e2e/pkg/manifest.go
@@ -161,7 +161,7 @@ type ManifestNode struct {
 	PersistentPeers []string `toml:"persistent_peers"`
 
 	// Database specifies the database backend: "goleveldb", "rocksdb",
-	// "pebbledb" or "badgerdb". Defaults to "goleveldb".
+	// "pebbledb", "cleveldb", "boltdb", or "badgerdb". Defaults to "goleveldb".
 	Database string `toml:"database"`
 
 	// PrivvalProtocol specifies the protocol used to sign consensus messages:

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -541,7 +541,7 @@ func (n Node) Validate(testnet Testnet) error {
 		return fmt.Errorf("invalid block sync setting %q", n.BlockSyncVersion)
 	}
 	switch n.Database {
-	case "goleveldb", "rocksdb", "badgerdb", "pebbledb":
+	case "goleveldb", "cleveldb", "boltdb", "rocksdb", "badgerdb", "pebbledb":
 	default:
 		return fmt.Errorf("invalid database setting %q", n.Database)
 	}


### PR DESCRIPTION
Fixes: #3640 

### Changes
This PR:
- [x]  reinstates boltdb and cleveldb as backends, but leaves them marked at deprecated.
- [x]  bumps cometbft-db to `v0.14.0` once released.

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
