### PR TITLE
ci: Remove Conventional Commits from PR checklist template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,4 +28,3 @@ https://github.com/orgs/cometbft/projects/1
 - [ ] Tests written/updated
 - [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
 - [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
-- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec


### PR DESCRIPTION
We already have an automated task that checks that the title is formatted. We don't need to mark it manually.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [X] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
