### PR TITLE
fix(mempool): encode tx.Hash() as %X in logs

### DIFF
--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -304,7 +304,7 @@ func (mem *CListMempool) CheckTx(tx types.Tx, sender p2p.ID) (*abcicli.ReqRes, e
 		// (eg. after committing a block, txs are removed from mempool but not cache),
 		// so we only record the sender for txs still in the mempool.
 		if err := mem.addSender(tx.Key(), sender); err != nil {
-			mem.logger.Error("Could not add sender to tx", "tx", tx.Hash(), "sender", sender, "err", err)
+			mem.logger.Error("Could not add sender to tx", "tx", log.NewLazySprintf("%X", tx.Hash()), "sender", sender, "err", err)
 		}
 		// TODO: consider punishing peer for dups,
 		// its non-trivial since invalid txs can become valid,
@@ -349,7 +349,7 @@ func (mem *CListMempool) handleCheckTxResponse(tx types.Tx, sender p2p.ID) func(
 			mem.tryRemoveFromCache(tx)
 			mem.logger.Debug(
 				"Rejected invalid transaction",
-				"tx", tx.Hash(),
+				"tx", log.NewLazySprintf("%X", tx.Hash()),
 				"res", res,
 				"err", postCheckErr,
 			)
@@ -419,7 +419,7 @@ func (mem *CListMempool) addTx(memTx *mempoolTx, sender p2p.ID) {
 
 	mem.logger.Debug(
 		"Added transaction",
-		"tx", tx.Hash(),
+		"tx", log.NewLazySprintf("%X", tx.Hash()),
 		"height", mem.height.Load(),
 		"total", mem.Size(),
 	)
@@ -443,7 +443,7 @@ func (mem *CListMempool) RemoveTxByKey(txKey types.TxKey) error {
 	delete(mem.txsMap, txKey)
 	tx := elem.Value.(*mempoolTx).tx
 	mem.txsBytes -= int64(len(tx))
-	mem.logger.Debug("Removed transaction", "tx", tx.Hash(), "height", mem.height.Load(), "total", mem.Size())
+	mem.logger.Debug("Removed transaction", "tx", log.NewLazySprintf("%X", tx.Hash()), "height", mem.height.Load(), "total", mem.Size())
 	return nil
 }
 
@@ -497,7 +497,7 @@ func (mem *CListMempool) handleRecheckTxResponse(tx types.Tx) func(res *abci.Res
 		// If tx is invalid, remove it from the mempool and the cache.
 		if (res.Code != abci.CodeTypeOK) || postCheckErr != nil {
 			// Tx became invalidated due to newly committed block.
-			mem.logger.Debug("Tx is no longer valid", "tx", tx.Hash(), "res", res, "postCheckErr", postCheckErr)
+			mem.logger.Debug("Tx is no longer valid", "tx", log.NewLazySprintf("%X", tx.Hash()), "res", res, "postCheckErr", postCheckErr)
 			if err := mem.RemoveTxByKey(tx.Key()); err != nil {
 				mem.logger.Debug("Transaction could not be removed from mempool", "err", err)
 			} else {
@@ -640,7 +640,7 @@ func (mem *CListMempool) Update(
 		// https://github.com/tendermint/tendermint/issues/3322.
 		if err := mem.RemoveTxByKey(tx.Key()); err != nil {
 			mem.logger.Debug("Committed transaction not in local mempool (not an error)",
-				"tx", tx.Hash(),
+				"tx", log.NewLazySprintf("%X", tx.Hash()),
 				"error", err.Error())
 		}
 	}


### PR DESCRIPTION
in vocdoni CI we check for log lines with "invalid chars", and we spotted some at cometbft logs.
```
comet: tx already received from peer sender=cb6a9612b39147cfc40e7514b334139004b7bf17 tx="W�:��2�{ڋUn-:�ы��ؖZWS��E]iE-"
```

you likely intended that tx= to be a hex string, so here's a proposed fix

