### PR TITLE
fix(config): Dynamic mempool type when writing config

### DIFF
--- a/.changelog/unreleased/improvements/4281-use-embed-pkg-for-template-string.md
+++ b/.changelog/unreleased/improvements/4281-use-embed-pkg-for-template-string.md
@@ -1,0 +1,2 @@
+- `[config]` Dynamic mempool type when writing config
+  ([\#4281](https://github.com/cometbft/cometbft/pull/4281))

--- a/config/config.toml.tpl
+++ b/config/config.toml.tpl
@@ -321,7 +321,7 @@ dial_timeout = "{{ .P2P.DialTimeout }}"
 #  - "nop"   : nop-mempool (short for no operation; the ABCI app is responsible
 #  for storing, disseminating and proposing txs). "create_empty_blocks=false" is
 #  not supported.
-type = "flood"
+type = "{{ .Mempool.Type }}"
 
 # recheck (default: true) defines whether CometBFT should recheck the
 # validity for all remaining transaction in the mempool after a block.


### PR DESCRIPTION
When writing `config.toml` via `config.WriteConfigFile` the `mempool.type` field is hardcoded to `flood`. This fixes it to populate it from provided config struct.