### PR TITLE
revert(types): Revert #3543 (backport #3549)

### DIFF
--- a/.changelog/v0.38.11/bug-fixes/3528-evidence-missing-json-tags.md
+++ b/.changelog/v0.38.11/bug-fixes/3528-evidence-missing-json-tags.md
@@ -1,2 +1,0 @@
-- `[types]` Added missing JSON tags to `DuplicateVoteEvidence` and `LightClientAttackEvidence`
-  types ([\#3528](https://github.com/cometbft/cometbft/issues/3528))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@ It also includes a few other bug fixes and performance improvements.
 
 ### BUG FIXES
 
-- `[types]` Added missing JSON tags to `DuplicateVoteEvidence` and `LightClientAttackEvidence`
-  types ([\#3528](https://github.com/cometbft/cometbft/issues/3528))
 - `[types]` Only check IFF vote is a non-nil Precommit if extensionsEnabled
   types ([\#3565](https://github.com/cometbft/cometbft/issues/3565))
 
@@ -332,7 +330,7 @@ gossip.
   ([\#1584](https://github.com/cometbft/cometbft/pull/1584))
 - `[config]` Add mempool parameters `experimental_max_gossip_connections_to_persistent_peers` and
   `experimental_max_gossip_connections_to_non_persistent_peers` for limiting the number of peers to
-  which the node gossip transactions. 
+  which the node gossip transactions.
   ([\#1558](https://github.com/cometbft/cometbft/pull/1558))
   ([\#1584](https://github.com/cometbft/cometbft/pull/1584))
 
@@ -744,4 +742,3 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/cosmos).
 ## Previous changes
 
 For changes released before the creation of CometBFT, please refer to the Tendermint Core [CHANGELOG.md](https://github.com/tendermint/tendermint/blob/a9feb1c023e172b542c972605311af83b777855b/CHANGELOG.md).
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ It also includes a few other bug fixes and performance improvements.
 
 ### BUG FIXES
 
+- `[types]` Added missing JSON tags to `DuplicateVoteEvidence` and `LightClientAttackEvidence`
+  types ([\#3528](https://github.com/cometbft/cometbft/issues/3528))
 - `[types]` Only check IFF vote is a non-nil Precommit if extensionsEnabled
   types ([\#3565](https://github.com/cometbft/cometbft/issues/3565))
 
@@ -330,7 +332,7 @@ gossip.
   ([\#1584](https://github.com/cometbft/cometbft/pull/1584))
 - `[config]` Add mempool parameters `experimental_max_gossip_connections_to_persistent_peers` and
   `experimental_max_gossip_connections_to_non_persistent_peers` for limiting the number of peers to
-  which the node gossip transactions.
+  which the node gossip transactions. 
   ([\#1558](https://github.com/cometbft/cometbft/pull/1558))
   ([\#1584](https://github.com/cometbft/cometbft/pull/1584))
 
@@ -742,3 +744,4 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/cosmos).
 ## Previous changes
 
 For changes released before the creation of CometBFT, please refer to the Tendermint Core [CHANGELOG.md](https://github.com/tendermint/tendermint/blob/a9feb1c023e172b542c972605311af83b777855b/CHANGELOG.md).
+

--- a/libs/os/os.go
+++ b/libs/os/os.go
@@ -41,7 +41,7 @@ func Kill() error {
 }
 
 func Exit(s string) {
-	fmt.Printf(s + "\n")
+	fmt.Println(s)
 	os.Exit(1)
 }
 

--- a/types/evidence.go
+++ b/types/evidence.go
@@ -37,9 +37,9 @@ type DuplicateVoteEvidence struct {
 	VoteB *Vote `json:"vote_b"`
 
 	// abci specific information
-	TotalVotingPower int64     `json:"total_voting_power"`
-	ValidatorPower   int64     `json:"validator_power"`
-	Timestamp        time.Time `json:"timestamp"`
+	TotalVotingPower int64
+	ValidatorPower   int64
+	Timestamp        time.Time
 }
 
 var _ Evidence = &DuplicateVoteEvidence{}
@@ -207,20 +207,13 @@ func DuplicateVoteEvidenceFromProto(pb *cmtproto.DuplicateVoteEvidence) (*Duplic
 // and Amnesia. These attacks are exhaustive. You can find a more detailed overview of this at
 // cometbft/docs/architecture/adr-047-handling-evidence-from-light-client.md
 type LightClientAttackEvidence struct {
-	ConflictingBlock *LightBlock `json:"conflicting_block"`
-	CommonHeight     int64       `json:"common_height"`
+	ConflictingBlock *LightBlock
+	CommonHeight     int64
 
-	// ABCI specific information
-
-	// validators in the validator set that misbehaved in creating the conflicting
-	// block
-	ByzantineValidators []*Validator `json:"byzantine_validators"`
-
-	// total voting power of the validator set at the common height
-	TotalVotingPower int64 `json:"total_voting_power"`
-
-	// timestamp of the block at the common height
-	Timestamp time.Time `json:"timestamp"`
+	// abci specific information
+	ByzantineValidators []*Validator // validators in the validator set that misbehaved in creating the conflicting block
+	TotalVotingPower    int64        // total voting power of the validator set at the common height
+	Timestamp           time.Time    // timestamp of the block at the common height
 }
 
 var _ Evidence = &LightClientAttackEvidence{}

--- a/types/evidence_test.go
+++ b/types/evidence_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/crypto/tmhash"
-	cmtjson "github.com/cometbft/cometbft/libs/json"
 	cmtrand "github.com/cometbft/cometbft/libs/rand"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	cmtversion "github.com/cometbft/cometbft/proto/tendermint/version"
@@ -310,24 +309,4 @@ func TestEvidenceProto(t *testing.T) {
 			require.Equal(t, tt.evidence, evi, tt.testName)
 		})
 	}
-}
-
-// Test that the new JSON tags are picked up correctly, see issue #3528.
-func TestDuplicateVoteEvidenceJSON(t *testing.T) {
-	var evidence DuplicateVoteEvidence
-	js, err := cmtjson.Marshal(evidence)
-	require.NoError(t, err)
-
-	wantJSON := `{"type":"tendermint/DuplicateVoteEvidence","value":{"vote_a":null,"vote_b":null,"total_voting_power":"0","validator_power":"0","timestamp":"0001-01-01T00:00:00Z"}}`
-	assert.Equal(t, wantJSON, string(js))
-}
-
-// Test that the new JSON tags are picked up correctly, see issue #3528.
-func TestLightClientAttackEvidenceJSON(t *testing.T) {
-	var evidence LightClientAttackEvidence
-	js, err := cmtjson.Marshal(evidence)
-	require.NoError(t, err)
-
-	wantJSON := `{"type":"tendermint/LightClientAttackEvidence","value":{"conflicting_block":null,"common_height":"0","byzantine_validators":null,"total_voting_power":"0","timestamp":"0001-01-01T00:00:00Z"}}`
-	assert.Equal(t, wantJSON, string(js))
 }

--- a/types/validator_set_test.go
+++ b/types/validator_set_test.go
@@ -331,7 +331,7 @@ func TestProposerSelection3(t *testing.T) {
 		got := vset.GetProposer().Address
 		expected := proposerOrder[j%4].Address
 		if !bytes.Equal(got, expected) {
-			t.Fatalf(fmt.Sprintf("vset.Proposer (%X) does not match expected proposer (%X) for (%d, %d)", got, expected, i, j))
+			t.Fatalf("vset.Proposer (%X) does not match expected proposer (%X) for (%d, %d)", got, expected, i, j)
 		}
 
 		// serialize, deserialize, check proposer
@@ -342,13 +342,11 @@ func TestProposerSelection3(t *testing.T) {
 		if i != 0 {
 			if !bytes.Equal(got, computed.Address) {
 				t.Fatalf(
-					fmt.Sprintf(
-						"vset.Proposer (%X) does not match computed proposer (%X) for (%d, %d)",
-						got,
-						computed.Address,
-						i,
-						j,
-					),
+					"vset.Proposer (%X) does not match computed proposer (%X) for (%d, %d)",
+					got,
+					computed.Address,
+					i,
+					j,
 				)
 			}
 		}


### PR DESCRIPTION
Given the discussion in #3528, we are reverting the changes made by #3543 in `v0.38.x` (backported with #3549).
Additionally, we are removing the changes made in #3543 from the CHANGELOG.

---

#### PR checklist

~- [ ] Tests written/updated~
~- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)~
~- [] Updated relevant documentation (`docs/` or `spec/`) and code comments~
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
