### PR TITLE
refactor(mempool/lanes)!: Add iterator interfaces and methods

### DIFF
--- a/.changelog/unreleased/breaking-changes/3638-mempool-add-iterator-methods.md
+++ b/.changelog/unreleased/breaking-changes/3638-mempool-add-iterator-methods.md
@@ -1,0 +1,4 @@
+- `[mempool]` Add `NewBlockingIterator` and `NewNonBlockingIterator` methods to
+  `Mempool` interface. Add `BlockingIterator` and `NonBlockingIterator`
+  interfaces. Deprecate `Iterator` interface in favor of `BlockingIterator`
+  ([\#3638](https://github.com/cometbft/cometbft/pull/3638)).

--- a/internal/consensus/replay_stubs.go
+++ b/internal/consensus/replay_stubs.go
@@ -47,6 +47,13 @@ func (emptyMempool) EnableTxsAvailable()           {}
 func (emptyMempool) TxsBytes() int64               { return 0 }
 func (emptyMempool) TxsFront() *clist.CElement     { return nil }
 func (emptyMempool) TxsWaitChan() <-chan struct{}  { return nil }
+func (emptyMempool) NewBlockingIterator() mempl.BlockingIterator {
+	return &mempl.BlockingWRRIterator{}
+}
+
+func (emptyMempool) NewNonBlockingIterator() mempl.NonBlockingIterator {
+	return &mempl.NonBlockingWRRIterator{}
+}
 
 // -----------------------------------------------------------------------------
 // newMockProxyApp uses ABCIResponses to give the right results.

--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -183,7 +183,7 @@ func TestReapMaxBytesMaxGas(t *testing.T) {
 
 	// Ensure gas calculation behaves as expected
 	addRandomTxs(t, mp, 1)
-	iter := NewBlockingWRRIterator(mp)
+	iter := mp.NewBlockingIterator()
 	tx0 := <-iter.WaitNextCh()
 	require.NotNil(t, tx0)
 	require.Equal(t, tx0.GasWanted(), int64(1), "transactions gas was set incorrectly")

--- a/mempool/iterators_test.go
+++ b/mempool/iterators_test.go
@@ -34,7 +34,7 @@ func TestIteratorNonBlocking(t *testing.T) {
 	}
 	require.Equal(t, n, mp.Size())
 
-	iter := NewWRRIterator(mp)
+	iter := mp.NewNonBlockingIterator()
 	expectedOrder := []int{
 		0, 11, 22, 33, 44, 55, 66, // lane 7
 		1, 2, 4, // lane 3
@@ -91,7 +91,7 @@ func TestIteratorNonBlockingOneLane(t *testing.T) {
 	}
 	require.Equal(t, 10, mp.Size())
 
-	iter := NewWRRIterator(mp)
+	iter := mp.NewNonBlockingIterator()
 	expectedOrder := []int{0, 11, 22, 33, 44, 55, 66, 77, 88, 99}
 
 	var next Entry
@@ -138,7 +138,7 @@ func TestIteratorRace(t *testing.T) {
 			defer wg.Done()
 
 			for counter.Load() < int64(numTxs) {
-				iter := NewBlockingWRRIterator(mp)
+				iter := mp.NewBlockingIterator()
 				entry := <-iter.WaitNextCh()
 				if entry == nil {
 					continue
@@ -154,7 +154,7 @@ func TestIteratorRace(t *testing.T) {
 			defer wg.Done()
 
 			for counter.Load() < int64(numTxs) {
-				iter := NewBlockingWRRIterator(mp)
+				iter := mp.NewBlockingIterator()
 				entry := <-iter.WaitNextCh()
 				if entry == nil {
 					continue
@@ -200,7 +200,7 @@ func TestIteratorEmptyLanes(t *testing.T) {
 	defer cleanup()
 
 	go func() {
-		iter := NewBlockingWRRIterator(mp)
+		iter := mp.NewBlockingIterator()
 		require.Zero(t, mp.Size())
 		entry := <-iter.WaitNextCh()
 		require.NotNil(t, entry)
@@ -234,7 +234,7 @@ func TestIteratorNoLanes(t *testing.T) {
 	go func() {
 		defer wg.Done()
 
-		iter := NewBlockingWRRIterator(mp)
+		iter := mp.NewBlockingIterator()
 		for counter < n {
 			entry := <-iter.WaitNextCh()
 			if entry == nil {
@@ -285,7 +285,7 @@ func TestIteratorExactOrder(t *testing.T) {
 		waitForNumTxsInMempool(numTxs, mp)
 		t.Log("Mempool full, starting to pick up transactions", mp.Size())
 
-		iter := NewBlockingWRRIterator(mp)
+		iter := mp.NewBlockingIterator()
 		for i := 0; i < numTxs; i++ {
 			entry := <-iter.WaitNextCh()
 			if entry == nil {
@@ -336,7 +336,7 @@ func TestIteratorCountOnly(t *testing.T) {
 	go func() {
 		defer wg.Done()
 
-		iter := NewBlockingWRRIterator(mp)
+		iter := mp.NewBlockingIterator()
 		for counter < n {
 			entry := <-iter.WaitNextCh()
 			if entry == nil {
@@ -386,8 +386,8 @@ func TestReapMatchesGossipOrder(t *testing.T) {
 
 		require.Equal(t, n, mp.Size())
 
-		gossipIter := NewBlockingWRRIterator(mp)
-		reapIter := NewWRRIterator(mp)
+		gossipIter := mp.NewBlockingIterator()
+		reapIter := mp.NewNonBlockingIterator()
 
 		// Check that both iterators return the same entry as in the reaped txs.
 		txs := make([]types.Tx, n)

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -104,6 +104,15 @@ type Mempool interface {
 
 	// SizeBytes returns the total size of all txs in the mempool.
 	SizeBytes() int64
+
+	// NewBlockingIterator returns an iterator on the mempool that blocks when
+	// there's no entry available. Entries may be added or removed from the
+	// mempool while iterating.
+	NewBlockingIterator() BlockingIterator
+
+	// NewNonBlockingIterator returns an iterator on the mempool that traverses
+	// all entries in certain order. The mempool cannot change while iterating.
+	NewNonBlockingIterator() NonBlockingIterator
 }
 
 // PreCheckFunc is an optional filter executed before CheckTx and rejects
@@ -170,7 +179,26 @@ type Entry interface {
 
 // An iterator is used to iterate through the mempool entries.
 // Multiple iterators should be allowed to run concurrently.
+//
+// Deprecated: renamed to BlockingIterator.
 type Iterator interface {
 	// WaitNextCh returns a channel on which to wait for the next available entry.
 	WaitNextCh() <-chan Entry
+}
+
+// A blocking iterator is used to iterate through the mempool entries. Entries
+// may be added or removed from the mempool while iterating. When no entry is
+// available in the mempool, it will wait until a new one is added. Multiple
+// iterators should be allowed to run concurrently.
+type BlockingIterator interface {
+	// WaitNextCh returns a channel on which to wait for the next available entry.
+	WaitNextCh() <-chan Entry
+}
+
+// A non-blocking iterator is used to iterate through the mempool entries. It
+// assumes that entries are not added or removed from the mempool while
+// iterating. Not concurrent safe.
+type NonBlockingIterator interface {
+	// WaitNextCh returns a channel on which to wait for the next available entry.
+	Next() Entry
 }

--- a/mempool/mocks/mempool.go
+++ b/mempool/mocks/mempool.go
@@ -121,6 +121,46 @@ func (_m *Mempool) Lock() {
 	_m.Called()
 }
 
+// NewBlockingIterator provides a mock function with given fields:
+func (_m *Mempool) NewBlockingIterator() mempool.BlockingIterator {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for NewBlockingIterator")
+	}
+
+	var r0 mempool.BlockingIterator
+	if rf, ok := ret.Get(0).(func() mempool.BlockingIterator); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(mempool.BlockingIterator)
+		}
+	}
+
+	return r0
+}
+
+// NewNonBlockingIterator provides a mock function with given fields:
+func (_m *Mempool) NewNonBlockingIterator() mempool.NonBlockingIterator {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for NewNonBlockingIterator")
+	}
+
+	var r0 mempool.NonBlockingIterator
+	if rf, ok := ret.Get(0).(func() mempool.NonBlockingIterator); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(mempool.NonBlockingIterator)
+		}
+	}
+
+	return r0
+}
+
 // PreUpdate provides a mock function with given fields:
 func (_m *Mempool) PreUpdate() {
 	_m.Called()

--- a/mempool/nop_mempool.go
+++ b/mempool/nop_mempool.go
@@ -80,6 +80,12 @@ func (*NopMempool) Size() int { return 0 }
 // SizeBytes always returns 0.
 func (*NopMempool) SizeBytes() int64 { return 0 }
 
+// NewBlockingIterator returns an empty blocking iterator.
+func (*NopMempool) NewBlockingIterator() BlockingIterator { return &BlockingWRRIterator{} }
+
+// NewNonBlockingIterator returns an empty non-blocking iterator.
+func (*NopMempool) NewNonBlockingIterator() NonBlockingIterator { return &NonBlockingWRRIterator{} }
+
 // NopMempoolReactor is a mempool reactor that does nothing.
 type NopMempoolReactor struct {
 	service.BaseService

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -217,7 +217,7 @@ func (memR *Reactor) broadcastTxRoutine(peer p2p.Peer) {
 		}
 	}
 
-	iter := NewBlockingWRRIterator(memR.mempool)
+	iter := memR.mempool.NewBlockingIterator()
 	var entry Entry
 	for {
 		// In case of both next.NextWaitChan() and peer.Quit() are variable at the same time


### PR DESCRIPTION
- Add `BlockingIterator` and `NonBlockingIterator` interfaces. `BlockingIterator` replaces `Iterator`, which is marked as deprecated.
- Add `NewBlockingIterator` and `NewNonBlockingIterator` methods  to `Mempool` interface. 
- On `recheck.init`, create a new `NonBlockingIterator` instead of reusing the same one.
- Remove the `Reset` method from `NonBlockingWRRIterator`.

---

#### PR checklist

- [X] Tests written/updated
- [X] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
