### PR TITLE
fix(store): `BenchmarkLoadValidators` no longer panics

### DIFF
--- a/state/store.go
+++ b/state/store.go
@@ -237,10 +237,18 @@ func NewStore(db dbm.DB, options StoreOptions) Store {
 		StoreOptions: options,
 	}
 
+	if options.DBKeyLayout == "" {
+		options.DBKeyLayout = "v1"
+	}
+
 	dbKeyLayoutVersion := setDBKeyLayout(&store, options.DBKeyLayout)
 
 	if options.Logger != nil {
-		options.Logger.Info("State store key layout version ", "version", "v"+dbKeyLayoutVersion)
+		options.Logger.Info(
+			"State store key layout version ",
+			"version",
+			"v"+dbKeyLayoutVersion,
+		)
 	}
 
 	return store


### PR DESCRIPTION
### Context
The `BenchmarkLoadValidators` benchmark in the `state` package panics because it can't find the validators' information for the specified heights. The issue is caused by a missing `DBKeyLayout` in the test database configuration, which leads to the `LoadValidators` call failing.

### This Changes
- the benchmark now creates a new state `Store` by explicitly specifying the `DBKeyLayout` in the `StoreOptions`. 
- `store` constructor checks if `DBKeyLayout` is set; if not, it sets it to a default value.

---

#### PR checklist

- [x] Tests written/updated
- ~[ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)~
- ~[] Updated relevant documentation (`docs/` or `spec/`) and code comments~
