### PR TITLE
chore: update auto-generated proto files in `v1.x`

### DIFF
--- a/api/cometbft/abci/v1/service.pb.go
+++ b/api/cometbft/abci/v1/service.pb.go
@@ -642,6 +642,7 @@ func _ABCIService_FinalizeBlock_Handler(srv interface{}, ctx context.Context, de
 	return interceptor(ctx, in, info, handler)
 }
 
+var ABCIService_serviceDesc = _ABCIService_serviceDesc
 var _ABCIService_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "cometbft.abci.v1.ABCIService",
 	HandlerType: (*ABCIServiceServer)(nil),

--- a/api/cometbft/abci/v1beta1/types.pb.go
+++ b/api/cometbft/abci/v1beta1/types.pb.go
@@ -4010,6 +4010,7 @@ func _ABCIApplication_ApplySnapshotChunk_Handler(srv interface{}, ctx context.Co
 	return interceptor(ctx, in, info, handler)
 }
 
+var ABCIApplication_serviceDesc = _ABCIApplication_serviceDesc
 var _ABCIApplication_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "cometbft.abci.v1beta1.ABCIApplication",
 	HandlerType: (*ABCIApplicationServer)(nil),

--- a/api/cometbft/abci/v1beta2/types.pb.go
+++ b/api/cometbft/abci/v1beta2/types.pb.go
@@ -2700,6 +2700,7 @@ func _ABCIApplication_ProcessProposal_Handler(srv interface{}, ctx context.Conte
 	return interceptor(ctx, in, info, handler)
 }
 
+var ABCIApplication_serviceDesc = _ABCIApplication_serviceDesc
 var _ABCIApplication_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "cometbft.abci.v1beta2.ABCIApplication",
 	HandlerType: (*ABCIApplicationServer)(nil),

--- a/api/cometbft/abci/v1beta3/types.pb.go
+++ b/api/cometbft/abci/v1beta3/types.pb.go
@@ -2742,6 +2742,7 @@ func _ABCI_FinalizeBlock_Handler(srv interface{}, ctx context.Context, dec func(
 	return interceptor(ctx, in, info, handler)
 }
 
+var ABCI_serviceDesc = _ABCI_serviceDesc
 var _ABCI_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "cometbft.abci.v1beta3.ABCI",
 	HandlerType: (*ABCIServer)(nil),

--- a/api/cometbft/rpc/grpc/v1beta1/types.pb.go
+++ b/api/cometbft/rpc/grpc/v1beta1/types.pb.go
@@ -339,6 +339,7 @@ func _BroadcastAPI_BroadcastTx_Handler(srv interface{}, ctx context.Context, dec
 	return interceptor(ctx, in, info, handler)
 }
 
+var BroadcastAPI_serviceDesc = _BroadcastAPI_serviceDesc
 var _BroadcastAPI_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "cometbft.rpc.grpc.v1beta1.BroadcastAPI",
 	HandlerType: (*BroadcastAPIServer)(nil),

--- a/api/cometbft/rpc/grpc/v1beta2/types.pb.go
+++ b/api/cometbft/rpc/grpc/v1beta2/types.pb.go
@@ -216,6 +216,7 @@ func _BroadcastAPI_BroadcastTx_Handler(srv interface{}, ctx context.Context, dec
 	return interceptor(ctx, in, info, handler)
 }
 
+var BroadcastAPI_serviceDesc = _BroadcastAPI_serviceDesc
 var _BroadcastAPI_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "cometbft.rpc.grpc.v1beta2.BroadcastAPI",
 	HandlerType: (*BroadcastAPIServer)(nil),

--- a/api/cometbft/rpc/grpc/v1beta3/types.pb.go
+++ b/api/cometbft/rpc/grpc/v1beta3/types.pb.go
@@ -217,6 +217,7 @@ func _BroadcastAPI_BroadcastTx_Handler(srv interface{}, ctx context.Context, dec
 	return interceptor(ctx, in, info, handler)
 }
 
+var BroadcastAPI_serviceDesc = _BroadcastAPI_serviceDesc
 var _BroadcastAPI_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "cometbft.rpc.grpc.v1beta3.BroadcastAPI",
 	HandlerType: (*BroadcastAPIServer)(nil),

--- a/api/cometbft/services/block/v1/block_service.pb.go
+++ b/api/cometbft/services/block/v1/block_service.pb.go
@@ -182,6 +182,7 @@ func (x *blockServiceGetLatestHeightServer) Send(m *GetLatestHeightResponse) err
 	return x.ServerStream.SendMsg(m)
 }
 
+var BlockService_serviceDesc = _BlockService_serviceDesc
 var _BlockService_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "cometbft.services.block.v1.BlockService",
 	HandlerType: (*BlockServiceServer)(nil),

--- a/api/cometbft/services/block_results/v1/block_results_service.pb.go
+++ b/api/cometbft/services/block_results/v1/block_results_service.pb.go
@@ -115,6 +115,7 @@ func _BlockResultsService_GetBlockResults_Handler(srv interface{}, ctx context.C
 	return interceptor(ctx, in, info, handler)
 }
 
+var BlockResultsService_serviceDesc = _BlockResultsService_serviceDesc
 var _BlockResultsService_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "cometbft.services.block_results.v1.BlockResultsService",
 	HandlerType: (*BlockResultsServiceServer)(nil),

--- a/api/cometbft/services/pruning/v1/service.pb.go
+++ b/api/cometbft/services/pruning/v1/service.pb.go
@@ -389,6 +389,7 @@ func _PruningService_GetBlockIndexerRetainHeight_Handler(srv interface{}, ctx co
 	return interceptor(ctx, in, info, handler)
 }
 
+var PruningService_serviceDesc = _PruningService_serviceDesc
 var _PruningService_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "cometbft.services.pruning.v1.PruningService",
 	HandlerType: (*PruningServiceServer)(nil),

--- a/api/cometbft/services/version/v1/version_service.pb.go
+++ b/api/cometbft/services/version/v1/version_service.pb.go
@@ -116,6 +116,7 @@ func _VersionService_GetVersion_Handler(srv interface{}, ctx context.Context, de
 	return interceptor(ctx, in, info, handler)
 }
 
+var VersionService_serviceDesc = _VersionService_serviceDesc
 var _VersionService_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "cometbft.services.version.v1.VersionService",
 	HandlerType: (*VersionServiceServer)(nil),


### PR DESCRIPTION
This PR fixes the protos in `v1.x` in order to make the `check proto` test to pass. 

Same idea as in #3650 but these files were generated in the `v1.x` branch as instead of trying to backport #3650 to `v1.x` since there might be changes to protos in `main` that are not in `v1.x` so this is the best approach to directly update the protos in `v1.x`

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [X] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
