### PR TITLE
docs(metrics): Fix typo

### DIFF
--- a/docs/explanation/core/metrics.md
+++ b/docs/explanation/core/metrics.md
@@ -11,7 +11,7 @@ This functionality is disabled by default.
 
 To enable the Prometheus metrics, set `instrumentation.prometheus=true` in your
 config file. Metrics will be served under `/metrics` on 26660 port by default.
-Listen address can be changed in the config file (see
+Listen address can be changed in the [config file](./configuration.md) (see
 `instrumentation.prometheus_listen_addr`).
 
 ## List of available metrics

--- a/docs/explanation/core/metrics.md
+++ b/docs/explanation/core/metrics.md
@@ -12,7 +12,7 @@ This functionality is disabled by default.
 To enable the Prometheus metrics, set `instrumentation.prometheus=true` in your
 config file. Metrics will be served under `/metrics` on 26660 port by default.
 Listen address can be changed in the config file (see
-`instrumentation.prometheus\_listen\_addr`).
+`instrumentation.prometheus_listen_addr`).
 
 ## List of available metrics
 


### PR DESCRIPTION
See https://docs.cometbft.com/v0.38/core/metrics :
> Listen address can be changed in the config file (see `instrumentation.prometheus\_listen\_addr`).
