### PR TITLE
fix(mempool): Decreased the sleep in `TestDOGDisabledRoutes`

### DIFF
--- a/mempool/reactor_test.go
+++ b/mempool/reactor_test.go
@@ -787,7 +787,7 @@ func TestDOGDisabledRoute(t *testing.T) {
 	reactors[0].redundancyControl.triggerAdjustment(reactors[0])
 	// Wait for the redundancy adjustment to kick in
 	// If the test starts failing, revisit this value
-	time.Sleep(100 * time.Second)
+	time.Sleep(100 * time.Millisecond)
 
 	reactors[2].router.mtx.RLock()
 	// Make sure that Node 3 has at least one disabled route


### PR DESCRIPTION
A mistake in the tests got merged with the  PR merging the DOG protocol into main. 

`TestDOGDisabledRoutes` was put asleep for 100s instead of 100ms. 

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
