### PR TITLE
fix(e2e): fix BLS-related failures

### DIFF
--- a/crypto/bls12381/key.go
+++ b/crypto/bls12381/key.go
@@ -30,6 +30,11 @@ var _ crypto.PrivKey = &PrivKey{}
 // PrivKey represents a BLS private key noop when blst is not set as a build flag and cgo is disabled.
 type PrivKey []byte
 
+// GenPrivKeyFromSecret returns ErrDisabled.
+func GenPrivKeyFromSecret([]byte) (PrivKey, error) {
+	return nil, ErrDisabled
+}
+
 // NewPrivateKeyFromBytes returns ErrDisabled.
 func NewPrivateKeyFromBytes([]byte) (PrivKey, error) {
 	return nil, ErrDisabled

--- a/crypto/bls12381/key_bls12381.go
+++ b/crypto/bls12381/key_bls12381.go
@@ -172,6 +172,9 @@ func (pubKey PubKey) VerifySignature(msg, sig []byte) bool {
 		return false
 	}
 
+	// VerifySignature expects a fixed size message
+	// https://pkg.go.dev/github.com/cosmos/crypto@v0.1.2/curves/bls12381#VerifySignature
+	var fixedSizeMsg [32]byte
 	if len(msg) > MaxMsgLen {
 		hash := sha256.Sum256(msg)
 		return signature.Verify(false, pubKey.pk, false, hash[:], dstMinSig)

--- a/crypto/bls12381/key_bls12381.go
+++ b/crypto/bls12381/key_bls12381.go
@@ -94,7 +94,7 @@ func (privKey PrivKey) Bytes() []byte {
 // PubKey returns the private key's public key. If the privkey is not valid
 // it returns a nil value.
 func (privKey PrivKey) PubKey() crypto.PubKey {
-	return &PubKey{pk: new(blstPublicKey).From(privKey.sk)}
+	return PubKey{pk: new(blstPublicKey).From(privKey.sk)}
 }
 
 // Type returns the type.

--- a/crypto/bls12381/key_test.go
+++ b/crypto/bls12381/key_test.go
@@ -35,6 +35,25 @@ func TestGenPrivateKey(t *testing.T) {
 	assert.NotNil(t, privKey)
 }
 
+func TestGenPrivKeyFromSecret(t *testing.T) {
+	secret := []byte("this is my secret")
+	privKey, err := bls12381.GenPrivKeyFromSecret(secret)
+	require.NoError(t, err)
+	assert.NotNil(t, privKey)
+}
+
+func TestGenPrivKeyFromSecret_SignVerify(t *testing.T) {
+	secret := []byte("this is my secret for priv key")
+	priv, err := bls12381.GenPrivKeyFromSecret(secret)
+	require.NoError(t, err)
+	msg := []byte("this is my message to sign")
+	sig, err := priv.Sign(msg)
+	require.NoError(t, err)
+
+	pub := priv.PubKey()
+	assert.True(t, pub.VerifySignature(msg, sig), "Signature did not verify")
+}
+
 func TestPrivKeyBytes(t *testing.T) {
 	privKey, err := bls12381.GenPrivKey()
 	require.NoError(t, err)

--- a/crypto/bls12381/key_test.go
+++ b/crypto/bls12381/key_test.go
@@ -158,7 +158,7 @@ func TestPubKey_MarshalJSON(t *testing.T) {
 	privKey, err := bls12381.GenPrivKey()
 	require.NoError(t, err)
 	defer privKey.Zeroize()
-	pubKey, _ := privKey.PubKey().(*bls12381.PubKey)
+	pubKey, _ := privKey.PubKey().(bls12381.PubKey)
 
 	jsonBytes, err := pubKey.MarshalJSON()
 	require.NoError(t, err)

--- a/crypto/encoding/codec_test.go
+++ b/crypto/encoding/codec_test.go
@@ -27,7 +27,10 @@ func TestPubKeyToFromProto(t *testing.T) {
 
 	pubkey, err := PubKeyFromProto(proto)
 	require.NoError(t, err)
-	assert.Equal(t, pk, pubkey)
+	assert.Equal(t, pk.Type(), pubkey.Type())
+	assert.Equal(t, pk.Bytes(), pubkey.Bytes())
+	assert.Equal(t, pk.Address(), pubkey.Address())
+	assert.Equal(t, pk.VerifySignature([]byte("msg"), []byte("sig")), pubkey.VerifySignature([]byte("msg"), []byte("sig")))
 
 	// secp256k1
 	pk = secp256k1.GenPrivKey().PubKey()
@@ -36,7 +39,10 @@ func TestPubKeyToFromProto(t *testing.T) {
 
 	pubkey, err = PubKeyFromProto(proto)
 	require.NoError(t, err)
-	assert.Equal(t, pk, pubkey)
+	assert.Equal(t, pk.Type(), pubkey.Type())
+	assert.Equal(t, pk.Bytes(), pubkey.Bytes())
+	assert.Equal(t, pk.Address(), pubkey.Address())
+	assert.Equal(t, pk.VerifySignature([]byte("msg"), []byte("sig")), pubkey.VerifySignature([]byte("msg"), []byte("sig")))
 
 	// bls12381
 	if bls12381.Enabled {
@@ -49,7 +55,10 @@ func TestPubKeyToFromProto(t *testing.T) {
 
 		pubkey, err := PubKeyFromProto(proto)
 		require.NoError(t, err)
-		assert.Equal(t, pk, pubkey)
+		assert.Equal(t, pk.Type(), pubkey.Type())
+		assert.Equal(t, pk.Bytes(), pubkey.Bytes())
+		assert.Equal(t, pk.Address(), pubkey.Address())
+		assert.Equal(t, pk.VerifySignature([]byte("msg"), []byte("sig")), pubkey.VerifySignature([]byte("msg"), []byte("sig")))
 	} else {
 		_, err = PubKeyToProto(bls12381.PubKey{})
 		assert.Error(t, err)
@@ -66,7 +75,10 @@ func TestPubKeyFromTypeAndBytes(t *testing.T) {
 	pk := ed25519.GenPrivKey().PubKey()
 	pubkey, err := PubKeyFromTypeAndBytes(pk.Type(), pk.Bytes())
 	assert.NoError(t, err)
-	assert.Equal(t, pk, pubkey)
+	assert.Equal(t, pk.Type(), pubkey.Type())
+	assert.Equal(t, pk.Bytes(), pubkey.Bytes())
+	assert.Equal(t, pk.Address(), pubkey.Address())
+	assert.Equal(t, pk.VerifySignature([]byte("msg"), []byte("sig")), pubkey.VerifySignature([]byte("msg"), []byte("sig")))
 
 	// ed25519 invalid size
 	_, err = PubKeyFromTypeAndBytes(pk.Type(), pk.Bytes()[:10])
@@ -76,7 +88,10 @@ func TestPubKeyFromTypeAndBytes(t *testing.T) {
 	pk = secp256k1.GenPrivKey().PubKey()
 	pubkey, err = PubKeyFromTypeAndBytes(pk.Type(), pk.Bytes())
 	assert.NoError(t, err)
-	assert.Equal(t, pk, pubkey)
+	assert.Equal(t, pk.Type(), pubkey.Type())
+	assert.Equal(t, pk.Bytes(), pubkey.Bytes())
+	assert.Equal(t, pk.Address(), pubkey.Address())
+	assert.Equal(t, pk.VerifySignature([]byte("msg"), []byte("sig")), pubkey.VerifySignature([]byte("msg"), []byte("sig")))
 
 	// secp256k1 invalid size
 	_, err = PubKeyFromTypeAndBytes(pk.Type(), pk.Bytes()[:10])
@@ -89,7 +104,10 @@ func TestPubKeyFromTypeAndBytes(t *testing.T) {
 		pk := privKey.PubKey()
 		pubkey, err = PubKeyFromTypeAndBytes(pk.Type(), pk.Bytes())
 		assert.NoError(t, err)
-		assert.Equal(t, pk, pubkey)
+		assert.Equal(t, pk.Type(), pubkey.Type())
+		assert.Equal(t, pk.Bytes(), pubkey.Bytes())
+		assert.Equal(t, pk.Address(), pubkey.Address())
+		assert.Equal(t, pk.VerifySignature([]byte("msg"), []byte("sig")), pubkey.VerifySignature([]byte("msg"), []byte("sig")))
 
 		// bls12381 invalid size
 		_, err = PubKeyFromTypeAndBytes(pk.Type(), pk.Bytes()[:10])

--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/object"
 
+	"github.com/cometbft/cometbft/crypto/bls12381"
 	"github.com/cometbft/cometbft/crypto/ed25519"
 	"github.com/cometbft/cometbft/crypto/secp256k1"
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
@@ -70,7 +71,7 @@ var (
 	pbtsUpdateHeight           = uniformChoice{int64(-1), int64(0), int64(1)}                // -1: genesis, 0: InitChain, 1: (use offset)
 	pbtsEnabled                = weightedChoice{true: 3, false: 1}
 	pbtsHeightOffset           = uniformChoice{int64(0), int64(10), int64(100)}
-	keyType                    = uniformChoice{ed25519.KeyType, secp256k1.KeyType}
+	keyType                    = uniformChoice{ed25519.KeyType, secp256k1.KeyType, bls12381.KeyType}
 )
 
 type generateConfig struct {

--- a/test/e2e/generator/generate_test.go
+++ b/test/e2e/generator/generate_test.go
@@ -1,4 +1,4 @@
-//go:build ((linux && amd64) || (linux && arm64) || (darwin && amd64) || (darwin && arm64) || (windows && amd64)) && bls12381
+//go:build bls12381
 
 package main
 

--- a/test/e2e/generator/generate_test.go
+++ b/test/e2e/generator/generate_test.go
@@ -1,4 +1,4 @@
-//go:build bls12381
+//go:build ((linux && amd64) || (linux && arm64) || (darwin && amd64) || (darwin && arm64) || (windows && amd64)) && bls12381
 
 package main
 

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -756,7 +756,7 @@ func (g *keyGenerator) Generate(keyType string) crypto.PrivKey {
 	case secp256k1.KeyType:
 		return secp256k1.GenPrivKeySecp256k1(seed)
 	case bls12381.KeyType:
-		pk, err := bls12381.GenPrivKey()
+		pk, err := bls12381.GenPrivKeyFromSecret(seed)
 		if err != nil {
 			panic(fmt.Sprintf("unrecoverable error when generating key; key type %s, err %v", bls12381.KeyType, err))
 		}


### PR DESCRIPTION
Part of #3720

`e2e` tests _require_ a method that generates a private key deterministically (from a secret). Without such method, is it not possible for the "tests" step of the `e2e` runner to recreate the node structure as it exists within the runner itself.

Manual nightly runs:
- [1st try](https://github.com/cometbft/cometbft/actions/runs/10424046666)
- [2nd try](https://github.com/cometbft/cometbft/actions/runs/10424939531), after 53321d4

---

#### PR checklist

- ~[ ] Tests written/updated~
- ~[ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)~
- ~[ ] Updated relevant documentation (`docs/` or `spec/`) and code comments~
