### PR TITLE
test(lane): add test with concurrent blocking iterators

### DIFF
--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -163,16 +163,33 @@ func addRandomTxs(t *testing.T, mp Mempool, count int) []types.Tx {
 	return txs
 }
 
+// addTxs adds to the mempool num transactions with sequential ids starting from
+// first.
 func addTxs(tb testing.TB, mp Mempool, first, num int) []types.Tx {
 	tb.Helper()
 	txs := make([]types.Tx, 0, num)
-	for i := first; i < num; i++ {
+	for i := first; i < first+num; i++ {
 		tx := kvstore.NewTxFromID(i)
 		_, err := mp.CheckTx(tx, "")
 		require.NoError(tb, err)
 		txs = append(txs, tx)
 	}
+	require.Equal(tb, num, len(txs))
 	return txs
+}
+
+func waitTimeout(wg *sync.WaitGroup, timeout time.Duration, doneFunc func(), timeoutFunc func()) {
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		doneFunc()
+	case <-time.After(timeout):
+		timeoutFunc()
+	}
 }
 
 func TestReapMaxBytesMaxGas(t *testing.T) {

--- a/mempool/iterators_test.go
+++ b/mempool/iterators_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -245,9 +246,11 @@ func TestBlockingIteratorsConsumeAllTxs(t *testing.T) {
 				// Iterate until all txs added to the mempool are accessed.
 				iter := NewBlockingIterator(mp)
 				counter := 0
+				nilCounter := 0
 				for counter < numTxs {
 					entry := <-iter.WaitNextCh()
 					if entry == nil {
+						nilCounter++
 						continue
 					}
 					if test == "no_lanes" {
@@ -258,7 +261,8 @@ func TestBlockingIteratorsConsumeAllTxs(t *testing.T) {
 					counter++
 				}
 				require.Equal(t, numTxs, counter)
-				t.Logf("%s: iterator %d finished\n", test, j)
+				assert.Zero(t, nilCounter, "got nil entries")
+				t.Logf("%s: iterator %d finished (nils=%d)\n", test, j, nilCounter)
 			}(i)
 		}
 


### PR DESCRIPTION
Test multiple blocking iterators accessing the mempool while txs are being added.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
