### PR TITLE
fix(lanes): Pass cancellable context to blocking iterator

### DIFF
--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -200,7 +200,7 @@ func TestReapMaxBytesMaxGas(t *testing.T) {
 
 	// Ensure gas calculation behaves as expected
 	addRandomTxs(t, mp, 1)
-	iter := NewBlockingIterator(mp)
+	iter := NewBlockingIterator(context.Background(), mp, t.Name())
 	tx0 := <-iter.WaitNextCh()
 	require.NotNil(t, tx0)
 	require.Equal(t, tx0.GasWanted(), int64(1), "transactions gas was set incorrectly")

--- a/mempool/iterators.go
+++ b/mempool/iterators.go
@@ -123,12 +123,21 @@ func NewBlockingIterator(mem *CListMempool) Iterator {
 func (iter *BlockingIterator) WaitNextCh() <-chan Entry {
 	ch := make(chan Entry)
 	go func() {
-		// Add the next entry to the channel if not nil.
-		lane := iter.pickLane()
-		if entry := iter.next(lane); entry != nil {
-			ch <- entry.Value.(Entry)
+		var lane types.Lane
+		for {
+			l, addTxCh := iter.pickLane()
+			if addTxCh == nil {
+				lane = l
+				break
+			}
+			// There are no transactions to take from any lane. Wait until at
+			// least one is added to the mempool and try again.
+			<-addTxCh
 		}
-		// Unblock the receiver (it may receive nil).
+		if elem := iter.next(lane); elem != nil {
+			ch <- elem.Value.(Entry)
+		}
+		// Unblock receiver in case no entry was sent (it will receive nil).
 		close(ch)
 	}()
 	return ch
@@ -137,14 +146,15 @@ func (iter *BlockingIterator) WaitNextCh() <-chan Entry {
 // pickLane returns a _valid_ lane on which to iterate, according to the WRR
 // algorithm. A lane is valid if it is not empty or it is not over-consumed,
 // meaning that the number of accessed entries in the lane has not yet reached
-// its priority value in the current WRR iteration. It will block until a
-// transaction is available in any lane.
-func (iter *BlockingIterator) pickLane() types.Lane {
-	// Start from the last accessed lane.
-	lane := iter.sortedLanes[iter.laneIndex]
-
+// its priority value in the current WRR iteration. It returns a channel to wait
+// for new transactions if all lanes are empty or don't have transactions that
+// have not yet been accessed.
+func (iter *BlockingIterator) pickLane() (types.Lane, chan struct{}) {
 	iter.mp.addTxChMtx.RLock()
 	defer iter.mp.addTxChMtx.RUnlock()
+
+	// Start from the last accessed lane.
+	lane := iter.sortedLanes[iter.laneIndex]
 
 	// Loop until finding a valid lane. If the current lane is not valid,
 	// continue with the next lower-priority lane, in a round robin fashion.
@@ -156,12 +166,9 @@ func (iter *BlockingIterator) pickLane() types.Lane {
 				iter.cursors[lane].Value.(*mempoolTx).seq == iter.mp.addTxLaneSeqs[lane]) {
 			numEmptyLanes++
 			if numEmptyLanes >= len(iter.sortedLanes) {
-				// There are no lanes with non-accessed entries. Wait until a new tx is added.
-				ch := iter.mp.addTxCh
-				iter.mp.addTxChMtx.RUnlock()
-				<-ch
-				iter.mp.addTxChMtx.RLock()
-				numEmptyLanes = 0
+				// There are no lanes with non-accessed entries. Wait until a
+				// new tx is added.
+				return 0, iter.mp.addTxCh
 			}
 			lane = iter.advanceIndexes()
 			continue
@@ -175,16 +182,11 @@ func (iter *BlockingIterator) pickLane() types.Lane {
 		}
 
 		_ = iter.advanceIndexes()
-		return lane
+		return lane, nil
 	}
 }
 
-// next returns the next element according to the IWRR algorithm.
-//
-// In classical WRR, the iterator cycles over the lanes. When a lane is selected, next returns an
-// entry from the selected lane. On subsequent calls, next will return the next entries from the
-// same lane until `lane` entries are accessed or the lane is empty, where `lane` is the priority.
-// The next time, next will select the successive lane with lower priority.
+// next returns the next entry from the given lane and updates to WRR variables.
 func (iter *BlockingIterator) next(lane types.Lane) *clist.CElement {
 	// Load the last accessed entry in the lane and set the next one.
 	var next *clist.CElement

--- a/mempool/iterators.go
+++ b/mempool/iterators.go
@@ -1,6 +1,7 @@
 package mempool
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/cometbft/cometbft/internal/clist"
@@ -100,10 +101,12 @@ func (iter *NonBlockingIterator) Next() Entry {
 // Unlike `NonBlockingIterator`, this iterator is expected to work with an evolving mempool.
 type BlockingIterator struct {
 	IWRRIterator
-	mp *CListMempool
+	ctx  context.Context
+	mp   *CListMempool
+	name string // for debugging
 }
 
-func NewBlockingIterator(mem *CListMempool) Iterator {
+func NewBlockingIterator(ctx context.Context, mem *CListMempool, name string) Iterator {
 	iter := IWRRIterator{
 		sortedLanes: mem.sortedLanes,
 		cursors:     make(map[types.Lane]*clist.CElement, len(mem.sortedLanes)),
@@ -111,7 +114,9 @@ func NewBlockingIterator(mem *CListMempool) Iterator {
 	}
 	return &BlockingIterator{
 		IWRRIterator: iter,
+		ctx:          ctx,
 		mp:           mem,
+		name:         name,
 	}
 }
 

--- a/mempool/iterators.go
+++ b/mempool/iterators.go
@@ -137,7 +137,12 @@ func (iter *BlockingIterator) WaitNextCh() <-chan Entry {
 			}
 			// There are no transactions to take from any lane. Wait until at
 			// least one is added to the mempool and try again.
-			<-addTxCh
+			select {
+			case <-addTxCh:
+			case <-iter.ctx.Done():
+				close(ch)
+				return
+			}
 		}
 		if elem := iter.next(lane); elem != nil {
 			ch <- elem.Value.(Entry)

--- a/mempool/iterators_test.go
+++ b/mempool/iterators_test.go
@@ -37,20 +37,37 @@ func TestIteratorNonBlocking(t *testing.T) {
 
 	iter := NewNonBlockingIterator(mp)
 	expectedOrder := []int{
-		0, 11, 22, 33, 44, 55, 66, // lane 7
-		1, 2, 4, // lane 3
+		// round counter 1:
+		0, // lane 7
+		1, // lane 3
 		3, // lane 1
-		77, 88, 99,
-		5, 7, 8,
-		6,
-		10, 13, 14,
-		9,
-		16, 17, 19,
-		12,
-		20, 23, 25,
-		15,
+		// round counter 2:
+		11, // lane 7
+		2,  // lane 3
+		// round counter 3:
+		22, // lane 7
+		4,  // lane 3
+		// round counter 4 - 7:
+		33, 44, 55, 66, // lane 7
+		// round counter 1:
+		77, // lane 7
+		5,  // lane 3
+		6,  // lane 1
+		// round counter 2:
+		88, // lane 7
+		7,  // lane 3
+		// round counter 3:
+		99, // lane 7
+		8,  // lane 3
+		// round counter 4- 7 have nothing
+		// round counter 1:
+		10, // lane 3
+		9,  // lane 1
+		// round counter 2:
+		13, // lane 3
+		// round counter 3:
+		14, // lane 3
 	}
-
 	var next Entry
 	counter := 0
 
@@ -296,7 +313,7 @@ func TestIteratorExactOrder(t *testing.T) {
 	const numTxs = 11
 	// Transactions are ordered into lanes by their IDs. This is the order in
 	// which they should appear following WRR
-	expectedTxIDs := []int{2, 5, 8, 1, 4, 3, 11, 7, 10, 6, 9}
+	expectedTxIDs := []int{2, 1, 3, 5, 4, 8, 11, 7, 6, 10, 9}
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -379,7 +396,7 @@ func TestIteratorCountOnly(t *testing.T) {
 }
 
 func TestReapMatchesGossipOrder(t *testing.T) {
-	const n = 10
+	const n = 100
 
 	tests := map[string]struct {
 		app *kvstore.Application
@@ -420,7 +437,6 @@ func TestReapMatchesGossipOrder(t *testing.T) {
 
 			reapTx := reapIter.Next().Tx()
 			txs[i] = reapTx
-
 			require.EqualValues(t, reapTx, gossipTx)
 			require.EqualValues(t, reapTx, reapedTx)
 			if test == "test_no_lanes" {


### PR DESCRIPTION
Depends on #4106; merge that one first.

This is equivalent to #4058 on the `main` branch. It was made on a different PR because there are too many differences in the code to be ported to the feature branch.

Besides the context, the iterator now also has a name which is used for debugging with concurrent iterators.
