### PR TITLE
typo-Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -148,6 +148,6 @@ retract (
 	v0.38.4
 	// a breaking change was introduced
 	v0.38.3
-	// superseeded by v0.38.3 because of ASA-2024-001
+	// superseded by v0.38.3 because of ASA-2024-001
 	[v0.38.0, v0.38.2]
 )


### PR DESCRIPTION
# Fix: Corrected typo in configuration file

## Changes
- `go.mod:151`: "superseeded" corrected to "superseded".

## Purpose
- Improved configuration file accuracy and professionalism by fixing the typo.
