### PR TITLE
ypo Fix in adr-059-evidence-composition-and-lifecycle.md

### DIFF
--- a/docs/references/architecture/tendermint-core/adr-059-evidence-composition-and-lifecycle.md
+++ b/docs/references/architecture/tendermint-core/adr-059-evidence-composition-and-lifecycle.md
@@ -121,7 +121,7 @@ type LightClientAttackEvidence struct {
 ```
 where the `Hash()` is the hash of the header and commonHeight.
 
-Note: It was also discussed whether to include the commit hash which captures the validators that signed the header. However this would open the opportunity for someone to propose multiple permutations of the same evidence (through different commit signatures) hence it was omitted. Consequentially, when it comes to verifying evidence in a block, for `LightClientAttackEvidence` we can't just check the hashes because someone could have the same hash as us but a different commit where less than 1/3 validators voted which would be an invalid version of the evidence. (see `fastCheck` for more details)
+Note: It was also discussed whether to include the commit hash which captures the validators that signed the header. However this would open the opportunity for someone to propose multiple permutations of the same evidence (through different commit signatures) hence it was omitted. Consequently, when it comes to verifying evidence in a block, for `LightClientAttackEvidence` we can't just check the hashes because someone could have the same hash as us but a different commit where less than 1/3 validators voted which would be an invalid version of the evidence. (see `fastCheck` for more details)
 
 ```go
 type DuplicateVoteEvidence {


### PR DESCRIPTION
### Pull Request Title:
**Typo Fix in `adr-059-evidence-composition-and-lifecycle.md`**

### Description:
This pull request addresses a typo in the documentation of the `LightClientAttackEvidence` type in the `adr-059-evidence-composition-and-lifecycle.md` file. Specifically, the phrase:

- **Before:** "Consequentially, when it comes to verifying evidence in a block, for `LightClientAttackEvidence` we can't just check the hashes because someone could have the same hash as us but a different commit where less than 1/3 validators voted which would be an invalid version of the evidence."
  
- **After:** "Consequently, when it comes to verifying evidence in a block, for `LightClientAttackEvidence` we can't just check the hashes because someone could have the same hash as us but a different commit where less than 1/3 validators voted which would be an invalid version of the evidence."

This typo is corrected to improve clarity and consistency in the documentation.

### Changes Made:
- Corrected the word "Consequentially" to "Consequently" for better accuracy and readability.

### Files Changed:
- `...nces/architecture/tendermint-core/adr-059-evidence-composition-and-lifecycle.md`

### Testing Instructions:
No functional changes, so no tests are required. This is purely a documentation update.

### Additional Notes:
This fix does not affect any code execution or behavior of the system; it is purely a textual correction to ensure the documentation is clear and accurate.
