### PR TITLE
chore: Bump go toolchain to `1.22.7` on `v0.38.x`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/cometbft/cometbft
 
 go 1.21
 
-toolchain go1.22.6
+toolchain go1.22.7
 
 require (
 	github.com/BurntSushi/toml v1.4.0


### PR DESCRIPTION
Helps with #4039 and to unblock merges to `v0.38.x`

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
