### PR TITLE
perf(p2p): do not remarshal envelope message within broadcast

### DIFF
--- a/.changelog/unreleased/improvements/4667-broadcast-single-message-marshal
+++ b/.changelog/unreleased/improvements/4667-broadcast-single-message-marshal
@@ -1,0 +1,2 @@
+- `[p2p]` Do not remarshal envelope message within broadcast
+  ([\#4667](https://github.com/cometbft/cometbft/pull/4667))

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -348,7 +348,11 @@ func (p *peer) Send(e Envelope) error {
 		// This should never happen.
 		return fmt.Errorf("stream %d not found", e.ChannelID)
 	}
-	err := p.send(e.Message, stream.Write /* blocking */)
+	msgBytes, err := e.marshalMessage()
+	if err != nil {
+		return err
+	}
+	err = p.send(e.Message, msgBytes, stream.Write /* blocking */)
 	if err != nil {
 		p.Logger.Error("Send", "err", err)
 		return err
@@ -367,8 +371,11 @@ func (p *peer) TrySend(e Envelope) error {
 		// This should never happen.
 		return fmt.Errorf("stream %d not found", e.ChannelID)
 	}
-
-	err := p.send(e.Message, stream.TryWrite /* non-blocking */)
+	msgBytes, err := e.marshalMessage()
+	if err != nil {
+		return err
+	}
+	err = p.send(e.Message, msgBytes, stream.TryWrite /* non-blocking */)
 	if err != nil {
 		if e, ok := err.(transport.WriteError); ok && e.Full() {
 			p.Logger.Debug("Send", "err", err)
@@ -381,22 +388,12 @@ func (p *peer) TrySend(e Envelope) error {
 	return nil
 }
 
-func (p *peer) send(msg proto.Message, writeFn func([]byte) (int, error)) error {
+func (p *peer) send(msg proto.Message, msgBytes []byte, writeFn func([]byte) (int, error)) error {
 	if !p.IsRunning() {
 		return errors.New("peer not running")
 	}
 
 	msgType := getMsgType(msg)
-	if w, ok := msg.(types.Wrapper); ok {
-		msg = w.Wrap()
-	}
-
-	msgBytes, err := proto.Marshal(msg)
-	if err != nil {
-		// This should never happen.
-		return fmt.Errorf("proto.Marshal: %w", err)
-	}
-
 	n, err := writeFn(msgBytes)
 	if err != nil {
 		return err

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -348,11 +348,7 @@ func (p *peer) Send(e Envelope) error {
 		// This should never happen.
 		return fmt.Errorf("stream %d not found", e.ChannelID)
 	}
-	msgBytes, err := e.marshalMessage()
-	if err != nil {
-		return err
-	}
-	err = p.send(e.Message, msgBytes, stream.Write /* blocking */)
+	err := p.send(e, stream.Write /* blocking */)
 	if err != nil {
 		p.Logger.Error("Send", "err", err)
 		return err
@@ -371,11 +367,7 @@ func (p *peer) TrySend(e Envelope) error {
 		// This should never happen.
 		return fmt.Errorf("stream %d not found", e.ChannelID)
 	}
-	msgBytes, err := e.marshalMessage()
-	if err != nil {
-		return err
-	}
-	err = p.send(e.Message, msgBytes, stream.TryWrite /* non-blocking */)
+	err := p.send(e, stream.TryWrite /* non-blocking */)
 	if err != nil {
 		if e, ok := err.(transport.WriteError); ok && e.Full() {
 			p.Logger.Debug("Send", "err", err)
@@ -388,12 +380,16 @@ func (p *peer) TrySend(e Envelope) error {
 	return nil
 }
 
-func (p *peer) send(msg proto.Message, msgBytes []byte, writeFn func([]byte) (int, error)) error {
+func (p *peer) send(e Envelope, writeFn func([]byte) (int, error)) error {
 	if !p.IsRunning() {
 		return errors.New("peer not running")
 	}
 
-	msgType := getMsgType(msg)
+	msgType := getMsgType(e.Message)
+	msgBytes, err := e.marshalMessage()
+	if err != nil {
+		return err
+	}
 	n, err := writeFn(msgBytes)
 	if err != nil {
 		return err

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -247,6 +247,7 @@ func (sw *Switch) OnStop() {
 //
 // NOTE: Broadcast uses goroutines, so order of broadcast may not be preserved.
 func (sw *Switch) Broadcast(e Envelope) {
+	_, _ = e.marshalMessage()
 	sw.peers.ForEach(func(p Peer) {
 		go func(peer Peer) {
 			_ = peer.Send(e)
@@ -259,6 +260,7 @@ func (sw *Switch) Broadcast(e Envelope) {
 //
 // NOTE: TryBroadcast uses goroutines, so order of broadcast may not be preserved.
 func (sw *Switch) TryBroadcast(e Envelope) {
+	_, _ = e.marshalMessage()
 	sw.peers.ForEach(func(p Peer) {
 		go func(peer Peer) {
 			_ = peer.TrySend(e)

--- a/p2p/types.go
+++ b/p2p/types.go
@@ -1,6 +1,8 @@
 package p2p
 
 import (
+	"fmt"
+
 	"github.com/cosmos/gogoproto/proto"
 
 	tmp2p "github.com/cometbft/cometbft/api/cometbft/p2p/v1"
@@ -41,6 +43,27 @@ type Envelope struct {
 	Src       Peer          // sender (empty if outbound)
 	Message   proto.Message // message payload
 	ChannelID byte
+
+	// messageBytes are stored after first call to marshalMessage()
+	messageBytes []byte
+}
+
+// marshalMessage marshals the Message field and stores it in a private field
+// for futur use.
+// It returns the marshaled Message.
+func (e *Envelope) marshalMessage() ([]byte, error) {
+	if e.messageBytes == nil {
+		msg := e.Message
+		if w, ok := msg.(types.Wrapper); ok {
+			msg = w.Wrap()
+		}
+		msgBytes, err := proto.Marshal(msg)
+		if err != nil {
+			return nil, fmt.Errorf("proto.Marshal: %w", err)
+		}
+		e.messageBytes = msgBytes
+	}
+	return e.messageBytes, nil
 }
 
 var (

--- a/p2p/types_test.go
+++ b/p2p/types_test.go
@@ -1,0 +1,30 @@
+package p2p
+
+import (
+	"testing"
+
+	"github.com/cosmos/gogoproto/proto"
+	"github.com/stretchr/testify/require"
+
+	p2pproto "github.com/cometbft/cometbft/api/cometbft/p2p/v1"
+)
+
+func TestEnvelopeMarshalMessage(t *testing.T) {
+	msg := &p2pproto.PexAddrs{
+		Addrs: []p2pproto.NetAddress{
+			{
+				ID: "0",
+			},
+		},
+	}
+	expectedMsgBytes, err := proto.Marshal(msg.Wrap())
+	require.NoError(t, err)
+
+	envelope := Envelope{
+		Message: msg,
+	}
+	msgBytes, err := envelope.marshalMessage()
+	require.NoError(t, err)
+	require.Equal(t, expectedMsgBytes, msgBytes)
+	require.Equal(t, expectedMsgBytes, envelope.messageBytes)
+}


### PR DESCRIPTION
Closes #4615 

This avoids multiple marshals of the `Envelope` message when broadcasting.