### PR TITLE
fix(mempool): Update variables in `CListMempool` atomically

### DIFF
--- a/.changelog/unreleased/bug-fixes/3694-mempool-update-variables-atomically.md
+++ b/.changelog/unreleased/bug-fixes/3694-mempool-update-variables-atomically.md
@@ -1,0 +1,3 @@
+- `[mempool]` Fix race condition when accessing entries by updating variables in
+  `CListMempool` atomically.
+  ([\#3694](https://github.com/cometbft/cometbft/issues/3694))

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -584,8 +584,8 @@ func (mem *CListMempool) ReapMaxTxs(max int) types.Txs {
 
 // GetTxByHash returns the types.Tx with the given hash if found in the mempool, otherwise returns nil.
 func (mem *CListMempool) GetTxByHash(hash []byte) types.Tx {
-	mem.txsMtx.Lock()
-	defer mem.txsMtx.Unlock()
+	mem.txsMtx.RLock()
+	defer mem.txsMtx.RUnlock()
 
 	if elem, ok := mem.txsMap[types.TxKey(hash)]; ok {
 		return elem.Value.(*mempoolTx).tx

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -145,7 +145,7 @@ func (mem *CListMempool) addSender(txKey types.TxKey, sender p2p.ID) error {
 	memTx := elem.Value.(*mempoolTx)
 	if found := memTx.addSender(sender); found {
 		// It should not be possible to receive twice a tx from the same sender.
-		return ErrTxAlreadySeen
+		return ErrTxAlreadyReceivedFromSender
 	}
 	return nil
 }

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -224,8 +224,8 @@ func (mem *CListMempool) FlushAppConn() error {
 
 // XXX: Unsafe! Calling Flush may leave mempool in inconsistent state.
 func (mem *CListMempool) Flush() {
-	mem.updateMtx.Lock()
-	defer mem.updateMtx.Unlock()
+	mem.updateMtx.RLock()
+	defer mem.updateMtx.RUnlock()
 
 	mem.cache.Reset()
 	mem.removeAllTxs()

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -49,11 +48,10 @@ type CListMempool struct {
 	// Keeps track of the rechecking process.
 	recheck *recheck
 
-	// Concurrent linked-list of valid txs.
-	// `txsMap`: txKey -> CElement is for quick access to txs.
-	// Transactions in both `txs` and `txsMap` must to be kept in sync.
-	txs    *clist.CList
-	txsMap sync.Map
+	// Data in `txs` and `txsMap` must to be kept in sync and updated atomically.
+	txsMtx cmtsync.RWMutex
+	txs    *clist.CList                    // concurrent linked-list of valid txs
+	txsMap map[types.TxKey]*clist.CElement // for quick access to txs
 
 	// Keep a cache of already-seen txs.
 	// This reduces the pressure on the proxyApp.
@@ -80,6 +78,7 @@ func NewCListMempool(
 		config:       cfg,
 		proxyAppConn: proxyAppConn,
 		txs:          clist.New(),
+		txsMap:       make(map[types.TxKey]*clist.CElement),
 		recheck:      newRecheck(),
 		logger:       log.NewNopLogger(),
 		metrics:      NopMetrics(),
@@ -97,13 +96,6 @@ func NewCListMempool(
 	}
 
 	return mp
-}
-
-func (mem *CListMempool) getCElement(txKey types.TxKey) (*clist.CElement, bool) {
-	if e, ok := mem.txsMap.Load(txKey); ok {
-		return e.(*clist.CElement), true
-	}
-	return nil, false
 }
 
 func (mem *CListMempool) addToCache(tx types.Tx) bool {
@@ -124,15 +116,38 @@ func (mem *CListMempool) tryRemoveFromCache(tx types.Tx) {
 }
 
 func (mem *CListMempool) removeAllTxs() {
+	mem.txsMtx.Lock()
+	defer mem.txsMtx.Unlock()
+
 	for e := mem.txs.Front(); e != nil; e = e.Next() {
 		mem.txs.Remove(e)
 		e.DetachPrev()
 	}
+	mem.txsMap = make(map[types.TxKey]*clist.CElement)
+	mem.txsBytes.Store(0)
+}
 
-	mem.txsMap.Range(func(key, _ any) bool {
-		mem.txsMap.Delete(key)
-		return true
-	})
+// addSender adds a peer ID to the list of senders on the entry corresponding to
+// tx, identified by its key.
+func (mem *CListMempool) addSender(txKey types.TxKey, sender p2p.ID) error {
+	if sender == noSender {
+		return nil
+	}
+
+	mem.txsMtx.Lock()
+	defer mem.txsMtx.Unlock()
+
+	elem, ok := mem.txsMap[txKey]
+	if !ok {
+		return ErrTxNotFound
+	}
+
+	memTx := elem.Value.(*mempoolTx)
+	if found := memTx.addSender(sender); found {
+		// It should not be possible to receive twice a tx from the same sender.
+		return ErrTxAlreadySeen
+	}
+	return nil
 }
 
 // NOTE: not thread safe - should only be called once, on startup.
@@ -209,17 +224,18 @@ func (mem *CListMempool) FlushAppConn() error {
 
 // XXX: Unsafe! Calling Flush may leave mempool in inconsistent state.
 func (mem *CListMempool) Flush() {
-	mem.updateMtx.RLock()
-	defer mem.updateMtx.RUnlock()
+	mem.updateMtx.Lock()
+	defer mem.updateMtx.Unlock()
 
-	mem.txsBytes.Store(0)
 	mem.cache.Reset()
-
 	mem.removeAllTxs()
 }
 
 func (mem *CListMempool) Contains(txKey types.TxKey) bool {
-	_, ok := mem.getCElement(txKey)
+	mem.txsMtx.RLock()
+	defer mem.txsMtx.RUnlock()
+
+	_, ok := mem.txsMap[txKey]
 	return ok
 }
 
@@ -278,18 +294,12 @@ func (mem *CListMempool) CheckTx(tx types.Tx, sender p2p.ID) (*abcicli.ReqRes, e
 
 	if added := mem.addToCache(tx); !added {
 		mem.metrics.AlreadyReceivedTxs.Add(1)
-		if sender != noSender {
-			// Record a new sender for a tx we've already seen.
-			// Note it's possible a tx is still in the cache but no longer in the mempool
-			// (eg. after committing a block, txs are removed from mempool but not cache),
-			// so we only record the sender for txs still in the mempool.
-			if elem, ok := mem.getCElement(tx.Key()); ok {
-				memTx := elem.Value.(*mempoolTx)
-				if found := memTx.addSender(sender); found {
-					// It should not be possible to receive twice a tx from the same sender.
-					mem.logger.Error("tx already received from peer", "tx", tx.Hash(), "sender", sender)
-				}
-			}
+		// Record a new sender for a tx we've already seen.
+		// Note it's possible a tx is still in the cache but no longer in the mempool
+		// (eg. after committing a block, txs are removed from mempool but not cache),
+		// so we only record the sender for txs still in the mempool.
+		if err := mem.addSender(tx.Key(), sender); err != nil {
+			mem.logger.Error("Could not add sender to tx", "tx", tx.Hash(), "sender", sender, "err", err)
 		}
 		// TODO: consider punishing peer for dups,
 		// its non-trivial since invalid txs can become valid,
@@ -349,55 +359,55 @@ func (mem *CListMempool) handleCheckTxResponse(tx types.Tx, sender p2p.ID) func(
 			return
 		}
 
+		// Check that tx is not already in the mempool. This can happen when the
+		// cache overflows. See https://github.com/cometbft/cometbft/pull/890.
+		txKey := tx.Key()
+		if mem.Contains(txKey) {
+			if err := mem.addSender(txKey, sender); err != nil {
+				mem.logger.Error("Could not add sender to tx", "tx", tx.Hash(), "sender", sender, "err", err)
+			}
+			mem.logger.Debug(
+				"transaction already in mempool, not adding it again",
+				"tx", tx.Hash(),
+				"height", mem.height.Load(),
+				"total", mem.Size(),
+			)
+			return
+		}
+
 		// Add tx to mempool and notify that new txs are available.
 		memTx := mempoolTx{
 			height:    mem.height.Load(),
 			gasWanted: res.GasWanted,
 			tx:        tx,
 		}
-		if mem.addTx(&memTx, sender) {
-			mem.notifyTxsAvailable()
-			if mem.onNewTx != nil {
-				mem.onNewTx(tx)
-			}
-			// update metrics
-			mem.metrics.Size.Set(float64(mem.Size()))
-			mem.metrics.SizeBytes.Set(float64(mem.SizeBytes()))
+		mem.addTx(&memTx, sender)
+		mem.notifyTxsAvailable()
+
+		if mem.onNewTx != nil {
+			mem.onNewTx(tx)
 		}
+
+		// update metrics
+		mem.metrics.Size.Set(float64(mem.Size()))
+		mem.metrics.SizeBytes.Set(float64(mem.SizeBytes()))
 	}
 }
 
-// Called from:
-//   - handleCheckTxResponse (lock not held) if tx is valid
-func (mem *CListMempool) addTx(memTx *mempoolTx, sender p2p.ID) bool {
+// Called from handleCheckTxResponse only on valid txs.
+// updateMtx is held when using the local ABCI client but not with an async client.
+func (mem *CListMempool) addTx(memTx *mempoolTx, sender p2p.ID) {
+	mem.txsMtx.Lock()
+	defer mem.txsMtx.Unlock()
+
 	tx := memTx.tx
-	txKey := tx.Key()
-
-	// Check if the transaction is already in the mempool.
-	if elem, ok := mem.getCElement(txKey); ok {
-		if sender != noSender {
-			// Update senders on existing entry.
-			memTx := elem.Value.(*mempoolTx)
-			if found := memTx.addSender(sender); found {
-				// It should not be possible to receive twice a tx from the same sender.
-				mem.logger.Error("tx already received from peer", "tx", tx.Hash(), "sender", sender)
-			}
-		}
-
-		mem.logger.Debug(
-			"transaction already in mempool, not adding it again",
-			"tx", tx.Hash(),
-			"height", mem.height.Load(),
-			"total", mem.Size(),
-		)
-		return false
-	}
 
 	// Add new transaction.
 	_ = memTx.addSender(sender)
 	e := mem.txs.PushBack(memTx)
-	mem.txsMap.Store(txKey, e)
+	mem.txsMap[tx.Key()] = e
 	mem.txsBytes.Add(int64(len(tx)))
+
 	mem.metrics.TxSizeBytes.Observe(float64(len(tx)))
 
 	mem.logger.Debug(
@@ -406,22 +416,24 @@ func (mem *CListMempool) addTx(memTx *mempoolTx, sender p2p.ID) bool {
 		"height", mem.height.Load(),
 		"total", mem.Size(),
 	)
-	return true
 }
 
 // RemoveTxByKey removes a transaction from the mempool by its TxKey index.
 // Called from:
-//   - Update (lock held) if tx was committed
-//   - handleRecheckTxResponse (lock not held) if tx was invalidated
+//   - Update (updateMtx held) if tx was committed
+//   - handleRecheckTxResponse (updateMtx not held) if tx was invalidated
 func (mem *CListMempool) RemoveTxByKey(txKey types.TxKey) error {
-	elem, ok := mem.getCElement(txKey)
+	mem.txsMtx.Lock()
+	defer mem.txsMtx.Unlock()
+
+	elem, ok := mem.txsMap[txKey]
 	if !ok {
 		return ErrTxNotFound
 	}
 
 	mem.txs.Remove(elem)
 	elem.DetachPrev()
-	mem.txsMap.Delete(txKey)
+	delete(mem.txsMap, txKey)
 	tx := elem.Value.(*mempoolTx).tx
 	mem.txsBytes.Add(int64(-len(tx)))
 	mem.logger.Debug("removed transaction", "tx", tx.Hash(), "height", mem.height.Load(), "total", mem.Size())
@@ -569,7 +581,10 @@ func (mem *CListMempool) ReapMaxTxs(max int) types.Txs {
 
 // GetTxByHash returns the types.Tx with the given hash if found in the mempool, otherwise returns nil.
 func (mem *CListMempool) GetTxByHash(hash []byte) types.Tx {
-	if elem, ok := mem.getCElement(types.TxKey(hash)); ok {
+	mem.txsMtx.Lock()
+	defer mem.txsMtx.Unlock()
+
+	if elem, ok := mem.txsMap[types.TxKey(hash)]; ok {
 		return elem.Value.(*mempoolTx).tx
 	}
 	return nil

--- a/mempool/errors.go
+++ b/mempool/errors.go
@@ -11,8 +11,9 @@ var ErrTxNotFound = errors.New("transaction not found in mempool")
 // ErrTxInCache is returned to the client if we saw tx earlier.
 var ErrTxInCache = errors.New("tx already exists in cache")
 
-// ErrTxAlreadySeen is returned if we saw tx earlier.
-var ErrTxAlreadySeen = errors.New("tx already already seen")
+// ErrTxAlreadyReceivedFromSender is returned if when processing a tx already
+// received from the same sender.
+var ErrTxAlreadyReceivedFromSender = errors.New("tx already received from the same sender")
 
 // ErrRecheckFull is returned when checking if the mempool is full and
 // rechecking is still in progress after a new block was committed.

--- a/mempool/errors.go
+++ b/mempool/errors.go
@@ -11,6 +11,9 @@ var ErrTxNotFound = errors.New("transaction not found in mempool")
 // ErrTxInCache is returned to the client if we saw tx earlier.
 var ErrTxInCache = errors.New("tx already exists in cache")
 
+// ErrTxAlreadySeen is returned if we saw tx earlier.
+var ErrTxAlreadySeen = errors.New("tx already already seen")
+
 // ErrRecheckFull is returned when checking if the mempool is full and
 // rechecking is still in progress after a new block was committed.
 var ErrRecheckFull = errors.New("mempool is still rechecking after a new committed block, so it is considered as full")


### PR DESCRIPTION
Fixes #3694 

This PR replaces:
```
type CListMempool struct {
	txsBytes atomic.Int64 // total size of mempool, in bytes
        ...
	txs    *clist.CList
	txsMap sync.Map
        ...
}
```
by
```
type CListMempool struct {
        ...
	txsMtx   cmtsync.RWMutex
	txs      *clist.CList                    // concurrent linked-list of valid txs
	txsMap   map[types.TxKey]*clist.CElement // for quick access to txs
	txsBytes int64                           // total size of mempool, in bytes
        ...
}
```
The new `txsMtx` mutex is used every time the variables `txs`, `txsMap`, and `txsBytes` are accessed.

---

#### PR checklist

- [ ] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
