### PR TITLE
feat(storage): Add unit tests for pebble implementation of `Iterator` interface.

### DIFF
--- a/internal/storage/pebbledb.go
+++ b/internal/storage/pebbledb.go
@@ -511,12 +511,6 @@ func newPebbleDBIterator(
 	start, end []byte,
 	isReverse bool,
 ) *pebbleDBIterator {
-	if isReverse && end == nil {
-		source.Last()
-	} else if !isReverse && start == nil {
-		source.First()
-	}
-
 	return &pebbleDBIterator{
 		source:    source,
 		start:     start,

--- a/internal/storage/pebbledb.go
+++ b/internal/storage/pebbledb.go
@@ -493,11 +493,11 @@ func newPebbleDBIterator(
 	isReverse bool,
 ) (*pebbleDBIterator, error) {
 	if start != nil && len(start) == 0 {
-		return nil, fmt.Errorf("iterator's lower bound: %s", errKeyEmpty)
+		return nil, fmt.Errorf("iterator's lower bound: %w", errKeyEmpty)
 	}
 
 	if end != nil && len(end) == 0 {
-		return nil, fmt.Errorf("iterator's upper bound: %s", errKeyEmpty)
+		return nil, fmt.Errorf("iterator's upper bound: %w", errKeyEmpty)
 	}
 
 	o := pebble.IterOptions{
@@ -506,7 +506,7 @@ func newPebbleDBIterator(
 	}
 	it, err := pDB.db.NewIter(&o)
 	if err != nil {
-		formatStr := "creating iterator with bounds [%X, %X]: %w"
+		formatStr := "iterator with bounds [%X, %X]: %w"
 		return nil, fmt.Errorf(formatStr, start, end, err)
 	}
 

--- a/internal/storage/pebbledb.go
+++ b/internal/storage/pebbledb.go
@@ -492,8 +492,12 @@ func newPebbleDBIterator(
 	start, end []byte,
 	isReverse bool,
 ) (*pebbleDBIterator, error) {
-	if (start != nil && len(start) == 0) || (end != nil && len(end) == 0) {
-		return nil, errKeyEmpty
+	if start != nil && len(start) == 0 {
+		return nil, fmt.Errorf("iterator's lower bound: %s", errKeyEmpty)
+	}
+
+	if end != nil && len(end) == 0 {
+		return nil, fmt.Errorf("iterator's upper bound: %s", errKeyEmpty)
 	}
 
 	o := pebble.IterOptions{

--- a/internal/storage/pebbledb_test.go
+++ b/internal/storage/pebbledb_test.go
@@ -537,14 +537,14 @@ func TestNewPebbleDBIterator(t *testing.T) {
 	t.Run("EmptyStartErr", func(t *testing.T) {
 		_, err := newPebbleDBIterator(nil, emptyKey, nil, false)
 		if !errors.Is(err, errKeyEmpty) {
-			t.Errorf("exptected error: %s\n got: %s", errKeyEmpty, err)
+			t.Errorf("expected error: %s\n got: %s", errKeyEmpty, err)
 		}
 	})
 
 	t.Run("EmptyEndErr", func(t *testing.T) {
 		_, err := newPebbleDBIterator(nil, nil, emptyKey, false)
 		if !errors.Is(err, errKeyEmpty) {
-			t.Errorf("exptected error: %s\n got: %s", errKeyEmpty, err)
+			t.Errorf("expected error: %s\n got: %s", errKeyEmpty, err)
 		}
 	})
 


### PR DESCRIPTION
Partially addresses #4486.

### Context
CometBFT will stop importing [cometbft-db](https://github.com/cometbft/cometbft-db) as a dependency to support multiple database backends. Instead, it will use [pebble](https://github.com/cockroachdb/pebble) by default.

### Changes
This PR adds unit tests to the pebble implementation of the `Iterator` interface that CometBFT will use once we remove cometbft-db.

---

#### PR checklist

- [ ] Tests written/updated
- ~[ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)~
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
