### PR TITLE
docs: fix typo in documentation in debugging.md

### DIFF
--- a/docs/guides/tools/debugging.md
+++ b/docs/guides/tools/debugging.md
@@ -70,7 +70,7 @@ entire CometBFT process.
 While in this inconsistent state, a node running CometBFT will not start up.
 The `inspect` command runs only a subset of CometBFT's RPC endpoints for querying the block store
 and state store.
-`inspect` allows operators to query a read-only view of the stage.
+`inspect` allows operators to query a read-only view of the state.
 `inspect` does not run the consensus engine at all and can therefore be used to debug
 processes that have crashed due to inconsistent state.
 


### PR DESCRIPTION
#### Description 
I noticed a typo in the documentation where "stage" was used instead of "state" in the following sentence:  
> `inspect` allows operators to query a read-only view of the stage.  

This should correctly refer to the **state** (state store) in CometBFT.

I've updated it to:  
> `inspect` allows operators to query a read-only view of the **state**.  

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
