### PR TITLE
chore(lanes): Revert a few changes that don't belong to this branch

### DIFF
--- a/abci/example/kvstore/kvstore.go
+++ b/abci/example/kvstore/kvstore.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -15,6 +14,7 @@ import (
 	"github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/crypto"
 	cryptoenc "github.com/cometbft/cometbft/crypto/encoding"
+	"github.com/cometbft/cometbft/crypto/tmhash"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/version"
 )
@@ -59,13 +59,12 @@ type Application struct {
 
 // NewApplication creates an instance of the kvstore from the provided database.
 func NewApplication(db dbm.DB) *Application {
-	// Map from lane name to its priority. Priority 0 is reserved. The higher
-	// the value, the higher the priority.
+	// Map from lane name to its priority. Priority 0 is reserved.
 	lanes := map[string]uint32{
-		"val":       9, // for validator updates
-		"foo":       7,
-		defaultLane: 3,
-		"bar":       1,
+		"val":       1, // lane for validator updates
+		"foo":       3, // lane 2
+		defaultLane: 7,
+		"bar":       9, // lane 3
 	}
 
 	// List of lane priorities
@@ -170,7 +169,10 @@ func (app *Application) CheckTx(_ context.Context, req *types.CheckTxRequest) (*
 	// If it is a validator update transaction, check that it is correctly formatted
 	if isValidatorTx(req.Tx) {
 		if _, _, _, err := parseValidatorTx(req.Tx); err != nil {
-			return &types.CheckTxResponse{Code: CodeTypeInvalidTxFormat}, nil //nolint:nilerr // error is not nil but it returns nil
+			if app.useLanes {
+				return &types.CheckTxResponse{Code: CodeTypeInvalidTxFormat, Lane: app.lanes["val"]}, nil
+			}
+			return &types.CheckTxResponse{Code: CodeTypeInvalidTxFormat}, nil
 		}
 	} else if !isValidTx(req.Tx) {
 		return &types.CheckTxResponse{Code: CodeTypeInvalidTxFormat}, nil
@@ -179,50 +181,19 @@ func (app *Application) CheckTx(_ context.Context, req *types.CheckTxRequest) (*
 	if !app.useLanes {
 		return &types.CheckTxResponse{Code: CodeTypeOK, GasWanted: 1}, nil
 	}
-
-	lane := app.assignLane(req.Tx)
-	return &types.CheckTxResponse{Code: CodeTypeOK, GasWanted: 1, Lane: lane}, nil
-}
-
-// assignLane deterministically computes a lane for the given tx.
-func (app *Application) assignLane(tx []byte) uint32 {
-	if isValidatorTx(tx) {
-		return app.lanes["val"] // priority 9
-	}
-
-	key, _, err := parseTx(tx)
-	if err != nil {
-		return app.lanes[defaultLane]
-	}
-
-	// If the transaction key is an integer (for example, a transaction of the
-	// form 2=2), we will assign a lane. Any other type of transaction will go
-	// to the default lane.
-	keyInt, err := strconv.Atoi(key)
-	if err != nil {
-		return app.lanes[defaultLane]
-	}
-
+	// Assign a lane to the transaction deterministically.
+	var lane uint32
+	txHash := tmhash.Sum(req.Tx)
 	switch {
-	case keyInt%11 == 0:
-		return app.lanes["foo"] // priority 7
-	case keyInt%3 == 0:
-		return app.lanes["bar"] // priority 1
+	case txHash[0] == 1 && txHash[1] == 0 && txHash[2] == 0:
+		lane = app.lanes["foo"]
+	case txHash[0] == 1 && txHash[1] == 1 && txHash[2] == 1:
+		lane = app.lanes["bar"]
 	default:
-		return app.lanes[defaultLane] // priority 3
+		lane = app.lanes[defaultLane]
 	}
-}
 
-// parseTx parses a tx in 'key=value' format into a key and value.
-func parseTx(tx []byte) (key, value string, err error) {
-	parts := bytes.Split(tx, []byte("="))
-	if len(parts) != 2 {
-		return "", "", fmt.Errorf("invalid tx format: %q", string(tx))
-	}
-	if len(parts[0]) == 0 {
-		return "", "", errors.New("key cannot be empty")
-	}
-	return string(parts[0]), string(parts[1]), nil
+	return &types.CheckTxResponse{Code: CodeTypeOK, GasWanted: 1, Lane: lane}, nil
 }
 
 // Tx must have a format like key:value or key=value. That is:

--- a/abci/example/kvstore/kvstore_test.go
+++ b/abci/example/kvstore/kvstore_test.go
@@ -238,35 +238,6 @@ func TestCheckTx(t *testing.T) {
 	}
 }
 
-func TestClientAssignLane(t *testing.T) {
-	kvstore := NewInMemoryApplication()
-	val := RandVal()
-
-	testCases := []struct {
-		lane uint32
-		tx   []byte
-	}{
-		{kvstore.lanes["foo"], NewTx("0", "0")},
-		{kvstore.lanes[defaultLane], NewTx("1", "1")},
-		{kvstore.lanes[defaultLane], NewTx("2", "2")},
-		{kvstore.lanes["bar"], NewTx("3", "3")},
-		{kvstore.lanes[defaultLane], NewTx("4", "4")},
-		{kvstore.lanes[defaultLane], NewTx("5", "5")},
-		{kvstore.lanes["bar"], NewTx("6", "6")},
-		{kvstore.lanes[defaultLane], NewTx("7", "7")},
-		{kvstore.lanes[defaultLane], NewTx("8", "8")},
-		{kvstore.lanes["bar"], NewTx("9", "9")},
-		{kvstore.lanes[defaultLane], NewTx("10", "10")},
-		{kvstore.lanes["foo"], NewTx("11", "11")},
-		{kvstore.lanes["bar"], NewTx("12", "12")},
-		{kvstore.lanes["val"], MakeValSetChangeTx(val)},
-	}
-
-	for idx, tc := range testCases {
-		require.Equal(t, tc.lane, kvstore.assignLane(tc.tx), idx)
-	}
-}
-
 func TestClientServer(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -252,36 +252,6 @@ func TestMempoolFilters(t *testing.T) {
 	}
 }
 
-func TestMempoolAddTxLane(t *testing.T) {
-	app := kvstore.NewInMemoryApplication()
-	cc := proxy.NewLocalClientCreator(app)
-	cfg := test.ResetTestRoot("mempool_test")
-	mp, cleanup := newMempoolWithAppAndConfig(cc, cfg)
-	defer cleanup()
-
-	for i := 0; i < 100; i++ {
-		tx := kvstore.NewTxFromID(i)
-		rr, err := mp.CheckTx(tx, noSender)
-		require.NoError(t, err)
-		rr.Wait()
-
-		// Check that the lane stored in the mempool entry is the same as the
-		// one assigned by the application.
-		entry := mp.txsMap[types.Tx(tx).Key()].Value.(*mempoolTx)
-		require.Equal(t, kvstoreAssignLane(i), entry.lane, "id %x", tx)
-	}
-}
-
-func kvstoreAssignLane(key int) types.Lane {
-	lane := 3
-	if key%11 == 0 {
-		lane = 7
-	} else if key%3 == 0 {
-		lane = 1
-	}
-	return types.Lane(lane)
-}
-
 func TestMempoolUpdate(t *testing.T) {
 	app := kvstore.NewInMemoryApplication()
 	cc := proxy.NewLocalClientCreator(app)

--- a/test/e2e/networks/simple.toml
+++ b/test/e2e/networks/simple.toml
@@ -1,2 +1,4 @@
 [node.validator00]
 [node.validator01]
+[node.validator02]
+[node.validator03]


### PR DESCRIPTION
- [restore simple.toml manifest](https://github.com/cometbft/cometbft/pull/3876/commits/89e8e1e74424d2cbda68819646f9c8871541588e)
- [Revert "feat(lanes): Change lane selection algorithm in kvstore app (](https://github.com/cometbft/cometbft/pull/3876/commits/8102290fd696c6244e5b1375fafa45c49cf2d5dc)https://github.com/cometbft/cometbft/pull/3762 
- [Revert "BenchTest"](https://github.com/cometbft/cometbft/pull/3876/commits/c060e28b65e948786028ad430bbbd318ce82e8a8) 