### PR TITLE
feat(storage): Add unit tests for pebble implementation of `DB` interface.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -134,6 +134,7 @@ linters-settings:
           - github.com/spf13
           - github.com/stretchr/testify
           - github.com/decred/dcrd/dcrec/secp256k1/v4
+          - github.com/cockroachdb/pebble
 
   revive:
     enable-all-rules: true

--- a/internal/storage/pebbledb.go
+++ b/internal/storage/pebbledb.go
@@ -259,6 +259,7 @@ func (pDB *PebbleDB) Close() error {
 }
 
 // Print prints all the key/value pairs in the database for debugging purposes.
+//
 // It implements the [DB] interface for type PebbleDB.
 func (pDB *PebbleDB) Print() error {
 	itr, err := pDB.Iterator(nil, nil)
@@ -277,12 +278,15 @@ func (pDB *PebbleDB) Print() error {
 }
 
 // Stats implements the [DB] interface.
+//
+// It implements the [DB] interface for type PebbleDB.
 func (*PebbleDB) Stats() map[string]string {
 	return nil
 }
 
 // NewBatch creates a batch for atomic database updates.
 // The caller is responsible for calling Batch.Close() once done.
+//
 // It implements the [DB] interface for type PebbleDB.
 func (pDB *PebbleDB) NewBatch() Batch {
 	return newPebbleDBBatch(pDB)

--- a/internal/storage/pebbledb.go
+++ b/internal/storage/pebbledb.go
@@ -150,8 +150,8 @@ func (pDB *PebbleDB) setWithOpts(
 //
 // It implements the [DB] interface for type PebbleDB.
 func (pDB *PebbleDB) Delete(key []byte) error {
-	wopts := pebble.NoSync
-	if err := pDB.deleteWithOpts(key, wopts); err != nil {
+	writeOpts := pebble.NoSync
+	if err := pDB.deleteWithOpts(key, writeOpts); err != nil {
 		return fmt.Errorf("unsynced delete: %w", err)
 	}
 
@@ -168,8 +168,8 @@ func (pDB *PebbleDB) Delete(key []byte) error {
 //
 // It implements the [DB] interface for type PebbleDB.
 func (pDB PebbleDB) DeleteSync(key []byte) error {
-	wopts := pebble.Sync
-	if err := pDB.deleteWithOpts(key, wopts); err != nil {
+	writeOpts := pebble.Sync
+	if err := pDB.deleteWithOpts(key, writeOpts); err != nil {
 		return fmt.Errorf("synced delete: %w", err)
 	}
 

--- a/internal/storage/pebbledb.go
+++ b/internal/storage/pebbledb.go
@@ -19,7 +19,6 @@ var _ DB = (*PebbleDB)(nil)
 // NewPebbleDB returns a new PebbleDB instance using the default options.
 func NewPebbleDB(name, dir string) (*PebbleDB, error) {
 	opts := &pebble.Options{}
-	opts.EnsureDefaults()
 
 	return NewPebbleDBWithOpts(name, dir, opts)
 }
@@ -195,6 +194,7 @@ func (pDB *PebbleDB) deleteWithOpts(
 }
 
 // Compact compacts the specified range of keys in the database.
+//
 // It implements the [DB] interface for type PebbleDB.
 func (pDB *PebbleDB) Compact(start, end []byte) error {
 	// Currently nil,nil is an invalid range in Pebble.

--- a/internal/storage/pebbledb_test.go
+++ b/internal/storage/pebbledb_test.go
@@ -308,13 +308,17 @@ func TestPrint(t *testing.T) {
 		t.Fatalf("Error creating pipe to capture os.Stdout contents: %s", err)
 	}
 
-	// redirect os.Stdout to print to the writer we just created
+	// store os.Stdout and redirect it to print to the writer we just created
+	stdOut := os.Stdout
 	os.Stdout = w
 
 	if err := pDB.Print(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	w.Close()
+
+	// restore os.Stdout
+	os.Stdout = stdOut
 
 	var buf bytes.Buffer
 	if _, err := io.Copy(&buf, r); err != nil {

--- a/internal/storage/pebbledb_test.go
+++ b/internal/storage/pebbledb_test.go
@@ -1,0 +1,153 @@
+package storage
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+)
+
+const _testDB = "test_db"
+
+func TestGet(t *testing.T) {
+	dbDirPath := t.TempDir()
+
+	pDB, err := NewPebbleDB(_testDB, dbDirPath)
+	if err != nil {
+		t.Fatalf("creating test DB: %s", err)
+	}
+
+	t.Cleanup(func() {
+		pDB.db.Close()
+	})
+
+	t.Run("EmptyKeyErr", func(t *testing.T) {
+		if _, err := pDB.Get(nil); !errors.Is(err, errKeyEmpty) {
+			t.Errorf("expected %s, got: %s", errKeyEmpty, err)
+		}
+	})
+
+	t.Run("KeyNotExistReturnsNil", func(t *testing.T) {
+		val, err := pDB.Get([]byte{'a'})
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if val != nil {
+			t.Errorf("expected nil value, got: %v", val)
+		}
+	})
+
+	t.Run("KeyExistReturnsValue", func(t *testing.T) {
+		var (
+			key = []byte{'a'}
+			val = []byte{'b'}
+		)
+		if err := pDB.db.Set(key, val, pebble.Sync); err != nil {
+			t.Fatalf("writing to test DB: %s", err)
+		}
+
+		gotVal, err := pDB.Get(key)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		if !bytes.Equal(gotVal, val) {
+			t.Errorf("expected value: %s, got: %s", val, gotVal)
+		}
+	})
+}
+
+func TestHas(t *testing.T) {
+	dbDirPath := t.TempDir()
+
+	pDB, err := NewPebbleDB(_testDB, dbDirPath)
+	if err != nil {
+		t.Fatalf("creating test DB: %s", err)
+	}
+
+	t.Cleanup(func() {
+		pDB.db.Close()
+	})
+
+	t.Run("EmptyKeyErr", func(t *testing.T) {
+		if _, err := pDB.Has(nil); !errors.Is(err, errKeyEmpty) {
+			t.Errorf("expected %s, got: %s", errKeyEmpty, err)
+		}
+	})
+
+	t.Run("KeyNotExistReturnsFalse", func(t *testing.T) {
+		hasKey, err := pDB.Has([]byte{'a'})
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if hasKey {
+			t.Error("expected false, but got true")
+		}
+	})
+
+	t.Run("KeyExistReturnsTrue", func(t *testing.T) {
+		var (
+			key = []byte{'a'}
+			val = []byte{'b'}
+		)
+		if err := pDB.db.Set(key, val, pebble.Sync); err != nil {
+			t.Fatalf("writing to test DB: %s", err)
+		}
+
+		hasKey, err := pDB.Has(key)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if !hasKey {
+			t.Error("expected true, but got false")
+		}
+	})
+}
+
+func TestSet(t *testing.T) {
+	dbDirPath := t.TempDir()
+
+	pDB, err := NewPebbleDB(_testDB, dbDirPath)
+	if err != nil {
+		t.Fatalf("creating test DB: %s", err)
+	}
+
+	t.Cleanup(func() {
+		pDB.db.Close()
+	})
+
+	t.Run("EmptyKeyErr", func(t *testing.T) {
+		if err := pDB.Set(nil, nil); !errors.Is(err, errKeyEmpty) {
+			t.Errorf("expected %s, got: %s", errKeyEmpty, err)
+		}
+	})
+
+	t.Run("NilValueErr", func(t *testing.T) {
+		if err := pDB.Set([]byte{'a'}, nil); !errors.Is(err, errValueNil) {
+			t.Errorf("expected %s, got: %s", errValueNil, err)
+		}
+	})
+
+	t.Run("NoErr", func(t *testing.T) {
+		var (
+			key = []byte{'a'}
+			val = []byte{0x01}
+		)
+		if err := pDB.Set(key, val); err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		storedVal, closer, err := pDB.db.Get(key)
+		if err != nil {
+			t.Fatalf("reading from test DB: %s", err)
+		}
+		t.Cleanup(func() {
+			closer.Close()
+		})
+
+		if !bytes.Equal(storedVal, val) {
+			t.Errorf("expected value: %s, got: %s", val, storedVal)
+		}
+	})
+}

--- a/internal/storage/pebbledb_test.go
+++ b/internal/storage/pebbledb_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"bytes"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -328,7 +329,12 @@ func TestPrint(t *testing.T) {
 
 	outputStr := buf.String()
 	for k, v := range kvPairs {
-		wantStr := fmt.Sprintf("[%X]:\t[%X]\n", k, v)
+		var (
+			kStr = strings.ToUpper(hex.EncodeToString([]byte(k)))
+			vStr = strings.ToUpper(hex.EncodeToString([]byte(v)))
+
+			wantStr = "[" + kStr + "]:\t[" + vStr + "]\n"
+		)
 		if !strings.Contains(outputStr, wantStr) {
 			formatStr := "this line was not printed: %q\nfull print: %q"
 			t.Errorf(formatStr, wantStr, outputStr)

--- a/internal/storage/pebbledb_test.go
+++ b/internal/storage/pebbledb_test.go
@@ -32,7 +32,7 @@ func TestGet(t *testing.T) {
 			t.Fatalf("unexpected error: %s", err)
 		}
 		if val != nil {
-			t.Errorf("expected nil value, got: %v", val)
+			t.Errorf("expected nil value, got: %s", val)
 		}
 	})
 
@@ -350,7 +350,7 @@ func newInMemDB() (*PebbleDB, func(), error) {
 	return pDB, closer, nil
 }
 
-// setelper is a utility function supporting TestSet.
+// setHelper is a utility function supporting TestSet.
 func setHelper(pDB *PebbleDB, writeOpts *pebble.WriteOptions) error {
 	var (
 		key = []byte{'a'}

--- a/internal/storage/pebbledb_test.go
+++ b/internal/storage/pebbledb_test.go
@@ -128,25 +128,13 @@ func TestSet(t *testing.T) {
 		noSync = pebble.NoSync
 	)
 	t.Run("EmptyKeyErr", func(t *testing.T) {
-		// called by Set
 		if err := pDB.setWithOpts(nil, nil, noSync); !errors.Is(err, errKeyEmpty) {
 			t.Errorf("non-sync write: expected %s, got: %s", errKeyEmpty, err)
-		}
-
-		// called by SetSync
-		if err := pDB.setWithOpts(nil, nil, sync); !errors.Is(err, errKeyEmpty) {
-			t.Errorf("sync write: expected %s, got: %s", errKeyEmpty, err)
 		}
 	})
 
 	t.Run("NilValueErr", func(t *testing.T) {
 		key := []byte{'a'}
-
-		// called by Set
-		if err := pDB.setWithOpts(key, nil, noSync); !errors.Is(err, errValueNil) {
-			t.Errorf("non-sync write: expected %s, got: %s", errValueNil, err)
-		}
-
 		// called by SetSync
 		if err := pDB.setWithOpts(key, nil, sync); !errors.Is(err, errValueNil) {
 			t.Errorf("sync write: expected %s, got: %s", errValueNil, err)

--- a/internal/storage/pebbledb_test.go
+++ b/internal/storage/pebbledb_test.go
@@ -105,6 +105,12 @@ func TestHas(t *testing.T) {
 	})
 }
 
+// Rather than having two almost identical Test* functions testing *PebbleDB.Set and
+// *PebbleDB.SetSync, we have one test function that calls *PebbleDB.setWithOpts
+// once with pebble.NoSync and once with pebble.Sync.
+// This should be sufficient to test the Set and SetSync methods, because under the
+// hood they only differ in that they call setWithOpts with pebble.NoSync and
+// pebble.Sync respectively.
 func TestSet(t *testing.T) {
 	dbDirPath := t.TempDir()
 
@@ -117,37 +123,69 @@ func TestSet(t *testing.T) {
 		pDB.db.Close()
 	})
 
+	var (
+		sync   = pebble.Sync
+		noSync = pebble.NoSync
+	)
 	t.Run("EmptyKeyErr", func(t *testing.T) {
-		if err := pDB.Set(nil, nil); !errors.Is(err, errKeyEmpty) {
-			t.Errorf("expected %s, got: %s", errKeyEmpty, err)
+		// called by Set
+		if err := pDB.setWithOpts(nil, nil, noSync); !errors.Is(err, errKeyEmpty) {
+			t.Errorf("non-sync write: expected %s, got: %s", errKeyEmpty, err)
+		}
+
+		// called by SetSync
+		if err := pDB.setWithOpts(nil, nil, sync); !errors.Is(err, errKeyEmpty) {
+			t.Errorf("sync write: expected %s, got: %s", errKeyEmpty, err)
 		}
 	})
 
 	t.Run("NilValueErr", func(t *testing.T) {
-		if err := pDB.Set([]byte{'a'}, nil); !errors.Is(err, errValueNil) {
-			t.Errorf("expected %s, got: %s", errValueNil, err)
+		key := []byte{'a'}
+
+		// called by Set
+		if err := pDB.setWithOpts(key, nil, noSync); !errors.Is(err, errValueNil) {
+			t.Errorf("non-sync write: expected %s, got: %s", errValueNil, err)
+		}
+
+		// called by SetSync
+		if err := pDB.setWithOpts(key, nil, sync); !errors.Is(err, errValueNil) {
+			t.Errorf("sync write: expected %s, got: %s", errValueNil, err)
 		}
 	})
 
 	t.Run("NoErr", func(t *testing.T) {
+		// called by Set
 		var (
 			key = []byte{'a'}
 			val = []byte{0x01}
 		)
-		if err := pDB.Set(key, val); err != nil {
-			t.Fatalf("unexpected error: %s", err)
+		if err := pDB.setWithOpts(key, val, noSync); err != nil {
+			t.Fatalf("non-sync write: unexpected error: %s", err)
 		}
 
 		storedVal, closer, err := pDB.db.Get(key)
 		if err != nil {
 			t.Fatalf("reading from test DB: %s", err)
 		}
-		t.Cleanup(func() {
-			closer.Close()
-		})
-
 		if !bytes.Equal(storedVal, val) {
-			t.Errorf("expected value: %s, got: %s", val, storedVal)
+			t.Fatalf("expected value: %s, got: %s", val, storedVal)
 		}
+		closer.Close()
+
+		// called by SetSync
+		// By changing the value, we also tests overwriting.
+		val = []byte{0x02}
+		if err := pDB.setWithOpts(key, val, sync); err != nil {
+			t.Fatalf("sync write: unexpected error: %s", err)
+		}
+
+		storedVal, closer, err = pDB.db.Get(key)
+		if err != nil {
+			t.Fatalf("reading from test DB: %s", err)
+		}
+		if !bytes.Equal(storedVal, val) {
+			t.Fatalf("expected value: %s, got: %s", val, storedVal)
+		}
+		closer.Close()
 	})
 }


### PR DESCRIPTION
Partially addresses #4486.

### Context
CometBFT will stop importing [cometbft-db](https://github.com/cometbft/cometbft-db) as a dependency to support multiple database backends. Instead, it will use [pebble](https://github.com/cockroachdb/pebble) by default.

### Changes
This PR adds unit tests to the pebble implementation of the `DB` interface that CometBFT will use once we remove cometbft-db.

---

#### PR checklist

- [x] Tests written/updated
- ~[ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)~
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
