### PR TITLE
build(deps): Mock generation no longer uses the `latest` tag on `mockery`.

### DIFF
--- a/.changelog/unreleased/dependencies/4605-fix-mockery-version.md
+++ b/.changelog/unreleased/dependencies/4605-fix-mockery-version.md
@@ -1,0 +1,3 @@
+- pinned mockery's version to v2.49.2 to prevent potential
+  changes in mocks after each new release of mockery
+  ([\#4605](https://github.com/cometbft/cometbft/pull/4605))

--- a/scripts/mockery_generate.sh
+++ b/scripts/mockery_generate.sh
@@ -2,5 +2,4 @@
 #
 # Invoke Mockery v2 to update generated mocks for the given type.
 
-go run github.com/vektra/mockery/v2@latest --disable-version-string --case underscore --name "$*"
-
+go run github.com/vektra/mockery/v2@v2.49.2 --disable-version-string --case underscore --name "$*"


### PR DESCRIPTION
### Context
Using `latest` for `mockery` causes changes in the mocks with almost every new release, which in turn makes our CI fail. By fixing `mockery`'s version, we can prevent this issue. Additionally, `mockery`'s documentation suggests not to use `latest` anyway, so we were doing it incorrectly from the start.

### Changes
This PR pins the `mockery` version to `v2.49.2` (the latest release). The `main` branch already uses mocks generated with this version, so using any other version of `mockery` would alter the mocks again. At least we get the benefit from the latest bug fixes.

---

#### PR checklist

- ~[ ] Tests written/updated~
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- ~[ ] Updated relevant documentation (`docs/` or `spec/`) and code comments~
