### PR TITLE
ci: run tests 10 times in 20 groups

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         part: ["00", "01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"]
+        repeat: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     steps:
       - uses: actions/checkout@v4
       - run: echo "GO_VERSION=$(cat .github/workflows/go-version.env | grep GO_VERSION | cut -d '=' -f2)" >> $GITHUB_ENV


### PR DESCRIPTION
It seems that comet still has flaky tests.  I would like to suggest that this be merged to main, as this will surface those issues 10x faster than they're currently being surfaced.

If a test passes once it should pass 100x.

We can also think of this as a defense against the addition of future flaky tests, or a defense against situations where an issue may only occur intermittently.

If this approach is too expensive we should run it on Akash.

I estimate that probably takes a solid month of human time and I think that's cheaper than what this would cost for several years but if I'm wrong, let's do it that way.

Issue:
https://x.com/ChillinValidtn/status/1829472225193230445

Note: I'm at an airport, so there won't be a changelog entry.  

As an external contributor, unclog has always felt like a barrier to entry. 
---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
