### PR TITLE
fix(mempool): Extend `ErrInvalidTx` with `CheckTxResponse` info

### DIFF
--- a/.changelog/unreleased/breaking-changes/4550-mempool-err-invalid-tx.md
+++ b/.changelog/unreleased/breaking-changes/4550-mempool-err-invalid-tx.md
@@ -1,0 +1,2 @@
+- `[mempool]` Extend `ErrInvalidTx` with new fields taken from `CheckTxResponse`
+  ([\#4550](https://github.com/cometbft/cometbft/pull/4550)).

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -421,7 +421,7 @@ func (mem *CListMempool) handleCheckTxResponse(tx types.Tx, sender nodekey.ID) f
 			if postCheckErr != nil {
 				return postCheckErr
 			}
-			return ErrInvalidTx
+			return ErrInvalidTx{Code: res.Code, Data: res.Data, Log: res.Log, Codespace: res.Codespace, Hash: tx.Hash()}
 		}
 
 		// If the app returned a non-empty lane, use it; otherwise use the default lane.
@@ -647,7 +647,7 @@ func (mem *CListMempool) handleRecheckTxResponse(tx types.Tx) func(res *abci.Res
 			if postCheckErr != nil {
 				return postCheckErr
 			}
-			return ErrInvalidTx
+			return ErrInvalidTx{Code: res.Code, Data: res.Data, Log: res.Log, Codespace: res.Codespace, Hash: tx.Hash()}
 		}
 
 		return nil

--- a/mempool/errors.go
+++ b/mempool/errors.go
@@ -11,10 +11,6 @@ var ErrTxNotFound = errors.New("transaction not found in mempool")
 // ErrTxInCache is returned to the client if we saw tx earlier.
 var ErrTxInCache = errors.New("tx already exists in cache")
 
-// ErrInvalidTx is returned when a transaction that is trying to be added to the
-// mempool is invalid.
-var ErrInvalidTx = errors.New("tx is invalid")
-
 // ErrTxInMempool is returned when a transaction that is trying to be added to
 // the mempool is already there.
 var ErrTxInMempool = errors.New("transaction already in mempool, not adding it again")
@@ -30,6 +26,27 @@ var ErrLateRecheckResponse = errors.New("rechecking has finished; discard late r
 // ErrRecheckFull is returned when checking if the mempool is full and
 // rechecking is still in progress after a new block was committed.
 var ErrRecheckFull = errors.New("mempool is still rechecking after a new committed block, so it is considered as full")
+
+// ErrInvalidTx is returned when a transaction that is trying to be added to the
+// mempool is invalid.
+type ErrInvalidTx struct {
+	Code      uint32
+	Data      []byte
+	Log       string
+	Codespace string
+	Hash      []byte
+}
+
+func (e ErrInvalidTx) Error() string {
+	return fmt.Sprintf(
+		"tx %X is invalid: code=%d, data=%X, log='%s', codespace='%s'",
+		e.Hash,
+		e.Code,
+		e.Data,
+		e.Log,
+		e.Codespace,
+	)
+}
 
 // ErrTxTooLarge defines an error when a transaction is too big to be sent in a
 // message to other peers.


### PR DESCRIPTION
When calling the RPC endpoints `broadcast_tx_*`, the mempool returns a `reqRes` object with a potential error. Before #4040, `reqRes` didn't have an error. An error on the ABCI CheckTx call would be returned encoded in the fields Code, Log, etc, of `ResultBroadcastTx`. Any other internal error of the mempool would be discarded.

The problem is that now when the transaction is invalid, `broadcast_tx_*` return `ErrTxBroadcast{Source: ErrCheckTxFailed, ErrReason: err}` where `err`  is simply `ErrInvalidTx`, without any other information. This PR adds all the fields in `ResultBroadcastTx` (Code, Data, Log, Codespace, and Hash) to `ErrInvalidTx`, so that this information is available gain to the `broadcast_tx_*` caller.

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
