### PR TITLE
chore(e2e): remove `key_type` from ci manifest

### DIFF
--- a/test/e2e/networks/ci.toml
+++ b/test/e2e/networks/ci.toml
@@ -64,7 +64,6 @@ persist_interval = 3
 retain_blocks = 20
 enable_companion_pruning = true
 perturb = ["kill"]
-key_type = "secp256k1"
 
 [node.validator04]
 persistent_peers = ["validator01"]


### PR DESCRIPTION
key_type entry has no actual effect. The reason is that we never implemented the key_type at the node level in the e2e manifest, but rather at the testnet level.
