### PR TITLE
fix: remove redundant error check for PubKeyToProto

### DIFF
--- a/privval/signer_requestHandler.go
+++ b/privval/signer_requestHandler.go
@@ -37,10 +37,6 @@ func DefaultValidationRequestHandler(
 		}
 		pk, err := cryptoenc.PubKeyToProto(pubKey)
 		if err != nil {
-			return res, err
-		}
-
-		if err != nil {
 			res = mustWrapMsg(&privvalproto.PubKeyResponse{
 				PubKey: cryptoproto.PublicKey{}, Error: &privvalproto.RemoteSignerError{Code: 0, Description: err.Error()}})
 		} else {


### PR DESCRIPTION
I don't see this on main branch, so this is just a patch for v0.38.x

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
