### PR TITLE
fix: broken integration tests

### DIFF
--- a/tests.mk
+++ b/tests.mk
@@ -5,14 +5,20 @@
 
 BINDIR ?= $(GOPATH)/bin
 
+#?install_test_prereqs
+install_test_prereqs:
+	make install
+	make install_abci
+.PHONY: install_test_prereqs
+
 #?test_apps: Run the app tests
-test_apps: install
+test_apps: install_test_prereqs
 	@bash test/app/test.sh
 .PHONY: test_apps
 
 #?test_abci_cli: Test the cli against the examples in the tutorial at: ./docs/abci-cli.md
 # if test fails, update the docs ^
-test_abci_cli: install_abci
+test_abci_cli:
 	@bash abci/tests/test_cli/test.sh
 .PHONY: test_abci_cli
 


### PR DESCRIPTION
Looks like PR https://github.com/cometbft/cometbft/pull/4088 broke [the integration tests](https://github.com/cometbft/cometbft/actions/runs/11625455423/job/32390983977?pr=4377) and it's blocking the other PRs. This should fix it.

#### PR checklist

- [X] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
