### PR TITLE
refactor(e2e): change `*Node` to string in keys of some maps

### DIFF
--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -137,7 +137,7 @@ func generateTestnet(r *rand.Rand, opt map[string]any, upgradeVersion string, pr
 		ABCIProtocol:        nodeABCIProtocols.Choose(r).(string),
 		InitialHeight:       int64(opt["initialHeight"].(int)),
 		InitialState:        opt["initialState"].(map[string]string),
-		ValidatorsMap:       &map[string]int64{},
+		Validators:          &map[string]int64{},
 		ValidatorUpdatesMap: map[string]map[string]int64{},
 		KeyType:             keyType.Choose(r).(string),
 		Evidence:            evidence.Choose(r).(int),
@@ -221,7 +221,7 @@ func generateTestnet(r *rand.Rand, opt map[string]any, upgradeVersion string, pr
 
 		weight := int64(30 + r.Intn(71))
 		if startAt == 0 {
-			(*manifest.ValidatorsMap)[name] = weight
+			(*manifest.Validators)[name] = weight
 		} else {
 			manifest.ValidatorUpdatesMap[strconv.FormatInt(startAt+5, 10)] = map[string]int64{name: weight}
 		}
@@ -235,7 +235,7 @@ func generateTestnet(r *rand.Rand, opt map[string]any, upgradeVersion string, pr
 		startAt := manifest.NodesMap[name].StartAt
 		var weight int64
 		if startAt == 0 {
-			weight = (*manifest.ValidatorsMap)[name]
+			weight = (*manifest.Validators)[name]
 		} else {
 			weight = manifest.ValidatorUpdatesMap[strconv.FormatInt(startAt+5, 10)][name]
 		}
@@ -251,8 +251,8 @@ func generateTestnet(r *rand.Rand, opt map[string]any, upgradeVersion string, pr
 	switch opt["validators"].(string) {
 	case "genesis":
 	case "initchain":
-		manifest.ValidatorUpdatesMap["0"] = *manifest.ValidatorsMap
-		manifest.ValidatorsMap = &map[string]int64{}
+		manifest.ValidatorUpdatesMap["0"] = *manifest.Validators
+		manifest.Validators = &map[string]int64{}
 	default:
 		return manifest, fmt.Errorf("invalid validators option %q", opt["validators"])
 	}

--- a/test/e2e/pkg/manifest.go
+++ b/test/e2e/pkg/manifest.go
@@ -20,7 +20,7 @@ type Manifest struct {
 	// set in genesis. Defaults to nothing.
 	InitialState map[string]string `toml:"initial_state"`
 
-	// ValidatorsMap is the initial validator set in genesis, given as node names
+	// Validators is the initial validator set in genesis, given as node names
 	// and power:
 	//
 	// validators = { validator01 = 10; validator02 = 20; validator03 = 30 }
@@ -29,7 +29,7 @@ type Manifest struct {
 	// specifying an empty set will start with no validators in genesis, and
 	// the application must return the validator set in InitChain via the
 	// setting validator_update.0 (see below).
-	ValidatorsMap *map[string]int64 `toml:"validators"`
+	Validators *map[string]int64 `toml:"validators"`
 
 	// ValidatorUpdatesMap is a map of heights to validator names and their power,
 	// and will be returned by the ABCI application. For example, the following

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -81,8 +81,8 @@ type Testnet struct {
 	Dir  string
 
 	IP               *net.IPNet
-	Validators       map[*Node]int64
-	ValidatorUpdates map[int64]map[*Node]int64
+	Validators       map[string]int64
+	ValidatorUpdates map[int64]map[string]int64
 	Nodes            []*Node
 }
 
@@ -148,8 +148,8 @@ func NewTestnetFromManifest(manifest Manifest, file string, ifd InfrastructureDa
 		Dir:  dir,
 
 		IP:               ipNet,
-		Validators:       map[*Node]int64{},
-		ValidatorUpdates: map[int64]map[*Node]int64{},
+		Validators:       map[string]int64{},
+		ValidatorUpdates: map[int64]map[string]int64{},
 		Nodes:            []*Node{},
 	}
 	if testnet.InitialHeight == 0 {
@@ -289,12 +289,12 @@ func NewTestnetFromManifest(manifest Manifest, file string, ifd InfrastructureDa
 			if validator == nil {
 				return nil, fmt.Errorf("unknown validator %q", validatorName)
 			}
-			testnet.Validators[validator] = power
+			testnet.Validators[validator.Name] = power
 		}
 	} else {
 		for _, node := range testnet.Nodes {
 			if node.Mode == ModeValidator {
-				testnet.Validators[node] = 100
+				testnet.Validators[node.Name] = 100
 			}
 		}
 	}
@@ -305,13 +305,13 @@ func NewTestnetFromManifest(manifest Manifest, file string, ifd InfrastructureDa
 		if err != nil {
 			return nil, fmt.Errorf("invalid validator update height %q: %w", height, err)
 		}
-		valUpdate := map[*Node]int64{}
+		valUpdate := map[string]int64{}
 		for name, power := range validators {
 			node := testnet.LookupNode(name)
 			if node == nil {
 				return nil, fmt.Errorf("unknown validator %q for update at height %v", name, height)
 			}
-			valUpdate[node] = power
+			valUpdate[node.Name] = power
 		}
 		testnet.ValidatorUpdates[int64(height)] = valUpdate
 	}

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -281,14 +281,14 @@ func NewTestnetFromManifest(manifest Manifest, file string, ifd InfrastructureDa
 	}
 
 	// Set up genesis validators. If not specified explicitly, use all validator nodes.
-	if manifest.ValidatorsMap == nil {
+	if manifest.Validators == nil {
 		validatorsMap := make(map[string]int64)
 		for _, node := range testnet.Nodes {
 			if node.Mode == ModeValidator {
 				validatorsMap[node.Name] = 100
 			}
 		}
-		manifest.ValidatorsMap = &validatorsMap
+		manifest.Validators = &validatorsMap
 	}
 
 	// Set up validator updates.

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -150,9 +150,10 @@ func MakeGenesis(testnet *e2e.Testnet) (types.GenesisDoc, error) {
 	if testnet.PbtsUpdateHeight == -1 {
 		genesis.ConsensusParams.Feature.PbtsEnableHeight = testnet.PbtsEnableHeight
 	}
-	for validator, power := range testnet.Validators {
+	for valName, power := range testnet.Validators {
+		validator := testnet.LookupNode(valName)
 		genesis.Validators = append(genesis.Validators, types.GenesisValidator{
-			Name:    validator.Name,
+			Name:    valName,
 			Address: validator.PrivvalKey.PubKey().Address(),
 			PubKey:  validator.PrivvalKey.PubKey(),
 			Power:   power,
@@ -425,8 +426,9 @@ func MakeAppConfig(node *e2e.Node) ([]byte, error) {
 		validatorUpdates := map[string]map[string]int64{}
 		for height, validators := range node.Testnet.ValidatorUpdates {
 			updateVals := map[string]int64{}
-			for node, power := range validators {
-				updateVals[base64.StdEncoding.EncodeToString(node.PrivvalKey.PubKey().Bytes())] = power
+			for valName, power := range validators {
+				validator := node.Testnet.LookupNode(valName)
+				updateVals[base64.StdEncoding.EncodeToString(validator.PrivvalKey.PubKey().Bytes())] = power
 			}
 			validatorUpdates[strconv.FormatInt(height, 10)] = updateVals
 		}

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -150,7 +150,7 @@ func MakeGenesis(testnet *e2e.Testnet) (types.GenesisDoc, error) {
 	if testnet.PbtsUpdateHeight == -1 {
 		genesis.ConsensusParams.Feature.PbtsEnableHeight = testnet.PbtsEnableHeight
 	}
-	for valName, power := range testnet.Validators {
+	for valName, power := range *testnet.Manifest.ValidatorsMap {
 		validator := testnet.LookupNode(valName)
 		genesis.Validators = append(genesis.Validators, types.GenesisValidator{
 			Name:    valName,

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -150,7 +150,7 @@ func MakeGenesis(testnet *e2e.Testnet) (types.GenesisDoc, error) {
 	if testnet.PbtsUpdateHeight == -1 {
 		genesis.ConsensusParams.Feature.PbtsEnableHeight = testnet.PbtsEnableHeight
 	}
-	for valName, power := range *testnet.Manifest.ValidatorsMap {
+	for valName, power := range *testnet.Manifest.Validators {
 		validator := testnet.LookupNode(valName)
 		if validator == nil {
 			return types.GenesisDoc{}, fmt.Errorf("unknown validator %q for genesis doc", valName)

--- a/test/e2e/tests/block_test.go
+++ b/test/e2e/tests/block_test.go
@@ -151,7 +151,7 @@ func TestBlock_Time(t *testing.T) {
 	testnet := loadTestnet(t)
 
 	lastBlock := blocks[0]
-	valSchedule := newValidatorSchedule(testnet)
+	valSchedule := newValidatorSchedule(&testnet)
 	for _, block := range blocks[1:] {
 		require.Less(t, lastBlock.Time, block.Time)
 		lastBlock = block

--- a/test/e2e/tests/block_test.go
+++ b/test/e2e/tests/block_test.go
@@ -151,12 +151,12 @@ func TestBlock_Time(t *testing.T) {
 	testnet := loadTestnet(t)
 
 	lastBlock := blocks[0]
-	valSchedule := newValidatorSchedule(&testnet)
+	valSchedule := newValidatorSchedule(t, &testnet)
 	for _, block := range blocks[1:] {
 		require.Less(t, lastBlock.Time, block.Time)
 		lastBlock = block
 
-		valSchedule.Increment(1)
+		valSchedule.Increment(t, 1)
 		if testnet.PbtsEnableHeight == 0 || block.Height < testnet.PbtsEnableHeight {
 			expTime := block.LastCommit.MedianTime(valSchedule.Set)
 			require.Equal(t, expTime, block.Time, "height=%d", block.Height)

--- a/test/e2e/tests/validator_test.go
+++ b/test/e2e/tests/validator_test.go
@@ -2,6 +2,7 @@ package e2e_test
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -39,8 +40,8 @@ func TestValidator_Sets(t *testing.T) {
 			first += int64(node.RetainBlocks)
 		}
 
-		valSchedule := newValidatorSchedule(node.Testnet)
-		valSchedule.Increment(first - node.Testnet.InitialHeight)
+		valSchedule := newValidatorSchedule(t, node.Testnet)
+		valSchedule.Increment(t, first-node.Testnet.InitialHeight)
 
 		for h := first; h <= last; h++ {
 			validators := []*types.Validator{}
@@ -55,7 +56,7 @@ func TestValidator_Sets(t *testing.T) {
 			}
 			require.Equal(t, valSchedule.Set.Validators, validators,
 				"incorrect validator set at height %v", h)
-			valSchedule.Increment(1)
+			valSchedule.Increment(t, 1)
 		}
 	})
 }
@@ -71,7 +72,7 @@ func TestValidator_Propose(t *testing.T) {
 			return
 		}
 		address := node.PrivvalKey.PubKey().Address()
-		valSchedule := newValidatorSchedule(node.Testnet)
+		valSchedule := newValidatorSchedule(t, node.Testnet)
 
 		expectCount := 0
 		proposeCount := 0
@@ -82,7 +83,7 @@ func TestValidator_Propose(t *testing.T) {
 					proposeCount++
 				}
 			}
-			valSchedule.Increment(1)
+			valSchedule.Increment(t, 1)
 		}
 
 		if expectCount == 0 {
@@ -111,7 +112,7 @@ func TestValidator_Sign(t *testing.T) {
 			return
 		}
 		address := node.PrivvalKey.PubKey().Address()
-		valSchedule := newValidatorSchedule(node.Testnet)
+		valSchedule := newValidatorSchedule(t, node.Testnet)
 
 		expectCount := 0
 		signCount := 0
@@ -131,7 +132,7 @@ func TestValidator_Sign(t *testing.T) {
 			} else {
 				require.False(t, signed, "unexpected signature for block %v", block.LastCommit.Height)
 			}
-			valSchedule.Increment(1)
+			valSchedule.Increment(t, 1)
 		}
 
 		require.False(t, signCount == 0 && expectCount > 0,
@@ -150,26 +151,32 @@ type validatorSchedule struct {
 	testnet *e2e.Testnet
 }
 
-func newValidatorSchedule(testnet *e2e.Testnet) *validatorSchedule {
+func newValidatorSchedule(t *testing.T, testnet *e2e.Testnet) *validatorSchedule {
+	t.Helper()
 	valMap := *testnet.Manifest.ValidatorsMap     // genesis validators
 	if v, ok := testnet.ValidatorUpdates[0]; ok { // InitChain validators
 		valMap = v
 	}
+	vals, err := makeVals(testnet, valMap)
+	require.NoError(t, err)
 	return &validatorSchedule{
 		height:  testnet.InitialHeight,
-		Set:     types.NewValidatorSet(makeVals(testnet, valMap)),
+		Set:     types.NewValidatorSet(vals),
 		testnet: testnet,
 	}
 }
 
-func (s *validatorSchedule) Increment(heights int64) {
+func (s *validatorSchedule) Increment(t *testing.T, heights int64) {
+	t.Helper()
 	for i := int64(0); i < heights; i++ {
 		s.height++
 		if s.height > 2 {
 			// validator set updates are offset by 2, since they only take effect
 			// two blocks after they're returned.
 			if update, ok := s.testnet.ValidatorUpdates[s.height-2]; ok {
-				if err := s.Set.UpdateWithChangeSet(makeVals(s.testnet, update)); err != nil {
+				vals, err := makeVals(s.testnet, update)
+				require.NoError(t, err)
+				if err := s.Set.UpdateWithChangeSet(vals); err != nil {
 					panic(err)
 				}
 			}
@@ -178,11 +185,14 @@ func (s *validatorSchedule) Increment(heights int64) {
 	}
 }
 
-func makeVals(testnet *e2e.Testnet, valMap map[string]int64) []*types.Validator {
+func makeVals(testnet *e2e.Testnet, valMap map[string]int64) ([]*types.Validator, error) {
 	vals := make([]*types.Validator, 0, len(valMap))
 	for valName, power := range valMap {
 		validator := testnet.LookupNode(valName)
+		if validator == nil {
+			return nil, fmt.Errorf("unknown validator %q for `validatorSchedule`", valName)
+		}
 		vals = append(vals, types.NewValidator(validator.PrivvalKey.PubKey(), power))
 	}
-	return vals
+	return vals, nil
 }

--- a/test/e2e/tests/validator_test.go
+++ b/test/e2e/tests/validator_test.go
@@ -151,7 +151,7 @@ type validatorSchedule struct {
 }
 
 func newValidatorSchedule(testnet *e2e.Testnet) *validatorSchedule {
-	valMap := testnet.Validators                  // genesis validators
+	valMap := *testnet.Manifest.ValidatorsMap     // genesis validators
 	if v, ok := testnet.ValidatorUpdates[0]; ok { // InitChain validators
 		valMap = v
 	}

--- a/test/e2e/tests/validator_test.go
+++ b/test/e2e/tests/validator_test.go
@@ -146,8 +146,7 @@ func TestValidator_Sign(t *testing.T) {
 // validator set updates.
 type validatorSchedule struct {
 	Set     *types.ValidatorSet
-	height  int64                      // TODO remove
-	updates map[int64]map[string]int64 // TODO remove
+	height  int64
 	testnet *e2e.Testnet
 }
 
@@ -159,7 +158,6 @@ func newValidatorSchedule(testnet *e2e.Testnet) *validatorSchedule {
 	return &validatorSchedule{
 		height:  testnet.InitialHeight,
 		Set:     types.NewValidatorSet(makeVals(testnet, valMap)),
-		updates: testnet.ValidatorUpdates,
 		testnet: testnet,
 	}
 }
@@ -170,7 +168,7 @@ func (s *validatorSchedule) Increment(heights int64) {
 		if s.height > 2 {
 			// validator set updates are offset by 2, since they only take effect
 			// two blocks after they're returned.
-			if update, ok := s.updates[s.height-2]; ok {
+			if update, ok := s.testnet.ValidatorUpdates[s.height-2]; ok {
 				if err := s.Set.UpdateWithChangeSet(makeVals(s.testnet, update)); err != nil {
 					panic(err)
 				}

--- a/test/e2e/tests/validator_test.go
+++ b/test/e2e/tests/validator_test.go
@@ -153,7 +153,7 @@ type validatorSchedule struct {
 
 func newValidatorSchedule(t *testing.T, testnet *e2e.Testnet) *validatorSchedule {
 	t.Helper()
-	valMap := *testnet.Manifest.ValidatorsMap     // genesis validators
+	valMap := *testnet.Manifest.Validators        // genesis validators
 	if v, ok := testnet.ValidatorUpdates[0]; ok { // InitChain validators
 		valMap = v
 	}


### PR DESCRIPTION
Partially addresses #2458

Change the `*Node` as keys of some maps in `e2e` and replace them by the node's name.

Having pointers as keys of a map brings about subtleties (how comparison is done) that we don't need. Code is much clearer with node names, even if it takes a bit longer to execute some loops (we need to look up the nodes). But this is test code, so clarity and robustness comes before performance of the testing code.

I decided to tackle this refactor in an different PR, rather than piggybacking it to #2283

---

#### PR checklist

- [x] Tests written/updated
- ~[ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)~
- ~[ ] Updated relevant documentation (`docs/` or `spec/`) and code comments~
