### PR TITLE
fix(state): override app version if set by app at chain start

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -23,16 +23,15 @@ var (
 
 // -----------------------------------------------------------------------------
 
-// InitStateVersion sets the Consensus.Block and Software versions,
-// but leaves the Consensus.App version blank.
-// The Consensus.App version will be set during the Handshake, once
-// we hear from the app what protocol version it is running.
-var InitStateVersion = cmtstate.Version{
-	Consensus: cmtversion.Consensus{
-		Block: version.BlockProtocol,
-		App:   0,
-	},
-	Software: version.CMTSemVer,
+// InitStateVersion sets the Consensus.Block, Consensus.App and Software versions.
+func InitStateVersion(appVersion uint64) cmtstate.Version {
+	return cmtstate.Version{
+		Consensus: cmtversion.Consensus{
+			Block: version.BlockProtocol,
+			App:   appVersion,
+		},
+		Software: version.CMTSemVer,
+	}
 }
 
 // -----------------------------------------------------------------------------
@@ -319,8 +318,13 @@ func MakeGenesisState(genDoc *types.GenesisDoc) (State, error) {
 		nextValidatorSet = types.NewValidatorSet(validators).CopyIncrementProposerPriority(1)
 	}
 
+	appVersion := uint64(0)
+	if genDoc.ConsensusParams != nil {
+		appVersion = genDoc.ConsensusParams.Version.App
+	}
+
 	return State{
-		Version:       InitStateVersion,
+		Version:       InitStateVersion(appVersion),
 		ChainID:       genDoc.ChainID,
 		InitialHeight: genDoc.InitialHeight,
 

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cometbft/cometbft/internal/test"
 	sm "github.com/cometbft/cometbft/state"
 	"github.com/cometbft/cometbft/types"
+	"github.com/cometbft/cometbft/version"
 )
 
 // setupTestCase does setup common to all test cases.
@@ -81,6 +82,21 @@ func TestMakeGenesisStateNilValidators(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, state.Validators.Validators)
 	require.Empty(t, state.NextValidators.Validators)
+}
+
+func TestMakeGenesisStateSetsAppVersion(t *testing.T) {
+	cp := types.DefaultConsensusParams()
+	appVersion := uint64(5)
+	cp.Version.App = appVersion
+	doc := types.GenesisDoc{
+		ChainID:         "dummy",
+		ConsensusParams: cp,
+	}
+	require.Nil(t, doc.ValidateAndComplete())
+	state, err := sm.MakeGenesisState(&doc)
+	require.Nil(t, err)
+	require.Equal(t, appVersion, state.Version.Consensus.App)
+	require.Equal(t, version.BlockProtocol, state.Version.Consensus.Block)
 }
 
 // TestStateSaveLoad tests saving and loading State from a db.


### PR DESCRIPTION
Closes: #756 

@adizere, I found issue #756 and cherrypicked the associated PR (in celestia-core) to `main`.

I'm leaving it as draft as I'm not convinced the app version should be overridden in `Info`, rather than in `InitChain` (in particular in `InitChainResponse.consensus_params.version.App`

---

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- ~[ ] Updated relevant documentation (`docs/` or `spec/`) and code comments~
