### PR TITLE
typo fix adr-059-evidence-composition-and-lifecycle.md

### DIFF
--- a/docs/references/architecture/tendermint-core/adr-059-evidence-composition-and-lifecycle.md
+++ b/docs/references/architecture/tendermint-core/adr-059-evidence-composition-and-lifecycle.md
@@ -121,7 +121,7 @@ type LightClientAttackEvidence struct {
 ```
 where the `Hash()` is the hash of the header and commonHeight.
 
-Note: It was also discussed whether to include the commit hash which captures the validators that signed the header. However this would open the opportunity for someone to propose multiple permutations of the same evidence (through different commit signatures) hence it was omitted. Consequentially, when it comes to verifying evidence in a block, for `LightClientAttackEvidence` we can't just check the hashes because someone could have the same hash as us but a different commit where less than 1/3 validators voted which would be an invalid version of the evidence. (see `fastCheck` for more details)
+Note: It was also discussed whether to include the commit hash which captures the validators that signed the header. However this would open the opportunity for someone to propose multiple permutations of the same evidence (through different commit signatures) hence it was omitted. Consequently, when it comes to verifying evidence in a block, for `LightClientAttackEvidence` we can't just check the hashes because someone could have the same hash as us but a different commit where less than 1/3 validators voted which would be an invalid version of the evidence. (see `fastCheck` for more details)
 
 ```go
 type DuplicateVoteEvidence {


### PR DESCRIPTION
# Pull Request Title: Fix Typo in `adr-059-evidence-composition-and-lifecycle.md` (Consequently → Consequentially)

## Summary:
This pull request fixes a minor typo in the `adr-059-evidence-composition-and-lifecycle.md` document. The word "Consequently" was incorrectly spelled as "Consequently", which is now corrected.

## Changes Made:
- Corrected the word "Consequently" in the `adr-059-evidence-composition-and-lifecycle.md` file.

## Files Changed:
- `nces/architecture/tendermint-core/adr-059-evidence-composition-and-lifecycle.md`

## Testing:
- No testing is required as this change only affects documentation.

## Additional Notes:
- Fixing this typo improves the readability and clarity of the documentation.

---

Thank you for reviewing this change!
