### PR TITLE
fix(e2e): Reduce size of generated vote extensions and don't convert to Hex

### DIFF
--- a/.changelog/unreleased/bug-fixes/4721-nonrp-ext-e2e-fix.md
+++ b/.changelog/unreleased/bug-fixes/4721-nonrp-ext-e2e-fix.md
@@ -1,0 +1,3 @@
+- `[e2e]` Reduce size of vote extensions to match total the size of the extensions 
+before adding support for Non replay-protected extensions
+  ([\#4721](https://github.com/cometbft/cometbft/pull/4721))

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -727,7 +727,7 @@ func (cs *State) updateToState(state sm.State) {
 	timeoutCommit := state.NextBlockDelay
 	// If the ABCI app didn't set a delay, use the deprecated config value.
 	if timeoutCommit == 0 {
-		timeoutCommit = cs.config.TimeoutCommit
+		timeoutCommit = cs.config.TimeoutCommit //nolint:staticcheck
 	}
 	if cs.CommitTime.IsZero() {
 		// "Now" makes it easier to sync up dev nodes.
@@ -2336,7 +2336,7 @@ func (cs *State) addVote(vote *types.Vote, peerID p2p.ID) (added bool, err error
 		cs.evsw.FireEvent(types.EventVote, vote)
 
 		// if we can skip timeoutCommit and have all the votes now,
-		skipTimeoutCommit := cs.state.NextBlockDelay == 0 && cs.config.TimeoutCommit == 0
+		skipTimeoutCommit := cs.state.NextBlockDelay == 0 && cs.config.TimeoutCommit == 0 //nolint:staticcheck
 		if skipTimeoutCommit && cs.LastCommit.HasAll() {
 			// go straight to new round (skip timeout commit)
 			// cs.scheduleTimeout(time.Duration(0), cs.Height, 0, cstypes.RoundStepNewHeight)
@@ -2500,7 +2500,7 @@ func (cs *State) addVote(vote *types.Vote, peerID p2p.ID) (added bool, err error
 
 			if !blockID.IsNil() {
 				cs.enterCommit(height, vote.Round)
-				skipTimeoutCommit := cs.state.NextBlockDelay == 0 && cs.config.TimeoutCommit == 0
+				skipTimeoutCommit := cs.state.NextBlockDelay == 0 && cs.config.TimeoutCommit == 0 //nolint:staticcheck
 				if skipTimeoutCommit && precommits.HasAll() {
 					cs.enterNewRound(cs.Height, 0)
 				}

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -727,7 +727,7 @@ func (cs *State) updateToState(state sm.State) {
 	timeoutCommit := state.NextBlockDelay
 	// If the ABCI app didn't set a delay, use the deprecated config value.
 	if timeoutCommit == 0 {
-		timeoutCommit = cs.config.TimeoutCommit //nolint:staticcheck
+		timeoutCommit = cs.config.TimeoutCommit
 	}
 	if cs.CommitTime.IsZero() {
 		// "Now" makes it easier to sync up dev nodes.
@@ -2336,7 +2336,7 @@ func (cs *State) addVote(vote *types.Vote, peerID p2p.ID) (added bool, err error
 		cs.evsw.FireEvent(types.EventVote, vote)
 
 		// if we can skip timeoutCommit and have all the votes now,
-		skipTimeoutCommit := cs.state.NextBlockDelay == 0 && cs.config.TimeoutCommit == 0 //nolint:staticcheck
+		skipTimeoutCommit := cs.state.NextBlockDelay == 0 && cs.config.TimeoutCommit == 0
 		if skipTimeoutCommit && cs.LastCommit.HasAll() {
 			// go straight to new round (skip timeout commit)
 			// cs.scheduleTimeout(time.Duration(0), cs.Height, 0, cstypes.RoundStepNewHeight)
@@ -2500,7 +2500,7 @@ func (cs *State) addVote(vote *types.Vote, peerID p2p.ID) (added bool, err error
 
 			if !blockID.IsNil() {
 				cs.enterCommit(height, vote.Round)
-				skipTimeoutCommit := cs.state.NextBlockDelay == 0 && cs.config.TimeoutCommit == 0 //nolint:staticcheck
+				skipTimeoutCommit := cs.state.NextBlockDelay == 0 && cs.config.TimeoutCommit == 0
 				if skipTimeoutCommit && precommits.HasAll() {
 					cs.enterNewRound(cs.Height, 0)
 				}

--- a/test/e2e/app/app.go
+++ b/test/e2e/app/app.go
@@ -773,7 +773,7 @@ func (app *Application) ExtendVote(_ context.Context, req *abci.ExtendVoteReques
 	nonRpExt = slices.Concat(nonRpExt, ext[:extLen])
 
 	app.logger.Info("generated vote extension", "height", appHeight,
-		"vote_extension", hex.EncodeToString(ext[:4]), "ve_len", extLen,
+		"vote_extension", ext, "ve_len", extLen,
 		"non_rp_vote_extension", nonRpExt, "nrp_ve_len", len(nonRpExt))
 	return &abci.ExtendVoteResponse{
 		VoteExtension:  ext[:extLen],
@@ -1124,7 +1124,7 @@ func (app *Application) verifyExtensionTx(height int64, payload string) error {
 // It also checks the non replay protected extension: its height and its data.
 // Otherwise it is the size of the extension.
 func parseVoteExtensions(cfg *Config, expHeight int64, ext, nonRpExt []byte) (int64, error) {
-	parts := strings.Split(string(nonRpExt), "|")
+	parts := strings.SplitN(string(nonRpExt), "|", 2)
 	if len(parts) < 2 {
 		return 0, fmt.Errorf("non replay protected vote extension must have 2 parts (%d)", len(parts))
 	}
@@ -1139,7 +1139,8 @@ func parseVoteExtensions(cfg *Config, expHeight int64, ext, nonRpExt []byte) (in
 		)
 	}
 	xExt := string(ext)
-	if !bytes.Equal(nonRpExt[2:], ext) {
+
+	if parts[1] != xExt {
 		return 0, fmt.Errorf("non replay protected vote extension contains incorrect data (%s!=%s)",
 			xExt,
 			parts[1],

--- a/test/e2e/app/app.go
+++ b/test/e2e/app/app.go
@@ -1125,7 +1125,7 @@ func (app *Application) verifyExtensionTx(height int64, payload string) error {
 // Otherwise it is the size of the extension.
 func parseVoteExtensions(cfg *Config, expHeight int64, ext, nonRpExt []byte) (int64, error) {
 	parts := strings.Split(string(nonRpExt), "|")
-	if len(parts) != 2 {
+	if len(parts) < 2 {
 		return 0, fmt.Errorf("non replay protected vote extension must have 2 parts (%d)", len(parts))
 	}
 	height, err := strconv.ParseInt(parts[0], 10, 64)

--- a/test/e2e/app/app.go
+++ b/test/e2e/app/app.go
@@ -1138,7 +1138,7 @@ func parseVoteExtensions(cfg *Config, expHeight int64, ext, nonRpExt []byte) (in
 			height,
 		)
 	}
-	xExt := hex.EncodeToString(ext)
+	xExt := string(ext)
 	if parts[1] != xExt {
 		return 0, fmt.Errorf("non replay protected vote extension contains incorrect data (%s!=%s)",
 			xExt,

--- a/test/e2e/app/app.go
+++ b/test/e2e/app/app.go
@@ -768,14 +768,16 @@ func (app *Application) ExtendVote(_ context.Context, req *abci.ExtendVoteReques
 	}
 
 	// Replay protection mechanism consists of: (a) the randomness of the extension (nonce), and (b) including the height
-	nonRpExt := fmt.Sprintf("%d|%x", req.Height, ext[:extLen])
+	nonRpExt := []byte(fmt.Sprintf("%d|", req.Height))
+
+	nonRpExt = slices.Concat(nonRpExt, ext[:extLen])
 
 	app.logger.Info("generated vote extension", "height", appHeight,
 		"vote_extension", hex.EncodeToString(ext[:4]), "ve_len", extLen,
 		"non_rp_vote_extension", nonRpExt, "nrp_ve_len", len(nonRpExt))
 	return &abci.ExtendVoteResponse{
 		VoteExtension:  ext[:extLen],
-		NonRpExtension: []byte(nonRpExt),
+		NonRpExtension: nonRpExt,
 	}, nil
 }
 

--- a/test/e2e/app/app.go
+++ b/test/e2e/app/app.go
@@ -1139,7 +1139,7 @@ func parseVoteExtensions(cfg *Config, expHeight int64, ext, nonRpExt []byte) (in
 		)
 	}
 	xExt := string(ext)
-	if parts[1] != xExt {
+	if !bytes.Equal(nonRpExt[2:], ext) {
 		return 0, fmt.Errorf("non replay protected vote extension contains incorrect data (%s!=%s)",
 			xExt,
 			parts[1],

--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -68,11 +68,15 @@ var (
 	voteExtensionsUpdateHeight = uniformChoice{int64(-1), int64(0), int64(1)} // -1: genesis, 0: InitChain, 1: (use offset)
 	voteExtensionEnabled       = weightedChoice{true: 3, false: 1}
 	voteExtensionsHeightOffset = uniformChoice{int64(0), int64(10), int64(100)}
-	voteExtensionSize          = uniformChoice{uint(128), uint(512), uint(2048 / 2), uint(8192 / 2)} // TODO: define the right values depending on experiment results.
-	pbtsUpdateHeight           = uniformChoice{int64(-1), int64(0), int64(1)}                        // -1: genesis, 0: InitChain, 1: (use offset)
-	pbtsEnabled                = weightedChoice{true: 3, false: 1}
-	pbtsHeightOffset           = uniformChoice{int64(0), int64(10), int64(100)}
-	keyType                    = uniformChoice{ed25519.KeyType, secp256k1.KeyType, bls12381.KeyType}
+	// We have explicitly left the division by 2 here to explain why it is needed.
+	// When adding support for Non Replay-Protected Vote Extensions to the e2e,
+	// we double the size of the VE. This message was too big when contacting
+	// remote signers and surpassing also the maximum size of p2p messages.
+	voteExtensionSize = uniformChoice{uint(128), uint(512), uint(2048 / 2), uint(8192 / 2)} // TODO: define the right values depending on experiment results.
+	pbtsUpdateHeight  = uniformChoice{int64(-1), int64(0), int64(1)}                        // -1: genesis, 0: InitChain, 1: (use offset)
+	pbtsEnabled       = weightedChoice{true: 3, false: 1}
+	pbtsHeightOffset  = uniformChoice{int64(0), int64(10), int64(100)}
+	keyType           = uniformChoice{ed25519.KeyType, secp256k1.KeyType, bls12381.KeyType}
 	// TODO: reinstate this once the oscillation logic is fixed.
 	// constantFlip               = uniformChoice{true, false}.
 )

--- a/test/e2e/generator/generate.go
+++ b/test/e2e/generator/generate.go
@@ -68,8 +68,8 @@ var (
 	voteExtensionsUpdateHeight = uniformChoice{int64(-1), int64(0), int64(1)} // -1: genesis, 0: InitChain, 1: (use offset)
 	voteExtensionEnabled       = weightedChoice{true: 3, false: 1}
 	voteExtensionsHeightOffset = uniformChoice{int64(0), int64(10), int64(100)}
-	voteExtensionSize          = uniformChoice{uint(128), uint(512), uint(2048), uint(8192)} // TODO: define the right values depending on experiment results.
-	pbtsUpdateHeight           = uniformChoice{int64(-1), int64(0), int64(1)}                // -1: genesis, 0: InitChain, 1: (use offset)
+	voteExtensionSize          = uniformChoice{uint(128), uint(512), uint(2048 / 2), uint(8192 / 2)} // TODO: define the right values depending on experiment results.
+	pbtsUpdateHeight           = uniformChoice{int64(-1), int64(0), int64(1)}                        // -1: genesis, 0: InitChain, 1: (use offset)
 	pbtsEnabled                = weightedChoice{true: 3, false: 1}
 	pbtsHeightOffset           = uniformChoice{int64(0), int64(10), int64(100)}
 	keyType                    = uniformChoice{ed25519.KeyType, secp256k1.KeyType, bls12381.KeyType}

--- a/test/e2e/runner/evidence.go
+++ b/test/e2e/runner/evidence.go
@@ -105,8 +105,12 @@ func InjectEvidence(ctx context.Context, r *rand.Rand, testnet *e2e.Testnet, amo
 			if dve.VoteA.Height < testnet.VoteExtensionsEnableHeight {
 				dve.VoteA.Extension = nil
 				dve.VoteA.ExtensionSignature = nil
+				dve.VoteA.NonRpExtension = nil
+				dve.VoteA.NonRpExtensionSignature = nil
 				dve.VoteB.Extension = nil
 				dve.VoteB.ExtensionSignature = nil
+				dve.VoteB.NonRpExtension = nil
+				dve.VoteB.NonRpExtensionSignature = nil
 			}
 			ev = dve
 		}


### PR DESCRIPTION
PR #4688 increased the size of vote extensions used in the e2e app which resulted in e2e tests failing because the messages were too  big. 

This PR does two things:
- Does not convert the Non replay-protected vote extensions to a Hex String (as this doubles their size). 
- Uses a lower value for the generated VEs because this value will in practice be doubled (if the configuration size is 256, we will have `VoteExtension` of size 256 and `NonRpExtension` of size 256). 


---

#### PR checklist

- [ ] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
