### PR TITLE
feat(e2e): add new rollback perturbation

### DIFF
--- a/test/e2e/networks/ci.toml
+++ b/test/e2e/networks/ci.toml
@@ -69,7 +69,7 @@ key_type = "secp256k1"
 [node.validator04]
 persistent_peers = ["validator01"]
 database = "rocksdb"
-perturb = ["pause"]
+perturb = ["pause", "rollback","rollback","rollback","kill","kill","kill","rollback","rollback","rollback","kill","kill","kill"]
 
 [node.validator05]
 start_at = 1005 # Becomes part of the validator set at 1010

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -68,6 +68,7 @@ const (
 	PerturbationPause      Perturbation = "pause"
 	PerturbationRestart    Perturbation = "restart"
 	PerturbationUpgrade    Perturbation = "upgrade"
+	PerturbationRollback   Perturbation = "rollback"
 
 	EvidenceAgeHeight int64         = 14
 	EvidenceAgeTime   time.Duration = 1500 * time.Millisecond
@@ -611,7 +612,7 @@ func (n Node) Validate(testnet Testnet) error {
 				return errors.New("'upgrade' perturbation can appear at most once per node")
 			}
 			upgradeFound = true
-		case PerturbationDisconnect, PerturbationKill, PerturbationPause, PerturbationRestart:
+		case PerturbationDisconnect, PerturbationKill, PerturbationPause, PerturbationRestart, PerturbationRollback:
 		default:
 			return fmt.Errorf("invalid perturbation %q", perturbation)
 		}


### PR DESCRIPTION
Partially addresses #2458

As per title. Still need to add it to the generator, but 

---

#### PR checklist

- [x] Tests written/updated
- ~[ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)~
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
