### PR TITLE
typo fix parser.go

### DIFF
--- a/test/e2e/pkg/grammar/grammar-auto/parser/parser.go
+++ b/test/e2e/pkg/grammar/grammar-auto/parser/parser.go
@@ -2066,7 +2066,7 @@ type Error struct {
 	// Index of token that caused the error.
 	cI int
 
-	// Grammar slot at which the error occured.
+	// Grammar slot at which the error occurred.
 	Slot slot.Label
 
 	// The token at which the error occurred.


### PR DESCRIPTION
# Typo Fix in `parser.go`

## Description

This pull request fixes a typographical error in the **`parser.go`** file located in the `test/e2e/pkg/grammar/grammar-auto/parser` directory:

- **Typo:** Corrected "occured" to "occurred" in the code comment:
  - **Original:** "Grammar slot at which the error occured."
  - **Corrected:** "Grammar slot at which the error occurred."



