### PR TITLE
refactor(lanes): Simplify concurrency of `BlockingIterator`

### DIFF
--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -489,11 +489,11 @@ func (mem *CListMempool) addTx(tx types.Tx, gasWanted int64, sender p2p.ID, lane
 	return true
 }
 
-// newTxCh returns a channel to wait until a new transaction is added to the
+// addedTxCh returns a channel to wait until a new transaction is added to the
 // mempool.
 //
 // Safe for concurrent use by multiple iterators.
-func (mem *CListMempool) newTxCh() <-chan struct{} {
+func (mem *CListMempool) addedTxCh() <-chan struct{} {
 	mem.txsMtx.RLock()
 	ch := mem.addTxCh
 	mem.txsMtx.RUnlock()

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -60,7 +60,6 @@ type CListMempool struct {
 	numTxs    int64                           // total number of txs in the mempool
 	addTxCh   chan struct{}                   // blocks until the next tx is added
 	addTxSeq  int64                           // helps detect if new txs have been added to a given lane
-	addTxLane types.Lane                      // lane where the most recent transaction was added
 
 	addTxLaneSeqs sync.Map // sequence of the last tx added to a given lane (types.Lane -> int64)
 
@@ -471,7 +470,6 @@ func (mem *CListMempool) addTx(tx types.Tx, gasWanted int64, sender p2p.ID, lane
 	mem.laneBytes[lane] += int64(len(tx))
 
 	// Notify iterators there's a new transaction.
-	mem.addTxLane = lane
 	close(mem.addTxCh)
 	mem.addTxCh = make(chan struct{})
 

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -472,10 +472,10 @@ func (mem *CListMempool) addTx(tx types.Tx, gasWanted int64, sender p2p.ID, lane
 	// Notify iterators there's a new transaction.
 	select {
 	case mem.addTxCh <- lane:
+		close(mem.addTxCh)
+		mem.addTxCh = make(chan types.Lane)
 	default:
 	}
-	close(mem.addTxCh)
-	mem.addTxCh = make(chan types.Lane)
 
 	// Update metrics.
 	mem.metrics.TxSizeBytes.Observe(float64(len(tx)))

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -500,16 +500,6 @@ func (mem *CListMempool) addedTxCh() <-chan struct{} {
 	return ch
 }
 
-// latestTxLane returns the lane where the latest transaction was added.
-//
-// Safe for concurrent use by multiple iterators.
-func (mem *CListMempool) latestTxLane() types.Lane {
-	mem.txsMtx.RLock()
-	lane := mem.addTxLane
-	mem.txsMtx.RUnlock()
-	return lane
-}
-
 // lastTxSeq returns the sequence number of the latest transaction added to the
 // given lane. Note that sequence numbers start from 1.
 //

--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -166,7 +166,7 @@ func addRandomTxs(t *testing.T, mp Mempool, count int) []types.Tx {
 func addTxs(tb testing.TB, mp Mempool, first, num int) []types.Tx {
 	tb.Helper()
 	txs := make([]types.Tx, 0, num)
-	for i := first; i < num; i++ {
+	for i := first; i < first+num; i++ {
 		tx := kvstore.NewTxFromID(i)
 		_, err := mp.CheckTx(tx, "")
 		require.NoError(tb, err)

--- a/mempool/iterators.go
+++ b/mempool/iterators.go
@@ -118,11 +118,11 @@ func (iter *BlockingIterator) WaitNextCh() <-chan Entry {
 	go func() {
 		// Pick a lane containing the next entry to access.
 		lane, ok := iter.pickLane()
-		if !ok {
-			// There are no transactions to take from any lane. Wait until a new
-			// transaction is added to the mempool.
+		for !ok {
+			// There are no transactions to take from any lane. Wait until at
+			// least one transaction is added to the mempool and try again.
 			<-iter.mp.addedTxCh()
-			lane = iter.mp.latestTxLane()
+			lane, ok = iter.pickLane()
 		}
 
 		// Add the next entry to the channel if not nil.

--- a/mempool/iterators.go
+++ b/mempool/iterators.go
@@ -121,7 +121,7 @@ func (iter *BlockingIterator) WaitNextCh() <-chan Entry {
 		if !ok {
 			// There are no transactions to take from any lane. Wait until a new
 			// transaction is added to the mempool.
-			<-iter.mp.newTxCh()
+			<-iter.mp.addedTxCh()
 			lane = iter.mp.latestTxLane()
 		}
 

--- a/mempool/iterators.go
+++ b/mempool/iterators.go
@@ -139,9 +139,9 @@ func (iter *BlockingIterator) WaitNextCh() <-chan Entry {
 // pickLane returns a _valid_ lane containing the next transaction to access
 // according to the WRR algorithm. A lane is valid if it is not empty or it is
 // not over-consumed, meaning that the number of accessed entries in the lane
-// has not yet reached its priority value in the current WRR iteration. It will
-// block until a transaction is available in any lane. It returns false if all
-// lanes are empty or don't have transactions that have not yet been accessed.
+// has not yet reached its priority value in the current WRR iteration. It
+// returns false if all lanes are empty or don't have transactions that have not
+// yet been accessed.
 func (iter *BlockingIterator) pickLane() (types.Lane, bool) {
 	// Start from the last accessed lane.
 	lane := iter.sortedLanes[iter.laneIndex]


### PR DESCRIPTION
- Remove `addTxChMtx` and just use `txsMtx` instead to guard `addTxCh` and `addTxSeq`. These two variables are updated when adding a transaction, so they are already guarded by `txsMtx`.
- `addTxLaneSeqs` needs to be safely read concurrently by multiple iterators so I made it a `sync.Map`. With this change we don't need to lock `txsMtx` in `PickLane`.
- `PickLane` now is not blocking. Now, when it doesn't find a lane, it returns false, and blocking happens in `WaitNextCh`.
- A new variable `addTxLane` holds the lane where the latest transaction was added. Now each iterator that waits for a new tx can read this value to pick directly this lane.