### PR TITLE
chore(RPC): `Environment` stores only one in-memory copy of the Genesis

### DIFF
--- a/.changelog/unreleased/improvements/4235-4234-environment-stores-one-genesis.md
+++ b/.changelog/unreleased/improvements/4235-4234-environment-stores-one-genesis.md
@@ -1,0 +1,3 @@
+- Environment (RPC API) stores either a pointer to
+  a GenesisDoc or the genesis' chunks, but not both.
+  ([\#4235](https://github.com/cometbft/cometbft/pull/4235))

--- a/node/node.go
+++ b/node/node.go
@@ -758,7 +758,8 @@ func (n *Node) ConfigureRPC() (*rpccore.Environment, error) {
 		Config: *n.config.RPC,
 	}
 	if err := rpcCoreEnv.InitGenesisChunks(); err != nil {
-		return nil, err
+		errMsg := "could not create the genesis file chunks and cache them: %s"
+		return nil, fmt.Errorf(errMsg, err)
 	}
 	return &rpcCoreEnv, nil
 }

--- a/p2p/mocks/peer.go
+++ b/p2p/mocks/peer.go
@@ -53,7 +53,9 @@ func (_m *Peer) Get(key string) any {
 	if rf, ok := ret.Get(0).(func(string) any); ok {
 		r0 = rf(key)
 	} else {
-		r0 = ret.Get(0).(any)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(any)
+		}
 	}
 
 	return r0

--- a/rpc/core/env.go
+++ b/rpc/core/env.go
@@ -101,41 +101,6 @@ type Environment struct {
 	genChunks []string
 }
 
-func validatePage(pagePtr *int, perPage, totalCount int) (int, error) {
-	if perPage < 1 {
-		panic(fmt.Sprintf("zero or negative perPage: %d", perPage))
-	}
-
-	if pagePtr == nil { // no page parameter
-		return 1, nil
-	}
-
-	pages := ((totalCount - 1) / perPage) + 1
-	if pages == 0 {
-		pages = 1 // one page (even if it's empty)
-	}
-	page := *pagePtr
-	if page <= 0 || page > pages {
-		return 1, fmt.Errorf("page should be within [1, %d] range, given %d", pages, page)
-	}
-
-	return page, nil
-}
-
-func (*Environment) validatePerPage(perPagePtr *int) int {
-	if perPagePtr == nil { // no per_page parameter
-		return defaultPerPage
-	}
-
-	perPage := *perPagePtr
-	if perPage < 1 {
-		return defaultPerPage
-	} else if perPage > maxPerPage {
-		return maxPerPage
-	}
-	return perPage
-}
-
 // InitGenesisChunks checks whether it makes sense to create a cache of chunked
 // genesis data. It is called once on Node startup.
 // Rules of chunking:
@@ -193,6 +158,41 @@ func (env *Environment) InitGenesisChunks() error {
 	env.GenDoc = nil
 
 	return nil
+}
+
+func validatePage(pagePtr *int, perPage, totalCount int) (int, error) {
+	if perPage < 1 {
+		panic(fmt.Sprintf("zero or negative perPage: %d", perPage))
+	}
+
+	if pagePtr == nil { // no page parameter
+		return 1, nil
+	}
+
+	pages := ((totalCount - 1) / perPage) + 1
+	if pages == 0 {
+		pages = 1 // one page (even if it's empty)
+	}
+	page := *pagePtr
+	if page <= 0 || page > pages {
+		return 1, fmt.Errorf("page should be within [1, %d] range, given %d", pages, page)
+	}
+
+	return page, nil
+}
+
+func (*Environment) validatePerPage(perPagePtr *int) int {
+	if perPagePtr == nil { // no per_page parameter
+		return defaultPerPage
+	}
+
+	perPage := *perPagePtr
+	if perPage < 1 {
+		return defaultPerPage
+	} else if perPage > maxPerPage {
+		return maxPerPage
+	}
+	return perPage
 }
 
 func validateSkipCount(page, perPage int) int {

--- a/rpc/core/env.go
+++ b/rpc/core/env.go
@@ -112,7 +112,7 @@ type Environment struct {
 // GenDoc field will be set to nil. `/genesis` RPC API will redirect users to use
 // the `/genesis_chunked` API.
 func (env *Environment) InitGenesisChunks() error {
-	if env.genChunks != nil || len(env.genChunks) > 0 {
+	if len(env.genChunks) > 0 {
 		// we already computed the chunks, return.
 		return nil
 	}

--- a/rpc/core/env_test.go
+++ b/rpc/core/env_test.go
@@ -2,8 +2,12 @@ package core
 
 import (
 	"fmt"
+	"os"
+	"reflect"
 	"testing"
 
+	cmtjson "github.com/cometbft/cometbft/libs/json"
+	"github.com/cometbft/cometbft/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -23,6 +27,99 @@ func TestInitGenesisChunks(t *testing.T) {
 		}
 	})
 
+	// Tests with a genesis file <= 16MB, i.e., no chunking, pointer to GenesisDoc
+	// stored in GenDoc field.
+	// The test genesis file is the genesis that the ci.toml e2e test uses.
+	t.Run("NoChunking", func(t *testing.T) {
+		const fGenesisPath = "./testdata/genesis_ci.json"
+
+		genesisData, err := os.ReadFile(fGenesisPath)
+		if err != nil {
+			t.Fatalf("reading test genesis file at %q: %s", fGenesisPath, err)
+		}
+
+		genDoc := &types.GenesisDoc{}
+		if err := cmtjson.Unmarshal(genesisData, genDoc); err != nil {
+			t.Fatalf("test genesis serialization: %s", err)
+		}
+
+		env := &Environment{
+			genChunks: nil,
+			GenDoc:    genDoc,
+		}
+
+		if err := env.InitGenesisChunks(); err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			if env.genChunks != nil {
+				formatStr := "chunks slice should be nil, but it has length %d"
+				t.Fatalf(formatStr, len(env.genChunks))
+			}
+
+			// Because the genesis file is <= 16MB, there should be no chunking.
+			// Therefore, the original GenesisDoc should be stored in GenDoc field
+			// unchanged.
+			if !reflect.DeepEqual(env.GenDoc, genDoc) {
+				formatStr := "GenesisDoc in Environment.GenDoc should be the same as in test genesis file\nwant: %#v\ngot: %#v\n"
+				t.Errorf(formatStr, genDoc, env.GenDoc)
+			}
+		}
+	})
+
+	// Tests with a genesis file > 16MB, i.e., chunking, pointer to GenesisDoc is
+	// nil, chunks slice stored in genChunks field.
+	// The test genesis file is the osmosis chain genesis (~69MB).
+	t.Run("Chunking", func(t *testing.T) {
+		const fGenesisPath = "./testdata/genesis_osmosis.json"
+
+		genesisData, err := os.ReadFile(fGenesisPath)
+		if err != nil {
+			t.Fatalf("reading test genesis file at %q: %s", fGenesisPath, err)
+		}
+
+		genesisDoc := &types.GenesisDoc{}
+		if err := cmtjson.Unmarshal(genesisData, genesisDoc); err != nil {
+			t.Fatalf("test genesis serialization: %s", err)
+		}
+
+		env := &Environment{
+			genChunks: nil,
+			GenDoc:    genesisDoc,
+		}
+
+		if err := env.InitGenesisChunks(); err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			if env.GenDoc != nil {
+				formatStr := "pointer to GenesisDoc should be nil, but it's pointing to\n%#v"
+				t.Fatalf(formatStr, *env.GenDoc)
+			}
+
+			// Why do we re-marshal the genesis to JSON?
+			// Because InitGenesisChunks computes the number of chunks based on the
+			// size of the []byte slice containing the genesis serialized to JSON.
+			// To calculate the correct expected number of chunks in this test, we
+			// must also serialize the genesis to JSON and use the size of the
+			// resulting// []byte slice.
+			// We cannot use the size of the []byte slice obtained from reading the
+			// file (`genesisData` above) because the size would differ due to JSON
+			// serialization removing whitespace and formatting, omitting default or
+			// zero values, and optimizing data (e.g., numbers).
+			genesisJSON, err := cmtjson.Marshal(genesisDoc)
+			if err != nil {
+				t.Fatalf("test genesis re-serialization: %s", err)
+			}
+
+			// Because the genesis file is > 16MB, we expect chunks.
+			// genesisChunkSize is a global const (=16MB) defined in env.go.
+			genesisSize := len(genesisJSON)
+			wantChunks := (genesisSize + genesisChunkSize - 1) / genesisChunkSize
+			if len(env.genChunks) != wantChunks {
+				formatStr := "expected number of chunks: %d, but got: %d"
+				t.Errorf(formatStr, wantChunks, len(env.genChunks))
+			}
+		}
+	})
 }
 
 func TestPaginationPage(t *testing.T) {

--- a/rpc/core/env_test.go
+++ b/rpc/core/env_test.go
@@ -7,10 +7,11 @@ import (
 	"slices"
 	"testing"
 
-	cmtjson "github.com/cometbft/cometbft/libs/json"
-	"github.com/cometbft/cometbft/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	cmtjson "github.com/cometbft/cometbft/libs/json"
+	"github.com/cometbft/cometbft/types"
 )
 
 func TestInitGenesisChunks(t *testing.T) {

--- a/rpc/core/env_test.go
+++ b/rpc/core/env_test.go
@@ -8,6 +8,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestInitGenesisChunks(t *testing.T) {
+	t.Run("Error", func(t *testing.T) {
+		env := &Environment{
+			genChunks: nil,
+			GenDoc:    nil,
+		}
+		wantErrStr := "pointer to genesis is nil"
+
+		if err := env.InitGenesisChunks(); err == nil {
+			t.Error("expected error but got nil")
+		} else if err.Error() != wantErrStr {
+			t.Errorf("\nwantErr: %q\ngot: %q\n", wantErrStr, err.Error())
+		}
+	})
+
+}
+
 func TestPaginationPage(t *testing.T) {
 	cases := []struct {
 		totalCount int

--- a/rpc/core/env_test.go
+++ b/rpc/core/env_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"slices"
 	"testing"
 
 	cmtjson "github.com/cometbft/cometbft/libs/json"
@@ -24,6 +25,28 @@ func TestInitGenesisChunks(t *testing.T) {
 			t.Error("expected error but got nil")
 		} else if err.Error() != wantErrStr {
 			t.Errorf("\nwantErr: %q\ngot: %q\n", wantErrStr, err.Error())
+		}
+	})
+
+	// Calling InitGenesisChunks with an existing slice of chunks will return without
+	// doing anything.
+	t.Run("NoOp", func(t *testing.T) {
+		testChunks := []string{"chunk1", "chunk2"}
+		env := &Environment{
+			genChunks: testChunks,
+			GenDoc:    nil,
+		}
+
+		if err := env.InitGenesisChunks(); err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			if !slices.Equal(testChunks, env.genChunks) {
+				t.Fatalf("\nexpected chunks: %v\ngot: %v", testChunks, env.genChunks)
+			}
+			if env.GenDoc != nil {
+				formatStr := "pointer to GenesisDoc should be nil, but it's pointing to\n%#v"
+				t.Errorf(formatStr, *env.GenDoc)
+			}
 		}
 	})
 

--- a/rpc/core/net.go
+++ b/rpc/core/net.go
@@ -105,7 +105,7 @@ func (env *Environment) UnsafeDialPeers(
 // Genesis returns genesis file.
 // More: https://docs.cometbft.com/main/rpc/#/Info/genesis
 func (env *Environment) Genesis(*rpctypes.Context) (*ctypes.ResultGenesis, error) {
-	if len(env.genChunks) > 1 {
+	if len(env.genChunks) > 0 {
 		return nil, ErrGenesisRespSize
 	}
 

--- a/rpc/core/net.go
+++ b/rpc/core/net.go
@@ -1,10 +1,12 @@
 package core
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"strings"
 
+	cmtjson "github.com/cometbft/cometbft/libs/json"
 	"github.com/cometbft/cometbft/p2p"
 	ctypes "github.com/cometbft/cometbft/rpc/core/types"
 	rpctypes "github.com/cometbft/cometbft/rpc/jsonrpc/types"
@@ -112,8 +114,30 @@ func (env *Environment) Genesis(*rpctypes.Context) (*ctypes.ResultGenesis, error
 	return &ctypes.ResultGenesis{Genesis: env.GenDoc}, nil
 }
 
-func (env *Environment) GenesisChunked(_ *rpctypes.Context, chunk uint) (*ctypes.ResultGenesisChunk, error) {
+func (env *Environment) GenesisChunked(
+	_ *rpctypes.Context,
+	chunk uint,
+) (*ctypes.ResultGenesisChunk, error) {
 	if env.genChunks == nil {
+		// See discussion in the following PR for why we still serve chunk 0 even
+		// if env.genChunks is nil:
+		// https://github.com/cometbft/cometbft/pull/4235#issuecomment-2389109521
+		if chunk == 0 {
+			genesisJSON, err := cmtjson.Marshal(env.GenDoc)
+			if err != nil {
+				return nil, fmt.Errorf("retrieving requested chunk (id=0): %s", err)
+			}
+
+			genesisBase64 := base64.StdEncoding.EncodeToString(genesisJSON)
+			resp := &ctypes.ResultGenesisChunk{
+				TotalChunks: 1,
+				ChunkNumber: 0,
+				Data:        genesisBase64,
+			}
+
+			return resp, nil
+		}
+
 		return nil, ErrServiceConfig{ErrChunkNotInitialized}
 	}
 

--- a/rpc/core/testdata/genesis_ci.json
+++ b/rpc/core/testdata/genesis_ci.json
@@ -1,0 +1,49 @@
+{
+  "genesis_time": "2024-10-02T11:53:14.181969Z",
+  "chain_id": "ci",
+  "initial_height": "1000",
+  "consensus_params": {
+    "block": {
+      "max_bytes": "4194304",
+      "max_gas": "10000000"
+    },
+    "evidence": {
+      "max_age_num_blocks": "14",
+      "max_age_duration": "1500000000",
+      "max_bytes": "1048576"
+    },
+    "validator": {
+      "pub_key_types": [
+        "ed25519"
+      ]
+    },
+    "version": {
+      "app": "1"
+    },
+    "synchrony": {
+      "precision": "500000000",
+      "message_delay": "2000000000"
+    },
+    "feature": {
+      "vote_extensions_enable_height": "0",
+      "pbts_enable_height": "0"
+    }
+  },
+  "validators": [
+    {
+      "address": "75C02D9AC4DB1A1F802CECF9EADB4CC4CB952AE6",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "01E+NeFFiH8D2uQHJ+X45wePtfVPs9pncpBnv/g9DQs="
+      },
+      "power": "100",
+      "name": "validator01"
+    }
+  ],
+  "app_hash": "",
+  "app_state": {
+    "initial01": "a",
+    "initial02": "b",
+    "initial03": "c"
+  }
+}


### PR DESCRIPTION
Closes #4234.

### Changes
The [`Environment`](https://github.com/cometbft/cometbft/blob/8273634cdefb2fb22765a14f9acb9fca608e9982/rpc/core/env.go#L72) type will:
- Store a pointer to a `GenesisDoc` if the genesis file size is below a threshold currently set to 16 MB.
- If the genesis file exceeds this threshold, it will split it into 16 MB chunks and store the hashes of each chunk in memory in a slice. In this case, the pointer to the `GenesisDoc` will be `nil`. 

Because the `InitGenesisChunks` method of `Environment` is responsible for creating the chunks, most of the changes of this PR focus on refactoring this method and adding unit tests for it.

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
