### PR TITLE
chore(Node): Node does not keep a pointer to a GenesisDoc after initialization

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -740,7 +740,7 @@ var (
 	// ensure that `ConfigureRPC` initializes an `Environment` object only once.
 	_once sync.Once
 
-	// _rpcEnv is the `Environment` object serving RPC APIs. We treat is as a
+	// _rpcEnv is the `Environment` object serving RPC APIs. We treat it as a
 	// singleton and create it exactly once. See the docs of `ConfigureRPC` below
 	// for more details.
 	_rpcEnv *rpccore.Environment

--- a/node/node.go
+++ b/node/node.go
@@ -651,8 +651,6 @@ func (n *Node) OnStart() error {
 		return ErrStartPruning{Err: err}
 	}
 
-	n.genesisDoc = nil
-
 	return nil
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -652,6 +652,8 @@ func (n *Node) OnStart() error {
 		return ErrStartPruning{Err: err}
 	}
 
+	n.genesisDoc = nil
+
 	return nil
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -1025,6 +1025,11 @@ func (n *Node) PrivValidator() types.PrivValidator {
 	return n.privValidator
 }
 
+// GenesisDoc returns the Node's GenesisDoc.
+func (n *Node) GenesisDoc() *types.GenesisDoc {
+	return n.genesisDoc
+}
+
 // ProxyApp returns the Node's AppConns, representing its connections to the ABCI application.
 func (n *Node) ProxyApp() proxy.AppConns {
 	return n.proxyApp

--- a/node/node.go
+++ b/node/node.go
@@ -52,7 +52,8 @@ type Node struct {
 
 	// config
 	config        *cfg.Config
-	genesisDoc    *types.GenesisDoc   // initial validator set
+	genesisDoc    *types.GenesisDoc // initial validator set
+	genesisTime   time.Time
 	privValidator types.PrivValidator // local node's validator key
 
 	// network
@@ -583,7 +584,7 @@ func NewNodeWithCliParams(ctx context.Context,
 // OnStart starts the Node. It implements service.Service.
 func (n *Node) OnStart() error {
 	now := cmttime.Now()
-	genTime := n.genesisDoc.GenesisTime
+	genTime := n.genesisTime
 	if genTime.After(now) {
 		n.Logger.Info("Genesis time is in the future. Sleeping until then...", "genTime", genTime)
 		time.Sleep(genTime.Sub(now))

--- a/node/node.go
+++ b/node/node.go
@@ -651,6 +651,8 @@ func (n *Node) OnStart() error {
 		return ErrStartPruning{Err: err}
 	}
 
+	n.genesisDoc = nil
+
 	return nil
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -986,11 +986,6 @@ func (n *Node) PrivValidator() types.PrivValidator {
 	return n.privValidator
 }
 
-// GenesisDoc returns the Node's GenesisDoc.
-func (n *Node) GenesisDoc() *types.GenesisDoc {
-	return n.genesisDoc
-}
-
 // ProxyApp returns the Node's AppConns, representing its connections to the ABCI application.
 func (n *Node) ProxyApp() proxy.AppConns {
 	return n.proxyApp

--- a/node/node.go
+++ b/node/node.go
@@ -52,8 +52,13 @@ type Node struct {
 	service.BaseService
 
 	// config
-	config        *cfg.Config
-	genesisDoc    *types.GenesisDoc // initial validator set
+	config *cfg.Config
+
+	// genesisDoc stores the initial validator set.
+	// NOTE: this pointer will be set to nil once startup is done. In future work
+	// we plan to remove this field altogether so that the genesis isn't stored in
+	// memory at runtime.
+	genesisDoc    *types.GenesisDoc
 	genesisTime   time.Time
 	privValidator types.PrivValidator // local node's validator key
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -122,16 +122,16 @@ func TestNodeDelayedStart(t *testing.T) {
 
 	// create & start node
 	n, err := DefaultNewNode(config, log.TestingLogger(), CliParams{}, nil)
-	n.GenesisDoc().GenesisTime = now.Add(2 * time.Second)
+	n.genesisDoc.GenesisTime = now.Add(2 * time.Second)
 	require.NoError(t, err)
-	n.GenesisDoc().GenesisTime = now.Add(2 * time.Second)
+	n.genesisDoc.GenesisTime = now.Add(2 * time.Second)
 
 	err = n.Start()
 	require.NoError(t, err)
 	defer n.Stop() //nolint:errcheck // ignore for tests
 
 	startTime := cmttime.Now()
-	assert.True(t, true, startTime.After(n.GenesisDoc().GenesisTime))
+	assert.True(t, true, startTime.After(n.genesisDoc.GenesisTime))
 }
 
 func TestNodeSetAppVersion(t *testing.T) {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -122,16 +122,16 @@ func TestNodeDelayedStart(t *testing.T) {
 
 	// create & start node
 	n, err := DefaultNewNode(config, log.TestingLogger(), CliParams{}, nil)
-	n.genesisDoc.GenesisTime = now.Add(2 * time.Second)
+	n.genesisTime = now.Add(2 * time.Second)
 	require.NoError(t, err)
-	n.genesisDoc.GenesisTime = now.Add(2 * time.Second)
+	n.genesisTime = now.Add(2 * time.Second)
 
 	err = n.Start()
 	require.NoError(t, err)
 	defer n.Stop() //nolint:errcheck // ignore for tests
 
 	startTime := cmttime.Now()
-	assert.True(t, true, startTime.After(n.genesisDoc.GenesisTime))
+	assert.True(t, true, startTime.After(n.genesisTime))
 }
 
 func TestNodeSetAppVersion(t *testing.T) {

--- a/rpc/client/local/local.go
+++ b/rpc/client/local/local.go
@@ -50,6 +50,7 @@ func New(node *nm.Node) *Local {
 	if err != nil {
 		node.Logger.Error("Error configuring RPC", "err", err)
 	}
+
 	return &Local{
 		EventBus: node.EventBus(),
 		Logger:   log.NewNopLogger(),

--- a/rpc/core/env.go
+++ b/rpc/core/env.go
@@ -68,8 +68,14 @@ type mempoolReactor interface {
 	TryAddTx(tx types.Tx, sender p2p.Peer) (*abcicli.ReqRes, error)
 }
 
-// Environment contains objects and interfaces used by the RPC. It is expected
-// to be setup once during startup.
+// Environment contains the objects and interfaces used to serve the RPC APIs.
+// A Node creates an object of this type at startup.
+// An Environment should not be created directly, and it is recommended that
+// only one instance of Environment be created at runtime.
+// For this reason, callers should create one using the ConfigureRPC() method of
+// the Node type, because the Environment object it returns is a singleton.
+// Note: The Environment type was exported in the initial RPC API design; therefore,
+// unexporting it now could potentially break users.
 type Environment struct {
 	// external, thread safe interfaces
 	ProxyAppQuery   proxy.AppConnQuery
@@ -102,7 +108,7 @@ type Environment struct {
 }
 
 // InitGenesisChunks checks whether it makes sense to create a cache of chunked
-// genesis data. It is called once on Node startup.
+// genesis data. It is called on Node startup and should be called only once.
 // Rules of chunking:
 // - if the genesis file's size is <= 16MB, then no chunking. An `Environment`
 // object will store a pointer to the genesis in its GenDoc field. Its genChunks


### PR DESCRIPTION
Closes #4248.

### Changes
The `Node` type will:
 - create a singleton instance of `Environment` when setting up the RPC APIs.
 - set the pointer to the `GenesisDoc` to `nil` once startup is complete so that the GC can collect the in-memory `GenesisDoc` object.
 - store a `GenesisTime` field.

---

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
