### PR TITLE
docs(crypto/secp256k1): fix Address docs

### DIFF
--- a/crypto/secp256k1/secp256k1_test.go
+++ b/crypto/secp256k1/secp256k1_test.go
@@ -28,6 +28,17 @@ var secpDataTable = []keyData{
 	},
 }
 
+func TestPrivKey_Size(t *testing.T) {
+	privKey := secp256k1.GenPrivKey()
+	assert.Equal(t, secp256k1.PrivKeySize, len(privKey.Bytes()))
+}
+
+func TestPubKey_Size(t *testing.T) {
+	privKey := secp256k1.GenPrivKey()
+	pubKey := privKey.PubKey()
+	assert.Equal(t, secp256k1.PubKeySize, len(pubKey.Bytes()))
+}
+
 func TestPubKeySecp256k1Address(t *testing.T) {
 	for _, d := range secpDataTable {
 		privB, _ := hex.DecodeString(d.priv)

--- a/spec/core/encoding.md
+++ b/spec/core/encoding.md
@@ -59,11 +59,14 @@ CometBFT adopts [zip215](https://zips.z.cash/zip-0215) for verification of ed255
 
 #### Secp256k1
 
-The address is the first 20-bytes of the SHA256 hash of the raw 32-byte public key:
+The address is the RIPEMD160 hash of the SHA256 hash of the raw 33-byte public key:
+
 
 ```go
-address = SHA256(pubkey)[:20]
+address = RIPEMD160(SHA256(pubkey))
 ```
+
+RIPEMD160 checksum size is 20 bytes.
 
 The public key comprised of 32 bytes for one field element (the x-coordinate),
 plus one byte for the parity of the y-coordinate. The first byte depends is a


### PR DESCRIPTION
Also:
* assert ripemd160.Size == crypto.AddressSize
* write tests for PrivKeySize and PubKeySize

Closes #3727

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [x] Tests written/updated
- [ ] ~~Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)~~
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
