### PR TITLE
fix(e2e): skip missing snapshots

### DIFF
--- a/test/e2e/app/snapshots.go
+++ b/test/e2e/app/snapshots.go
@@ -116,10 +116,11 @@ func (s *SnapshotStore) Prune(n int) error {
 	for ; i < len(s.metadata)-n; i++ {
 		h := s.metadata[i].Height
 		filePath := filepath.Join(s.dir, fmt.Sprintf("%v.json", h))
-		if _, err := os.Stat(filePath); os.IsNotExist(err) {
-			continue
-		}
 		if err := os.Remove(filePath); err != nil {
+			// Trying to prune a non-existent snapshot?
+			if os.IsNotExist(err) {
+				continue
+			}
 			return err
 		}
 	}

--- a/test/e2e/app/snapshots.go
+++ b/test/e2e/app/snapshots.go
@@ -115,7 +115,11 @@ func (s *SnapshotStore) Prune(n int) error {
 	i := 0
 	for ; i < len(s.metadata)-n; i++ {
 		h := s.metadata[i].Height
-		if err := os.Remove(filepath.Join(s.dir, fmt.Sprintf("%v.json", h))); err != nil {
+		filePath := filepath.Join(s.dir, fmt.Sprintf("%v.json", h))
+		if _, err := os.Stat(filePath); os.IsNotExist(err) {
+			continue
+		}
+		if err := os.Remove(filePath); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
when pruning. Suggested by GH copilot while nightly test failure debugging.