### PR TITLE
feat(statesync)!: replace discovery_time with max_discovery_time

### DIFF
--- a/.changelog/unreleased/breaking-changes/3878-statesync-max-discovery-time.md
+++ b/.changelog/unreleased/breaking-changes/3878-statesync-max-discovery-time.md
@@ -1,0 +1,6 @@
+- `[statesync]` If the node can't discover snapshots for 2 min
+  (`statesync.max_discovery_time`), switch to blocksync. Remove
+  `statesync.discovery_time` from the configuration. If
+  `statesync.max_discovery_time` is zero, the node will be retrying
+  indefinitely.
+  [\#3878](https://github.com/cometbft/cometbft/issues/3878)

--- a/config/config.go
+++ b/config/config.go
@@ -1069,7 +1069,7 @@ type StateSyncConfig struct {
 	TrustPeriod         time.Duration `mapstructure:"trust_period"`
 	TrustHeight         int64         `mapstructure:"trust_height"`
 	TrustHash           string        `mapstructure:"trust_hash"`
-	DiscoveryTime       time.Duration `mapstructure:"discovery_time"`
+	MaxDiscoveryTime    time.Duration `mapstructure:"max_discovery_time"`
 	ChunkRequestTimeout time.Duration `mapstructure:"chunk_request_timeout"`
 	ChunkFetchers       int32         `mapstructure:"chunk_fetchers"`
 }
@@ -1087,7 +1087,7 @@ func (cfg *StateSyncConfig) TrustHashBytes() []byte {
 func DefaultStateSyncConfig() *StateSyncConfig {
 	return &StateSyncConfig{
 		TrustPeriod:         168 * time.Hour,
-		DiscoveryTime:       15 * time.Second,
+		MaxDiscoveryTime:    2 * time.Minute,
 		ChunkRequestTimeout: 10 * time.Second,
 		ChunkFetchers:       4,
 	}
@@ -1115,8 +1115,8 @@ func (cfg *StateSyncConfig) ValidateBasic() error {
 			}
 		}
 
-		if cfg.DiscoveryTime != 0 && cfg.DiscoveryTime < 5*time.Second {
-			return ErrInsufficientDiscoveryTime
+		if cfg.MaxDiscoveryTime < 0 {
+			return cmterrors.ErrNegativeField{Field: "max_discovery_time"}
 		}
 
 		if cfg.TrustPeriod <= 0 {

--- a/config/config.toml.tpl
+++ b/config/config.toml.tpl
@@ -405,8 +405,9 @@ trust_height = {{ .StateSync.TrustHeight }}
 trust_hash = "{{ .StateSync.TrustHash }}"
 trust_period = "{{ .StateSync.TrustPeriod }}"
 
-# Time to spend discovering snapshots before initiating a restore.
-discovery_time = "{{ .StateSync.DiscoveryTime }}"
+# Time to spend discovering snapshots before switching to blocksync. If set to
+# 0, state sync will be trying indefinitely.
+max_discovery_time = "{{ .StateSync.MaxDiscoveryTime }}"
 
 # Temporary directory for state sync snapshot chunks, defaults to the OS tempdir (typically /tmp).
 # Will create a new, randomly named directory within, and remove it when done.

--- a/config/errors.go
+++ b/config/errors.go
@@ -8,7 +8,6 @@ import (
 var (
 	ErrEmptyRPCServerEntry             = errors.New("found empty rpc_servers entry")
 	ErrNotEnoughRPCServers             = errors.New("at least two rpc_servers entries are required")
-	ErrInsufficientDiscoveryTime       = errors.New("snapshot discovery time must be at least five seconds")
 	ErrInsufficientChunkRequestTimeout = errors.New("timeout for re-requesting a chunk (chunk_request_timeout) is less than 5 seconds")
 	ErrUnknownLogFormat                = errors.New("unknown log_format (must be 'plain' or 'json')")
 	ErrSubscriptionBufferSizeInvalid   = fmt.Errorf("experimental_subscription_buffer_size must be >= %d", minSubscriptionBufferSize)

--- a/docs/explanation/core/state-sync.md
+++ b/docs/explanation/core/state-sync.md
@@ -1,36 +1,45 @@
---- 
+---
 order: 11
 ---
 
 # State Sync
 
-With block sync a node is downloading all of the data of an application from genesis and verifying it.
-With state sync your node will download data related to the head or near the head of the chain and verify the data.
-This leads to drastically shorter times for joining a network.
+With block sync a node is downloading all of the data of an application from
+genesis and verifying it.
+
+With state sync your node will download data related to the head or near the
+head of the chain and verify the data. This leads to drastically shorter times
+for joining a network.
 
 ## Using State Sync
 
-State sync will continuously work in the background to supply nodes with chunked data when bootstrapping.
+State sync will continuously work in the background to supply nodes with
+chunked data when bootstrapping.
 
-> NOTE: Before trying to use state sync, see if the application you are operating a node for supports it.
+> NOTE: Before trying to use state sync, see if the application you are
+> operating a node for supports it.
 
-Under the state sync section in `config.toml` you will find multiple settings that need to be configured in order for your node to use state sync.
+Under the state sync section in `config.toml` you will find multiple settings
+that need to be configured in order for your node to use state sync.
 
 Lets breakdown the settings:
 
-- `enable`: Enable is to inform the node that you will be using state sync to bootstrap your node.
-- `rpc_servers`: RPC servers are needed because state sync utilizes the light client for verification.
+- `enable`: Enable is to inform the node that you will be using state sync to
+  bootstrap your node.
+- `rpc_servers`: RPC servers are needed because state sync utilizes the light
+  client for verification.
     - 2 servers are required, more is always helpful.
-- `temp_dir`: Temporary directory is store the chunks in the machines local storage, If nothing is set it will create a directory in `/tmp`
 
-The next information you will need to acquire it through publicly exposed RPC's or a block explorer which you trust.
-
-- `trust_height`: Trusted height defines at which height your node should trust the chain.
-- `trust_hash`: Trusted hash is the hash in the `BlockID` corresponding to the trusted height.
+- `trust_height`: Trusted height defines at which height your node should trust
+  the chain.
+- `trust_hash`: Trusted hash is the hash of the block at the trusted height.
 - `trust_period`: Trust period is the period in which headers can be verified.
   > :warning: This value should be significantly smaller than the unbonding period.
 
-If you are relying on publicly exposed RPC's to get the need information, you can use `curl` and [`jq`][jq].
+For other settings, visit the [Configuration](./configuration) page.
+
+If you need to get the information you need from publicly exposed RPCs, you 
+can use `curl` and [`jq`][jq].
 
 Example:
 

--- a/docs/references/config/config.toml.md
+++ b/docs/references/config/config.toml.md
@@ -1509,17 +1509,15 @@ trust_period = "168h0m0s"
 For Cosmos SDK-based chains, `statesync.trust_period` should usually be about 2/3rd of the unbonding period
 (about 2 weeks) during which they can be financially punished (slashed) for misbehavior.
 
-### statesync.discovery_time
-Time to spend discovering snapshots before initiating a restore.
+### statesync.max_discovery_time
+Time to spend discovering snapshots before switching to blocksync. If set to 0, state sync will be trying indefinitely.
 ```toml
-discovery_time = "15s"
+max_discovery_time = "2m"
 ```
 
-If `discovery_time` is &gt; 0 and  &lt; 5 seconds, its value will be overridden to 5 seconds.
+If `max_discovery_time` is zero, the node will keep trying to discover snapshots indefinitely.
 
-If `discovery_time` is zero, the node will not wait for replies once it has broadcast the "snapshot request" message to its peers. If no snapshot data is received, state sync will fail without retrying.
-
-If `discovery_time` is &gt;= 5 seconds, the node will broadcast the "snapshot request" message to its peers and then wait for `discovery_time`. If no snapshot data has been received after that period, the node will retry: it will broadcast the "snapshot request" message again and wait for `discovery_time`, and so on.
+If `max_discovery_time` is greater than zero, the node will broadcast the "snapshot request" message to its peers and then wait for 5 sec. If no snapshot data has been received after that period, the node will retry: it will broadcast the "snapshot request" message again and wait for 5s, and so on until `max_discovery_time` is reached, after which the node will switch to blocksync.
 
 ### statesync.temp_dir
 Temporary directory for state sync snapshot chunks.

--- a/internal/blocksync/reactor.go
+++ b/internal/blocksync/reactor.go
@@ -131,25 +131,26 @@ func (bcR *Reactor) SetLogger(l log.Logger) {
 // OnStart implements service.Service.
 func (bcR *Reactor) OnStart() error {
 	if bcR.blockSync {
-		err := bcR.pool.Start()
-		if err != nil {
-			return err
-		}
-		bcR.poolRoutineWg.Add(1)
-		go func() {
-			defer bcR.poolRoutineWg.Done()
-			bcR.poolRoutine(false)
-		}()
+		return bcR.startPool(false)
 	}
 	return nil
 }
 
-// SwitchToBlockSync is called by the state sync reactor when switching to block sync.
+// SwitchToBlockSync is called by the statesync reactor when switching to blocksync.
 func (bcR *Reactor) SwitchToBlockSync(state sm.State) error {
 	bcR.blockSync = true
-	bcR.initialState = state
 
-	bcR.pool.height = state.LastBlockHeight + 1
+	if !state.IsEmpty() { // if we have a state, start from there
+		bcR.initialState = state
+		bcR.pool.height = state.LastBlockHeight + 1
+		return bcR.startPool(true)
+	}
+
+	// if we don't have a state due to an error or a timeout, start from genesis.
+	return bcR.startPool(false)
+}
+
+func (bcR *Reactor) startPool(stateSynced bool) error {
 	err := bcR.pool.Start()
 	if err != nil {
 		return err
@@ -157,7 +158,7 @@ func (bcR *Reactor) SwitchToBlockSync(state sm.State) error {
 	bcR.poolRoutineWg.Add(1)
 	go func() {
 		defer bcR.poolRoutineWg.Done()
-		bcR.poolRoutine(true)
+		bcR.poolRoutine(stateSynced)
 	}()
 	return nil
 }

--- a/statesync/reactor.go
+++ b/statesync/reactor.go
@@ -264,7 +264,7 @@ func (r *Reactor) recentSnapshots(n uint32) ([]*snapshot, error) {
 
 // Sync runs a state sync, returning the new state and last commit at the snapshot height.
 // The caller must store the state and commit in the state database and block store.
-func (r *Reactor) Sync(stateProvider StateProvider, discoveryTime time.Duration) (sm.State, *types.Commit, error) {
+func (r *Reactor) Sync(stateProvider StateProvider, maxDiscoveryTime time.Duration) (sm.State, *types.Commit, error) {
 	r.mtx.Lock()
 	if r.syncer != nil {
 		r.mtx.Unlock()
@@ -286,7 +286,8 @@ func (r *Reactor) Sync(stateProvider StateProvider, discoveryTime time.Duration)
 
 	hook()
 
-	state, commit, err := r.syncer.SyncAny(discoveryTime, hook)
+	const discoveryTime = 5 * time.Second
+	state, commit, err := r.syncer.SyncAny(discoveryTime, maxDiscoveryTime, hook)
 
 	r.mtx.Lock()
 	r.syncer = nil

--- a/statesync/syncer.go
+++ b/statesync/syncer.go
@@ -23,10 +23,6 @@ import (
 const (
 	// chunkTimeout is the timeout while waiting for the next chunk from the chunk queue.
 	chunkTimeout = 2 * time.Minute
-
-	// minimumDiscoveryTime is the lowest allowable time for a
-	// SyncAny discovery time.
-	minimumDiscoveryTime = 5 * time.Second
 )
 
 var (
@@ -139,18 +135,18 @@ func (s *syncer) RemovePeer(peer p2p.Peer) {
 	s.snapshots.RemovePeer(peer.ID())
 }
 
-// SyncAny tries to sync any of the snapshots in the snapshot pool, waiting to discover further
-// snapshots if none were found and discoveryTime > 0. It returns the latest state and block commit
-// which the caller must use to bootstrap the node.
-func (s *syncer) SyncAny(discoveryTime time.Duration, retryHook func()) (sm.State, *types.Commit, error) {
-	if discoveryTime != 0 && discoveryTime < minimumDiscoveryTime {
-		discoveryTime = 5 * minimumDiscoveryTime
-	}
+// SyncAny tries to sync any of the snapshots in the snapshot pool, waiting to
+// discover further snapshots if none were found within discoveryTime. It
+// returns the latest state and block commit which the caller must use to
+// bootstrap the node.
+//
+// If none snapshots are found after maxDiscoveryTime, errNoSnapshots is
+// returned.
+func (s *syncer) SyncAny(discoveryTime, maxDiscoveryTime time.Duration, retryHook func()) (sm.State, *types.Commit, error) {
+	timeStart := time.Now()
 
-	if discoveryTime > 0 {
-		s.logger.Info("Discovering snapshots", "discoverTime", discoveryTime)
-		time.Sleep(discoveryTime)
-	}
+	s.logger.Info(fmt.Sprintf("Discovering snapshots for %v", discoveryTime))
+	time.Sleep(discoveryTime)
 
 	// The app may ask us to retry a snapshot restoration, in which case we need to reuse
 	// the snapshot and chunk queue from the previous loop iteration.
@@ -166,11 +162,11 @@ func (s *syncer) SyncAny(discoveryTime time.Duration, retryHook func()) (sm.Stat
 			chunks = nil
 		}
 		if snapshot == nil {
-			if discoveryTime == 0 {
+			if maxDiscoveryTime > 0 && time.Since(timeStart) >= maxDiscoveryTime {
 				return sm.State{}, nil, errNoSnapshots
 			}
 			retryHook()
-			s.logger.Info("sync any", "msg", log.NewLazySprintf("Discovering snapshots for %v", discoveryTime))
+			s.logger.Info("sync any", "msg", fmt.Sprintf("Discovering snapshots for %v", discoveryTime))
 			time.Sleep(discoveryTime)
 			continue
 		}

--- a/statesync/syncer_test.go
+++ b/statesync/syncer_test.go
@@ -28,7 +28,10 @@ import (
 	"github.com/cometbft/cometbft/version"
 )
 
-const testAppVersion = 9
+const (
+	testAppVersion   = 9
+	maxDiscoveryTime = 1 * time.Millisecond // Not 0 because 0 means no timeout.
+)
 
 // Sets up a basic syncer that can be used to test OfferSnapshot requests.
 func setupOfferSyncer() (*syncer, *proxymocks.AppConnSnapshot) {
@@ -213,7 +216,7 @@ func TestSyncer_SyncAny(t *testing.T) {
 		LastBlockAppHash: []byte("app_hash"),
 	}, nil)
 
-	newState, lastCommit, err := syncer.SyncAny(0, func() {})
+	newState, lastCommit, err := syncer.SyncAny(0, maxDiscoveryTime, func() {})
 	require.NoError(t, err)
 
 	time.Sleep(50 * time.Millisecond) // wait for peers to receive requests
@@ -235,7 +238,7 @@ func TestSyncer_SyncAny(t *testing.T) {
 
 func TestSyncer_SyncAny_noSnapshots(t *testing.T) {
 	syncer, _ := setupOfferSyncer()
-	_, _, err := syncer.SyncAny(0, func() {})
+	_, _, err := syncer.SyncAny(0, maxDiscoveryTime, func() {})
 	assert.Equal(t, errNoSnapshots, err)
 }
 
@@ -249,7 +252,7 @@ func TestSyncer_SyncAny_abort(t *testing.T) {
 		Snapshot: toABCI(s), AppHash: []byte("app_hash"),
 	}).Once().Return(&abci.OfferSnapshotResponse{Result: abci.OFFER_SNAPSHOT_RESULT_ABORT}, nil)
 
-	_, _, err = syncer.SyncAny(0, func() {})
+	_, _, err = syncer.SyncAny(0, maxDiscoveryTime, func() {})
 	assert.Equal(t, errAbort, err)
 	connSnapshot.AssertExpectations(t)
 }
@@ -280,7 +283,7 @@ func TestSyncer_SyncAny_reject(t *testing.T) {
 		Snapshot: toABCI(s11), AppHash: []byte("app_hash"),
 	}).Once().Return(&abci.OfferSnapshotResponse{Result: abci.OFFER_SNAPSHOT_RESULT_REJECT}, nil)
 
-	_, _, err = syncer.SyncAny(0, func() {})
+	_, _, err = syncer.SyncAny(0, maxDiscoveryTime, func() {})
 	assert.Equal(t, errNoSnapshots, err)
 	connSnapshot.AssertExpectations(t)
 }
@@ -307,7 +310,7 @@ func TestSyncer_SyncAny_reject_format(t *testing.T) {
 		Snapshot: toABCI(s11), AppHash: []byte("app_hash"),
 	}).Once().Return(&abci.OfferSnapshotResponse{Result: abci.OFFER_SNAPSHOT_RESULT_ABORT}, nil)
 
-	_, _, err = syncer.SyncAny(0, func() {})
+	_, _, err = syncer.SyncAny(0, maxDiscoveryTime, func() {})
 	assert.Equal(t, errAbort, err)
 	connSnapshot.AssertExpectations(t)
 }
@@ -345,7 +348,7 @@ func TestSyncer_SyncAny_reject_sender(t *testing.T) {
 		Snapshot: toABCI(sa), AppHash: []byte("app_hash"),
 	}).Once().Return(&abci.OfferSnapshotResponse{Result: abci.OFFER_SNAPSHOT_RESULT_REJECT}, nil)
 
-	_, _, err = syncer.SyncAny(0, func() {})
+	_, _, err = syncer.SyncAny(0, maxDiscoveryTime, func() {})
 	assert.Equal(t, errNoSnapshots, err)
 	connSnapshot.AssertExpectations(t)
 }
@@ -361,7 +364,7 @@ func TestSyncer_SyncAny_abciError(t *testing.T) {
 		Snapshot: toABCI(s), AppHash: []byte("app_hash"),
 	}).Once().Return(nil, errBoom)
 
-	_, _, err = syncer.SyncAny(0, func() {})
+	_, _, err = syncer.SyncAny(0, maxDiscoveryTime, func() {})
 	require.ErrorIs(t, err, errBoom)
 	connSnapshot.AssertExpectations(t)
 }

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -224,7 +224,6 @@ func MakeConfig(node *e2e.Node) (*config.Config, error) {
 	cfg.P2P.AddrBookStrict = false
 
 	cfg.DBBackend = node.Database
-	cfg.StateSync.DiscoveryTime = 5 * time.Second
 	cfg.BlockSync.Version = node.BlockSyncVersion
 	cfg.Consensus.PeerGossipIntraloopSleepDuration = node.Testnet.PeerGossipIntraloopSleepDuration
 	cfg.Mempool.ExperimentalMaxGossipConnectionsToNonPersistentPeers = int(node.Testnet.ExperimentalMaxGossipConnectionsToNonPersistentPeers)
@@ -300,6 +299,7 @@ func MakeConfig(node *e2e.Node) (*config.Config, error) {
 		if len(cfg.StateSync.RPCServers) < 2 {
 			return nil, errors.New("unable to find 2 suitable state sync RPC servers")
 		}
+		cfg.StateSync.MaxDiscoveryTime = 30 * time.Second
 	}
 
 	cfg.P2P.Seeds = ""


### PR DESCRIPTION
if the node can't discover snapshots for 2 min
(`statesync.max_discovery_time`), switch to blocksync. Remove
`statesync.discovery_time` from the configuration. If
`statesync.max_discovery_time` is zero, the node will be retrying
indefinitely.

Closes https://github.com/cometbft/cometbft/issues/3878
