### PR TITLE
e2e: update version to match v1.x (#3868)

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,9 +1,9 @@
 package version
 
 const (
-	// CMTSemVer is used as the fallback version of CometBFT
-	// when not using git describe. It uses semantic versioning format.
-	CMTSemVer = "1.0.0-dev"
+	// CMTSemVer is the used as the fallback version of CometBFT
+	// when not using git describe. It is formatted with semantic versioning.
+	CMTSemVer = "1.0.0-rc1"
 	// ABCISemVer is the semantic version of the ABCI protocol.
 	ABCISemVer  = "2.1.0"
 	ABCIVersion = ABCISemVer


### PR DESCRIPTION
close: 3868

update version to run e2e `v1.x` images

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
