### PR TITLE
types: return error when adding part to nil PartSet

### DIFF
--- a/types/part_set.go
+++ b/types/part_set.go
@@ -279,10 +279,6 @@ func (ps *PartSet) Total() uint32 {
 }
 
 func (ps *PartSet) AddPart(part *Part) (bool, error) {
-	if ps == nil {
-		return false, errors.New("cannot add part to nil PartSet")
-	}
-
 	ps.mtx.Lock()
 	defer ps.mtx.Unlock()
 

--- a/types/part_set.go
+++ b/types/part_set.go
@@ -279,10 +279,8 @@ func (ps *PartSet) Total() uint32 {
 }
 
 func (ps *PartSet) AddPart(part *Part) (bool, error) {
-	// TODO: remove this? would be preferable if this only returned (false, nil)
-	// when its a duplicate block part
 	if ps == nil {
-		return false, nil
+		return false, errors.New("cannot add part to nil PartSet")
 	}
 
 	ps.mtx.Lock()


### PR DESCRIPTION
## Description

This PR improves the error handling in `PartSet.AddPart` method by returning a proper error when attempting to add a part to a nil PartSet. Previously, the method would silently return `(false, nil)`, which made it difficult to distinguish between a duplicate part and a nil PartSet case.

Fixes TODO comment in `types/part_set.go`.

## Changes

- Changed `AddPart` to return `(false, error)` when `PartSet` is nil
- Removed TODO comment as the issue is now resolved
- Made the API more predictable by reserving `(false, nil)` return only for duplicate parts

## Motivation

The change makes the API more predictable and easier to debug by:
1. Following Go's error handling best practices
2. Making it clear why an operation failed
3. Reserving `(false, nil)` return specifically for duplicate parts

