### PR TITLE
feat(e2e): Add `--internal-ip` flag to `load` command

### DIFF
--- a/.changelog/unreleased/features/3963-e2e-load-internal-ip.md
+++ b/.changelog/unreleased/features/3963-e2e-load-internal-ip.md
@@ -1,0 +1,3 @@
+- `[e2e]` Add new `--internal-ip` flag to `load` command for sending the load to
+  the nodes' internal IP addresses. This is useful when running from inside a
+  private network ([\#3963](https://github.com/cometbft/cometbft/pull/3963)).

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -710,6 +710,13 @@ func (n Node) Client() (*rpchttp.HTTP, error) {
 	return rpchttp.New(fmt.Sprintf("http://%s:%v/v1", n.ExternalIP, n.RPCProxyPort))
 }
 
+// ClientInternalIP returns an RPC client using the node's internal IP.
+// This is useful for running the loader from inside a private DO network.
+func (n Node) ClientInternalIP() (*rpchttp.HTTP, error) {
+	//nolint:nosprintfhostport
+	return rpchttp.New(fmt.Sprintf("http://%s:%v/v1", n.InternalIP, n.RPCProxyPort))
+}
+
 // GRPCClient creates a gRPC client for the node.
 func (n Node) GRPCClient(ctx context.Context) (grpcclient.Client, error) {
 	return grpcclient.New(

--- a/test/e2e/runner/main.go
+++ b/test/e2e/runner/main.go
@@ -125,7 +125,7 @@ func NewCLI() *CLI {
 			ctx, loadCancel := context.WithCancel(context.Background())
 			defer loadCancel()
 			go func() {
-				err := Load(ctx, cli.testnet)
+				err := Load(ctx, cli.testnet, false)
 				if err != nil {
 					logger.Error(fmt.Sprintf("Transaction load failed: %v", err.Error()))
 				}
@@ -237,13 +237,21 @@ func NewCLI() *CLI {
 		},
 	})
 
-	cli.root.AddCommand(&cobra.Command{
+	var useInternalIP bool
+	loadCmd := &cobra.Command{
 		Use:   "load",
-		Short: "Generates transaction load until the command is canceled",
-		RunE: func(_ *cobra.Command, _ []string) (err error) {
-			return Load(context.Background(), cli.testnet)
+		Short: "Generates transaction load until the command is canceled.",
+		RunE: func(cmd *cobra.Command, _ []string) (err error) {
+			useInternalIP, err = cmd.Flags().GetBool("internal-ip")
+			if err != nil {
+				return err
+			}
+			return Load(context.Background(), cli.testnet, useInternalIP)
 		},
-	})
+	}
+	loadCmd.PersistentFlags().BoolVar(&useInternalIP, "internal-ip", false,
+		"Use nodes' internal IP addresses when sending transaction load. For running from inside a DO private network.")
+	cli.root.AddCommand(loadCmd)
 
 	cli.root.AddCommand(&cobra.Command{
 		Use:   "evidence [amount]",
@@ -338,7 +346,7 @@ Does not run any perturbations.
 			ctx, loadCancel := context.WithCancel(cmd.Context())
 			defer loadCancel()
 			go func() {
-				err := Load(ctx, cli.testnet)
+				err := Load(ctx, cli.testnet, false)
 				if err != nil {
 					logger.Error(fmt.Sprintf("Transaction load errored: %v", err.Error()))
 				}


### PR DESCRIPTION
The new flag `--internal-ip` will make the `runner load` command to use the nodes' internal IP addresses when sending the transaction load. This is needed when running `load` from a node in a DigitalOcean private network.


---

#### PR checklist

- [ ] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
