### PR TITLE
docs(changelog): Fix broken links to ADRs in .CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,16 +24,16 @@ team, including:
    transaction dissemination mechanism, for example a standalone mempool-like
    process that can be scaled independently of the consensus engine/application.
    This requires application developers to implement their own gossip/networking
-   mechanisms. See [ADR 111](./docs/architecture/adr-111-nop-mempool.md) for
+   mechanisms. See [ADR 111](./docs/references/architecture/adr-111-nop-mempool.md) for
    details.
 5. The first officially supported release of the [data companion
-   API](./docs/architecture/adr-101-data-companion-pull-api.md).
+   API](./docs/references/architecture/adr-101-data-companion-pull-api.md).
 6. Versioning of both the Protobuf definitions _and_ RPC. By versioning our
    APIs, we aim to provide a level of commitment to API stability while
    simultaneously affording ourselves the ability to roll out substantial
    changes in non-breaking releases of CometBFT. See [ADR
-   103](./docs/architecture/adr-103-proto-versioning.md) and [ADR
-   107](./docs/architecture/adr-107-betaize-proto-versions.md).
+   103](./docs/references/architecture/adr-103-proto-versioning.md) and [ADR
+   107](./docs/references/architecture/adr-107-betaize-proto-versions.md).
 7. Moving many Go packages that are currently publicly accessible into the
    `internal` directory such that the team can roll out substantial changes in
    future without needing to worry about causing breakages in users' codebases.
@@ -41,7 +41,7 @@ team, including:
    hampered the team's ability to roll out impactful new changes to users, as
    previously such changes required a new breaking release (which currently
    takes 6 to 12 months to reach production use for many users). See [ADR
-   109](./docs/architecture/adr-109-reduce-go-api-surface.md) for more details.
+   109](./docs/references/architecture/adr-109-reduce-go-api-surface.md) for more details.
 
 None of these changes are state machine-breaking for CometBFT-based networks,
 but could be breaking for some users who depend on the Protobuf definitions type
@@ -482,7 +482,7 @@ on the `/block_results` RPC endpoint.
   and make `GenFilePV` flexible to accept different key generators.
   ([\#3517](https://github.com/cometbft/cometbft/pull/3517))
 - `[proto]` Add definitions and generated code for
-  [ADR-101](./docs/architecture/adr-101-data-companion-pull-api.md)
+  [ADR-101](./docs/references/architecture/adr-101-data-companion-pull-api.md)
   `PruningService` in the `cometbft.services.pruning.v1` proto package
   ([\#1097](https://github.com/cometbft/cometbft/issues/1097))
 - `[rpc/grpc]` Add privileged gRPC server and client facilities, in
@@ -491,7 +491,7 @@ on the `/block_results` RPC endpoint.
   without authentication and should never be exposed to public internet
   ([\#1097](https://github.com/cometbft/cometbft/issues/1097))
 - `[rpc/grpc]` Add a pruning service adding on the privileged gRPC server API to
-  give an [ADR-101](./docs/architecture/adr-101-data-companion-pull-api.md) data
+  give an [ADR-101](./docs/references/architecture/adr-101-data-companion-pull-api.md) data
   companion control over block data retained by the node. The
   `WithPruningService` option method in `server/privileged` is provided to
   configure the pruning service


### PR DESCRIPTION
This PR fixes the links to ADRs in the .CHANGELOG. 
