### PR TITLE
build(deps): Remove cometbft-db from cometbft build.

### DIFF
--- a/.changelog/unreleased/dependencies/4650-update-build-process.md
+++ b/.changelog/unreleased/dependencies/4650-update-build-process.md
@@ -1,0 +1,2 @@
+- cometbft no longer uses cometbft-db in its Dockerfiles, Makefiles, CI
+  ([\#4650](https://github.com/cometbft/cometbft/pull/4650))

--- a/.changelog/unreleased/dependencies/4650-update-build-process.md
+++ b/.changelog/unreleased/dependencies/4650-update-build-process.md
@@ -1,2 +1,0 @@
-- cometbft no longer uses cometbft-db in its Dockerfiles, Makefiles, CI
-  ([\#4650](https://github.com/cometbft/cometbft/pull/4650))

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -74,7 +74,7 @@ linters-settings:
       - default # Default section: contains all imports that could not be matched to another section type.
       - blank # blank imports
       - dot # dot imports
-      - prefix(github.com/cometbft/cometbft, github.com/cometbft/cometbft-db, github.com/cometbft/cometbft-load-test)
+      - prefix(github.com/cometbft/cometbft, github.com/cometbft/cometbft-load-test)
     custom-order: true
   depguard:
     rules:

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -1,4 +1,4 @@
-COMETBFT_BUILD_OPTIONS += badgerdb,rocksdb,clock_skew,bls12381
+COMETBFT_BUILD_OPTIONS += clock_skew,bls12381
 IMAGE_TAG=cometbft/e2e-node:local-version
 
 include ../../common.mk

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -1,7 +1,7 @@
-# We need to build in a Linux environment to support C libraries, e.g. RocksDB.
+# We need to build in a Linux environment to support C libraries.
 # We use Debian instead of Alpine, so that we can use binary database packages
 # instead of spending time compiling them.
-FROM cometbft/cometbft-db-testing:v1.0.1
+FROM golang:1.23.1
 
 RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
 
@@ -9,7 +9,7 @@ RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
 RUN apt-get -qq install -y iputils-ping iproute2 >/dev/null
 
 # Set up build directory /src/cometbft
-ENV COMETBFT_BUILD_OPTIONS badgerdb,rocksdb,clock_skew,bls12381
+ENV COMETBFT_BUILD_OPTIONS clock_skew,bls12381
 WORKDIR /src/cometbft
 
 # Fetch dependencies separately (for layer caching)

--- a/test/e2e/docker/Dockerfile.debug
+++ b/test/e2e/docker/Dockerfile.debug
@@ -1,14 +1,14 @@
-# We need to build in a Linux environment to support C libraries, e.g. RocksDB.
+# We need to build in a Linux environment to support C libraries.
 # We use Debian instead of Alpine, so that we can use binary database packages
 # instead of spending time compiling them.
-FROM cometbft/cometbft-db-testing:v1.0.1
+FROM golang:1.23.1
 
 RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
 RUN apt-get -qq install -y zsh vim >/dev/null
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
 # Set up build directory /src/cometbft
-ENV COMETBFT_BUILD_OPTIONS badgerdb,rocksdb,nostrip,clock_skew,bls12381
+ENV COMETBFT_BUILD_OPTIONS nostrip,clock_skew,bls12381
 WORKDIR /src/cometbft
 
 # Fetch dependencies separately (for layer caching)


### PR DESCRIPTION
Partially addresses #4486.

This PR removes cometbft-db from cometbft build process:
- Dockerfiles
- Makefiles
- CI 

###  Note to Reviewers
Please add in the discussion below any file that I have forgotten to update.

---

#### PR checklist

- ~[ ] Tests written/updated~
- ~[ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)~
- ~[ ] Updated relevant documentation (`docs/` or `spec/`) and code comments~
