### PR TITLE
chore(store): `store.v1LegacyLayout` no longer uses `fmt.Sprintf()` to create DB keys.

### DIFF
--- a/.changelog/unreleased/improvements/4489-blockstore-v1LegacyLayout-sprintf.md
+++ b/.changelog/unreleased/improvements/4489-blockstore-v1LegacyLayout-sprintf.md
@@ -1,0 +1,2 @@
+- `[store]` `v1LegacyLayout` keys no longer use `fmt.Sprintf`
+  ([\#4489](https://github.com/cometbft/cometbft/pull/4489))

--- a/store/db_key_layout.go
+++ b/store/db_key_layout.go
@@ -1,7 +1,7 @@
 package store
 
 import (
-	"fmt"
+	"strconv"
 
 	"github.com/google/orderedcode"
 )
@@ -24,32 +24,37 @@ type v1LegacyLayout struct{}
 
 // CalcBlockCommitKey implements BlockKeyLayout.
 func (*v1LegacyLayout) CalcBlockCommitKey(height int64) []byte {
-	return []byte(fmt.Sprintf("C:%v", height))
+	return []byte("C:" + strconv.FormatInt(height, 10))
 }
 
 // CalcBlockHashKey implements BlockKeyLayout.
 func (*v1LegacyLayout) CalcBlockHashKey(hash []byte) []byte {
-	return []byte(fmt.Sprintf("BH:%x", hash))
+	return append([]byte{'B', 'H', ':'}, hash...)
 }
 
 // CalcBlockMetaKey implements BlockKeyLayout.
 func (*v1LegacyLayout) CalcBlockMetaKey(height int64) []byte {
-	return []byte(fmt.Sprintf("H:%v", height))
+	return []byte("H:" + strconv.FormatInt(height, 10))
 }
 
 // CalcBlockPartKey implements BlockKeyLayout.
 func (*v1LegacyLayout) CalcBlockPartKey(height int64, partIndex int) []byte {
-	return []byte(fmt.Sprintf("P:%v:%v", height, partIndex))
+	var (
+		keyPrefix = "P:"
+		keySuffix = strconv.FormatInt(height, 10) + ":" + strconv.Itoa(partIndex)
+		keyStr    = keyPrefix + keySuffix
+	)
+	return []byte(keyStr)
 }
 
 // CalcExtCommitKey implements BlockKeyLayout.
 func (*v1LegacyLayout) CalcExtCommitKey(height int64) []byte {
-	return []byte(fmt.Sprintf("EC:%v", height))
+	return []byte("EC:" + strconv.FormatInt(height, 10))
 }
 
 // CalcSeenCommitKey implements BlockKeyLayout.
 func (*v1LegacyLayout) CalcSeenCommitKey(height int64) []byte {
-	return []byte(fmt.Sprintf("SC:%v", height))
+	return []byte("SC:" + strconv.FormatInt(height, 10))
 }
 
 var _ BlockKeyLayout = (*v1LegacyLayout)(nil)

--- a/store/db_key_layout.go
+++ b/store/db_key_layout.go
@@ -51,7 +51,17 @@ func (*v1LegacyLayout) CalcBlockHashKey(hash []byte) []byte {
 
 // CalcBlockMetaKey implements BlockKeyLayout.
 func (*v1LegacyLayout) CalcBlockMetaKey(height int64) []byte {
-	return []byte("H:" + strconv.FormatInt(height, 10))
+	var (
+		keyPrefixLen = 2 // len("H:")
+
+		// the longest int64 has 19 digits, therefore its string representation is
+		// 20 bytes long (19 digits + 1 byte for the sign).
+		key = make([]byte, keyPrefixLen, keyPrefixLen+20)
+	)
+	key[0], key[1] = 'H', ':'
+	key = strconv.AppendInt(key, height, 10)
+
+	return key
 }
 
 // CalcBlockPartKey implements BlockKeyLayout.

--- a/store/db_key_layout.go
+++ b/store/db_key_layout.go
@@ -76,7 +76,17 @@ func (*v1LegacyLayout) CalcBlockPartKey(height int64, partIndex int) []byte {
 
 // CalcExtCommitKey implements BlockKeyLayout.
 func (*v1LegacyLayout) CalcExtCommitKey(height int64) []byte {
-	return []byte("EC:" + strconv.FormatInt(height, 10))
+	var (
+		keyPrefixLen = 3 // len("EC:")
+
+		// the longest int64 has 19 digits, therefore its string representation is
+		// 20 bytes long (19 digits + 1 byte for the sign).
+		key = make([]byte, keyPrefixLen, keyPrefixLen+20)
+	)
+	key[0], key[1], key[2] = 'E', 'C', ':'
+	key = strconv.AppendInt(key, height, 10)
+
+	return key
 }
 
 // CalcSeenCommitKey implements BlockKeyLayout.

--- a/store/db_key_layout.go
+++ b/store/db_key_layout.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"encoding/hex"
-	"slices"
 	"strconv"
 
 	"github.com/google/orderedcode"
@@ -41,15 +40,11 @@ func (*v1LegacyLayout) CalcBlockCommitKey(height int64) []byte {
 
 // CalcBlockHashKey implements BlockKeyLayout.
 func (*v1LegacyLayout) CalcBlockHashKey(hash []byte) []byte {
-	var (
-		prefix    = []byte{'B', 'H', ':'}
-		lenPrefix = len(prefix)
-		key       = make([]byte, lenPrefix+hex.EncodedLen(len(hash)))
-	)
+	// 3 is the length of "BH:"
+	key := make([]byte, 3+hex.EncodedLen(len(hash)))
 
-	copy(key, prefix)
-
-	hex.Encode(key[lenPrefix:], hash)
+	key[0], key[1], key[2] = 'B', 'H', ':'
+	hex.Encode(key[3:], hash)
 
 	return key
 }

--- a/store/db_key_layout.go
+++ b/store/db_key_layout.go
@@ -25,13 +25,11 @@ type v1LegacyLayout struct{}
 
 // CalcBlockCommitKey implements BlockKeyLayout.
 func (*v1LegacyLayout) CalcBlockCommitKey(height int64) []byte {
-	var (
-		keyPrefixLen = 2 // len("C:")
+	// The longest int64 has 19 digits, therefore its string representation is
+	// 20 bytes long (19 digits + 1 byte for the sign).
+	// 2 is the length of "C:"
+	key := make([]byte, 2, 2+20)
 
-		// the longest int64 has 19 digits, therefore its string representation is
-		// 20 bytes long (19 digits + 1 byte for the sign).
-		key = make([]byte, keyPrefixLen, keyPrefixLen+20)
-	)
 	key[0], key[1] = 'C', ':'
 	key = strconv.AppendInt(key, height, 10)
 
@@ -51,13 +49,11 @@ func (*v1LegacyLayout) CalcBlockHashKey(hash []byte) []byte {
 
 // CalcBlockMetaKey implements BlockKeyLayout.
 func (*v1LegacyLayout) CalcBlockMetaKey(height int64) []byte {
-	var (
-		keyPrefixLen = 2 // len("H:")
+	// the longest int64 has 19 digits, therefore its string representation is
+	// 20 bytes long (19 digits + 1 byte for the sign).
+	// 2 is the length of "H:"
+	key := make([]byte, 2, 2+20)
 
-		// the longest int64 has 19 digits, therefore its string representation is
-		// 20 bytes long (19 digits + 1 byte for the sign).
-		key = make([]byte, keyPrefixLen, keyPrefixLen+20)
-	)
 	key[0], key[1] = 'H', ':'
 	key = strconv.AppendInt(key, height, 10)
 
@@ -84,13 +80,11 @@ func (*v1LegacyLayout) CalcBlockPartKey(height int64, partIndex int) []byte {
 
 // CalcExtCommitKey implements BlockKeyLayout.
 func (*v1LegacyLayout) CalcExtCommitKey(height int64) []byte {
-	var (
-		keyPrefixLen = 3 // len("EC:")
+	// the longest int64 has 19 digits, therefore its string representation is
+	// 20 bytes long (19 digits + 1 byte for the sign).
+	// 3 is the length of "EC:"
+	key := make([]byte, 3, 3+20)
 
-		// the longest int64 has 19 digits, therefore its string representation is
-		// 20 bytes long (19 digits + 1 byte for the sign).
-		key = make([]byte, keyPrefixLen, keyPrefixLen+20)
-	)
 	key[0], key[1], key[2] = 'E', 'C', ':'
 	key = strconv.AppendInt(key, height, 10)
 
@@ -99,13 +93,11 @@ func (*v1LegacyLayout) CalcExtCommitKey(height int64) []byte {
 
 // CalcSeenCommitKey implements BlockKeyLayout.
 func (*v1LegacyLayout) CalcSeenCommitKey(height int64) []byte {
-	var (
-		keyPrefixLen = 3 // len("SC:")
+	// the longest int64 has 19 digits, therefore its string representation is
+	// 20 bytes long (19 digits + 1 byte for the sign).
+	// 3 is the length of "SC:"
+	key := make([]byte, 3, 3+20)
 
-		// the longest int64 has 19 digits, therefore its string representation is
-		// 20 bytes long (19 digits + 1 byte for the sign).
-		key = make([]byte, keyPrefixLen, keyPrefixLen+20)
-	)
 	key[0], key[1], key[2] = 'S', 'C', ':'
 	key = strconv.AppendInt(key, height, 10)
 

--- a/store/db_key_layout.go
+++ b/store/db_key_layout.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"encoding/hex"
 	"strconv"
 
 	"github.com/google/orderedcode"
@@ -29,7 +30,10 @@ func (*v1LegacyLayout) CalcBlockCommitKey(height int64) []byte {
 
 // CalcBlockHashKey implements BlockKeyLayout.
 func (*v1LegacyLayout) CalcBlockHashKey(hash []byte) []byte {
-	return append([]byte{'B', 'H', ':'}, hash...)
+	hexHash := make([]byte, hex.EncodedLen(len(hash)))
+	hex.Encode(hexHash, hash)
+
+	return append([]byte{'B', 'H', ':'}, hexHash...)
 }
 
 // CalcBlockMetaKey implements BlockKeyLayout.

--- a/store/db_key_layout.go
+++ b/store/db_key_layout.go
@@ -21,14 +21,23 @@ type BlockKeyLayout interface {
 	CalcBlockHashKey(hash []byte) []byte
 }
 
+// v1LegacyLayout is a legacy implementation of BlockKeyLayout, kept for backwards
+// compatibility. Newer code should use [v2Layout].
 type v1LegacyLayout struct{}
 
+// In the following [v1LegacyLayout] methods, we preallocate the key's slice to speed
+// up append operations and avoid extra allocations.
+// The size of the slice is the length of the prefix plus the length the string
+// representation of a 64-bit integer. Namely, the longest 64-bit int has 19 digits,
+// therefore its string representation is 20 bytes long (19 digits + 1 byte for the
+// sign).
+
 // CalcBlockCommitKey implements BlockKeyLayout.
+// It returns a database key of the form "C:<height>" to store/retrieve the commit
+// of the block at the given height to/from the database.
 func (*v1LegacyLayout) CalcBlockCommitKey(height int64) []byte {
 	const prefixLen = len("C:")
 
-	// The longest int64 has 19 digits, therefore its string representation is
-	// 20 bytes long (19 digits + 1 byte for the sign).
 	key := make([]byte, prefixLen, prefixLen+20)
 
 	key[0], key[1] = 'C', ':'
@@ -38,6 +47,8 @@ func (*v1LegacyLayout) CalcBlockCommitKey(height int64) []byte {
 }
 
 // CalcBlockHashKey implements BlockKeyLayout.
+// It returns a database key of the form "BH:hex(<hash>)" to store/retrieve a block
+// to/from the database using its hash.
 func (*v1LegacyLayout) CalcBlockHashKey(hash []byte) []byte {
 	const prefixLen = len("BH:")
 
@@ -50,12 +61,11 @@ func (*v1LegacyLayout) CalcBlockHashKey(hash []byte) []byte {
 }
 
 // CalcBlockMetaKey implements BlockKeyLayout.
+// It returns a database key of the form "H:<height>" to store/retrieve the metadata
+// of the block at the given height to/from the database.
 func (*v1LegacyLayout) CalcBlockMetaKey(height int64) []byte {
 	const prefixLen = len("H:")
 
-	// the longest int64 has 19 digits, therefore its string representation is
-	// 20 bytes long (19 digits + 1 byte for the sign).
-	// 2 is the length of "H:"
 	key := make([]byte, prefixLen, prefixLen+20)
 
 	key[0], key[1] = 'H', ':'
@@ -65,15 +75,13 @@ func (*v1LegacyLayout) CalcBlockMetaKey(height int64) []byte {
 }
 
 // CalcBlockPartKey implements BlockKeyLayout.
+// It returns a database key of the form "P:<height>:<partIndex>" to store/retrieve a
+// block part to/from the database.
 func (*v1LegacyLayout) CalcBlockPartKey(height int64, partIndex int) []byte {
 	const prefixLen = len("P:")
 
-	// Preallocate the slice to speed up append operations and avoid extra
-	// allocations.
-	// The longest int64 has 19 digits, therefore its string representation is
-	// 20 bytes long (19 digits + 1 byte for the sign). Here we have 2 ints,
-	// therefore 20+20 bytes.
-	// The total size is is: 2 (prefixLen) + 20 + 1 (len(":")) + 20
+	// Here we have 2 ints, therefore 20+20 bytes.
+	// The total size is : 2 (prefixLen) + 20 + 1 (len(":")) + 20
 	key := make([]byte, prefixLen, prefixLen+20+1+20)
 
 	key[0], key[1] = 'P', ':'
@@ -85,11 +93,11 @@ func (*v1LegacyLayout) CalcBlockPartKey(height int64, partIndex int) []byte {
 }
 
 // CalcExtCommitKey implements BlockKeyLayout.
+// It returns a database key of the form "EC:<height>" to store/retrieve the
+// ExtendedCommit for the given height to/from the database.
 func (*v1LegacyLayout) CalcExtCommitKey(height int64) []byte {
 	const prefixLen = len("EC:")
 
-	// the longest int64 has 19 digits, therefore its string representation is
-	// 20 bytes long (19 digits + 1 byte for the sign).
 	key := make([]byte, prefixLen, prefixLen+20)
 
 	key[0], key[1], key[2] = 'E', 'C', ':'
@@ -99,12 +107,11 @@ func (*v1LegacyLayout) CalcExtCommitKey(height int64) []byte {
 }
 
 // CalcSeenCommitKey implements BlockKeyLayout.
+// It returns a database key of the form "SC:<height>" to store/retrieve a locally
+// seen commit for the given height to/from the database.
 func (*v1LegacyLayout) CalcSeenCommitKey(height int64) []byte {
 	const prefixLen = len("SC:")
 
-	// the longest int64 has 19 digits, therefore its string representation is
-	// 20 bytes long (19 digits + 1 byte for the sign).
-	// 3 is the length of "SC:"
 	key := make([]byte, prefixLen, prefixLen+20)
 
 	key[0], key[1], key[2] = 'S', 'C', ':'

--- a/store/db_key_layout.go
+++ b/store/db_key_layout.go
@@ -91,7 +91,17 @@ func (*v1LegacyLayout) CalcExtCommitKey(height int64) []byte {
 
 // CalcSeenCommitKey implements BlockKeyLayout.
 func (*v1LegacyLayout) CalcSeenCommitKey(height int64) []byte {
-	return []byte("SC:" + strconv.FormatInt(height, 10))
+	var (
+		keyPrefixLen = 3 // len("SC:")
+
+		// the longest int64 has 19 digits, therefore its string representation is
+		// 20 bytes long (19 digits + 1 byte for the sign).
+		key = make([]byte, keyPrefixLen, keyPrefixLen+20)
+	)
+	key[0], key[1], key[2] = 'S', 'C', ':'
+	key = strconv.AppendInt(key, height, 10)
+
+	return key
 }
 
 var _ BlockKeyLayout = (*v1LegacyLayout)(nil)

--- a/store/db_key_layout.go
+++ b/store/db_key_layout.go
@@ -25,10 +25,11 @@ type v1LegacyLayout struct{}
 
 // CalcBlockCommitKey implements BlockKeyLayout.
 func (*v1LegacyLayout) CalcBlockCommitKey(height int64) []byte {
+	const prefixLen = len("C:")
+
 	// The longest int64 has 19 digits, therefore its string representation is
 	// 20 bytes long (19 digits + 1 byte for the sign).
-	// 2 is the length of "C:"
-	key := make([]byte, 2, 2+20)
+	key := make([]byte, prefixLen, prefixLen+20)
 
 	key[0], key[1] = 'C', ':'
 	key = strconv.AppendInt(key, height, 10)
@@ -38,21 +39,24 @@ func (*v1LegacyLayout) CalcBlockCommitKey(height int64) []byte {
 
 // CalcBlockHashKey implements BlockKeyLayout.
 func (*v1LegacyLayout) CalcBlockHashKey(hash []byte) []byte {
-	// 3 is the length of "BH:"
-	key := make([]byte, 3+hex.EncodedLen(len(hash)))
+	const prefixLen = len("BH:")
+
+	key := make([]byte, prefixLen+hex.EncodedLen(len(hash)))
 
 	key[0], key[1], key[2] = 'B', 'H', ':'
-	hex.Encode(key[3:], hash)
+	hex.Encode(key[prefixLen:], hash)
 
 	return key
 }
 
 // CalcBlockMetaKey implements BlockKeyLayout.
 func (*v1LegacyLayout) CalcBlockMetaKey(height int64) []byte {
+	const prefixLen = len("H:")
+
 	// the longest int64 has 19 digits, therefore its string representation is
 	// 20 bytes long (19 digits + 1 byte for the sign).
 	// 2 is the length of "H:"
-	key := make([]byte, 2, 2+20)
+	key := make([]byte, prefixLen, prefixLen+20)
 
 	key[0], key[1] = 'H', ':'
 	key = strconv.AppendInt(key, height, 10)
@@ -62,13 +66,15 @@ func (*v1LegacyLayout) CalcBlockMetaKey(height int64) []byte {
 
 // CalcBlockPartKey implements BlockKeyLayout.
 func (*v1LegacyLayout) CalcBlockPartKey(height int64, partIndex int) []byte {
+	const prefixLen = len("P:")
+
 	// Preallocate the slice to speed up append operations and avoid extra
 	// allocations.
 	// The longest int64 has 19 digits, therefore its string representation is
 	// 20 bytes long (19 digits + 1 byte for the sign). Here we have 2 ints,
 	// therefore 20+20 bytes.
-	// The total size is is: 2 (len("P:")) + 20 + 1 (len(":")) + 20
-	key := make([]byte, 2, 2+20+1+20)
+	// The total size is is: 2 (prefixLen) + 20 + 1 (len(":")) + 20
+	key := make([]byte, prefixLen, prefixLen+20+1+20)
 
 	key[0], key[1] = 'P', ':'
 	key = strconv.AppendInt(key, height, 10)
@@ -80,10 +86,11 @@ func (*v1LegacyLayout) CalcBlockPartKey(height int64, partIndex int) []byte {
 
 // CalcExtCommitKey implements BlockKeyLayout.
 func (*v1LegacyLayout) CalcExtCommitKey(height int64) []byte {
+	const prefixLen = len("EC:")
+
 	// the longest int64 has 19 digits, therefore its string representation is
 	// 20 bytes long (19 digits + 1 byte for the sign).
-	// 3 is the length of "EC:"
-	key := make([]byte, 3, 3+20)
+	key := make([]byte, prefixLen, prefixLen+20)
 
 	key[0], key[1], key[2] = 'E', 'C', ':'
 	key = strconv.AppendInt(key, height, 10)
@@ -93,10 +100,12 @@ func (*v1LegacyLayout) CalcExtCommitKey(height int64) []byte {
 
 // CalcSeenCommitKey implements BlockKeyLayout.
 func (*v1LegacyLayout) CalcSeenCommitKey(height int64) []byte {
+	const prefixLen = len("SC:")
+
 	// the longest int64 has 19 digits, therefore its string representation is
 	// 20 bytes long (19 digits + 1 byte for the sign).
 	// 3 is the length of "SC:"
-	key := make([]byte, 3, 3+20)
+	key := make([]byte, prefixLen, prefixLen+20)
 
 	key[0], key[1], key[2] = 'S', 'C', ':'
 	key = strconv.AppendInt(key, height, 10)

--- a/store/db_key_layout.go
+++ b/store/db_key_layout.go
@@ -24,13 +24,21 @@ type BlockKeyLayout interface {
 type v1LegacyLayout struct{}
 
 // CalcBlockCommitKey implements BlockKeyLayout.
-// It builds a key in the format "C:height".
-func (v *v1LegacyLayout) CalcBlockCommitKey(height int64) []byte {
-	return v.buildKey([]byte{'C', ':'}, height)
+func (*v1LegacyLayout) CalcBlockCommitKey(height int64) []byte {
+	var (
+		keyPrefixLen = 2 // len("C:")
+
+		// the longest int64 has 19 digits, therefore its string representation is
+		// 20 bytes long (19 digits + 1 byte for the sign).
+		key = make([]byte, keyPrefixLen, keyPrefixLen+20)
+	)
+	key[0], key[1] = 'C', ':'
+	key = strconv.AppendInt(key, height, 10)
+
+	return key
 }
 
 // CalcBlockHashKey implements BlockKeyLayout.
-// It builds a key in the format "BH:hash".
 func (*v1LegacyLayout) CalcBlockHashKey(hash []byte) []byte {
 	// 3 is the length of "BH:"
 	key := make([]byte, 3+hex.EncodedLen(len(hash)))
@@ -42,13 +50,21 @@ func (*v1LegacyLayout) CalcBlockHashKey(hash []byte) []byte {
 }
 
 // CalcBlockMetaKey implements BlockKeyLayout.
-// It builds a key in the format "H:height".
-func (v *v1LegacyLayout) CalcBlockMetaKey(height int64) []byte {
-	return v.buildKey([]byte{'H', ':'}, height)
+func (*v1LegacyLayout) CalcBlockMetaKey(height int64) []byte {
+	var (
+		keyPrefixLen = 2 // len("H:")
+
+		// the longest int64 has 19 digits, therefore its string representation is
+		// 20 bytes long (19 digits + 1 byte for the sign).
+		key = make([]byte, keyPrefixLen, keyPrefixLen+20)
+	)
+	key[0], key[1] = 'H', ':'
+	key = strconv.AppendInt(key, height, 10)
+
+	return key
 }
 
 // CalcBlockPartKey implements BlockKeyLayout.
-// It builds a key in the format "P:height:partIndex".
 func (*v1LegacyLayout) CalcBlockPartKey(height int64, partIndex int) []byte {
 	// Preallocate the slice to speed up append operations and avoid extra
 	// allocations.
@@ -67,26 +83,30 @@ func (*v1LegacyLayout) CalcBlockPartKey(height int64, partIndex int) []byte {
 }
 
 // CalcExtCommitKey implements BlockKeyLayout.
-// It builds a key in the format "EC:height".
-func (v *v1LegacyLayout) CalcExtCommitKey(height int64) []byte {
-	return v.buildKey([]byte{'E', 'C', ':'}, height)
+func (*v1LegacyLayout) CalcExtCommitKey(height int64) []byte {
+	var (
+		keyPrefixLen = 3 // len("EC:")
+
+		// the longest int64 has 19 digits, therefore its string representation is
+		// 20 bytes long (19 digits + 1 byte for the sign).
+		key = make([]byte, keyPrefixLen, keyPrefixLen+20)
+	)
+	key[0], key[1], key[2] = 'E', 'C', ':'
+	key = strconv.AppendInt(key, height, 10)
+
+	return key
 }
 
 // CalcSeenCommitKey implements BlockKeyLayout.
-// It builds a key in the format "SC:height".
-func (v *v1LegacyLayout) CalcSeenCommitKey(height int64) []byte {
-	return v.buildKey([]byte{'S', 'C', ':'}, height)
-}
+func (*v1LegacyLayout) CalcSeenCommitKey(height int64) []byte {
+	var (
+		keyPrefixLen = 3 // len("SC:")
 
-// buildKey constructs a v1 layout key in the format [prefix|height].
-func (*v1LegacyLayout) buildKey(prefix []byte, height int64) []byte {
-	// Preallocate the slice to speed up append operations and avoid extra
-	// allocations.
-	// The longest int64 has 19 digits, therefore its string representation is
-	// 20 bytes long (19 digits + 1 byte for the sign).
-	key := make([]byte, 0, len(prefix)+20)
-
-	key = append(key, prefix...)
+		// the longest int64 has 19 digits, therefore its string representation is
+		// 20 bytes long (19 digits + 1 byte for the sign).
+		key = make([]byte, keyPrefixLen, keyPrefixLen+20)
+	)
+	key[0], key[1], key[2] = 'S', 'C', ':'
 	key = strconv.AppendInt(key, height, 10)
 
 	return key

--- a/store/db_key_layout.go
+++ b/store/db_key_layout.go
@@ -30,10 +30,16 @@ func (*v1LegacyLayout) CalcBlockCommitKey(height int64) []byte {
 
 // CalcBlockHashKey implements BlockKeyLayout.
 func (*v1LegacyLayout) CalcBlockHashKey(hash []byte) []byte {
-	hexHash := make([]byte, hex.EncodedLen(len(hash)))
-	hex.Encode(hexHash, hash)
+	var (
+		prefix    = []byte{'B', 'H', ':'}
+		lenPrefix = len(prefix)
+		key       = make([]byte, lenPrefix+hex.EncodedLen(len(hash)))
+	)
+	copy(key, prefix)
 
-	return append([]byte{'B', 'H', ':'}, hexHash...)
+	hex.Encode(key[lenPrefix:], hash)
+
+	return key
 }
 
 // CalcBlockMetaKey implements BlockKeyLayout.

--- a/store/db_key_layout_test.go
+++ b/store/db_key_layout_test.go
@@ -48,32 +48,3 @@ func FuzzCalcBlockPartKey(f *testing.F) {
 		}
 	})
 }
-
-func FuzzBuildKey(f *testing.F) {
-	layout := &v1LegacyLayout{}
-
-	f.Add([]byte("prefix:"), int64(42))
-	f.Add([]byte("H:"), int64(42))
-	f.Add([]byte("p"), int64(1234567890123456789))
-	f.Add([]byte{}, int64(-1))
-	f.Add([]byte("anotherPrefix"), int64(-9223372036854775808))
-	f.Add([]byte(":"), int64(9223372036854775807))
-
-	f.Fuzz(func(t *testing.T, prefix []byte, height int64) {
-		key := layout.buildKey(prefix, height)
-
-		gotPrefix := string(key[:len(prefix)])
-		if len(key) < len(prefix) || gotPrefix != string(prefix) {
-			t.Fatalf("key does not start with prefix: %s, got: %s", prefix, key)
-		}
-
-		heightStr := string(key[len(prefix):])
-		gotHeight, err := strconv.ParseInt(heightStr, 10, 64)
-		if err != nil {
-			t.Fatalf("parsing height from key: %s, error: %s", key, err)
-		}
-		if gotHeight != height {
-			t.Fatalf("want height %d, but got %d", height, gotHeight)
-		}
-	})
-}

--- a/store/db_key_layout_test.go
+++ b/store/db_key_layout_test.go
@@ -2,18 +2,21 @@ package store
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"strconv"
 	"testing"
 )
 
+// run: go test -fuzz=FuzzCalcBlockPartKey -fuzztime 30s
 func FuzzCalcBlockPartKey(f *testing.F) {
 	layout := &v1LegacyLayout{}
 
 	f.Add(int64(0), 0)
-	f.Add(int64(1234567890123456789), 1)
-	f.Add(int64(-9223372036854775808), -1)
+	f.Add(int64(141241), 980)
+	f.Add(int64(1234567890), 12345678901)
 	f.Add(int64(9223372036854775807), 2147483647)
-	f.Add(int64(0), -2147483648)
+	f.Add(int64(42), 2147483648)
 
 	f.Fuzz(func(t *testing.T, height int64, partIndex int) {
 		key := layout.CalcBlockPartKey(height, partIndex)
@@ -45,6 +48,42 @@ func FuzzCalcBlockPartKey(f *testing.F) {
 		}
 		if gotPartIndex != partIndex {
 			t.Errorf("want partIndex %d, but got %d", partIndex, gotPartIndex)
+		}
+	})
+}
+
+// run: go test -fuzz=FuzzCalcBlockHashKey -fuzztime 30s
+func FuzzCalcBlockHashKey(f *testing.F) {
+	layout := &v1LegacyLayout{}
+
+	f.Add([]byte{})
+	f.Add([]byte{0x00})
+	f.Add([]byte{0xFF})
+	f.Add([]byte{0x01, 0x02, 0x03, 0x04})
+	f.Add(make([]byte, 32))
+
+	// empty hash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+	f.Add(sha256.New().Sum(nil))
+
+	f.Fuzz(func(t *testing.T, hash []byte) {
+		key := layout.CalcBlockHashKey(hash)
+
+		if len(key) < 3 || key[0] != 'B' || key[1] != 'H' || key[2] != ':' {
+			t.Fatalf("key does not start with 'BH:': %s", key)
+		}
+
+		var (
+			hashHex = key[3:]
+			gotHash = make([]byte, len(hash))
+		)
+		_, err := hex.Decode(gotHash, hashHex)
+		if err != nil {
+			t.Fatalf("decoding hash from key: %s, error: %s", key, err)
+		}
+
+		// Ensure the decoded hash matches the input hash.
+		if !bytes.Equal(gotHash, hash) {
+			t.Fatalf("want hash %x\ngot: %x\n", hash, gotHash)
 		}
 	})
 }

--- a/store/db_key_layout_test.go
+++ b/store/db_key_layout_test.go
@@ -1,9 +1,53 @@
 package store
 
 import (
+	"bytes"
 	"strconv"
 	"testing"
 )
+
+func FuzzCalcBlockPartKey(f *testing.F) {
+	layout := &v1LegacyLayout{}
+
+	f.Add(int64(0), 0)
+	f.Add(int64(1234567890123456789), 1)
+	f.Add(int64(-9223372036854775808), -1)
+	f.Add(int64(9223372036854775807), 2147483647)
+	f.Add(int64(0), -2147483648)
+
+	f.Fuzz(func(t *testing.T, height int64, partIndex int) {
+		key := layout.CalcBlockPartKey(height, partIndex)
+
+		// Ensure the key starts with the "P:" prefix.
+		// 2 is the length of "P:".
+		if len(key) < 2 || key[0] != 'P' || key[1] != ':' {
+			t.Fatalf("key does not start with 'P:': %s", key)
+		}
+
+		sepIndex := bytes.LastIndexByte(key, ':')
+		if sepIndex == -1 {
+			t.Fatalf("key does not have ':' between height and partIndex: %s", key)
+		}
+
+		heightStr := string(key[2:sepIndex])
+		gotHeight, err := strconv.ParseInt(heightStr, 10, 64)
+		if err != nil {
+			t.Fatalf("parsing height from key: %s, error: %s", key, err)
+		}
+		if gotHeight != height {
+			t.Fatalf("want height %d, but got %d", height, gotHeight)
+		}
+
+		partIndexStr := string(key[sepIndex+1:])
+		gotPartIndex, err := strconv.Atoi(partIndexStr)
+		if err != nil {
+			t.Fatalf("parsing partIndex from key: %s, error: %s", key, err)
+		}
+		if gotPartIndex != partIndex {
+			t.Errorf("want partIndex %d, but got %d", partIndex, gotPartIndex)
+		}
+	})
+}
 
 func FuzzBuildKey(f *testing.F) {
 	layout := &v1LegacyLayout{}

--- a/store/db_key_layout_test.go
+++ b/store/db_key_layout_test.go
@@ -1,0 +1,35 @@
+package store
+
+import (
+	"strconv"
+	"testing"
+)
+
+func FuzzBuildKey(f *testing.F) {
+	layout := &v1LegacyLayout{}
+
+	f.Add([]byte("prefix:"), int64(42))
+	f.Add([]byte("H:"), int64(42))
+	f.Add([]byte("p"), int64(1234567890123456789))
+	f.Add([]byte{}, int64(-1))
+	f.Add([]byte("anotherPrefix"), int64(-9223372036854775808))
+	f.Add([]byte(":"), int64(9223372036854775807))
+
+	f.Fuzz(func(t *testing.T, prefix []byte, height int64) {
+		key := layout.buildKey(prefix, height)
+
+		gotPrefix := string(key[:len(prefix)])
+		if len(key) < len(prefix) || gotPrefix != string(prefix) {
+			t.Fatalf("key does not start with prefix: %s, got: %s", prefix, key)
+		}
+
+		heightStr := string(key[len(prefix):])
+		gotHeight, err := strconv.ParseInt(heightStr, 10, 64)
+		if err != nil {
+			t.Fatalf("parsing height from key: %s, error: %s", key, err)
+		}
+		if gotHeight != height {
+			t.Fatalf("want height %d, but got %d", height, gotHeight)
+		}
+	})
+}


### PR DESCRIPTION
The `v1LegacyLayout` type of pkg `store` uses `fmt.Sprintf()` to create the DB keys. 
This PR refactors functions using `fmt.Sprintf` to improve their speed and memory usage.

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
