### PR TITLE
feat(e2e): for loading with num-nodes-per-tx, use one channel per node

### DIFF
--- a/test/e2e/pkg/manifest.go
+++ b/test/e2e/pkg/manifest.go
@@ -88,7 +88,7 @@ type Manifest struct {
 	LoadTxConnections int `toml:"load_tx_connections"`
 	LoadMaxSeconds    int `toml:"load_max_seconds"`
 	LoadMaxTxs        int `toml:"load_max_txs"`
-	LoadDuplicateTxs  int `toml:"load_duplicate_txs"`
+	LoadNumNodesPerTx int `toml:"load_num_nodes_per_tx"`
 
 	// Weight for each lane defined by the app. The transaction loader will
 	// assign lanes to generated transactions proportionally to their weights.

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -181,6 +181,9 @@ func NewTestnetFromManifest(manifest Manifest, file string, ifd InfrastructureDa
 	if testnet.LoadTxSizeBytes == 0 {
 		testnet.LoadTxSizeBytes = defaultTxSizeBytes
 	}
+	if testnet.LoadNumNodesPerTx == 0 {
+		testnet.LoadNumNodesPerTx = 1
+	}
 
 	if len(testnet.Lanes) == 0 {
 		testnet.Lanes = app.DefaultLanes()
@@ -502,7 +505,7 @@ func (t Testnet) Validate() error {
 			return err
 		}
 	}
-	if t.LoadDuplicateTxs > len(t.Nodes) {
+	if t.LoadNumNodesPerTx > len(t.Nodes) {
 		return errors.New("value must be less or equal to the number of nodes in the manifest")
 	}
 	return nil

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -508,6 +508,9 @@ func (t Testnet) Validate() error {
 	if t.LoadNumNodesPerTx > len(t.Nodes) {
 		return errors.New("value must be less or equal to the number of nodes in the manifest")
 	}
+	if len(t.LoadTargetNodes) > 0 && t.LoadNumNodesPerTx > len(t.LoadTargetNodes) {
+		return errors.New("value must be less or equal to the number of target nodes")
+	}
 	return nil
 }
 

--- a/test/e2e/runner/main.go
+++ b/test/e2e/runner/main.go
@@ -272,10 +272,10 @@ func NewCLI() *CLI {
 			} else if len(loadTargetNodes) > 0 {
 				cli.testnet.LoadTargetNodes = loadTargetNodes
 			}
-			if duplicateTxsToN, err := cmd.Flags().GetInt("num-nodes-per-tx"); err != nil {
+			if numNodesPerTx, err := cmd.Flags().GetInt("num-nodes-per-tx"); err != nil {
 				return err
-			} else if duplicateTxsToN > 0 {
-				cli.testnet.LoadDuplicateTxs = duplicateTxsToN
+			} else if numNodesPerTx > 0 {
+				cli.testnet.LoadNumNodesPerTx = numNodesPerTx
 			}
 			if err = cli.testnet.Validate(); err != nil {
 				return err


### PR DESCRIPTION
Solves #4430

by fixing #4513

This solution creates multiple transaction channels, one per node in the testnet. On each transaction generated, it will send the transaction to  `LoadNumNodesPerTx` random channels.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
