### PR TITLE
test(mempool): TestReactorNoBroadcastToSender fails

### DIFF
--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -254,6 +254,7 @@ func (memR *Reactor) broadcastTxRoutine(peer p2p.Peer) {
 
 		// Do not send this transaction if we receive it from peer.
 		if memTx.isSender(peer.ID()) {
+			memR.Logger.Debug("Skipping tx", "tx", memTx.tx)
 			continue
 		}
 


### PR DESCRIPTION
Improve `TestReactorNoBroadcastToSender` to catch the bug introduced by https://github.com/cometbft/cometbft/pull/3657.

DRAFT, hard to get what I want.

---

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
