### PR TITLE
fix(config): do not populate deprecated timeout_commit with non-zero value

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1230,7 +1230,7 @@ func DefaultConsensusConfig() *ConsensusConfig {
 		TimeoutProposeDelta:              500 * time.Millisecond,
 		TimeoutVote:                      1000 * time.Millisecond,
 		TimeoutVoteDelta:                 500 * time.Millisecond,
-		TimeoutCommit:                    1000 * time.Millisecond,
+		TimeoutCommit:                    0 * time.Millisecond,
 		CreateEmptyBlocks:                true,
 		CreateEmptyBlocksInterval:        0 * time.Second,
 		PeerGossipSleepDuration:          100 * time.Millisecond,

--- a/internal/confix/data/v1.0.toml
+++ b/internal/confix/data/v1.0.toml
@@ -463,8 +463,8 @@ timeout_vote_delta = "500ms"
 # How long we wait after committing a block, before starting on the new
 # height (this gives us a chance to receive some more precommits, even
 # though we already have +2/3).
-# Set to 0 if you want to make progress as soon as the node has all the precommits.
-timeout_commit = "1s"
+# Deprecated: use `next_block_delay` in the ABCI application's `FinalizeBlockResponse`.
+timeout_commit = "0s"
 
 # Deprecated: set `timeout_commit` to 0 instead.
 skip_timeout_commit = false


### PR DESCRIPTION
Closes #4337 
