### PR TITLE
docs: clarifiy VE and PBTS enable height set to 0 (manual backport #3879)

### DIFF
--- a/api/cometbft/types/v1/params.pb.go
+++ b/api/cometbft/types/v1/params.pb.go
@@ -473,7 +473,10 @@ func (m *SynchronyParams) GetMessageDelay() *time.Duration {
 
 // FeatureParams configure the height from which features of CometBFT are enabled.
 type FeatureParams struct {
-	// First height during which vote extensions will be enabled.
+	// Height during which vote extensions will be enabled.
+	//
+	// A value of 0 means vote extensions are disabled. A value > 0 denotes
+	// the height at which vote extensions will be (or have been) enabled.
 	//
 	// During the specified height, and for all subsequent heights, precommit
 	// messages that do not contain valid extension data will be considered
@@ -487,6 +490,9 @@ type FeatureParams struct {
 	// Cannot be set to heights lower or equal to the current blockchain height.
 	VoteExtensionsEnableHeight *types.Int64Value `protobuf:"bytes,1,opt,name=vote_extensions_enable_height,json=voteExtensionsEnableHeight,proto3" json:"vote_extensions_enable_height,omitempty"`
 	// Height at which Proposer-Based Timestamps (PBTS) will be enabled.
+	//
+	// A value of 0 means PBTS is disabled. A value > 0 denotes the height at
+	// which PBTS will be (or has been) enabled.
 	//
 	// From the specified height, and for all subsequent heights, the PBTS
 	// algorithm will be used to produce and validate block timestamps. Prior to

--- a/proto/cometbft/types/v1/params.proto
+++ b/proto/cometbft/types/v1/params.proto
@@ -109,7 +109,10 @@ message SynchronyParams {
 
 // FeatureParams configure the height from which features of CometBFT are enabled.
 message FeatureParams {
-  // First height during which vote extensions will be enabled.
+  // Height during which vote extensions will be enabled.
+  //
+  // A value of 0 means vote extensions are disabled. A value > 0 denotes
+  // the height at which vote extensions will be (or have been) enabled.
   //
   // During the specified height, and for all subsequent heights, precommit
   // messages that do not contain valid extension data will be considered
@@ -124,6 +127,9 @@ message FeatureParams {
   google.protobuf.Int64Value vote_extensions_enable_height = 1 [(gogoproto.nullable) = true];
 
   // Height at which Proposer-Based Timestamps (PBTS) will be enabled.
+  //
+  // A value of 0 means PBTS is disabled. A value > 0 denotes the height at
+  // which PBTS will be (or has been) enabled.
   //
   // From the specified height, and for all subsequent heights, the PBTS
   // algorithm will be used to produce and validate block timestamps. Prior to

--- a/spec/abci/abci++_app_requirements.md
+++ b/spec/abci/abci++_app_requirements.md
@@ -677,6 +677,9 @@ Must have `MaxBytes > 0`.
 
 Height at which Proposer-Based Timestamps (PBTS) will be enabled.
 
+A value of 0 means that PBTS is disabled. A value > 0 denotes the
+height at which PBTS will be (or has been) enabled.
+
 From the specified height, and for all subsequent heights, the PBTS
 algorithm will be used to produce and validate block timestamps. Prior to
 this height, or when this height is set to 0, the legacy BFT Time
@@ -692,7 +695,9 @@ Must have `PbtsEnableHeight > [Current height]`
 
 This parameter is either 0 or a positive height at which vote extensions
 become mandatory. If the value is zero (which is the default), vote
-extensions are not expected. Otherwise, at all heights greater than the
+extensions are disabled, and are therefore precommit messages received
+from other nodes are not expected to contain vote extensions.
+If the value is greater than zero, at all heights greater than the
 configured height `H` vote extensions must be present (even if empty).
 When the configured height `H` is reached, `PrepareProposal` will not
 include vote extensions yet, but `ExtendVote` and `VerifyVoteExtension` will
@@ -1076,7 +1081,7 @@ For a detailed description on the upgrade path, please refer to the correspondin
 
 There is a newly introduced [**consensus parameter**](./abci%2B%2B_app_requirements.md#abciparamsvoteextensionsenableheight): `VoteExtensionsEnableHeight`.
 This parameter represents the height at which vote extensions are
-required for consensus to proceed, with 0 being the default value (no vote extensions).
+required for consensus to proceed, with 0 being the default value (vote extensions disabled).
 A chain can enable vote extensions either:
 - at genesis by setting `VoteExtensionsEnableHeight` to be equal, e.g., to the `InitialHeight`
 - or via the application logic by changing the `ConsensusParam` to configure the

--- a/spec/core/data_structures.md
+++ b/spec/core/data_structures.md
@@ -43,8 +43,9 @@ The CometBFT blockchain consists of a short list of data types:
     - [BlockParams](#blockparams)
     - [EvidenceParams](#evidenceparams)
     - [ValidatorParams](#validatorparams)
-    - [ABCIParams](#abciparams)
     - [VersionParams](#versionparams)
+    - [ABCIParams](#abciparams)
+    - [FeatureParams](#featureparams)
     - [SynchronyParams](#synchronyparams)
 
 
@@ -550,7 +551,7 @@ The `ABCIParams` type has been **deprecated** from CometBFT `v1.0`.
 From the configured height, and for all subsequent heights, the corresponding
 feature will be enabled.
 Cannot be set to heights lower or equal to the current blockchain height.
-A value of 0 indicates that the feature is disabled.
+A value of 0 (the default) indicates that the feature is disabled.
 
 ### SynchronyParams
 

--- a/types/params.go
+++ b/types/params.go
@@ -77,6 +77,8 @@ type VersionParams struct {
 }
 
 // FeatureParams configure the height from which features of CometBFT are enabled.
+// A value of 0 means the feature is disabled. A value > 0 denotes
+// the height at which the feature will be (or has been) enabled.
 type FeatureParams struct {
 	VoteExtensionsEnableHeight int64 `json:"vote_extensions_enable_height"`
 	PbtsEnableHeight           int64 `json:"pbts_enable_height"`


### PR DESCRIPTION
Retrying  #3882 manually

---

#### PR checklist

- ~[ ] Tests written/updated~
- ~[ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)~
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
