### PR TITLE
test(e2e): fix debug level on workflow

### DIFF
--- a/.changelog/unreleased/improvements/3880-e2e-manual-debug-workflow.md
+++ b/.changelog/unreleased/improvements/3880-e2e-manual-debug-workflow.md
@@ -1,2 +1,0 @@
-- `[e2e]` Add e2e manual debug workflow
-  ([\#3880](https://github.com/cometbft/cometbft/issues/3880))

--- a/.changelog/unreleased/improvements/3880-e2e-manual-debug-workflow.md
+++ b/.changelog/unreleased/improvements/3880-e2e-manual-debug-workflow.md
@@ -1,0 +1,2 @@
+- `[e2e]` Add e2e manual debug workflow
+  ([\#3880](https://github.com/cometbft/cometbft/issues/3880))

--- a/.github/workflows/e2e-manual-debug.yml
+++ b/.github/workflows/e2e-manual-debug.yml
@@ -32,7 +32,7 @@ jobs:
         if: matrix.group != 5
         working-directory: test/e2e
         # When changing -g, also change the matrix groups above
-        run: ./build/generator -g 5 -d networks/nightly/ -p -l "debug,p2p:info"
+        run: ./build/generator -g 5 -d networks/nightly/ -p -l "*:debug,p2p:info"
 
       - name: Run p2p testnets (${{ matrix.group }})
         if: matrix.group != 5

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -111,7 +111,7 @@ If you need to generate manifests with a specific `log_level` that will configur
 CometBFT's config file for each node, you can specify the level using the flags `-l` or `--log-level`.
 
 ```
-./build/generator -g 2 -d networks/nightly/ -l debug
+./build/generator -g 2 -d networks/nightly/ -l "*:debug,p2p:info"
 ```
 
 This will add the specified log level on each generated manifest (TOML file):


### PR DESCRIPTION
The `log_level` on the `e2e-manual-debug` was set incorrectly. This PR fixes it.

Realized after running a `e2e-manual-debug` workflow,[ all tests failed](https://github.com/cometbft/cometbft/actions/runs/10597473846) with:

```
validator01  | E[2024-08-28|13:20:29.330] failed to setup config: expected list in a form of "module:level" pairs, given pair debug, list [debug p2p:info] 
```

instead of using log level:

```
"debug,p2p:info"
```

this PR fixes it and uses the correct one:

```
"*:debug,p2p:info"
```

> NOTE: Also added a changelog entry for the new e2e workflow, previous PR only had a changelog entry for the generator new log level option

#### PR checklist

- [ ] Tests written/updated
- [X] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [X] Updated relevant documentation (`docs/` or `spec/`) and code comments
