### PR TITLE
feat(e2e): `Manifest`, renamed `ValidatorsMap` -> `Validators`

### DIFF
--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -137,7 +137,7 @@ func generateTestnet(r *rand.Rand, opt map[string]any, upgradeVersion string, pr
 		ABCIProtocol:        nodeABCIProtocols.Choose(r).(string),
 		InitialHeight:       int64(opt["initialHeight"].(int)),
 		InitialState:        opt["initialState"].(map[string]string),
-		ValidatorsMap:       &map[string]int64{},
+		Validators:          &map[string]int64{},
 		ValidatorUpdatesMap: map[string]map[string]int64{},
 		KeyType:             keyType.Choose(r).(string),
 		Evidence:            evidence.Choose(r).(int),
@@ -221,7 +221,7 @@ func generateTestnet(r *rand.Rand, opt map[string]any, upgradeVersion string, pr
 
 		weight := int64(30 + r.Intn(71))
 		if startAt == 0 {
-			(*manifest.ValidatorsMap)[name] = weight
+			(*manifest.Validators)[name] = weight
 		} else {
 			manifest.ValidatorUpdatesMap[strconv.FormatInt(startAt+5, 10)] = map[string]int64{name: weight}
 		}
@@ -235,7 +235,7 @@ func generateTestnet(r *rand.Rand, opt map[string]any, upgradeVersion string, pr
 		startAt := manifest.NodesMap[name].StartAt
 		var weight int64
 		if startAt == 0 {
-			weight = (*manifest.ValidatorsMap)[name]
+			weight = (*manifest.Validators)[name]
 		} else {
 			weight = manifest.ValidatorUpdatesMap[strconv.FormatInt(startAt+5, 10)][name]
 		}
@@ -251,8 +251,8 @@ func generateTestnet(r *rand.Rand, opt map[string]any, upgradeVersion string, pr
 	switch opt["validators"].(string) {
 	case "genesis":
 	case "initchain":
-		manifest.ValidatorUpdatesMap["0"] = *manifest.ValidatorsMap
-		manifest.ValidatorsMap = &map[string]int64{}
+		manifest.ValidatorUpdatesMap["0"] = *manifest.Validators
+		manifest.Validators = &map[string]int64{}
 	default:
 		return manifest, fmt.Errorf("invalid validators option %q", opt["validators"])
 	}

--- a/test/e2e/pkg/manifest.go
+++ b/test/e2e/pkg/manifest.go
@@ -20,7 +20,7 @@ type Manifest struct {
 	// set in genesis. Defaults to nothing.
 	InitialState map[string]string `toml:"initial_state"`
 
-	// ValidatorsMap is the initial validator set in genesis, given as node names
+	// Validators is the initial validator set in genesis, given as node names
 	// and power:
 	//
 	// validators = { validator01 = 10; validator02 = 20; validator03 = 30 }
@@ -29,7 +29,7 @@ type Manifest struct {
 	// specifying an empty set will start with no validators in genesis, and
 	// the application must return the validator set in InitChain via the
 	// setting validator_update.0 (see below).
-	ValidatorsMap *map[string]int64 `toml:"validators"`
+	Validators *map[string]int64 `toml:"validators"`
 
 	// ValidatorUpdatesMap is a map of heights to validator names and their power,
 	// and will be returned by the ABCI application. For example, the following

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -281,14 +281,14 @@ func NewTestnetFromManifest(manifest Manifest, file string, ifd InfrastructureDa
 	}
 
 	// Set up genesis validators. If not specified explicitly, use all validator nodes.
-	if manifest.ValidatorsMap == nil {
+	if manifest.Validators == nil {
 		validatorsMap := make(map[string]int64)
 		for _, node := range testnet.Nodes {
 			if node.Mode == ModeValidator {
 				validatorsMap[node.Name] = 100
 			}
 		}
-		manifest.ValidatorsMap = &validatorsMap
+		manifest.Validators = &validatorsMap
 	}
 
 	// Set up validator updates.

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -150,7 +150,7 @@ func MakeGenesis(testnet *e2e.Testnet) (types.GenesisDoc, error) {
 	if testnet.PbtsUpdateHeight == -1 {
 		genesis.ConsensusParams.Feature.PbtsEnableHeight = testnet.PbtsEnableHeight
 	}
-	for valName, power := range *testnet.Manifest.ValidatorsMap {
+	for valName, power := range *testnet.Manifest.Validators {
 		validator := testnet.LookupNode(valName)
 		if validator == nil {
 			return types.GenesisDoc{}, fmt.Errorf("unknown validator %q for genesis doc", valName)

--- a/test/e2e/tests/validator_test.go
+++ b/test/e2e/tests/validator_test.go
@@ -153,7 +153,7 @@ type validatorSchedule struct {
 
 func newValidatorSchedule(t *testing.T, testnet *e2e.Testnet) *validatorSchedule {
 	t.Helper()
-	valMap := *testnet.Manifest.ValidatorsMap     // genesis validators
+	valMap := *testnet.Manifest.Validators        // genesis validators
 	if v, ok := testnet.ValidatorUpdates[0]; ok { // InitChain validators
 		valMap = v
 	}


### PR DESCRIPTION
As per title.

It was like this before https://github.com/cometbft/cometbft/pull/3964, so restoring original name.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
