### PR TITLE
Fix typos in documentation and code comments

### DIFF
--- a/crypto/ed25519/ed25519.go
+++ b/crypto/ed25519/ed25519.go
@@ -19,7 +19,7 @@ var (
 	ErrInvalidSignature = errors.New("ed25519: invalid signature")
 )
 
-// ErrInvalidKeyLen describes an error resulting from an passing in a
+// ErrInvalidKeyLen describes an error resulting from a passing in a
 // key with an invalid key in the call to [BatchVerifier.Add].
 type ErrInvalidKeyLen struct {
 	Got, Want int

--- a/docs/references/architecture/adr-template.md
+++ b/docs/references/architecture/adr-template.md
@@ -40,7 +40,7 @@ Accepted | Rejected | Deprecated | Superseded by
 ## Alternative Approaches
 
 > This section contains information around alternative options that are considered
-> before making a decision. It should contain a explanation on why the alternative
+> before making a decision. It should contain an explanation on why the alternative
 > approach(es) were not chosen.
 
 ## Decision

--- a/docs/references/architecture/tendermint-core/adr-002-event-subscription.md
+++ b/docs/references/architecture/tendermint-core/adr-002-event-subscription.md
@@ -61,7 +61,7 @@ for the most apps (I guess we'll see).
 /txs/search?query="abci.account.owner = Igor"
 ```
 
-For historic queries we will need a indexing storage (Postgres, SQLite, ...).
+For historic queries we will need an indexing storage (Postgres, SQLite, ...).
 
 ### Issues
 

--- a/docs/references/architecture/tendermint-core/adr-026-general-merkle-proof.md
+++ b/docs/references/architecture/tendermint-core/adr-026-general-merkle-proof.md
@@ -29,7 +29,7 @@ Since a proof can treat various data type, `Run()` takes `[][]byte` as the argum
 
 ### ProofOp
 
-`type ProofOp` is a protobuf message which is a triple of `Type string`, `Key []byte`, and `Data []byte`. `ProofOperator` and `ProofOp`are interconvertible, using `ProofOperator.ProofOp()` and `OpDecoder()`, where `OpDecoder` is a function that each proof type can register for their own encoding scheme. For example, we can add an byte for encoding scheme before the serialized proof, supporting JSON decoding.
+`type ProofOp` is a protobuf message which is a triple of `Type string`, `Key []byte`, and `Data []byte`. `ProofOperator` and `ProofOp`are interconvertible, using `ProofOperator.ProofOp()` and `OpDecoder()`, where `OpDecoder` is a function that each proof type can register for their own encoding scheme. For example, we can add a byte for encoding scheme before the serialized proof, supporting JSON decoding.
 
 ## Status
 

--- a/internal/consensus/msgs_test.go
+++ b/internal/consensus/msgs_test.go
@@ -362,7 +362,7 @@ func TestWALMsgProto(t *testing.T) {
 
 			if !tt.wantErr {
 				require.NoError(t, err)
-				assert.Equal(t, tt.msg, msg, tt.testName) // need the concrete type as WAL Message is a empty interface
+				assert.Equal(t, tt.msg, msg, tt.testName) // need the concrete type as WAL Message is an empty interface
 			} else {
 				require.Error(t, err, tt.testName)
 			}

--- a/spec/light-client/detection/README.md
+++ b/spec/light-client/detection/README.md
@@ -54,7 +54,7 @@ on the following components.
 ### TODOs
 
 We decided to merge the files while there are still open points to
-address to record the current state an move forward. In particular,
+address to record the current state a move forward. In particular,
 the following points need to be addressed:
 
 - <https://github.com/informalsystems/tendermint-rs/pull/479#discussion_r466504876>

--- a/spec/p2p/legacy-docs/messages/pex.md
+++ b/spec/p2p/legacy-docs/messages/pex.md
@@ -25,7 +25,7 @@ PexRequest is an empty message requesting a list of peers.
 
 ### PexResponse
 
-PexResponse is an list of net addresses provided to a peer to dial.
+PexResponse is a list of net addresses provided to a peer to dial.
 
 | Name  | Type                               | Description                              | Field Number |
 |-------|------------------------------------|------------------------------------------|--------------|

--- a/spec/p2p/legacy-docs/messages/pex.md
+++ b/spec/p2p/legacy-docs/messages/pex.md
@@ -50,7 +50,7 @@ PexRequest is an empty message requesting a list of peers.
 
 ### PexResponseV2
 
-PexResponse is an list of net addresses provided to a peer to dial.
+PexResponse is a list of net addresses provided to a peer to dial.
 
 | Name  | Type                               | Description                              | Field Number |
 |-------|------------------------------------|------------------------------------------|--------------|


### PR DESCRIPTION
- Corrected the usage of "a" to "an" before words starting with vowel sounds (e.g., "an explanation", "an indexing").
- Fixed minor spelling mistakes in documentation and code comments.