### PR TITLE
fix(types): validate `PubKey.Type` in `Validator`

### DIFF
--- a/crypto/encoding/codec.go
+++ b/crypto/encoding/codec.go
@@ -46,20 +46,20 @@ func init() {
 // returns ErrUnsupportedKey if the pubkey type is unsupported.
 func PubKeyToProto(k crypto.PubKey) (pc.PublicKey, error) {
 	var kp pc.PublicKey
-	switch k := k.(type) {
-	case ed25519.PubKey:
+	switch k.Type() {
+	case ed25519.KeyType:
 		kp = pc.PublicKey{
 			Sum: &pc.PublicKey_Ed25519{
-				Ed25519: k,
+				Ed25519: k.Bytes(),
 			},
 		}
-	case secp256k1.PubKey:
+	case secp256k1.KeyType:
 		kp = pc.PublicKey{
 			Sum: &pc.PublicKey_Secp256K1{
-				Secp256K1: k,
+				Secp256K1: k.Bytes(),
 			},
 		}
-	case *bls12381.PubKey, bls12381.PubKey:
+	case bls12381.KeyType:
 		if !bls12381.Enabled {
 			return kp, ErrUnsupportedKey{KeyType: bls12381.KeyType}
 		}
@@ -70,12 +70,7 @@ func PubKeyToProto(k crypto.PubKey) (pc.PublicKey, error) {
 			},
 		}
 	default:
-		kt := reflect.TypeOf(k)
-		if kt == nil {
-			return kp, ErrUnsupportedKey{KeyType: "<nil>"}
-		} else {
-			return kp, ErrUnsupportedKey{KeyType: kt.String()}
-		}
+		return kp, ErrUnsupportedKey{KeyType: k.Type()}
 	}
 	return kp, nil
 }

--- a/crypto/encoding/codec.go
+++ b/crypto/encoding/codec.go
@@ -46,6 +46,11 @@ func init() {
 // returns ErrUnsupportedKey if the pubkey type is unsupported.
 func PubKeyToProto(k crypto.PubKey) (pc.PublicKey, error) {
 	var kp pc.PublicKey
+
+	if k == nil {
+		return kp, ErrUnsupportedKey{KeyType: "<nil>"}
+	}
+
 	switch k.Type() {
 	case ed25519.KeyType:
 		kp = pc.PublicKey{

--- a/crypto/encoding/codec_test.go
+++ b/crypto/encoding/codec_test.go
@@ -58,7 +58,7 @@ func TestPubKeyToFromProto(t *testing.T) {
 	// unsupported key type
 	_, err = PubKeyToProto(unsupportedPubKey{})
 	require.Error(t, err)
-	assert.Equal(t, ErrUnsupportedKey{KeyType: "unsupportedPubKey"}, err)
+	assert.Equal(t, ErrUnsupportedKey{KeyType: unsupportedPubKey{}.Type()}, err)
 }
 
 func TestPubKeyFromTypeAndBytes(t *testing.T) {

--- a/crypto/encoding/codec_test.go
+++ b/crypto/encoding/codec_test.go
@@ -58,7 +58,7 @@ func TestPubKeyToFromProto(t *testing.T) {
 	// unsupported key type
 	_, err = PubKeyToProto(unsupportedPubKey{})
 	require.Error(t, err)
-	assert.Equal(t, ErrUnsupportedKey{KeyType: "encoding.unsupportedPubKey"}, err)
+	assert.Equal(t, ErrUnsupportedKey{KeyType: "unsupportedPubKey"}, err)
 }
 
 func TestPubKeyFromTypeAndBytes(t *testing.T) {

--- a/internal/keytypes/keytypes.go
+++ b/internal/keytypes/keytypes.go
@@ -32,6 +32,7 @@ func init() {
 	}
 }
 
+// GenPrivKey generates a private key of the given type.
 func GenPrivKey(keyType string) (crypto.PrivKey, error) {
 	genF, ok := keyTypes[keyType]
 	if !ok {
@@ -40,6 +41,7 @@ func GenPrivKey(keyType string) (crypto.PrivKey, error) {
 	return genF()
 }
 
+// SupportedKeyTypesStr returns a string of supported key types.
 func SupportedKeyTypesStr() string {
 	keyTypesSlice := make([]string, 0, len(keyTypes))
 	for k := range keyTypes {
@@ -48,10 +50,17 @@ func SupportedKeyTypesStr() string {
 	return strings.Join(keyTypesSlice, ", ")
 }
 
+// ListSupportedKeyTypes returns a list of supported key types.
 func ListSupportedKeyTypes() []string {
 	keyTypesSlice := make([]string, 0, len(keyTypes))
 	for k := range keyTypes {
 		keyTypesSlice = append(keyTypesSlice, k)
 	}
 	return keyTypesSlice
+}
+
+// IsSupported returns true if the key type is supported.
+func IsSupported(keyType string) bool {
+	_, ok := keyTypes[keyType]
+	return ok
 }

--- a/types/validator.go
+++ b/types/validator.go
@@ -10,8 +10,12 @@ import (
 	cmtproto "github.com/cometbft/cometbft/api/cometbft/types/v1"
 	"github.com/cometbft/cometbft/crypto"
 	ce "github.com/cometbft/cometbft/crypto/encoding"
+	"github.com/cometbft/cometbft/internal/keytypes"
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
 )
+
+// ErrUnsupportedPubKeyType is returned when a public key type is not supported.
+var ErrUnsupportedPubKeyType = errors.New("unsupported pubkey type, must be one of: " + keytypes.SupportedKeyTypesStr())
 
 // Volatile state for each Validator
 // NOTE: The ProposerPriority is not included in Validator.Hash();
@@ -50,6 +54,10 @@ func (v *Validator) ValidateBasic() error {
 	addr := v.PubKey.Address()
 	if !bytes.Equal(v.Address, addr) {
 		return fmt.Errorf("validator address is incorrectly derived from pubkey. Exp: %v, got %v", addr, v.Address)
+	}
+
+	if !keytypes.IsSupported(v.PubKey.Type()) {
+		return ErrUnsupportedPubKeyType
 	}
 
 	return nil
@@ -120,15 +128,10 @@ func ValidatorListString(vals []*Validator) string {
 // These are the bytes that gets hashed in consensus. It excludes address
 // as its redundant with the pubkey. This also excludes ProposerPriority
 // which changes every round.
-//
-// If the public key is unsupported, it returns nil. Caller must handle `nil`
-// as it would handle an error.
 func (v *Validator) Bytes() []byte {
 	pk, err := ce.PubKeyToProto(v.PubKey)
 	if err != nil {
-		// Unsupported key.
-		// Since this is used by the light client, we should not panic here.
-		return nil
+		panic(err)
 	}
 
 	pbv := cmtproto.SimpleValidator{

--- a/types/validator_test.go
+++ b/types/validator_test.go
@@ -97,7 +97,7 @@ func TestValidatorValidateBasic(t *testing.T) {
 		{
 			val: &Validator{
 				PubKey:  unsupportedPubKey{},
-				Address: nil,
+				Address: unsupportedPubKey{}.Address(),
 			},
 			err: true,
 			msg: ErrUnsupportedPubKeyType.Error(),

--- a/types/validator_test.go
+++ b/types/validator_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/crypto"
 )
 
 func TestValidatorProtoBuf(t *testing.T) {
@@ -38,6 +40,13 @@ func TestValidatorProtoBuf(t *testing.T) {
 		}
 	}
 }
+
+type unsupportedPubKey struct{}
+
+func (unsupportedPubKey) Address() crypto.Address             { return nil }
+func (unsupportedPubKey) Bytes() []byte                       { return nil }
+func (unsupportedPubKey) VerifySignature([]byte, []byte) bool { return false }
+func (unsupportedPubKey) Type() string                        { return "unsupportedPubKey" }
 
 func TestValidatorValidateBasic(t *testing.T) {
 	priv := NewMockPV()
@@ -84,6 +93,14 @@ func TestValidatorValidateBasic(t *testing.T) {
 			},
 			err: true,
 			msg: fmt.Sprintf("validator address is incorrectly derived from pubkey. Exp: %v, got 61", pubKey.Address()),
+		},
+		{
+			val: &Validator{
+				PubKey:  unsupportedPubKey{},
+				Address: nil,
+			},
+			err: true,
+			msg: ErrUnsupportedPubKeyType.Error(),
 		},
 	}
 


### PR DESCRIPTION
Otherwise, we could panic in the light client upon receiving a Validator w/ a pubkey of unsupported type. Previous attempt https://github.com/cometbft/cometbft/pull/3702

Refs https://github.com/cometbft/cometbft/issues/3699

---

#### PR checklist

- [x] Tests written/updated
- [ ] ~~Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)~~
- [ ] ~~Updated relevant documentation (`docs/` or `spec/`) and code comments~~
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
