### PR TITLE
test(e2e): give the runner extra time to wait for a killed node

### DIFF
--- a/.changelog/unreleased/improvements/4351-e2e-kill-perturbation-timeout.md
+++ b/.changelog/unreleased/improvements/4351-e2e-kill-perturbation-timeout.md
@@ -1,0 +1,2 @@
+- `[e2e]` increase the timeout value during a `kill` node perturbation
+  ([\#4351](https://github.com/cometbft/cometbft/pull/4351))

--- a/test/e2e/runner/perturb.go
+++ b/test/e2e/runner/perturb.go
@@ -64,6 +64,10 @@ func PerturbNode(ctx context.Context, node *e2e.Node, perturbation e2e.Perturbat
 		}
 		if node.PersistInterval == 0 {
 			timeout *= 5
+		} else {
+			// still need to give some extra time to the runner
+			// to wait for the node to restart when killing
+			timeout *= 2
 		}
 
 	case e2e.PerturbationPause:

--- a/test/e2e/runner/rpc.go
+++ b/test/e2e/runner/rpc.go
@@ -92,9 +92,11 @@ func waitForNode(ctx context.Context, node *e2e.Node, height int64, timeout time
 			return nil, ctx.Err()
 		case <-timer.C:
 			status, err := client.Status(ctx)
+			sinceLastChanged := time.Since(lastChanged)
 			switch {
-			case time.Since(lastChanged) > timeout:
-				return nil, fmt.Errorf("timed out waiting for %v to reach height %v", node.Name, height)
+			case sinceLastChanged > timeout:
+				return nil, fmt.Errorf("waiting for node %v timed out: exceeded %v wait timeout after waiting for %v",
+					node.Name, timeout, sinceLastChanged)
 			case err != nil:
 			case status.SyncInfo.LatestBlockHeight >= height && (height == 0 || !status.SyncInfo.CatchingUp):
 				return status, nil


### PR DESCRIPTION
One reason some e2e tests are failing is that the kill perturbation has a short timeout value of 20 seconds, causing waitForNode to time out. Doubling this timeout improves test stability and helps ensure the tests pass

[test failure](https://github.com/cometbft/cometbft/actions/runs/11546210646/job/32134226559)

#### PR checklist

- [ ] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
