### PR TITLE
test(mempool/lanes): Prepare consensus tests for lanes

### DIFF
--- a/internal/consensus/common_test.go
+++ b/internal/consensus/common_test.go
@@ -430,11 +430,24 @@ func subscribeToVoterBuffered(cs *State, addr []byte) <-chan cmtpubsub.Message {
 }
 
 // -------------------------------------------------------------------------------
+// application
+
+func newAppWithInfo(t *testing.T) (*kvstore.Application, []byte, *mempl.LanesInfo) {
+	t.Helper()
+	app := kvstore.NewInMemoryApplication()
+	resp, err := app.Info(context.Background(), proxy.InfoRequest)
+	require.NoError(t, err)
+	lanesInfo, err := mempl.BuildLanesInfo(resp.LanePriorities, types.Lane(resp.DefaultLanePriority))
+	require.NoError(t, err)
+	return app, resp.LastBlockAppHash, lanesInfo
+}
+
+// -------------------------------------------------------------------------------
 // consensus states
 
 func newState(state sm.State, pv types.PrivValidator, app abci.Application) *State {
 	config := test.ResetTestRoot("consensus_state_test")
-	return newStateWithConfig(config, state, pv, app)
+	return newStateWithConfig(config, state, pv, app, nil)
 }
 
 func newStateWithConfig(
@@ -442,9 +455,10 @@ func newStateWithConfig(
 	state sm.State,
 	pv types.PrivValidator,
 	app abci.Application,
+	lanesInfo *mempl.LanesInfo,
 ) *State {
 	blockDB := dbm.NewMemDB()
-	return newStateWithConfigAndBlockStore(thisConfig, state, pv, app, blockDB)
+	return newStateWithConfigAndBlockStore(thisConfig, state, pv, app, blockDB, lanesInfo)
 }
 
 func newStateWithConfigAndBlockStore(
@@ -453,6 +467,7 @@ func newStateWithConfigAndBlockStore(
 	pv types.PrivValidator,
 	app abci.Application,
 	blockDB dbm.DB,
+	lanesInfo *mempl.LanesInfo,
 ) *State {
 	// Get BlockStore
 	blockStore := store.NewBlockStore(blockDB)
@@ -468,7 +483,7 @@ func newStateWithConfigAndBlockStore(
 	// Make Mempool
 	mempool := mempl.NewCListMempool(config.Mempool,
 		proxyAppConnMem,
-		nil,
+		lanesInfo,
 		state.LastBlockHeight,
 		mempl.WithMetrics(memplMetrics),
 		mempl.WithPreCheck(sm.TxPreCheck(state)),
@@ -842,7 +857,7 @@ func randConsensusNet(t *testing.T, nValidators int, testName string, tickerFunc
 		_, err := app.InitChain(context.Background(), &abci.InitChainRequest{Validators: vals})
 		require.NoError(t, err)
 
-		css[i] = newStateWithConfigAndBlockStore(thisConfig, state, privVals[i], app, stateDB)
+		css[i] = newStateWithConfigAndBlockStore(thisConfig, state, privVals[i], app, stateDB, nil)
 		css[i].SetTimeoutTicker(tickerFunc())
 		css[i].SetLogger(logger.With("validator", i, "module", "consensus"))
 	}
@@ -904,7 +919,7 @@ func randConsensusNetWithPeers(
 		_, err = app.InitChain(context.Background(), &abci.InitChainRequest{Validators: vals})
 		require.NoError(t, err)
 
-		css[i] = newStateWithConfig(thisConfig, state, privVal, app)
+		css[i] = newStateWithConfig(thisConfig, state, privVal, app, nil)
 		css[i].SetTimeoutTicker(tickerFunc())
 		css[i].SetLogger(logger.With("validator", i, "module", "consensus"))
 	}

--- a/internal/consensus/mempool_test.go
+++ b/internal/consensus/mempool_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cometbft/cometbft/abci/example/kvstore"
 	abci "github.com/cometbft/cometbft/abci/types"
 	mempl "github.com/cometbft/cometbft/mempool"
-	"github.com/cometbft/cometbft/proxy"
 	sm "github.com/cometbft/cometbft/state"
 	"github.com/cometbft/cometbft/types"
 )
@@ -29,11 +28,9 @@ func TestMempoolNoProgressUntilTxsAvailable(t *testing.T) {
 	defer os.RemoveAll(config.RootDir)
 	config.Consensus.CreateEmptyBlocks = false
 	state, privVals := randGenesisState(1, nil)
-	app := kvstore.NewInMemoryApplication()
-	resp, err := app.Info(context.Background(), proxy.InfoRequest)
-	require.NoError(t, err)
-	state.AppHash = resp.LastBlockAppHash
-	cs := newStateWithConfig(config, state, privVals[0], app)
+	app, lastBlockAppHash, lanesInfo := newAppWithInfo(t)
+	state.AppHash = lastBlockAppHash
+	cs := newStateWithConfig(config, state, privVals[0], app, lanesInfo)
 	assertMempool(cs.txNotifier).EnableTxsAvailable()
 	height, round := cs.Height, cs.Round
 	newBlockCh := subscribe(cs.eventBus, types.EventQueryNewBlock)
@@ -53,11 +50,9 @@ func TestMempoolProgressAfterCreateEmptyBlocksInterval(t *testing.T) {
 
 	config.Consensus.CreateEmptyBlocksInterval = ensureTimeout
 	state, privVals := randGenesisState(1, nil)
-	app := kvstore.NewInMemoryApplication()
-	resp, err := app.Info(context.Background(), proxy.InfoRequest)
-	require.NoError(t, err)
-	state.AppHash = resp.LastBlockAppHash
-	cs := newStateWithConfig(config, state, privVals[0], app)
+	app, lastBlockAppHash, lanesInfo := newAppWithInfo(t)
+	state.AppHash = lastBlockAppHash
+	cs := newStateWithConfig(config, state, privVals[0], app, lanesInfo)
 
 	assertMempool(cs.txNotifier).EnableTxsAvailable()
 
@@ -74,7 +69,8 @@ func TestMempoolProgressInHigherRound(t *testing.T) {
 	defer os.RemoveAll(config.RootDir)
 	config.Consensus.CreateEmptyBlocks = false
 	state, privVals := randGenesisState(1, nil)
-	cs := newStateWithConfig(config, state, privVals[0], kvstore.NewInMemoryApplication())
+	app, _, lanesInfo := newAppWithInfo(t)
+	cs := newStateWithConfig(config, state, privVals[0], app, lanesInfo)
 	assertMempool(cs.txNotifier).EnableTxsAvailable()
 	height, round := cs.Height, cs.Round
 	newBlockCh := subscribe(cs.eventBus, types.EventQueryNewBlock)
@@ -121,7 +117,8 @@ func TestMempoolTxConcurrentWithCommit(t *testing.T) {
 	state, privVals := randGenesisState(1, nil)
 	blockDB := dbm.NewMemDB()
 	stateStore := sm.NewStore(blockDB, sm.StoreOptions{DiscardABCIResponses: false})
-	cs := newStateWithConfigAndBlockStore(config, state, privVals[0], kvstore.NewInMemoryApplication(), blockDB)
+	app, _, lanesInfo := newAppWithInfo(t)
+	cs := newStateWithConfigAndBlockStore(config, state, privVals[0], app, blockDB, lanesInfo)
 	err := stateStore.Save(state)
 	require.NoError(t, err)
 	newBlockEventsCh := subscribe(cs.eventBus, types.EventQueryNewBlockEvents)
@@ -144,10 +141,10 @@ func TestMempoolTxConcurrentWithCommit(t *testing.T) {
 
 func TestMempoolRmBadTx(t *testing.T) {
 	state, privVals := randGenesisState(1, nil)
-	app := kvstore.NewInMemoryApplication()
 	blockDB := dbm.NewMemDB()
 	stateStore := sm.NewStore(blockDB, sm.StoreOptions{DiscardABCIResponses: false})
-	cs := newStateWithConfigAndBlockStore(config, state, privVals[0], app, blockDB)
+	app, _, lanesInfo := newAppWithInfo(t)
+	cs := newStateWithConfigAndBlockStore(config, state, privVals[0], app, blockDB, lanesInfo)
 	err := stateStore.Save(state)
 	require.NoError(t, err)
 

--- a/internal/consensus/pbts_test.go
+++ b/internal/consensus/pbts_test.go
@@ -112,7 +112,7 @@ func newPBTSTestHarness(ctx context.Context, t *testing.T, tc pbtsTestConfigurat
 	consensusParams.Feature.PbtsEnableHeight = 1
 
 	state, privVals := randGenesisStateWithTime(validators, consensusParams, tc.genesisTime)
-	cs := newStateWithConfig(cfg, state, privVals[0], kvstore.NewInMemoryApplication())
+	cs := newStateWithConfig(cfg, state, privVals[0], kvstore.NewInMemoryApplication(), nil)
 	vss := make([]*validatorStub, validators)
 	for i := 0; i < validators; i++ {
 		vss[i] = newValidatorStub(privVals[i], int32(i))

--- a/internal/consensus/replay_test.go
+++ b/internal/consensus/replay_test.go
@@ -82,6 +82,7 @@ func startNewStateAndWaitForBlock(
 		privValidator,
 		kvstore.NewInMemoryApplication(),
 		blockDB,
+		nil,
 	)
 	cs.SetLogger(logger)
 
@@ -189,6 +190,7 @@ LOOP:
 			privValidator,
 			kvstore.NewInMemoryApplication(),
 			blockDB,
+			nil,
 		)
 		cs.SetLogger(logger)
 


### PR DESCRIPTION
In the consensus tests related to mempool, the mempool is initialised without lanes info. This PR queries the app and pass the lanes info when creating the mempool.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
