### PR TITLE
docs: corrected typos, broken links, and updated references in documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ To get started quickly with an example application, see the [quick start guide](
 To learn about application development on CometBFT, see the [Application Blockchain Interface](https://github.com/cometbft/cometbft/tree/main/spec/abci).
 
 For more details on using CometBFT, see the respective documentation for
-[CometBFT internals](explanation/core/), [benchmarking and monitoring](guides/tools/), and [network deployments](guides/networks/).
+[CometBFT internals](explanation/core/), [benchmarking and monitoring](guides/tools/).
 
 ## Contribute
 

--- a/spec/consensus/consensus.md
+++ b/spec/consensus/consensus.md
@@ -62,7 +62,7 @@ parameters over each successive round.
 
 ```md
                          +-------------------------------------+
-                         v                                     |(Wait til `CommmitTime+timeoutCommit`)
+                         v                                     |(Wait til `CommitTime+timeoutCommit`)
                    +-----------+                         +-----+-----+
       +----------> |  Propose  +--------------+          | NewHeight |
       |            +-----------+              |          +-----------+
@@ -315,7 +315,7 @@ adversary.
 For these types of attacks, a subset of the validators through external
 means should coordinate to sign a reorg-proposal that chooses a fork
 (and any evidence thereof) and the initial subset of validators with
-their signatures. Validators who sign such a reorg-proposal forego its
+their signatures. Validators who sign such a reorg-proposal forgo its
 collateral on all other forks. Clients should verify the signatures on
 the reorg-proposal, verify any evidence, and make a judgement or prompt
 the end-user for a decision. For example, a phone wallet app may prompt

--- a/spec/consensus/evidence.md
+++ b/spec/consensus/evidence.md
@@ -74,14 +74,14 @@ type LightClientAttackEvidence struct {
 If a node receives evidence, it will first try to verify it, then persist it.
 Evidence of byzantine behavior should only be committed once (uniqueness) and
 should be committed within a certain period from the point that it occurred
-(timely). Timelines is defined by the `EvidenceParams`: `MaxAgeNumBlocks` and
+(timely). Timeline is defined by the `EvidenceParams`: `MaxAgeNumBlocks` and
 `MaxAgeDuration`. In Proof of Stake chains where validators are bonded, evidence
 age should be less than the unbonding period so validators still can be
 punished. Given these two properties the following initial checks are made.
 
 1. Has the evidence expired? This is done by taking the height of the `Vote`
    within `DuplicateVoteEvidence` or `CommonHeight` within
-   `LightClientAttakEvidence`. The evidence height is then used to retrieve the
+   `LightClientAttackEvidence`. The evidence height is then used to retrieve the
    header and thus the time of the block that corresponds to the evidence. If
    `CurrentHeight - MaxAgeNumBlocks > EvidenceHeight` && `CurrentTime -
    MaxAgeDuration > EvidenceTime`, the evidence is considered expired and

--- a/spec/consensus/wal.md
+++ b/spec/consensus/wal.md
@@ -28,5 +28,5 @@ WAL. Then it will go to precommit, and that time it will work because the
 private validator contains the `LastSignBytes` and then we’ll replay the
 precommit from the WAL.
 
-Make sure to read about [WAL corruption](https://github.com/cometbft/cometbft/blob/main/docs/core/running-in-production.md#wal-corruption)
+Make sure to read about [WAL corruption](https://github.com/cometbft/cometbft/blob/main/docs/explanation/core/running-in-production.md#wal-corruption)
 and recovery strategies.


### PR DESCRIPTION
This pull request addresses the following changes:
- Fixed typographical errors in `consensus.md` and `evidence.md`.
- Corrected a broken link in `wal.md`.
- Updated directory references in `README.md` for better navigation. Removed the part that referenced a non-existent directory and file to avoid confusion.

**PR Checklist**:
- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments