### PR TITLE
fix typo Update adr-037-deliver-block.md

### DIFF
--- a/docs/references/architecture/tendermint-core/adr-037-deliver-block.md
+++ b/docs/references/architecture/tendermint-core/adr-037-deliver-block.md
@@ -24,7 +24,7 @@ speed up communications between application and Tendermint.
 
 As @jaekwon [mentioned](https://github.com/tendermint/tendermint/issues/2901#issuecomment-477746128)
 in discussion not all application will benefit from this solution. In some cases,
-when application handles transaction consequentially, it way slow down the blockchain,
+when application handles transaction consequently, it way slow down the blockchain,
 because it need to wait until full block is transmitted to application to start
 processing it. Also, in the case of complete change of ABCI, we need to force all the apps
 to change their implementation completely. That's why I propose to introduce one more ABCI


### PR DESCRIPTION
# Fix Typo in `adr-037-deliver-block.md`

**Author**: @pinkflower32  
**Branch**: `pinkflower32:fix.typo`  
**Base**: `cometbft:main`  

## Description
This pull request corrects a typo in the `adr-037-deliver-block.md` file. Specifically, the word "consequentially" was corrected to "consequently" for improved accuracy and clarity.

## Changes
- Corrected the typo: replaced "consequentially" with "consequently."

## Commit Details
- **Commit**: `fix typo Update adr-037-deliver-block.md`  
- **Contributor**: @pinkflower32  
- **Date**: January 22, 2025  

## Additional Notes
- Maintainers are allowed to edit this pull request if needed.
- Contributions follow the repository’s contributing guidelines, security policy, and code of conduct.
