### PR TITLE
docs: Quotation marks are used incorrectly.

### DIFF
--- a/spec/light-client/README.md
+++ b/spec/light-client/README.md
@@ -103,7 +103,7 @@ version 001. The TLA+ properties can be found in the
 [TLA+ specification](verification/Lightclient_A_1.tla).
  The experiments were run in an AWS instance equipped with 32GB
 RAM and a 4-core Intel® Xeon® CPU E5-2686 v4 @ 2.30GHz CPU.
-We write “✗=k” when a bug is reported at depth k, and “✓<=k” when
+We write "✗=k" when a bug is reported at depth k, and "✓<=k" when
 no bug is reported up to depth k.
 
 ![Experimental results](experiments.png)


### PR DESCRIPTION
Quotation marks are used incorrectly.