### PR TITLE
Fix Typo in `adr-037-deliver-block.md

### DIFF
--- a/docs/references/architecture/tendermint-core/adr-037-deliver-block.md
+++ b/docs/references/architecture/tendermint-core/adr-037-deliver-block.md
@@ -12,7 +12,7 @@ Initial conversation: https://github.com/tendermint/tendermint/issues/2901
 
 Some applications can handle transactions in parallel, or at least some
 part of tx processing can be parallelized. Now it is not possible for developer
-to execute txs in parallel because Tendermint delivers them consequentially.
+to execute txs in parallel because Tendermint delivers them consequently.
 
 ## Decision
 


### PR DESCRIPTION
# Pull Request Title  
**Fix Typo in `adr-037-deliver-block.md`**

## Description  
This pull request corrects a typo in the `adr-037-deliver-block.md` file to enhance the clarity and professionalism of the documentation.

### Changes Made:
- **File Modified:** `docs/references/architecture/tendermint-core/adr-037-deliver-block.md`
- **Summary of Changes:**  
  - Corrected the typo from `consequentially` to `consequently`.

## Checklist  
- [x] Fixed the typo in the markdown file.
- [x] Verified that the document renders correctly after the correction.
- [x] Followed the project's contributing guidelines, security policy, and code of conduct.

## Additional Notes  
This update improves the readability of the architectural reference document, making it clearer for developers and contributors working on transaction parallelization.

---

**Allow edits by maintainers:** [x]
