### PR TITLE
chore: rename whitelist->allowlist, blacklist->denylist

### DIFF
--- a/p2p/pex/addrbook.go
+++ b/p2p/pex/addrbook.go
@@ -94,7 +94,7 @@ type addrBook struct {
 	ourAddrs   map[string]struct{}
 	privateIDs map[p2p.ID]struct{}
 	addrLookup map[p2p.ID]*knownAddress // new & old
-	badPeers   map[p2p.ID]*knownAddress // blacklisted peers
+	badPeers   map[p2p.ID]*knownAddress // banned peers
 	bucketsOld []map[string]*knownAddress
 	bucketsNew []map[string]*knownAddress
 	nOld       int
@@ -803,7 +803,7 @@ func (a *addrBook) addBadPeer(addr *p2p.NetAddress, banTime time.Duration) bool 
 		// add to bad peer list
 		ka.ban(banTime)
 		a.badPeers[addr.ID] = ka
-		a.Logger.Info("Add address to blacklist", "addr", addr)
+		a.Logger.Info("Add address to denylist", "addr", addr)
 	}
 	return true
 }

--- a/p2p/pex/addrbook_test.go
+++ b/p2p/pex/addrbook_test.go
@@ -431,7 +431,7 @@ func TestBanBadPeers(t *testing.T) {
 	assert.True(t, book.IsBanned(addr))
 
 	err := book.AddAddress(addr, addr)
-	// book should not add address from the blacklist
+	// book should not add address from the denylist
 	require.Error(t, err)
 
 	time.Sleep(1 * time.Second)

--- a/spec/abci/abci++_app_requirements.md
+++ b/spec/abci/abci++_app_requirements.md
@@ -1052,7 +1052,7 @@ can be spoofed by adversaries.
 Apps may also want to consider state sync denial-of-service vectors, where adversaries provide
 invalid or harmful snapshots to prevent nodes from joining the network. The application can
 counteract this by asking CometBFT to ban peers. As a last resort, node operators can use
-P2P configuration options to whitelist a set of trusted peers that can provide valid snapshots.
+P2P configuration options to list an exclusive set of trusted peers that can provide valid snapshots.
 
 ##### Transition to Consensus
 

--- a/spec/p2p/legacy-docs/peer.md
+++ b/spec/p2p/legacy-docs/peer.md
@@ -74,8 +74,8 @@ Before continuing, we check if the new peer has the same ID as ourselves or
 an existing peer. If so, we disconnect.
 
 We also check the peer's address and public key against
-an optional whitelist which can be managed through the ABCI app -
-if the whitelist is enabled and the peer does not qualify, the connection is
+an optional allowlist which can be managed through the ABCI app -
+if the allowlist is enabled and the peer does not qualify, the connection is
 terminated.
 
 ### CometBFT Version Handshake


### PR DESCRIPTION
in statesync, adopt "rejectlist" instead
to match the wording used in that package
