### PR TITLE
fix(e2e): remove bls from e2e generator

### DIFF
--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -13,7 +13,6 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/object"
 
-	"github.com/cometbft/cometbft/crypto/bls12381"
 	"github.com/cometbft/cometbft/crypto/ed25519"
 	"github.com/cometbft/cometbft/crypto/secp256k1"
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
@@ -71,7 +70,7 @@ var (
 	pbtsUpdateHeight           = uniformChoice{int64(-1), int64(0), int64(1)}                // -1: genesis, 0: InitChain, 1: (use offset)
 	pbtsEnabled                = weightedChoice{true: 3, false: 1}
 	pbtsHeightOffset           = uniformChoice{int64(0), int64(10), int64(100)}
-	keyType                    = uniformChoice{ed25519.KeyType, secp256k1.KeyType, bls12381.KeyType}
+	keyType                    = uniformChoice{ed25519.KeyType, secp256k1.KeyType}
 )
 
 type generateConfig struct {


### PR DESCRIPTION
Part of #3720

With this change, the `e2e` generator no longer generates manifests with bls as key type, so bls is no longer tested in the nightlies.

This is temporary, to be reverted also as part of #3720 in a future PR

Manual nightly run: [here](https://github.com/cometbft/cometbft/actions/runs/10418554752/job/28854915428)

---

#### PR checklist

- ~[ ] Tests written/updated~
- ~[ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)~
- ~[ ] Updated relevant documentation (`docs/` or `spec/`) and code comments~
