### PR TITLE
Retract v0.38.14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -140,6 +140,8 @@ require (
 )
 
 retract (
+	// bumped go version in minor release
+	v0.38.14
 	// a regression was introduced
 	v0.38.4
 	// a breaking change was introduced


### PR DESCRIPTION
Part of #4444.

Retracts `v0.38.14`. 
 
---

#### PR checklist

~- [ ] Tests written/updated~
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
~- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments~
