### PR TITLE
fix: fixed argument handling in shell script

### DIFF
--- a/scripts/mockery_generate.sh
+++ b/scripts/mockery_generate.sh
@@ -2,4 +2,4 @@
 #
 # Invoke Mockery v2 to update generated mocks for the given type.
 
-go run github.com/vektra/mockery/v2@v2.50.0 --name "$*"
+go run github.com/vektra/mockery/v2@v2.50.0 --name "$@"


### PR DESCRIPTION
I’ve corrected an issue where the `$*` variable in the shell script was passing all arguments as a single string.
This caused problems when handling names with spaces or multiple words.
Now, `$@` is used instead to ensure arguments are passed as separate parameters, which resolves the issue.

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
