### PR TITLE
perf(log)!: `LazyHash` for producing txs and blocks debug hashes

### DIFF
--- a/.changelog/unreleased/breaking-changes/4340-lazy-hash.md
+++ b/.changelog/unreleased/breaking-changes/4340-lazy-hash.md
@@ -1,4 +1,6 @@
 - `[log]` LazyBlockHash -> LazyHash
-  * LazyHash lazily stringifies things with a `Hash` method
-  * tx `Hash` ret type changed to HexBytes to fit interface
+  * LazyBlockHash replaced with more generic LazyHash which lazily evaluates
+    a tx or block hash when the stringer interface is invoked. Good for use
+    with debug statements so the item is only hashed when print is invoked
+  * tx `Hash` ret type changed to HexBytes to fit this interface
   [\#4340](https://github.com/cometbft/cometbft/pull/4340)

--- a/.changelog/unreleased/breaking-changes/4340-lazy-hash.md
+++ b/.changelog/unreleased/breaking-changes/4340-lazy-hash.md
@@ -1,0 +1,4 @@
+- `[log]` LazyBlockHash -> LazyHash
+  * LazyHash lazily stringifies things with a `Hash` method
+  * tx `Hash` ret type changed to HexBytes to fit interface
+  [\#4340](https://github.com/cometbft/cometbft/pull/4340)

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1784,7 +1784,7 @@ func (cs *State) enterCommit(height int64, commitRound int32) {
 		if !cs.ProposalBlockParts.HasHeader(blockID.PartSetHeader) {
 			logger.Info(
 				"Commit is for a block we do not know about; set ProposalBlock=nil",
-				"proposal", log.NewLazyBlockHash(cs.ProposalBlock),
+				"proposal", log.NewLazyHash(cs.ProposalBlock),
 				"commit", blockID.Hash,
 			)
 
@@ -1821,7 +1821,7 @@ func (cs *State) tryFinalizeCommit(height int64) {
 		// TODO: ^^ wait, why does it matter that we're a validator?
 		logger.Debug(
 			"Failed attempt to finalize commit; we do not have the commit block",
-			"proposal_block", log.NewLazyBlockHash(cs.ProposalBlock),
+			"proposal_block", log.NewLazyHash(cs.ProposalBlock),
 			"commit_block", blockID.Hash,
 		)
 		return
@@ -1863,7 +1863,7 @@ func (cs *State) finalizeCommit(height int64) {
 
 	logger.Info(
 		"Finalizing commit of block",
-		"hash", log.NewLazyBlockHash(block),
+		"hash", log.NewLazyHash(block),
 		"root", block.AppHash,
 		"num_txs", len(block.Txs),
 	)
@@ -2220,7 +2220,7 @@ func (cs *State) handleCompleteProposal(blockHeight int64) {
 			cs.Logger.Debug(
 				"Updating valid block to new proposal block",
 				"valid_round", cs.Round,
-				"valid_block_hash", log.NewLazyBlockHash(cs.ProposalBlock),
+				"valid_block_hash", log.NewLazyHash(cs.ProposalBlock),
 			)
 
 			cs.ValidRound = cs.Round
@@ -2433,7 +2433,7 @@ func (cs *State) addVote(vote *types.Vote, peerID nodekey.ID) (added bool, err e
 				} else {
 					cs.Logger.Debug(
 						"Valid block we do not know about; set ProposalBlock=nil",
-						"proposal", log.NewLazyBlockHash(cs.ProposalBlock),
+						"proposal", log.NewLazyHash(cs.ProposalBlock),
 						"block_id", blockID.Hash,
 					)
 

--- a/libs/log/lazy.go
+++ b/libs/log/lazy.go
@@ -30,8 +30,8 @@ type hashable interface {
 	Hash() cmtbytes.HexBytes
 }
 
-// NewLazyHash defers Hash until the Stringer interface is invoked. This is
-// particularly useful for avoiding calling Sprintf when debugging is not
+// NewLazyHash defers calling `Hash()` until the Stringer interface is invoked.
+// This is particularly useful for avoiding calling Sprintf when debugging is not
 // active.
 func NewLazyHash(inner hashable) *LazyHash {
 	return &LazyHash{inner}

--- a/libs/log/lazy.go
+++ b/libs/log/lazy.go
@@ -22,21 +22,21 @@ func (l *LazySprintf) String() string {
 	return fmt.Sprintf(l.format, l.args...)
 }
 
-type LazyBlockHash struct {
-	block hashable
+type lazyHash struct {
+	inner hashable
 }
 
 type hashable interface {
 	Hash() cmtbytes.HexBytes
 }
 
-// NewLazyBlockHash defers block Hash until the Stringer interface is invoked.
-// This is particularly useful for avoiding calling Sprintf when debugging is not
+// NewLazyHash defers Hash until the Stringer interface is invoked. This is
+// particularly useful for avoiding calling Sprintf when debugging is not
 // active.
-func NewLazyBlockHash(block hashable) *LazyBlockHash {
-	return &LazyBlockHash{block}
+func NewLazyHash(block hashable) *lazyHash {
+	return &lazyHash{block}
 }
 
-func (l *LazyBlockHash) String() string {
-	return l.block.Hash().String()
+func (l *lazyHash) String() string {
+	return l.inner.Hash().String()
 }

--- a/libs/log/lazy.go
+++ b/libs/log/lazy.go
@@ -22,7 +22,7 @@ func (l *LazySprintf) String() string {
 	return fmt.Sprintf(l.format, l.args...)
 }
 
-type lazyHash struct {
+type LazyHash struct {
 	inner hashable
 }
 
@@ -33,10 +33,10 @@ type hashable interface {
 // NewLazyHash defers Hash until the Stringer interface is invoked. This is
 // particularly useful for avoiding calling Sprintf when debugging is not
 // active.
-func NewLazyHash(inner hashable) *lazyHash {
-	return &lazyHash{inner}
+func NewLazyHash(inner hashable) *LazyHash {
+	return &LazyHash{inner}
 }
 
-func (l *lazyHash) String() string {
+func (l *LazyHash) String() string {
 	return l.inner.Hash().String()
 }

--- a/libs/log/lazy.go
+++ b/libs/log/lazy.go
@@ -22,6 +22,10 @@ func (l *LazySprintf) String() string {
 	return fmt.Sprintf(l.format, l.args...)
 }
 
+// LazyHash is a wrapper around a hashable object that defers the Hash call
+// until the Stringer interface is invoked.
+// This is particularly useful for avoiding calling Sprintf when debugging is
+// not active.
 type LazyHash struct {
 	inner hashable
 }

--- a/libs/log/lazy.go
+++ b/libs/log/lazy.go
@@ -33,8 +33,8 @@ type hashable interface {
 // NewLazyHash defers Hash until the Stringer interface is invoked. This is
 // particularly useful for avoiding calling Sprintf when debugging is not
 // active.
-func NewLazyHash(block hashable) *lazyHash {
-	return &lazyHash{block}
+func NewLazyHash(inner hashable) *lazyHash {
+	return &lazyHash{inner}
 }
 
 func (l *lazyHash) String() string {

--- a/libs/log/lazy_test.go
+++ b/libs/log/lazy_test.go
@@ -1,0 +1,25 @@
+package log_test
+
+import (
+	"testing"
+
+	"github.com/cometbft/cometbft/internal/test"
+	"github.com/cometbft/cometbft/libs/log"
+)
+
+func TestLazyHash_Txs(t *testing.T) {
+	const height = 2
+	const numTxs = 5
+	txs := test.MakeNTxs(height, numTxs)
+
+	for i := 0; i < numTxs; i++ {
+		hash := txs[i].Hash()
+		lazyHash := log.NewLazyHash(txs[i])
+		if lazyHash.String() != hash.String() {
+			t.Fatalf("expected %s, got %s", hash.String(), lazyHash.String())
+		}
+		if len(hash) <= 0 {
+			t.Fatalf("expected non-empty hash, got empty hash")
+		}
+	}
+}

--- a/libs/log/lazy_test.go
+++ b/libs/log/lazy_test.go
@@ -13,12 +13,11 @@ func TestLazyHash_Txs(t *testing.T) {
 	txs := test.MakeNTxs(height, numTxs)
 
 	for i := 0; i < numTxs; i++ {
-		hash := txs[i].Hash()
 		lazyHash := log.NewLazyHash(txs[i])
-		if lazyHash.String() != hash.String() {
-			t.Fatalf("expected %s, got %s", hash.String(), lazyHash.String())
+		if lazyHash.String() != txs[i].Hash().String() {
+			t.Fatalf("expected %s, got %s", txs[i].Hash().String(), lazyHash.String())
 		}
-		if len(hash) <= 0 {
+		if len(lazyHash.String()) <= 0 {
 			t.Fatalf("expected non-empty hash, got empty hash")
 		}
 	}

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -367,7 +367,7 @@ func (mem *CListMempool) CheckTx(tx types.Tx, sender nodekey.ID) (*abcicli.ReqRe
 		// (eg. after committing a block, txs are removed from mempool but not cache),
 		// so we only record the sender for txs still in the mempool.
 		if err := mem.addSender(tx.Key(), sender); err != nil {
-			mem.logger.Error("Could not add sender to tx", "tx", fmt.Sprintf("%X", log.NewLazyHash(tx)), "sender", sender, "err", err)
+			mem.logger.Error("Could not add sender to tx", "tx", log.NewLazyHash(tx), "sender", sender, "err", err)
 		}
 		// TODO: consider punishing peer for dups,
 		// its non-trivial since invalid txs can become valid,
@@ -380,7 +380,7 @@ func (mem *CListMempool) CheckTx(tx types.Tx, sender nodekey.ID) (*abcicli.ReqRe
 		Type: abci.CHECK_TX_TYPE_CHECK,
 	})
 	if err != nil {
-		panic(fmt.Errorf("CheckTx request for tx %s failed: %w", fmt.Sprintf("%X", log.NewLazyHash(tx)), err))
+		panic(fmt.Errorf("CheckTx request for tx %s failed: %w", log.NewLazyHash(tx), err))
 	}
 	reqRes.SetCallback(mem.handleCheckTxResponse(tx, sender))
 
@@ -412,7 +412,7 @@ func (mem *CListMempool) handleCheckTxResponse(tx types.Tx, sender nodekey.ID) f
 			mem.tryRemoveFromCache(tx)
 			mem.logger.Debug(
 				"Rejected invalid transaction",
-				"tx", fmt.Sprintf("%X", log.NewLazyHash(tx)),
+				"tx", log.NewLazyHash(tx),
 				"res", res,
 				"err", postCheckErr,
 			)
@@ -449,7 +449,7 @@ func (mem *CListMempool) handleCheckTxResponse(tx types.Tx, sender nodekey.ID) f
 			if err := mem.addSender(txKey, sender); err != nil {
 				mem.logger.Error("Could not add sender to tx", "tx", tx.Hash(), "sender", sender, "err", err)
 			}
-			mem.logger.Debug("Reject tx", "tx", fmt.Sprintf("%X", log.NewLazyHash(tx)), "height", mem.height.Load(), "err", ErrTxInMempool)
+			mem.logger.Debug("Reject tx", "tx", log.NewLazyHash(tx), "height", mem.height.Load(), "err", ErrTxInMempool)
 			return ErrTxInMempool
 		}
 
@@ -511,7 +511,7 @@ func (mem *CListMempool) addTx(tx types.Tx, gasWanted int64, sender nodekey.ID, 
 
 	mem.logger.Debug(
 		"Added transaction",
-		"tx", fmt.Sprintf("%X", log.NewLazyHash(tx)),
+		"tx", log.NewLazyHash(tx),
 		"lane", lane,
 		"height", mem.height.Load(),
 		"total", mem.numTxs,
@@ -548,7 +548,7 @@ func (mem *CListMempool) RemoveTxByKey(txKey types.TxKey) error {
 
 	mem.logger.Debug(
 		"Removed transaction",
-		"tx", fmt.Sprintf("%X", log.NewLazyHash(memTx.tx)),
+		"tx", log.NewLazyHash(memTx.tx),
 		"lane", memTx.lane,
 		"height", mem.height.Load(),
 		"total", mem.numTxs,
@@ -610,7 +610,7 @@ func (mem *CListMempool) handleRecheckTxResponse(tx types.Tx) func(res *abci.Res
 
 		// Check whether the rechecking process has finished.
 		if mem.recheck.done() {
-			mem.logger.Error("Failed to recheck tx", "tx", fmt.Sprintf("%X", log.NewLazyHash(tx)), "err", ErrLateRecheckResponse)
+			mem.logger.Error("Failed to recheck tx", "tx", log.NewLazyHash(tx), "err", ErrLateRecheckResponse)
 			return ErrLateRecheckResponse
 		}
 		mem.metrics.RecheckTimes.Add(1)
@@ -629,7 +629,7 @@ func (mem *CListMempool) handleRecheckTxResponse(tx types.Tx) func(res *abci.Res
 		// If tx is invalid, remove it from the mempool and the cache.
 		if (res.Code != abci.CodeTypeOK) || postCheckErr != nil {
 			// Tx became invalidated due to newly committed block.
-			mem.logger.Debug("Tx is no longer valid", "tx", fmt.Sprintf("%X", log.NewLazyHash(tx)), "res", res, "postCheckErr", postCheckErr)
+			mem.logger.Debug("Tx is no longer valid", "tx", log.NewLazyHash(tx), "res", res, "postCheckErr", postCheckErr)
 			if err := mem.RemoveTxByKey(tx.Key()); err != nil {
 				mem.logger.Debug("Transaction could not be removed from mempool", "err", err)
 				return err
@@ -790,7 +790,7 @@ func (mem *CListMempool) Update(
 		// https://github.com/tendermint/tendermint/issues/3322.
 		if err := mem.RemoveTxByKey(tx.Key()); err != nil {
 			mem.logger.Debug("Committed transaction not in local mempool (not an error)",
-				"tx", fmt.Sprintf("%X", log.NewLazyHash(tx)),
+				"tx", log.NewLazyHash(tx),
 				"error", err.Error())
 		}
 	}
@@ -855,7 +855,7 @@ func (mem *CListMempool) recheckTxs() {
 			Type: abci.CHECK_TX_TYPE_RECHECK,
 		})
 		if err != nil {
-			panic(fmt.Errorf("(re-)CheckTx request for tx %s failed: %w", fmt.Sprintf("%X", log.NewLazyHash(memTx.Tx())), err))
+			panic(fmt.Errorf("(re-)CheckTx request for tx %s failed: %w", log.NewLazyHash(memTx.Tx()), err))
 		}
 		resReq.SetCallback(mem.handleRecheckTxResponse(memTx.Tx()))
 	}

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -380,7 +380,7 @@ func (mem *CListMempool) CheckTx(tx types.Tx, sender nodekey.ID) (*abcicli.ReqRe
 		Type: abci.CHECK_TX_TYPE_CHECK,
 	})
 	if err != nil {
-		panic(fmt.Errorf("CheckTx request for tx %s failed: %w", log.NewLazyHash(tx), err))
+		panic(fmt.Errorf("CheckTx request for tx %s failed: %w", tx.Hash(), err))
 	}
 	reqRes.SetCallback(mem.handleCheckTxResponse(tx, sender))
 
@@ -399,7 +399,7 @@ func (mem *CListMempool) handleCheckTxResponse(tx types.Tx, sender nodekey.ID) f
 
 		// Check that rechecking txs is not in process.
 		if !mem.recheck.done() {
-			panic(fmt.Sprint("rechecking has not finished; cannot check new tx", log.NewLazyHash(tx)))
+			panic(fmt.Sprint("rechecking has not finished; cannot check new tx ", tx.Hash()))
 		}
 
 		var postCheckErr error
@@ -855,7 +855,7 @@ func (mem *CListMempool) recheckTxs() {
 			Type: abci.CHECK_TX_TYPE_RECHECK,
 		})
 		if err != nil {
-			panic(fmt.Errorf("(re-)CheckTx request for tx %s failed: %w", log.NewLazyHash(memTx.Tx()), err))
+			panic(fmt.Errorf("(re-)CheckTx request for tx %s failed: %w", memTx.Tx().Hash(), err))
 		}
 		resReq.SetCallback(mem.handleRecheckTxResponse(memTx.Tx()))
 	}

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -399,7 +399,7 @@ func (mem *CListMempool) handleCheckTxResponse(tx types.Tx, sender nodekey.ID) f
 
 		// Check that rechecking txs is not in process.
 		if !mem.recheck.done() {
-			panic(fmt.Sprintf("rechecking has not finished; cannot check new tx", log.NewLazyHash(tx)))
+			panic(fmt.Sprint("rechecking has not finished; cannot check new tx", log.NewLazyHash(tx)))
 		}
 
 		var postCheckErr error

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -399,7 +399,7 @@ func (mem *CListMempool) handleCheckTxResponse(tx types.Tx, sender nodekey.ID) f
 
 		// Check that rechecking txs is not in process.
 		if !mem.recheck.done() {
-			panic(fmt.Sprintf("rechecking has not finished; cannot check new tx %X", log.NewLazyHash(tx)))
+			panic(fmt.Sprintf("rechecking has not finished; cannot check new tx", log.NewLazyHash(tx)))
 		}
 
 		var postCheckErr error

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -367,7 +367,7 @@ func (mem *CListMempool) CheckTx(tx types.Tx, sender nodekey.ID) (*abcicli.ReqRe
 		// (eg. after committing a block, txs are removed from mempool but not cache),
 		// so we only record the sender for txs still in the mempool.
 		if err := mem.addSender(tx.Key(), sender); err != nil {
-			mem.logger.Error("Could not add sender to tx", "tx", log.NewLazySprintf("%X", tx.Hash()), "sender", sender, "err", err)
+			mem.logger.Error("Could not add sender to tx", "tx", fmt.Sprintf("%X", log.NewLazyHash(tx)), "sender", sender, "err", err)
 		}
 		// TODO: consider punishing peer for dups,
 		// its non-trivial since invalid txs can become valid,
@@ -380,7 +380,7 @@ func (mem *CListMempool) CheckTx(tx types.Tx, sender nodekey.ID) (*abcicli.ReqRe
 		Type: abci.CHECK_TX_TYPE_CHECK,
 	})
 	if err != nil {
-		panic(fmt.Errorf("CheckTx request for tx %s failed: %w", log.NewLazySprintf("%X", tx.Hash()), err))
+		panic(fmt.Errorf("CheckTx request for tx %s failed: %w", fmt.Sprintf("%X", log.NewLazyHash(tx)), err))
 	}
 	reqRes.SetCallback(mem.handleCheckTxResponse(tx, sender))
 
@@ -399,7 +399,7 @@ func (mem *CListMempool) handleCheckTxResponse(tx types.Tx, sender nodekey.ID) f
 
 		// Check that rechecking txs is not in process.
 		if !mem.recheck.done() {
-			panic(log.NewLazySprintf("rechecking has not finished; cannot check new tx %X", tx.Hash()))
+			panic(fmt.Sprintf("rechecking has not finished; cannot check new tx %X", log.NewLazyHash(tx)))
 		}
 
 		var postCheckErr error
@@ -412,7 +412,7 @@ func (mem *CListMempool) handleCheckTxResponse(tx types.Tx, sender nodekey.ID) f
 			mem.tryRemoveFromCache(tx)
 			mem.logger.Debug(
 				"Rejected invalid transaction",
-				"tx", log.NewLazySprintf("%X", tx.Hash()),
+				"tx", fmt.Sprintf("%X", log.NewLazyHash(tx)),
 				"res", res,
 				"err", postCheckErr,
 			)
@@ -449,7 +449,7 @@ func (mem *CListMempool) handleCheckTxResponse(tx types.Tx, sender nodekey.ID) f
 			if err := mem.addSender(txKey, sender); err != nil {
 				mem.logger.Error("Could not add sender to tx", "tx", tx.Hash(), "sender", sender, "err", err)
 			}
-			mem.logger.Debug("Reject tx", "tx", log.NewLazySprintf("%X", tx.Hash()), "height", mem.height.Load(), "err", ErrTxInMempool)
+			mem.logger.Debug("Reject tx", "tx", fmt.Sprintf("%X", log.NewLazyHash(tx)), "height", mem.height.Load(), "err", ErrTxInMempool)
 			return ErrTxInMempool
 		}
 
@@ -511,7 +511,7 @@ func (mem *CListMempool) addTx(tx types.Tx, gasWanted int64, sender nodekey.ID, 
 
 	mem.logger.Debug(
 		"Added transaction",
-		"tx", log.NewLazySprintf("%X", tx.Hash()),
+		"tx", fmt.Sprintf("%X", log.NewLazyHash(tx)),
 		"lane", lane,
 		"height", mem.height.Load(),
 		"total", mem.numTxs,
@@ -548,7 +548,7 @@ func (mem *CListMempool) RemoveTxByKey(txKey types.TxKey) error {
 
 	mem.logger.Debug(
 		"Removed transaction",
-		"tx", log.NewLazySprintf("%X", memTx.tx.Hash()),
+		"tx", fmt.Sprintf("%X", log.NewLazyHash(memTx.tx)),
 		"lane", memTx.lane,
 		"height", mem.height.Load(),
 		"total", mem.numTxs,
@@ -610,7 +610,7 @@ func (mem *CListMempool) handleRecheckTxResponse(tx types.Tx) func(res *abci.Res
 
 		// Check whether the rechecking process has finished.
 		if mem.recheck.done() {
-			mem.logger.Error("Failed to recheck tx", "tx", log.NewLazySprintf("%X", tx.Hash()), "err", ErrLateRecheckResponse)
+			mem.logger.Error("Failed to recheck tx", "tx", fmt.Sprintf("%X", log.NewLazyHash(tx)), "err", ErrLateRecheckResponse)
 			return ErrLateRecheckResponse
 		}
 		mem.metrics.RecheckTimes.Add(1)
@@ -629,7 +629,7 @@ func (mem *CListMempool) handleRecheckTxResponse(tx types.Tx) func(res *abci.Res
 		// If tx is invalid, remove it from the mempool and the cache.
 		if (res.Code != abci.CodeTypeOK) || postCheckErr != nil {
 			// Tx became invalidated due to newly committed block.
-			mem.logger.Debug("Tx is no longer valid", "tx", log.NewLazySprintf("%X", tx.Hash()), "res", res, "postCheckErr", postCheckErr)
+			mem.logger.Debug("Tx is no longer valid", "tx", fmt.Sprintf("%X", log.NewLazyHash(tx)), "res", res, "postCheckErr", postCheckErr)
 			if err := mem.RemoveTxByKey(tx.Key()); err != nil {
 				mem.logger.Debug("Transaction could not be removed from mempool", "err", err)
 				return err
@@ -790,7 +790,7 @@ func (mem *CListMempool) Update(
 		// https://github.com/tendermint/tendermint/issues/3322.
 		if err := mem.RemoveTxByKey(tx.Key()); err != nil {
 			mem.logger.Debug("Committed transaction not in local mempool (not an error)",
-				"tx", log.NewLazySprintf("%X", tx.Hash()),
+				"tx", fmt.Sprintf("%X", log.NewLazyHash(tx)),
 				"error", err.Error())
 		}
 	}
@@ -855,7 +855,7 @@ func (mem *CListMempool) recheckTxs() {
 			Type: abci.CHECK_TX_TYPE_RECHECK,
 		})
 		if err != nil {
-			panic(fmt.Errorf("(re-)CheckTx request for tx %s failed: %w", log.NewLazySprintf("%X", memTx.Tx().Hash()), err))
+			panic(fmt.Errorf("(re-)CheckTx request for tx %s failed: %w", fmt.Sprintf("%X", log.NewLazyHash(memTx.Tx())), err))
 		}
 		resReq.SetCallback(mem.handleRecheckTxResponse(memTx.Tx()))
 	}

--- a/test/e2e/tests/app_test.go
+++ b/test/e2e/tests/app_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	cmtbytes "github.com/cometbft/cometbft/libs/bytes"
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 	"github.com/cometbft/cometbft/types"
 )

--- a/test/e2e/tests/app_test.go
+++ b/test/e2e/tests/app_test.go
@@ -93,7 +93,7 @@ func TestApp_Tx(t *testing.T) {
 		require.Zero(t, res.Code)
 
 		hash := tx.Hash()
-		require.Equal(t, res.Hash, cmtbytes.HexBytes(hash))
+		require.Equal(t, res.Hash, hash)
 		waitTime := 1 * time.Minute
 		require.Eventuallyf(t, func() bool {
 			txResp, err := client.Tx(ctx, hash, false)

--- a/types/tx.go
+++ b/types/tx.go
@@ -26,7 +26,7 @@ type (
 )
 
 // Hash computes the TMHASH hash of the wire encoded transaction.
-func (tx Tx) Hash() []byte {
+func (tx Tx) Hash() cmtbytes.HexBytes {
 	return tmhash.Sum(tx)
 }
 


### PR DESCRIPTION
Closes #4167 

Generalizes LazyBlockHash as LazyHash so now Txs and Blocks are hashed only on evaluation of the debug printf

#go-api-breaking