### PR TITLE
feat(storage): Top level commands create a new database using `config.DefaultDBProvider()`

### DIFF
--- a/cmd/cometbft/commands/light.go
+++ b/cmd/cometbft/commands/light.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	cfg "github.com/cometbft/cometbft/config"
 	cmtdb "github.com/cometbft/cometbft/db"
 	cmtos "github.com/cometbft/cometbft/internal/os"
 	"github.com/cometbft/cometbft/libs/log"
@@ -118,7 +119,14 @@ func runProxy(_ *cobra.Command, args []string) error {
 		witnessesAddrs = strings.Split(witnessAddrsJoined, ",")
 	}
 
-	db, err := cmtdb.New("light-client-db", home)
+	configCopy := cfg.DefaultConfig()
+	configCopy.RootDir = home
+	configCopy.DBPath = ""
+	dbCtx := &cfg.DBContext{
+		ID:     "light-client-db",
+		Config: configCopy,
+	}
+	db, err := cfg.DefaultDBProvider(dbCtx)
 	if err != nil {
 		return fmt.Errorf("can't create a db: %w", err)
 	}

--- a/cmd/cometbft/commands/reindex_event.go
+++ b/cmd/cometbft/commands/reindex_event.go
@@ -116,7 +116,11 @@ func loadEventSinks(cfg *cmtcfg.Config, chainID string) (indexer.BlockIndexer, t
 		}
 		return es.BlockIndexer(), es.TxIndexer(), nil
 	case "kv":
-		store, err := cmtdb.New("tx_index", cfg.DBDir())
+		dbCtx := &cmtcfg.DBContext{
+			ID:     "tx_index",
+			Config: cfg,
+		}
+		store, err := cmtcfg.DefaultDBProvider(dbCtx)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/cmd/cometbft/commands/reindex_event_test.go
+++ b/cmd/cometbft/commands/reindex_event_test.go
@@ -11,7 +11,6 @@ import (
 
 	abcitypes "github.com/cometbft/cometbft/abci/types"
 	cmtcfg "github.com/cometbft/cometbft/config"
-	cmtdb "github.com/cometbft/cometbft/db"
 	"github.com/cometbft/cometbft/internal/test"
 	blockmocks "github.com/cometbft/cometbft/state/indexer/mocks"
 	"github.com/cometbft/cometbft/state/mocks"
@@ -112,12 +111,20 @@ func TestLoadBlockStore(t *testing.T) {
 	_, _, err := loadStateAndBlockStore(cfg)
 	require.Error(t, err)
 
-	blkStore, err := cmtdb.New("blockstore", cfg.DBDir())
+	dbCtx := &cmtcfg.DBContext{
+		ID:     "blockstore",
+		Config: cfg,
+	}
+	blkStore, err := cmtcfg.DefaultDBProvider(dbCtx)
 	require.NoError(t, err)
 	require.NoError(t, blkStore.Close())
 
 	// Get StateStore
-	sttStore, err := cmtdb.New("state", cfg.DBDir())
+	dbCtx = &cmtcfg.DBContext{
+		ID:     "state",
+		Config: cfg,
+	}
+	sttStore, err := cmtcfg.DefaultDBProvider(dbCtx)
 	require.NoError(t, err)
 	require.NoError(t, sttStore.Close())
 

--- a/cmd/cometbft/commands/rollback.go
+++ b/cmd/cometbft/commands/rollback.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/cobra"
 
 	cfg "github.com/cometbft/cometbft/config"
-	cmtdb "github.com/cometbft/cometbft/db"
 	"github.com/cometbft/cometbft/internal/os"
 	"github.com/cometbft/cometbft/state"
 	"github.com/cometbft/cometbft/store"
@@ -71,7 +70,11 @@ func loadStateAndBlockStore(config *cfg.Config) (*store.BlockStore, state.Store,
 	}
 
 	// Get BlockStore
-	blockStoreDB, err := cmtdb.New("blockstore", config.DBDir())
+	blockStoreDBCtx := &cfg.DBContext{
+		ID:     "blockstore",
+		Config: config,
+	}
+	blockStoreDB, err := cfg.DefaultDBProvider(blockStoreDBCtx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -82,7 +85,11 @@ func loadStateAndBlockStore(config *cfg.Config) (*store.BlockStore, state.Store,
 	}
 
 	// Get StateStore
-	stateDB, err := cmtdb.New("state", config.DBDir())
+	stateStoreDBCtx := &cfg.DBContext{
+		ID:     "state",
+		Config: config,
+	}
+	stateDB, err := cfg.DefaultDBProvider(stateStoreDBCtx)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
### Context
As part of the work in #4601, we want to allow users to use their own database if they don't like pebble. As CometBFT will use the same [DB interface](https://github.com/cometbft/cometbft-db/blob/8bd4531b5122530f39a90d385cb0b0523dbe881e/types.go#L21) that cometbft-db uses, users can provide their own implementation of the interface that uses a different database under the hood. They will, therefore, have to change the [`config.DefaultDBProvider` function](https://github.com/cometbft/cometbft/blob/b8df798fd85c68e289c595df0b233f37df5db616/config/db.go#L30) to return their implementation instead of our default.

To minimize the places in the code to change, we think that users should only change the `config.DefaultDBProvider` to user thei DB. Therefore, some places in the code must change to user this function rather than calling `db.NewDB()` directly.

### This PR
This PR changes the commands in the `cmd` folder to use `config.DefaultDBProvider()` to create databases.

---

#### PR checklist

- [x] Tests written/updated
- ~[ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)~
- ~[] Updated relevant documentation (`docs/` or `spec/`) and code comments~
