### PR TITLE
build(deps): update python module `requests` to v2.32.3

### DIFF
--- a/.changelog/unreleased/dependencies/4053-update-python-requests-dep.md
+++ b/.changelog/unreleased/dependencies/4053-update-python-requests-dep.md
@@ -1,0 +1,2 @@
+- updated python module "requests" to latest version unaffected by CVE-2023-32681
+  and CVE-2024-35195 ([\#4053](https://github.com/cometbft/cometbft/pull/4053))

--- a/scripts/qa/reporting/requirements.txt
+++ b/scripts/qa/reporting/requirements.txt
@@ -11,4 +11,4 @@ python-dateutil==2.8.2
 six==1.16.0
 pandas==1.5.3
 prometheus-pandas==0.3.2
-requests==2.28.2
+requests==2.32.3


### PR DESCRIPTION
### Context
The project has a dependency on an old version of the python module [requests](https://pypi.org/project/requests/2.32.3/), which is vulnerable to [CVE-2023-32681](https://nvd.nist.gov/vuln/detail/CVE-2023-32681) and [CVE-2024-35195](https://nvd.nist.gov/vuln/detail/CVE-2024-35195).

### This Change
This PR updates the version of the python module `requests` to the latest unaffected by vulnerabilities.

---

#### PR checklist

~- [ ] Tests written/updated~
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
~- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments~
