### PR TITLE
feat(spec): Add lanes to abci spec

### DIFF
--- a/spec/abci/abci++_methods.md
+++ b/spec/abci/abci++_methods.md
@@ -38,13 +38,15 @@ title: Methods
 
 * **Response**:
 
-    | Name                | Type   | Description                                         | Field Number | Deterministic |
-    |---------------------|--------|-----------------------------------------------------|--------------|---------------|
-    | data                | string | Some arbitrary information                          | 1            | N/A           |
-    | version             | string | The application software semantic version           | 2            | N/A           |
-    | app_version         | uint64 | The application version                             | 3            | N/A           |
-    | last_block_height   | int64  | Latest height for which the app persisted its state | 4            | N/A           |
-    | last_block_app_hash | bytes  | Latest AppHash returned by `FinalizeBlock`          | 5            | N/A           |
+    | Name                | Type   | Description                                                               | Field Number | Deterministic |
+    |---------------------|--------|---------------------------------------------------------------------------|--------------|---------------|
+    | data                | string | Some arbitrary information                                                | 1            | N/A           |
+    | version             | string | The application software semantic version                                 | 2            | N/A           |
+    | app_version         | uint64 | The application version                                                   | 3            | N/A           |
+    | last_block_height   | int64  | Latest height for which the app persisted its state                       | 4            | N/A           |
+    | last_block_app_hash | bytes  | Latest AppHash returned by `FinalizeBlock`                                | 5            | N/A           |
+    | lane_priorities     | map<string, uint32>  | Map of lane identifiers and their corresponding priorities  | 6            | N/A           |
+    | default_lane        | uint32  | The identifier of the default lane                                       | 7            | N/A           |
 
 * **Usage**:
     * Return information about the application state.
@@ -53,6 +55,11 @@ title: Methods
     * The returned `app_version` will be included in the Header of every block.
     * CometBFT expects `last_block_app_hash` and `last_block_height` to
       be updated and persisted during `Commit`.
+    * The application does not have to define `lane_priorities`. In that case, CometBFT will assign all transactions to one lane. 
+    * `lane_priorties` is empty if and only if `default_lane` is empty.
+    * `default_lane` has to be one of the identifiers defined in `lane_priorities`.
+    * The lowest priority a lane can have is `1`. The value `0` is reserved for when applications do not assign lanes (empty `lane_id` in `ResponseCheckTx`).
+  
 
 > Note: Semantic version is a reference to [semantic versioning](https://semver.org/). Semantic versions in info will be displayed as X.X.x.
 
@@ -141,6 +148,8 @@ title: Methods
     | gas_used   | int64                                             | Amount of gas consumed by transaction.                               | 6            | N/A           |
     | events     | repeated [Event](abci++_basic_concepts.md#events) | Type & Key-Value events for indexing transactions (e.g. by account). | 7            | N/A           |
     | codespace  | string                                            | Namespace for the `code`.                                            | 8            | N/A           |
+    | lane_id    | string                                            | The id of the lane to which the transaction is assigned.             | 12            | N/A           |
+    
 
 * **Usage**:
 
@@ -154,6 +163,9 @@ title: Methods
     * Transactions where `CheckTxResponse.Code != 0` will be rejected - they will not be broadcast
       to other nodes or included in a proposal block.
       CometBFT attributes no other value to the response code.
+    * If `lane_id` is an empty string, it means that the application did not set any lane in the
+      response message, so the transaction will be assigned to the default lane.
+    * The value of `lane_id` has to be in the range of lanes defined by the application in `ResponseInfo`. 
 
 ### Commit
 

--- a/spec/abci/abci++_methods.md
+++ b/spec/abci/abci++_methods.md
@@ -56,7 +56,7 @@ title: Methods
     * CometBFT expects `last_block_app_hash` and `last_block_height` to
       be updated and persisted during `Commit`.
     * The application does not have to define `lane_priorities`. In that case, CometBFT will assign all transactions to one lane. 
-    * `lane_priorties` is empty if and only if `default_lane` is empty.
+    * `lane_priorities` is empty if and only if `default_lane` is empty.
     * `default_lane` has to be one of the identifiers defined in `lane_priorities`.
     * The lowest priority a lane can have is `1`. The value `0` is reserved for when applications do not assign lanes (empty `lane_id` in `ResponseCheckTx`).
   


### PR DESCRIPTION
This PR adds information about the extra fields used in ABCI to support lanes. 

---

