### PR TITLE
feat(mempool/lanes): Store lane in `mempoolTx` and remove `txsLanes`

### DIFF
--- a/mempool/errors.go
+++ b/mempool/errors.go
@@ -11,9 +11,6 @@ var ErrTxNotFound = errors.New("transaction not found in mempool")
 // ErrTxInCache is returned to the client if we saw tx earlier.
 var ErrTxInCache = errors.New("tx already exists in cache")
 
-// ErrLaneNotFound is returned to the client when a lane is not found.
-var ErrLaneNotFound = errors.New("lane not found in mempool")
-
 // ErrTxAlreadyReceivedFromSender is returned if when processing a tx already
 // received from the same sender.
 var ErrTxAlreadyReceivedFromSender = errors.New("tx already received from the same sender")

--- a/mempool/mempoolTx.go
+++ b/mempool/mempoolTx.go
@@ -13,6 +13,7 @@ type mempoolTx struct {
 	height    int64    // height that this tx had been validated in
 	gasWanted int64    // amount of gas this tx states it will require
 	tx        types.Tx // validated by the application
+	lane      types.Lane
 	seq       int64
 
 	// ids of peers who've sent us this tx (as a map for quick lookups).


### PR DESCRIPTION
We don't need to store the lane in a separate map. We can just extend `mempoolTx` with a `lane` field.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
