### PR TITLE
test(e2e): Log multiple failed sent txs in one line

### DIFF
--- a/test/e2e/runner/load.go
+++ b/test/e2e/runner/load.go
@@ -24,7 +24,7 @@ func Load(ctx context.Context, testnet *e2e.Testnet) error {
 	initialTimeout := 1 * time.Minute
 	stallTimeout := 30 * time.Second
 	chSuccess := make(chan struct{})
-	chFailed := make(chan struct{})
+	chFailed := make(chan error)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -47,6 +47,7 @@ func Load(ctx context.Context, testnet *e2e.Testnet) error {
 
 	// Monitor successful and failed transactions, and abort on stalls.
 	success, failed := 0, 0
+	errorCounter := make(map[string]int)
 	timeout := initialTimeout
 	for {
 		rate := log.NewLazySprintf("%.1f", float64(success)/time.Since(started).Seconds())
@@ -55,8 +56,9 @@ func Load(ctx context.Context, testnet *e2e.Testnet) error {
 		case <-chSuccess:
 			success++
 			timeout = stallTimeout
-		case <-chFailed:
+		case err := <-chFailed:
 			failed++
+			errorCounter[err.Error()]++
 		case <-time.After(timeout):
 			return fmt.Errorf("unable to submit transactions for %v", timeout)
 		case <-ctx.Done():
@@ -72,6 +74,16 @@ func Load(ctx context.Context, testnet *e2e.Testnet) error {
 		if total%testnet.LoadTxBatchSize == 0 {
 			successRate := float64(success) / float64(total)
 			logger.Debug("load", "success", success, "failed", failed, "success/total", log.NewLazySprintf("%.2f", successRate), "tx/s", rate)
+			if len(errorCounter) > 0 {
+				for err, c := range errorCounter {
+					if c == 1 {
+						logger.Error("failed to send transaction", "err", err)
+					} else {
+						logger.Error("failed to send multiple transactions", "count", c, "err", err)
+					}
+				}
+				errorCounter = make(map[string]int)
+			}
 		}
 
 		// Check if reached max number of allowed transactions to send.
@@ -148,7 +160,7 @@ FOR_LOOP:
 
 // loadProcess processes transactions by sending transactions received on the txCh
 // to the client.
-func loadProcess(ctx context.Context, txCh <-chan types.Tx, chSuccess chan<- struct{}, chFailed chan<- struct{}, n *e2e.Node) {
+func loadProcess(ctx context.Context, txCh <-chan types.Tx, chSuccess chan<- struct{}, chFailed chan<- error, n *e2e.Node) {
 	var client *rpchttp.HTTP
 	var err error
 	s := struct{}{}
@@ -161,8 +173,7 @@ func loadProcess(ctx context.Context, txCh <-chan types.Tx, chSuccess chan<- str
 			}
 		}
 		if _, err = client.BroadcastTxSync(ctx, tx); err != nil {
-			logger.Error("failed to send transaction", "err", err)
-			chFailed <- s
+			chFailed <- err
 			continue
 		}
 		chSuccess <- s


### PR DESCRIPTION
Currently `runner load` will log an error for every tx that it failed to send, which can hundreds of lines. With this change, every distinct error will be logged once every ~1 second, with the number of times it failed during that time.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
