### PR TITLE
perf: Remove External Votes From Wal

### DIFF
--- a/internal/consensus/byzantine_test.go
+++ b/internal/consensus/byzantine_test.go
@@ -231,10 +231,10 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 			proposal.Signature = p.Signature
 
 			// send proposal and block parts on internal msg queue
-			lazyProposer.sendInternalMessage(msgInfo{&ProposalMessage{proposal}, "", cmttime.Now()})
+			lazyProposer.sendInternalMessage(msgInfo{&ProposalMessage{proposal}, "", cmttime.Now(), true})
 			for i := 0; i < int(blockParts.Total()); i++ {
 				part := blockParts.GetPart(i)
-				lazyProposer.sendInternalMessage(msgInfo{&BlockPartMessage{lazyProposer.Height, lazyProposer.Round, part}, "", time.Time{}})
+				lazyProposer.sendInternalMessage(msgInfo{&BlockPartMessage{lazyProposer.Height, lazyProposer.Round, part}, "", time.Time{}, true})
 			}
 			lazyProposer.Logger.Info("Signed proposal", "height", height, "round", round, "proposal", proposal)
 			lazyProposer.Logger.Debug(fmt.Sprintf("Signed proposal block: %v", block))

--- a/internal/consensus/reactor.go
+++ b/internal/consensus/reactor.go
@@ -334,13 +334,13 @@ func (conR *Reactor) Receive(e p2p.Envelope) {
 		switch msg := msg.(type) {
 		case *ProposalMessage:
 			ps.SetHasProposal(msg.Proposal)
-			conR.conS.peerMsgQueue <- msgInfo{msg, e.Src.ID(), cmttime.Now()}
+			conR.conS.peerMsgQueue <- msgInfo{msg, e.Src.ID(), cmttime.Now(), true}
 		case *ProposalPOLMessage:
 			ps.ApplyProposalPOLMessage(msg)
 		case *BlockPartMessage:
 			ps.SetHasProposalBlockPart(msg.Height, msg.Round, int(msg.Part.Index))
 			conR.Metrics.BlockParts.With("peer_id", string(e.Src.ID())).Add(1)
-			conR.conS.peerMsgQueue <- msgInfo{msg, e.Src.ID(), time.Time{}}
+			conR.conS.peerMsgQueue <- msgInfo{msg, e.Src.ID(), time.Time{}, true}
 		default:
 			conR.Logger.Error(fmt.Sprintf("Unknown message type %v", reflect.TypeOf(msg)))
 		}
@@ -359,7 +359,7 @@ func (conR *Reactor) Receive(e p2p.Envelope) {
 			conR.rsMtx.RUnlock()
 			ps.SetHasVoteFromPeer(msg.Vote, height, valSize, lastCommitSize)
 
-			cs.peerMsgQueue <- msgInfo{msg, e.Src.ID(), time.Time{}}
+			cs.peerMsgQueue <- msgInfo{msg, e.Src.ID(), time.Time{}, true}
 
 		default:
 			// don't punish (leave room for soft upgrades)

--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -3019,26 +3019,26 @@ func TestStateOutputsBlockPartsStats(t *testing.T) {
 	}
 
 	cs.ProposalBlockParts = types.NewPartSetFromHeader(parts.Header())
-	cs.handleMsg(msgInfo{msg, peer.ID(), time.Time{}})
+	cs.handleMsg(msgInfo{msg, peer.ID(), time.Time{}, true})
 
 	statsMessage := <-cs.statsMsgQueue
 	require.Equal(t, msg, statsMessage.Msg, "")
 	require.Equal(t, peer.ID(), statsMessage.PeerID, "")
 
 	// sending the same part from different peer
-	cs.handleMsg(msgInfo{msg, "peer2", time.Time{}})
+	cs.handleMsg(msgInfo{msg, "peer2", time.Time{}, true})
 
 	// sending the part with the same height, but different round
 	msg.Round = 1
-	cs.handleMsg(msgInfo{msg, peer.ID(), time.Time{}})
+	cs.handleMsg(msgInfo{msg, peer.ID(), time.Time{}, true})
 
 	// sending the part from the smaller height
 	msg.Height = 0
-	cs.handleMsg(msgInfo{msg, peer.ID(), time.Time{}})
+	cs.handleMsg(msgInfo{msg, peer.ID(), time.Time{}, true})
 
 	// sending the part from the bigger height
 	msg.Height = 3
-	cs.handleMsg(msgInfo{msg, peer.ID(), time.Time{}})
+	cs.handleMsg(msgInfo{msg, peer.ID(), time.Time{}, true})
 
 	select {
 	case <-cs.statsMsgQueue:
@@ -3061,20 +3061,20 @@ func TestStateOutputVoteStats(t *testing.T) {
 	vote := signVote(vss[1], types.PrecommitType, chainID, blockID, true)
 
 	voteMessage := &VoteMessage{vote}
-	cs.handleMsg(msgInfo{voteMessage, peer.ID(), time.Time{}})
+	cs.handleMsg(msgInfo{voteMessage, peer.ID(), time.Time{}, true})
 
 	statsMessage := <-cs.statsMsgQueue
 	require.Equal(t, voteMessage, statsMessage.Msg, "")
 	require.Equal(t, peer.ID(), statsMessage.PeerID, "")
 
 	// sending the same part from different peer
-	cs.handleMsg(msgInfo{&VoteMessage{vote}, "peer2", time.Time{}})
+	cs.handleMsg(msgInfo{&VoteMessage{vote}, "peer2", time.Time{}, true})
 
 	// sending the vote for the bigger height
 	incrementHeight(vss[1])
 	vote = signVote(vss[1], types.PrecommitType, chainID, blockID, true)
 
-	cs.handleMsg(msgInfo{&VoteMessage{vote}, peer.ID(), time.Time{}})
+	cs.handleMsg(msgInfo{&VoteMessage{vote}, peer.ID(), time.Time{}, true})
 
 	select {
 	case <-cs.statsMsgQueue:

--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -139,6 +139,7 @@ func generateTestnet(r *rand.Rand, opt map[string]any, upgradeVersion string, pr
 		InitialHeight:       int64(opt["initialHeight"].(int)),
 		InitialState:        opt["initialState"].(map[string]string),
 		Validators:          &map[string]int64{},
+		Perturbations:       []map[string]e2e.Perturbation{},
 		ValidatorUpdatesMap: map[string]map[string]int64{},
 		KeyType:             keyType.Choose(r).(string),
 		Evidence:            evidence.Choose(r).(int),

--- a/test/e2e/networks/networkRestart.toml
+++ b/test/e2e/networks/networkRestart.toml
@@ -1,0 +1,39 @@
+evidence = 10
+vote_extensions_enable_height = 11
+abci_protocol = "builtin"
+
+[validators]
+  validator01 = 50
+  validator02 = 50
+  validator03 = 50
+  validator04 = 50
+
+
+[[perturbations]]
+validator01 = "kill"
+validator02 = "kill"
+validator03 = "kill"
+validator04 = "kill"
+[[perturbations]]
+validator01 = "restart"
+validator02 = "restart"
+validator03 = "restart"
+validator04 = "restart"
+
+
+[node]
+  [node.validator01]
+    mode = "validator"
+    version = "cometbft/e2e-node:local-version"
+  [node.validator02]
+    mode = "validator"
+    version = "cometbft/e2e-node:local-version"
+    persistent_peers = ["validator01"]
+  [node.validator03]
+    mode = "validator"
+    version = "cometbft/e2e-node:local-version"
+    persistent_peers = ["validator01"]
+  [node.validator04]
+    mode = "validator"
+    version = "cometbft/e2e-node:local-version"
+    persistent_peers = ["validator01"]

--- a/test/e2e/pkg/manifest.go
+++ b/test/e2e/pkg/manifest.go
@@ -31,6 +31,20 @@ type Manifest struct {
 	// setting validator_update.0 (see below).
 	Validators *map[string]int64 `toml:"validators"`
 
+	// Perturbations is the set of concurrent perturbations to make to the network.
+	//
+	// Each entry should contain validator names and the operation to perform on them.
+	// For example, the following will kill all validators at roughly the same time:
+	//
+	// [[perturbations]]
+	//   validator01 = "kill"
+	//	 validator02 = "kill
+	//	 validator03 = "kill
+	//	 validator04 = "kill
+	//
+	// Defaults for un-included nodes is to run no perturbations.
+	Perturbations []map[string]Perturbation `toml:"perturbations"`
+
 	// ValidatorUpdatesMap is a map of heights to validator names and their power,
 	// and will be returned by the ABCI application. For example, the following
 	// changes the power of validator01 and validator02 at height 1000:


### PR DESCRIPTION
Don't write votes coming from external nodes to the WAL.

This will improve both CPU time spent in terms of blocking syscalls and churn in terms of memory allocation for vote buffers being flushed to disk. You can see the effects in these images:
![Screenshot 2024-10-25 at 5 07 02 PM](https://github.com/user-attachments/assets/76785025-dd43-45c3-8ef0-ef8e1e04e39e)

![Screenshot 2024-10-25 at 4 55 27 PM](https://github.com/user-attachments/assets/7db05ae6-097f-428b-8d2e-e940cfb4da3e)

Also adds a new e2e test to better exercise crash recovery. This introduces network-wide perturbations which allow us to kill or restart every node on the network at once. 

Follow ups for this PR:
* I want to introduce some additional configuration options to allow us to specify sleep times for concurrent perturbations.  
The kill and restart in the included test file ends up recovering from each one on the same round without advancing in between them since there is no delay to allow the nodes to produce another round before running the next perturbation.

---

#### PR checklist


- [X] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
