### PR TITLE
fix(e2e): application logger does not use colors

### DIFF
--- a/test/e2e/app/app.go
+++ b/test/e2e/app/app.go
@@ -191,7 +191,7 @@ func NewApplication(cfg *Config) (*Application, error) {
 	for keyType := range cmttypes.ABCIPubKeyTypesToNames {
 		allKeyTypes = append(allKeyTypes, keyType)
 	}
-	logger := log.NewLogger(os.Stdout)
+	logger := log.NewLoggerWithColor(os.Stdout, false)
 	logger.Info("Application started!")
 	if cfg.NoLanes {
 		return &Application{

--- a/test/e2e/app/app.go
+++ b/test/e2e/app/app.go
@@ -156,6 +156,9 @@ type Config struct {
 	// * An existing validator will be chosen, and its power will alternate 0 and 1
 	// * `ConsensusParams` will be flipping on and off key types not set at genesis
 	ConstantFlip bool `toml:"constant_flip"`
+
+	// Colored log output.
+	LogColors bool `toml:"log_colors"`
 }
 
 func DefaultConfig(dir string) *Config {
@@ -191,7 +194,7 @@ func NewApplication(cfg *Config) (*Application, error) {
 	for keyType := range cmttypes.ABCIPubKeyTypesToNames {
 		allKeyTypes = append(allKeyTypes, keyType)
 	}
-	logger := log.NewLoggerWithColor(os.Stdout, false)
+	logger := log.NewLoggerWithColor(os.Stdout, cfg.LogColors)
 	logger.Info("Application started!")
 	if cfg.NoLanes {
 		return &Application{


### PR DESCRIPTION
Follow-up of #4475.

The e2e application by default produces a colorized output. This should not be the case for the same reasons explained in https://github.com/cometbft/cometbft/issues/4452.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
