### PR TITLE
revert(crypto): revert BLS sig size downgrade

### DIFF
--- a/.changelog/unreleased/improvements/3624-crypto-bls-sig-size.md
+++ b/.changelog/unreleased/improvements/3624-crypto-bls-sig-size.md
@@ -1,2 +1,0 @@
-- `[crypto]` Reduce BLS signature size to 48 bytes by increasing pubkey size to
-  192 bytes ([\#3624](https://github.com/cometbft/cometbft/issues/3624)

--- a/crypto/bls12381/const.go
+++ b/crypto/bls12381/const.go
@@ -4,9 +4,9 @@ const (
 	// PrivKeySize defines the length of the PrivKey byte array.
 	PrivKeySize = 32
 	// PubKeySize defines the length of the PubKey byte array.
-	PubKeySize = 192
+	PubKeySize = 96
 	// SignatureLength defines the byte length of a BLS signature.
-	SignatureLength = 48
+	SignatureLength = 96
 	// KeyType is the string constant for the BLS12-381 algorithm.
 	KeyType = "bls12_381"
 	// MaxMsgLen defines the maximum length of the message bytes as passed to Sign.

--- a/crypto/bls12381/key_bls12381.go
+++ b/crypto/bls12381/key_bls12381.go
@@ -28,6 +28,9 @@ var (
 )
 
 // For minimal-pubkey-size operations.
+//
+// Changing this to 'minimal-signature-size' would render CometBFT not Ethereum
+// compatible.
 type (
 	blstPublicKey          = blst.P1Affine
 	blstSignature          = blst.P2Affine

--- a/crypto/bls12381/key_bls12381.go
+++ b/crypto/bls12381/key_bls12381.go
@@ -27,10 +27,10 @@ var (
 	dstMinSig = []byte("BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_")
 )
 
-// For minimal-signature-size operations.
+// For minimal-pubkey-size operations.
 type (
-	blstPublicKey          = blst.P2Affine
-	blstSignature          = blst.P1Affine
+	blstPublicKey          = blst.P1Affine
+	blstSignature          = blst.P2Affine
 	blstAggregateSignature = blst.P1Aggregate
 	blstAggregatePublicKey = blst.P2Aggregate
 )

--- a/state/tx_filter_test.go
+++ b/state/tx_filter_test.go
@@ -23,8 +23,8 @@ func TestTxFilter(t *testing.T) {
 		tx    types.Tx
 		isErr bool
 	}{
-		{types.Tx(cmtrand.Bytes(2155)), false},
-		{types.Tx(cmtrand.Bytes(2156)), true},
+		{types.Tx(cmtrand.Bytes(2122)), false},
+		{types.Tx(cmtrand.Bytes(2123)), true},
 		{types.Tx(cmtrand.Bytes(3000)), true},
 	}
 

--- a/types/block.go
+++ b/types/block.go
@@ -597,10 +597,10 @@ const (
 	// 4 bytes for field tags + 1 byte for signature LEN + 1 byte for
 	// validator address LEN + 1 byte for timestamp LEN.
 	maxCommitSigProtoEncOverhead = 4 + 1 + 1 + 1 + 3 // 3 ???
-	// Commit sig size is made up of MaxSignatureSize (64) bytes for the
+	// Commit sig size is made up of MaxSignatureSize (96) bytes for the
 	// signature, 20 bytes for the address, 1 byte for the flag and 14 bytes for
 	// the timestamp.
-	MaxCommitSigBytes = 99 + maxCommitSigProtoEncOverhead
+	MaxCommitSigBytes = 131 + maxCommitSigProtoEncOverhead
 )
 
 // CommitSig is a part of the Vote included in a Commit.
@@ -612,8 +612,8 @@ type CommitSig struct {
 }
 
 func MaxCommitBytes(valCount int) int64 {
-	// 1 byte field tag + 1 byte LEN
-	const protoRepeatedFieldLenOverhead int64 = 2
+	// 1 byte field tag + 1 byte LEN + 1 byte ???
+	const protoRepeatedFieldLenOverhead int64 = 3
 	// From the repeated commit sig field
 	return MaxCommitOverheadBytes + ((MaxCommitSigBytes + protoRepeatedFieldLenOverhead) * int64(valCount))
 }

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -458,10 +458,10 @@ func TestBlockMaxDataBytes(t *testing.T) {
 	}{
 		0: {-10, 1, 0, true, 0},
 		1: {10, 1, 0, true, 0},
-		2: {808, 1, 0, true, 0},
-		3: {842, 1, 0, false, 0},
-		4: {843, 1, 0, false, 1},
-		5: {953, 2, 0, false, 0},
+		2: {841, 1, 0, true, 0},
+		3: {875, 1, 0, false, 0},
+		4: {876, 1, 0, false, 1},
+		5: {1019, 2, 0, false, 0},
 	}
 
 	for i, tc := range testCases {
@@ -488,8 +488,8 @@ func TestBlockMaxDataBytesNoEvidence(t *testing.T) {
 		0: {-10, 1, true, 0},
 		1: {10, 1, true, 0},
 		2: {841, 1, true, 0},
-		3: {842, 1, false, 0},
-		4: {843, 1, false, 1},
+		3: {875, 1, false, 0},
+		4: {876, 1, false, 1},
 	}
 
 	for i, tc := range testCases {


### PR DESCRIPTION
because it's not Ethereum compatible and breaks Berachain

Reverts https://github.com/cometbft/cometbft/pull/3627

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
