### PR TITLE
fix(store): `TxIndexer` no longer leaks its database's goroutines.

### DIFF
--- a/internal/inspect/inspect_test.go
+++ b/internal/inspect/inspect_test.go
@@ -31,9 +31,12 @@ func TestInspectConstructor(t *testing.T) {
 	t.Cleanup(leaktest.Check(t))
 	defer func() { _ = os.RemoveAll(cfg.RootDir) }()
 	t.Run("from config", func(t *testing.T) {
-		d, err := inspect.NewFromConfig(cfg)
+		i, err := inspect.NewFromConfig(cfg)
 		require.NoError(t, err)
-		require.NotNil(t, d)
+		require.NotNil(t, i)
+
+		err = i.Close()
+		require.NoError(t, err)
 	})
 }
 
@@ -44,7 +47,9 @@ func TestInspectRun(t *testing.T) {
 	t.Run("from config", func(t *testing.T) {
 		d, err := inspect.NewFromConfig(cfg)
 		require.NoError(t, err)
+
 		ctx, cancel := context.WithCancel(context.Background())
+
 		stoppedWG := &sync.WaitGroup{}
 		stoppedWG.Add(1)
 		go func() {

--- a/state/indexer/sink/psql/backport.go
+++ b/state/indexer/sink/psql/backport.go
@@ -70,6 +70,10 @@ func (BackportTxIndexer) Search(context.Context, *query.Query, txindex.Paginatio
 
 func (BackportTxIndexer) SetLogger(log.Logger) {}
 
+func (b BackportTxIndexer) Close() error {
+	return b.psql.Stop()
+}
+
 // BlockIndexer returns a bridge that implements the CometBFT v0.34 block
 // indexer interface, using the Postgres event sink as a backing store.
 func (es *EventSink) BlockIndexer() BackportBlockIndexer {

--- a/state/txindex/indexer.go
+++ b/state/txindex/indexer.go
@@ -36,6 +36,11 @@ type TxIndexer interface {
 	GetRetainHeight() (int64, error)
 
 	SetRetainHeight(retainHeight int64) error
+
+	// Close closes the underlying database that a TxIndexer uses. It is the
+	// responsibility of the creator of the TxIndexer to call Close when done with
+	// it.
+	Close() error
 }
 
 // Batch groups together multiple Index operations to be performed at the same time.

--- a/state/txindex/indexer_service.go
+++ b/state/txindex/indexer_service.go
@@ -128,4 +128,6 @@ func (is *IndexerService) OnStop() {
 	if is.eventBus.IsRunning() {
 		_ = is.eventBus.UnsubscribeAll(context.Background(), subscriber)
 	}
+
+	is.txIdxr.Close()
 }

--- a/state/txindex/kv/kv.go
+++ b/state/txindex/kv/kv.go
@@ -61,6 +61,13 @@ func WithCompaction(compact bool, compactionInterval int64) IndexerOption {
 	}
 }
 
+func (txi *TxIndex) Close() error {
+	if err := txi.store.Close(); err != nil {
+		return fmt.Errorf("closing transaction index: %w", err)
+	}
+	return nil
+}
+
 func (txi *TxIndex) Prune(retainHeight int64) (numPruned int64, newRetainHeight int64, err error) {
 	// Returns numPruned, newRetainHeight, err
 	// numPruned: the number of heights pruned. E.x. if heights {1, 3, 7} were pruned, numPruned == 3

--- a/state/txindex/mocks/tx_indexer.go
+++ b/state/txindex/mocks/tx_indexer.go
@@ -38,6 +38,24 @@ func (_m *TxIndexer) AddBatch(b *txindex.Batch) error {
 	return r0
 }
 
+// Close provides a mock function with no fields
+func (_m *TxIndexer) Close() error {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Close")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Get provides a mock function with given fields: hash
 func (_m *TxIndexer) Get(hash []byte) (*v1.TxResult, error) {
 	ret := _m.Called(hash)

--- a/state/txindex/null/null.go
+++ b/state/txindex/null/null.go
@@ -48,3 +48,7 @@ func (*TxIndex) Search(_ context.Context, _ *query.Query, _ txindex.Pagination) 
 
 func (*TxIndex) SetLogger(log.Logger) {
 }
+
+func (*TxIndex) Close() error {
+	return nil
+}


### PR DESCRIPTION
---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
