### PR TITLE
feat(crypto): update `bls12381` pkg

### DIFF
--- a/crypto/bls12381/key.go
+++ b/crypto/bls12381/key.go
@@ -85,7 +85,7 @@ func NewPublicKeyFromBytes([]byte) (*PubKey, error) {
 }
 
 // NewPublicKeyFromCompressedBytes returns ErrDisabled.
-func NewPublicKeyFromCompressedBytes(bz []byte) (*PubKey, error) {
+func NewPublicKeyFromCompressedBytes([]byte) (*PubKey, error) {
 	return nil, ErrDisabled
 }
 
@@ -95,7 +95,7 @@ func (PubKey) Address() crypto.Address {
 }
 
 // Compress always panics.
-func (pubKey PubKey) Compress() []byte {
+func (PubKey) Compress() []byte {
 	panic("bls12_381 is disabled")
 }
 

--- a/crypto/bls12381/key.go
+++ b/crypto/bls12381/key.go
@@ -84,8 +84,18 @@ func NewPublicKeyFromBytes([]byte) (*PubKey, error) {
 	return nil, ErrDisabled
 }
 
+// NewPublicKeyFromCompressedBytes returns ErrDisabled.
+func NewPublicKeyFromCompressedBytes(bz []byte) (*PubKey, error) {
+	return nil, ErrDisabled
+}
+
 // Address always panics.
 func (PubKey) Address() crypto.Address {
+	panic("bls12_381 is disabled")
+}
+
+// Compress always panics.
+func (pubKey PubKey) Compress() []byte {
 	panic("bls12_381 is disabled")
 }
 

--- a/crypto/bls12381/key_bls12381.go
+++ b/crypto/bls12381/key_bls12381.go
@@ -19,8 +19,6 @@ const (
 	Enabled = true
 )
 
-const ()
-
 var (
 	// ErrDecompression is returned when the decompression of a compressed 48-byte
 	// long BLS12-381 public key fails.


### PR DESCRIPTION
### Changes
- added func `NewPublicKeyFromCompressedBytes` to create a new BLS12-381 public key from a slice of bytes representing a compressed 48-bytes BLS12-381 key created elsewhere.
- added method `Compress` to type `PubKey` to return compress the BLS12-381 public key from 96 to 48 bytes.
- added a new exported error `ErrPubKeyDecompression`.

