### PR TITLE
fix(p2p/pex): do not send PEX request in fast dial mode

### DIFF
--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -410,7 +410,7 @@ func (r *Reactor) ensurePeersRoutine() {
 
 	// fire once immediately.
 	// ensures we dial the seeds right away if the book is empty
-	r.ensurePeers()
+	r.ensurePeers(true)
 
 	// fire periodically
 	ticker := time.NewTicker(r.ensurePeersPeriod)
@@ -418,9 +418,9 @@ func (r *Reactor) ensurePeersRoutine() {
 	for {
 		select {
 		case <-ticker.C:
-			r.ensurePeers()
+			r.ensurePeers(true)
 		case <-r.ensurePeersCh:
-			r.ensurePeers()
+			r.ensurePeers(false)
 		case <-r.book.Quit():
 			return
 		case <-r.Quit():
@@ -434,7 +434,7 @@ func (r *Reactor) ensurePeersRoutine() {
 // heuristic that we haven't perfected yet, or, perhaps is manually edited by
 // the node operator. It should not be used to compute what addresses are
 // already connected or not.
-func (r *Reactor) ensurePeers() {
+func (r *Reactor) ensurePeers(ensurePeersPeriodElapsed bool) {
 	var (
 		out, in, dial = r.Switch.NumPeers()
 		numToDial     = r.Switch.MaxNumOutboundPeers() - (out + dial)
@@ -504,7 +504,7 @@ func (r *Reactor) ensurePeers() {
 	if r.book.NeedMoreAddrs() {
 		// 1) Pick a random peer and ask for more.
 		peer := r.Switch.Peers().Random()
-		if peer != nil {
+		if peer != nil && ensurePeersPeriodElapsed {
 			r.Logger.Info("We need more addresses. Sending pexRequest to random peer", "peer", peer)
 			r.RequestAddrs(peer)
 		}


### PR DESCRIPTION
Solves #4620.

Fixes an issue introduced by https://github.com/cometbft/cometbft/pull/3360.

In short, when receiving addresses from a configured seed node, the peer immediately dials the received addresses, without waiting for the `defaultEnsurePeersPeriod` (30s). This is a desired behavior, the "fast dial mode" in the title.

However, for preventing abuse, a node only accepts PEX requests from a peer every `minReceiveRequestInterval()` time, set to `defaultEnsurePeersPeriod/3` (10s). When running this "fast dial mode", however, a PEX request can be send, in some unlucky setup, to the same peer without waiting for the full defaultEnsurePeersPeriod` (30s).

The problem is that at the receive side, a node keeps track of the latest PEX request received from each peer. If two requests are received with an interval lower than `minReceiveRequestInterval()`, the peer is considered abusive: it is disconnected with an `ErrReceivedPEXRequestTooSoon` error and banned from the address book.

This PR proposes a workaround to prevent the above mentioned scenario.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments