### PR TITLE
chore(node): `Node` no longer uses a singleton to create an `rpc.Environment`

### DIFF
--- a/.changelog/unreleased/improvements/4639-remove-sync-once.md
+++ b/.changelog/unreleased/improvements/4639-remove-sync-once.md
@@ -1,0 +1,2 @@
+- `[node]` `Node` no longer uses a singleton to create an `rpccore.Environment`
+  ([\#4639](https://github.com/cometbft/cometbft/pull/4639))

--- a/node/node.go
+++ b/node/node.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -730,72 +729,46 @@ func (n *Node) OnStop() {
 	}
 }
 
-var (
-	// The following globals are only relevant to the `ConfigurerRPC` method below.
-	// The '_' prefix is to signal to other parts of the code that these are global
-	// unexported variables.
-
-	// _once is a special object that executes a function only once. We use it to
-	// ensure that `ConfigureRPC` initializes an `Environment` object only once.
-	_once sync.Once
-
-	// _rpcEnv is the `Environment` object serving RPC APIs. We treat it as a
-	// singleton and create it exactly once. See the docs of `ConfigureRPC` below
-	// for more details.
-	_rpcEnv *rpccore.Environment
-)
-
 // ConfigureRPC initializes and returns an `Environment` object with all the data
-// it needs to serve the RPC APIs. The function ensures that the `Environment` is
-// created only once to prevent other parts of the code from creating duplicate
-// `Environment` instances by calling this function directly. This is important
-// because `Environment` stores a copy of the genesis in memory; therefore,
-// multiple independent `Environment` instances would each load the genesis into
-// memory.
+// it needs to serve the RPC APIs.
 func (n *Node) ConfigureRPC() (*rpccore.Environment, error) {
-	var errToReturn error
+	pubKey, err := n.privValidator.GetPubKey()
+	if pubKey == nil || err != nil {
+		return nil, ErrGetPubKey{Err: err}
+	}
 
-	_once.Do(func() {
-		pubKey, err := n.privValidator.GetPubKey()
-		if pubKey == nil || err != nil {
-			errToReturn = ErrGetPubKey{Err: err}
-			return
-		}
+	rpcEnv := &rpccore.Environment{
+		ProxyAppQuery:   n.proxyApp.Query(),
+		ProxyAppMempool: n.proxyApp.Mempool(),
 
-		_rpcEnv = &rpccore.Environment{
-			ProxyAppQuery:   n.proxyApp.Query(),
-			ProxyAppMempool: n.proxyApp.Mempool(),
+		StateStore:     n.stateStore,
+		BlockStore:     n.blockStore,
+		EvidencePool:   n.evidencePool,
+		ConsensusState: n.consensusState,
+		P2PPeers:       n.sw,
+		P2PTransport:   n,
+		PubKey:         pubKey,
 
-			StateStore:     n.stateStore,
-			BlockStore:     n.blockStore,
-			EvidencePool:   n.evidencePool,
-			ConsensusState: n.consensusState,
-			P2PPeers:       n.sw,
-			P2PTransport:   n,
-			PubKey:         pubKey,
+		TxIndexer:        n.txIndexer,
+		BlockIndexer:     n.blockIndexer,
+		ConsensusReactor: n.consensusReactor,
+		MempoolReactor:   n.mempoolReactor,
+		EventBus:         n.eventBus,
+		Mempool:          n.mempool,
 
-			TxIndexer:        n.txIndexer,
-			BlockIndexer:     n.blockIndexer,
-			ConsensusReactor: n.consensusReactor,
-			MempoolReactor:   n.mempoolReactor,
-			EventBus:         n.eventBus,
-			Mempool:          n.mempool,
+		Logger: n.Logger.With("module", "rpc"),
 
-			Logger: n.Logger.With("module", "rpc"),
+		Config: *n.config.RPC,
 
-			Config: *n.config.RPC,
+		GenesisFilePath: n.config.GenesisFile(),
+	}
 
-			GenesisFilePath: n.config.GenesisFile(),
-		}
+	n.Logger.Info("Creating genesis file chunks if genesis file is too big...")
+	if err := rpcEnv.InitGenesisChunks(); err != nil {
+		return nil, fmt.Errorf("configuring RPC API environment: %w", err)
+	}
 
-		n.Logger.Info("Creating genesis file chunks if genesis file is too big...")
-		if err := _rpcEnv.InitGenesisChunks(); err != nil {
-			errToReturn = fmt.Errorf("configuring RPC API environment: %w", err)
-			return
-		}
-	})
-
-	return _rpcEnv, errToReturn
+	return rpcEnv, nil
 }
 
 func (n *Node) startRPC() ([]net.Listener, error) {


### PR DESCRIPTION
### Context
Because `rpc.Environment` does not store a `GenesisDoc` in memory anymore, (see #1290), we don't need to create it as a singleton. The risk of storing multiple copies of the genesis in memory isn't there anymore, because we now load it from disk.

### This Change
This PR removes the `sync.Once` construct that we put in place.

### Additional Note
The change also ensures that [`TestProvider`](https://github.com/cometbft/cometbft/blob/b16c6fc2c8b2fc5a468fead32a8fe9057d6cce2f/light/provider/http/http_test.go#L36) in the `light/provider/http` package behaves as expected. In `main`, this test passes because it's set up using a [`MemDB`](https://github.com/cometbft/cometbft-db/blob/4cf60c715fe8daccb9dce3b24295575bd461d5d8/memdb.go#L52), which is a dummy in-memory store rather than a real database. Thus, database `Get` operations always succeed.

However, in the context of the [work to remove cometbft-db](https://github.com/cometbft/cometbft/pull/4601), we now use a "real" database, i.e., one that a `Node` closes when it shuts down. Since the `Environment` object was treated as a singleton, each iteration of `TestProvider` created a new `Node` using the same underlying database. This database would be closed at the end of the first iteration when that iteration's `Node` shut down. Subsequent iterations then attempted to call `Get` on a closed database, causing a panic.

This change fixes that issue.

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- ~[ ] Updated relevant documentation (`docs/` or `spec/`) and code comments~
