### PR TITLE
chore(state): `v1LegacyLayout` keys no longer use `fmt.Sprintf()`.

### DIFF
--- a/.changelog/unreleased/improvements/4484-v1keylayout-sprintf.md
+++ b/.changelog/unreleased/improvements/4484-v1keylayout-sprintf.md
@@ -1,0 +1,1 @@
+- v1LegacyLayout keys no longer use fmt.Sprintf ([\#4484](https://github.com/cometbft/cometbft/pull/4484))

--- a/state/store.go
+++ b/state/store.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/cosmos/gogoproto/proto"
@@ -46,17 +47,17 @@ type v1LegacyLayout struct{}
 
 // CalcABCIResponsesKey implements StateKeyLayout.
 func (v1LegacyLayout) CalcABCIResponsesKey(height int64) []byte {
-	return []byte(fmt.Sprintf("abciResponsesKey:%v", height))
+	return []byte("abciResponsesKey:" + strconv.FormatInt(height, 10))
 }
 
 // store.StoreOptions.DBKeyLayout.calcConsensusParamsKey implements StateKeyLayout.
 func (v1LegacyLayout) CalcConsensusParamsKey(height int64) []byte {
-	return []byte(fmt.Sprintf("consensusParamsKey:%v", height))
+	return []byte("consensusParamsKey:" + strconv.FormatInt(height, 10))
 }
 
 // store.StoreOptions.DBKeyLayout.CalcValidatorsKey implements StateKeyLayout.
 func (v1LegacyLayout) CalcValidatorsKey(height int64) []byte {
-	return []byte(fmt.Sprintf("validatorsKey:%v", height))
+	return []byte("validatorsKey:" + strconv.FormatInt(height, 10))
 }
 
 var _ KeyLayout = (*v1LegacyLayout)(nil)


### PR DESCRIPTION
The `v1LegacyLayout` type uses `fmt.Sprintf()` to create the DB keys. This PR substitutes `fmt.Sprintf` with string concatenation, which is 3-4 times faster for such a simple string.

In general, we shouldn't use `fmt.Sprintf()` to concatenate strings, because it's inefficient. 
Exceptions could be constructing error messages (but we should use `fmt.Errorf()` for that) or tests.

---

#### PR checklist

- ~[ ] Tests written/updated~
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- ~[ ] Updated relevant documentation (`docs/` or `spec/`) and code comments~
