### PR TITLE
build(deps): bump Go version to 1.22.11

### DIFF
--- a/docs/guides/go-built-in.md
+++ b/docs/guides/go-built-in.md
@@ -46,7 +46,7 @@ Verify that you have the latest version of Go installed (refer to the [official 
 
 ```bash
 $ go version
-go version go1.22.7 darwin/amd64
+go version go1.22.11 darwin/amd64
 ```
 
 ## 1.2 Creating a new Go project

--- a/docs/guides/go.md
+++ b/docs/guides/go.md
@@ -46,7 +46,7 @@ Verify that you have the latest version of Go installed (refer to the [official 
 
 ```bash
 $ go version
-go version go1.22.7 darwin/amd64
+go version go1.22.11 darwin/amd64
 ```
 
 ## 1.2 Creating a new Go project

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cometbft/cometbft
 
-go 1.22.7
+go 1.22.11
 
 require (
 	github.com/BurntSushi/toml v1.4.0


### PR DESCRIPTION
due to sec vuln

Port of https://github.com/cometbft/cometbft/pull/4888
