### PR TITLE
feat(lanes): Change lane selection algorithm in kvstore app

### DIFF
--- a/abci/example/kvstore/kvstore.go
+++ b/abci/example/kvstore/kvstore.go
@@ -195,6 +195,7 @@ func (app *Application) assignLane(tx []byte) uint32 {
 		return app.lanes[defaultLane]
 	}
 
+// If the tx is of the form 2=2 we will assign it a lane. For any other type of transaction sent to the kvstore, it will go to the default lane.  
 	keyInt, err := strconv.Atoi(key)
 	if err != nil {
 		return app.lanes[defaultLane]

--- a/abci/example/kvstore/kvstore.go
+++ b/abci/example/kvstore/kvstore.go
@@ -195,7 +195,9 @@ func (app *Application) assignLane(tx []byte) uint32 {
 		return app.lanes[defaultLane]
 	}
 
-// If the tx is of the form 2=2 we will assign it a lane. For any other type of transaction sent to the kvstore, it will go to the default lane.  
+	// If the transaction key is an integer (for example, a transaction of the
+	// form 2=2), we will assign a lane. Any other type of transaction will go
+	// to the default lane.
 	keyInt, err := strconv.Atoi(key)
 	if err != nil {
 		return app.lanes[defaultLane]

--- a/abci/example/kvstore/kvstore.go
+++ b/abci/example/kvstore/kvstore.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -14,7 +15,6 @@ import (
 	"github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/crypto"
 	cryptoenc "github.com/cometbft/cometbft/crypto/encoding"
-	"github.com/cometbft/cometbft/crypto/tmhash"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/version"
 )
@@ -59,12 +59,13 @@ type Application struct {
 
 // NewApplication creates an instance of the kvstore from the provided database.
 func NewApplication(db dbm.DB) *Application {
-	// Map from lane name to its priority. Priority 0 is reserved.
+	// Map from lane name to its priority. Priority 0 is reserved. The higher
+	// the value, the higher the priority.
 	lanes := map[string]uint32{
-		"val":       1, // lane for validator updates
-		"foo":       3, // lane 2
-		defaultLane: 7,
-		"bar":       9, // lane 3
+		"val":       9, // for validator updates
+		"foo":       7,
+		defaultLane: 3,
+		"bar":       1,
 	}
 
 	// List of lane priorities
@@ -166,34 +167,64 @@ func (app *Application) InitChain(_ context.Context, req *types.InitChainRequest
 // - `=` is not the first or last byte.
 // - if key is `val` that the validator update transaction is also valid.
 func (app *Application) CheckTx(_ context.Context, req *types.CheckTxRequest) (*types.CheckTxResponse, error) {
+	code := CodeTypeOK
 	// If it is a validator update transaction, check that it is correctly formatted
 	if isValidatorTx(req.Tx) {
 		if _, _, _, err := parseValidatorTx(req.Tx); err != nil {
-			if app.useLanes {
-				return &types.CheckTxResponse{Code: CodeTypeInvalidTxFormat, Lane: app.lanes["val"]}, nil
-			}
-			return &types.CheckTxResponse{Code: CodeTypeInvalidTxFormat}, nil
+			code = CodeTypeInvalidTxFormat
 		}
 	} else if !isValidTx(req.Tx) {
-		return &types.CheckTxResponse{Code: CodeTypeInvalidTxFormat}, nil
+		code = CodeTypeInvalidTxFormat
 	}
 
 	if !app.useLanes {
-		return &types.CheckTxResponse{Code: CodeTypeOK, GasWanted: 1}, nil
-	}
-	// Assign a lane to the transaction deterministically.
-	var lane uint32
-	txHash := tmhash.Sum(req.Tx)
-	switch {
-	case txHash[0] == 1 && txHash[1] == 0 && txHash[2] == 0:
-		lane = app.lanes["foo"]
-	case txHash[0] == 1 && txHash[1] == 1 && txHash[2] == 1:
-		lane = app.lanes["bar"]
-	default:
-		lane = app.lanes[defaultLane]
+		return &types.CheckTxResponse{Code: code, GasWanted: 1}, nil
 	}
 
-	return &types.CheckTxResponse{Code: CodeTypeOK, GasWanted: 1, Lane: lane}, nil
+	lane := uint32(0)
+	if code == CodeTypeOK {
+		lane = app.assignLane(req.Tx)
+	}
+
+	return &types.CheckTxResponse{Code: code, GasWanted: 1, Lane: lane}, nil
+}
+
+// assignLane deterministically computes a lane for the given tx.
+func (app *Application) assignLane(tx []byte) uint32 {
+	if isValidatorTx(tx) {
+		return app.lanes["val"] // priority 9
+	}
+
+	key, _, err := parseTx(tx)
+	if err != nil {
+		return app.lanes[defaultLane]
+	}
+
+	keyInt, err := strconv.Atoi(key)
+	if err != nil {
+		return app.lanes[defaultLane]
+	}
+
+	switch {
+	case keyInt%11 == 0:
+		return app.lanes["foo"] // priority 7
+	case keyInt%3 == 0:
+		return app.lanes["bar"] // priority 1
+	default:
+		return app.lanes[defaultLane] // priority 3
+	}
+}
+
+// parseTx parses a tx in 'key=value' format into a key and value.
+func parseTx(tx []byte) (key, value string, err error) {
+	parts := bytes.Split(tx, []byte("="))
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("invalid tx format: %q", string(tx))
+	}
+	if len(parts[0]) == 0 {
+		return "", "", errors.New("key cannot be empty")
+	}
+	return string(parts[0]), string(parts[1]), nil
 }
 
 // Tx must have a format like key:value or key=value. That is:

--- a/abci/example/kvstore/kvstore_test.go
+++ b/abci/example/kvstore/kvstore_test.go
@@ -238,6 +238,35 @@ func TestCheckTx(t *testing.T) {
 	}
 }
 
+func TestClientAssignLane(t *testing.T) {
+	kvstore := NewInMemoryApplication()
+	val := RandVal()
+
+	testCases := []struct {
+		lane uint32
+		tx   []byte
+	}{
+		{kvstore.lanes["foo"], NewTx("0", "0")},
+		{kvstore.lanes[defaultLane], NewTx("1", "1")},
+		{kvstore.lanes[defaultLane], NewTx("2", "2")},
+		{kvstore.lanes["bar"], NewTx("3", "3")},
+		{kvstore.lanes[defaultLane], NewTx("4", "4")},
+		{kvstore.lanes[defaultLane], NewTx("5", "5")},
+		{kvstore.lanes["bar"], NewTx("6", "6")},
+		{kvstore.lanes[defaultLane], NewTx("7", "7")},
+		{kvstore.lanes[defaultLane], NewTx("8", "8")},
+		{kvstore.lanes["bar"], NewTx("9", "9")},
+		{kvstore.lanes[defaultLane], NewTx("10", "10")},
+		{kvstore.lanes["foo"], NewTx("11", "11")},
+		{kvstore.lanes["bar"], NewTx("12", "12")},
+		{kvstore.lanes["val"], MakeValSetChangeTx(val)},
+	}
+
+	for idx, tc := range testCases {
+		require.Equal(t, tc.lane, kvstore.assignLane(tc.tx), idx)
+	}
+}
+
 func TestClientServer(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -269,15 +269,19 @@ func TestMempoolAddTxLane(t *testing.T) {
 
 		// Check that the lane stored in the mempool entry is the same as the
 		// one assigned by the application.
-		lane := mp.txsMap[types.Tx(tx).Key()].Value.(*mempoolTx).lane
-		expectedLane := 3
-		if i%11 == 0 {
-			expectedLane = 7
-		} else if i%3 == 0 {
-			expectedLane = 1
-		}
-		require.Equal(t, types.Lane(expectedLane), lane, "id %x", tx)
+		entry := mp.txsMap[types.Tx(tx).Key()].Value.(*mempoolTx)
+		require.Equal(t, kvstoreAssignLane(i), entry.lane, "id %x", tx)
 	}
+}
+
+func kvstoreAssignLane(key int) types.Lane {
+	lane := 3
+	if key%11 == 0 {
+		lane = 7
+	} else if key%3 == 0 {
+		lane = 1
+	}
+	return types.Lane(lane)
 }
 
 func TestMempoolUpdate(t *testing.T) {

--- a/test/e2e/app/app.go
+++ b/test/e2e/app/app.go
@@ -25,7 +25,6 @@ import (
 	cmtproto "github.com/cometbft/cometbft/api/cometbft/types/v1"
 	"github.com/cometbft/cometbft/crypto"
 	cryptoenc "github.com/cometbft/cometbft/crypto/encoding"
-	"github.com/cometbft/cometbft/crypto/tmhash"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/libs/protoio"
 	cmttypes "github.com/cometbft/cometbft/types"
@@ -162,11 +161,12 @@ func NewApplication(cfg *Config) (*Application, error) {
 	logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout))
 	logger.Info("Application started!")
 
-	// Map from lane name to its priority. Priority 0 is reserved.
+	// Map from lane name to its priority. Priority 0 is reserved. The higher
+	// the value, the higher the priority.
 	lanes := map[string]uint32{
-		"foo":       1, // lane 1
-		"bar":       4, // lane 2
-		defaultLane: 9, // default lane
+		"foo":       9,
+		"bar":       4,
+		defaultLane: 1,
 	}
 
 	// List of lane priorities
@@ -315,19 +315,31 @@ func (app *Application) CheckTx(_ context.Context, req *abci.CheckTxRequest) (*a
 		time.Sleep(app.cfg.CheckTxDelay)
 	}
 
-	// Assign a lane to the transaction deterministically.
-	var lane uint32
-	txHash := tmhash.Sum(req.Tx)
-	switch {
-	case txHash[0] == 0 && txHash[1] == 0 && txHash[2] == 0 && txHash[3] == 0:
-		lane = app.lanes["foo"]
-	case txHash[0] == 0:
-		lane = app.lanes["bar"]
-	default:
-		lane = app.lanes[defaultLane]
-	}
+	lane := app.assignLane(req.Tx)
 
 	return &abci.CheckTxResponse{Code: kvstore.CodeTypeOK, GasWanted: 1, Lane: lane}, nil
+}
+
+// assignLane deterministically computes a lane for the given tx.
+func (app *Application) assignLane(tx []byte) uint32 {
+	key, _, err := parseTx(tx)
+	if err != nil {
+		return app.lanes[defaultLane]
+	}
+
+	keyInt, err := strconv.Atoi(key)
+	if err != nil {
+		return app.lanes[defaultLane]
+	}
+
+	switch {
+	case keyInt%11 == 0:
+		return app.lanes["foo"] // priority 7
+	case keyInt%3 == 0:
+		return app.lanes["bar"] // priority 1
+	default:
+		return app.lanes[defaultLane] // priority 3
+	}
 }
 
 // FinalizeBlock implements ABCI.


### PR DESCRIPTION
Depends on #3833

Currently it computes a hash to assign a lane, which makes it impossible to easily reproduce in tests. With this change it will use the key in a "key=value" transaction.