### PR TITLE
test(e2e): log tx hash after failed e2e test

### DIFF
--- a/test/e2e/tests/app_test.go
+++ b/test/e2e/tests/app_test.go
@@ -99,7 +99,7 @@ func TestApp_Tx(t *testing.T) {
 			txResp, err := client.Tx(ctx, hash, false)
 			return err == nil && bytes.Equal(txResp.Tx, tx)
 		}, waitTime, time.Second,
-			"submitted tx wasn't committed after %v", waitTime,
+			"submitted tx (%X) wasn't committed after %v", hash, waitTime,
 		)
 
 		// NOTE: we don't test abci query of the light client


### PR DESCRIPTION
log the tx hash when `e2e` app test fails

#### PR checklist

- [X] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
