### PR TITLE
ci: update upload-artifact version

### DIFF
--- a/.github/workflows/gobenchdata-base.yml
+++ b/.github/workflows/gobenchdata-base.yml
@@ -25,6 +25,6 @@ jobs:
 
       - run: go test -bench . -benchmem ./... | gobenchdata --json base.json
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: base.json

--- a/.github/workflows/gobenchdata-current.yml
+++ b/.github/workflows/gobenchdata-current.yml
@@ -27,7 +27,7 @@ jobs:
 
       - run: go test -bench . -benchmem ./... | gobenchdata --json current.json
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: current.json
 


### PR DESCRIPTION
Fixes "Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/"