### PR TITLE
docs: add note about Go version bumps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,8 +207,8 @@ When updating dependencies, please only update the particular dependencies you
 need. Instead of running `go get -u=patch`, which will update anything, specify
 exactly the dependency you want to update.
 
-Do not bump the major Go version in a patch release (i.e. v0.34.x, v0.37.x,
-v0.38.x branches) unless there's a very good reason to do so.
+Do not bump the major Go version in a patch release (namely, `v0.34.x`, `v0.37.x`,
+`v0.38.x` branches) unless there's a pressing reason to do so (e.g., known security vulnerabilities).
 
 ## Logging
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,6 +207,9 @@ When updating dependencies, please only update the particular dependencies you
 need. Instead of running `go get -u=patch`, which will update anything, specify
 exactly the dependency you want to update.
 
+Do not bump the major Go version in a patch release (i.e. v0.34.x, v0.37.x,
+v0.38.x branches) unless there's a very good reason to do so.
+
 ## Logging
 
 Operators, consensus engine and application developers all need information from
@@ -227,12 +230,12 @@ Nth message, or a summary message every minute or hour).
 
 ### Log levels
 
-Different log levels should target different groups of users. At present, only
-**Debug**, **Info** and **Error** levels are supported.
+Different log levels should target different groups of users. CometBFT supports
+**Debug**, **Info**, **Warn** and **Error** levels.
 
 - **Debug**: Should primarily target consensus engine developers (i.e. core team
   members and developers working on CometBFT forks).
-- **Info** and **Error**: Should primarily target operators and application
+- **Info**, **Warn** and **Error**: Should primarily target operators and application
   developers.
 
 ### Sensitive information


### PR DESCRIPTION
Part of https://github.com/cometbft/cometbft/issues/4444.