### PR TITLE
fix(e2e): do not oscilate validator set when it contains a single validator

### DIFF
--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -357,7 +357,7 @@ func NewTestnetFromManifest(manifest Manifest, file string, ifd InfrastructureDa
 		testnet.ValidatorUpdates[int64(height)] = valUpdate
 	}
 
-	if testnet.ConstantFlip {
+	if testnet.ConstantFlip && len(testnet.Validators) > 1 {
 		// Pick "lowest" validator by name
 		var minNode string
 		for n := range testnet.Validators {

--- a/test/e2e/run-multiple.sh
+++ b/test/e2e/run-multiple.sh
@@ -24,7 +24,7 @@ for MANIFEST in "$@"; do
 	cat "$MANIFEST"
 
 	if ! ./build/runner -f "$MANIFEST"; then
-		echo "==> Testnet failed"
+		echo "==> Testnet failed: $MANIFEST"
 
 		echo "==> Dumping container logs for $MANIFEST..."
 		./build/runner -f "$MANIFEST" logs


### PR DESCRIPTION
This issue was introduced by https://github.com/cometbft/cometbft/pull/2283.

I've sneaked in a minor change in the script, so that we can grep for "Testnet failed" and go directly to the right manifests.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
