### PR TITLE
**Fix Typo in `lexer.go`**

### DIFF
--- a/test/e2e/pkg/grammar/grammar-auto/lexer/lexer.go
+++ b/test/e2e/pkg/grammar/grammar-auto/lexer/lexer.go
@@ -243,7 +243,7 @@ func (l *Lexer) GetLineColumn(i int) (line, col int) {
 	return
 }
 
-// GetLineColumnOfToken returns the line and column of token[i] in the imput
+// GetLineColumnOfToken returns the line and column of token[i] in the input
 func (l *Lexer) GetLineColumnOfToken(i int) (line, col int) {
 	return l.GetLineColumn(l.Tokens[i].Lext())
 }


### PR DESCRIPTION
# Pull Request Title  
**Fix Typo in `lexer.go`**

## Description  
This pull request corrects a typo in the `lexer.go` file. The word "imput" has been corrected to "input" in the function comment to ensure proper spelling.

### Changes Made:
- **File Modified:** `lexer.go`
- **Summary of Changes:**  
  - Corrected the typo from "imput" to "input" in the comment on line 243.

## Checklist  
- [x] Fixed the typo in the file.
- [x] Verified that the code comment is now correctly spelled.

## Additional Notes  
This change improves the readability and professionalism of the code comments.

---

**Allow edits by maintainers:** [x]
