### PR TITLE
docs(Node): Expand docs of `GenesisDocProvider`

### DIFF
--- a/node/setup.go
+++ b/node/setup.go
@@ -64,6 +64,9 @@ type CliParams struct {
 // GenesisDocProvider returns a GenesisDoc together with its SHA256 checksum.
 // It allows the GenesisDoc to be pulled from sources other than the
 // filesystem, for instance from a distributed key-value store cluster.
+// It is the responsibility of the GenesisDocProvider to ensure that the SHA256
+// checksum correctly matches the GenesisDoc, that is:
+// sha256(GenesisDoc) == Sha256Checksum.
 type GenesisDocProvider func() (ChecksummedGenesisDoc, error)
 
 // DefaultGenesisDocProviderFunc returns a GenesisDocProvider that loads


### PR DESCRIPTION
### Context
`GenesisDocProvider` is a function that users can implement and provide when creating a new `Node`. The function allows users to decide how the `GenesisDoc` should be provisioned to the chain. When called, it returns a [`ChecksummedGenesisDoc`](https://github.com/cometbft/cometbft/blob/87a8c8948bf9926aff37f344b4120163f12cb4ad/node/setup.go#L46), an object that stores both the `GenesisDoc` and its SHA256 checksum.

Our code does not verify the internal consistency of the `ChecksummedGenesisDoc`. Specifically, it does not check whether the `Sha256Checksum` field is actually the hash of the `GenesisDoc` field it contains. We rely on the `GenesisDocProvider` to ensure that `SHA256(GenesisDoc) == Sha256Checksum`. However, this critical assumption isn't explicitly documented in the `GenesisDocProvider` docs.

### This Change
This PR updates the documentation to clarify that it's the implementer's responsibility to verify the internal consistency between the `GenesisDoc` and its SHA256 checksum.

---

#### PR checklist

~- [ ] Tests written/updated~
~- [] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)~
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
