### PR TITLE
refactor(mempool): give reason why tx is invalid

### DIFF
--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -422,7 +422,7 @@ func (mem *CListMempool) handleCheckTxResponse(tx types.Tx, sender nodekey.ID) f
 				return postCheckErr
 			}
 
-			return fmt.Errorf("%s: %w", res.Log, ErrInvalidTx)
+			return fmt.Errorf("%w: %s", ErrInvalidTx, res.Log)
 		}
 
 		// If the app returned a non-empty lane, use it; otherwise use the default lane.
@@ -649,7 +649,7 @@ func (mem *CListMempool) handleRecheckTxResponse(tx types.Tx) func(res *abci.Res
 				return postCheckErr
 			}
 
-			return fmt.Errorf("%s: %w", res.Log, ErrInvalidTx)
+			return fmt.Errorf("%w: %s", ErrInvalidTx, res.Log)
 		}
 
 		return nil

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -421,7 +421,8 @@ func (mem *CListMempool) handleCheckTxResponse(tx types.Tx, sender nodekey.ID) f
 			if postCheckErr != nil {
 				return postCheckErr
 			}
-			return ErrInvalidTx
+
+			return fmt.Errorf("%s: %w", res.Log, ErrInvalidTx)
 		}
 
 		// If the app returned a non-empty lane, use it; otherwise use the default lane.
@@ -647,7 +648,8 @@ func (mem *CListMempool) handleRecheckTxResponse(tx types.Tx) func(res *abci.Res
 			if postCheckErr != nil {
 				return postCheckErr
 			}
-			return ErrInvalidTx
+
+			return fmt.Errorf("%s: %w", res.Log, ErrInvalidTx)
 		}
 
 		return nil


### PR DESCRIPTION
Gives back more info to the client when a tx is invalid. (due to changes in https://github.com/cometbft/cometbft/pull/4040)
Right now it is only debug logged on the node, which is not so useful for the client to understand what's up.

Additionally, I am not even sure if returning an error here instead of the response is great.
This is a client breaking changes. Before the tx would go through but the ABCI response would be non-zero (15 - no signature supplied).

```yaml
code: 15
codespace: sdk
data: ""
events: []
gas_used: "0"
gas_wanted: "0"
height: "0"
info: ""
logs: []
raw_log: 'empty signatures: no signatures supplied'
timestamp: ""
tx: null
txhash: 7F704013E8B09D4FF382EE8B67D37B5B3CD777E610A765437E07F309EACA5738
```

Now it fails earlier with with an rpc error:

```bash
error in json rpc client, with http response metadata: (Status: 200 OK, Protocol HTTP/1.1). RPC error -32603 - Internal error: broadcast error on transaction validation: tx is invalid
```

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
