### PR TITLE
Correct misspelled variable and function names in core logic and tests for improved clarity and consistency

### DIFF
--- a/docs/references/rfc/rfc-100-abci-vote-extension-propag.md
+++ b/docs/references/rfc/rfc-100-abci-vote-extension-propag.md
@@ -254,7 +254,7 @@ We now briefly describe the current catch-up mechanisms in the reactors concerne
 
 Full nodes optionally run statesync just after starting, when they start from scratch.
 If statesync succeeds, an Application snapshot is installed, and CometBFT jumps from height 0 directly
-to the height the Application snapshop represents, without applying the block of any previous height.
+to the height the Application snapshot represents, without applying the block of any previous height.
 Some light blocks are received and stored in the block store for running light-client verification of
 all the skipped blocks. Light blocks are incomplete blocks, typically containing the header and the
 canonical commit but, e.g., no transactions. They are stored in the block store as "signed headers".

--- a/docs/references/rfc/tendermint-core/rfc-017-abci++-vote-extension-propag.md
+++ b/docs/references/rfc/tendermint-core/rfc-017-abci++-vote-extension-propag.md
@@ -244,7 +244,7 @@ We now briefly describe the current catch-up mechanisms in the reactors concerne
 
 Full nodes optionally run statesync just after starting, when they start from scratch.
 If statesync succeeds, an Application snapshot is installed, and Tendermint jumps from height 0 directly
-to the height the Application snapshop represents, without applying the block of any previous height.
+to the height the Application snapshot represents, without applying the block of any previous height.
 Some light blocks are received and stored in the block store for running light-client verification of
 all the skipped blocks. Light blocks are incomplete blocks, typically containing the header and the
 canonical commit but, e.g., no transactions. They are stored in the block store as "signed headers".

--- a/state/store.go
+++ b/state/store.go
@@ -477,7 +477,7 @@ func (store dbStore) Bootstrap(state State) error {
 // encoding not preserving ordering: https://github.com/tendermint/tendermint/issues/4567
 // This will cause some old states to be left behind when doing incremental partial prunes,
 // specifically older checkpoints and LastHeightChanged targets.
-func (store dbStore) PruneStates(from int64, to int64, evidenceThresholdHeight int64, previosulyPrunedStates uint64) (uint64, error) {
+func (store dbStore) PruneStates(from int64, to int64, evidenceThresholdHeight int64, previouslyPrunedStates uint64) (uint64, error) {
 	defer addTimeSample(store.StoreOptions.Metrics.StoreAccessDurationSeconds.With("method", "prune_states"), time.Now())()
 	if from <= 0 || to <= 0 {
 		return 0, fmt.Errorf("from height %v and to height %v must be greater than 0", from, to)
@@ -606,7 +606,7 @@ func (store dbStore) PruneStates(from int64, to int64, evidenceThresholdHeight i
 	}
 
 	// We do not want to panic or interrupt consensus on compaction failure
-	if store.StoreOptions.Compact && previosulyPrunedStates+pruned >= uint64(store.StoreOptions.CompactionInterval) {
+	if store.StoreOptions.Compact && previouslyPrunedStates+pruned >= uint64(store.StoreOptions.CompactionInterval) {
 		// When the range is nil,nil, the database will try to compact
 		// ALL levels. Another option is to set a predefined range of
 		// specific keys.

--- a/state/store.go
+++ b/state/store.go
@@ -676,7 +676,7 @@ func (store dbStore) PruneABCIResponses(targetRetainHeight int64, forceCompact b
 // ------------------------------------------------------------------------
 
 // TxResultsHash returns the root hash of a Merkle tree of
-// ExecTxResulst responses (see ABCIResults.Hash)
+// ExecTxResults responses (see ABCIResults.Hash)
 //
 // See merkle.SimpleHashFromByteSlices.
 func TxResultsHash(txResults []*abci.ExecTxResult) []byte {

--- a/state/txindex/kv/kv.go
+++ b/state/txindex/kv/kv.go
@@ -30,7 +30,7 @@ const (
 	tagKeySeparator          = "/"
 	tagKeySeparatorRune      = '/'
 	eventSeqSeparator        = "$es$"
-	eventSeqSeperatorRuneAt0 = '$'
+	eventSeqSeparatorRuneAt0 = '$'
 )
 
 var (
@@ -1043,7 +1043,7 @@ func extractEventSeqFromKey(key []byte) string {
 	}
 
 	for ; endPos < len(key); endPos++ {
-		if key[endPos] == eventSeqSeperatorRuneAt0 {
+		if key[endPos] == eventSeqSeparatorRuneAt0 {
 			eventSeq := string(key[endPos:])
 			if eventSeq, ok := strings.CutPrefix(eventSeq, eventSeqSeparator); ok {
 				return eventSeq

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -370,7 +370,7 @@ func TestBlockStoreSaveLoadBlock(t *testing.T) {
 }
 
 // stripExtensions removes all VoteExtension data from an ExtendedCommit. This
-// is useful when dealing with an ExendedCommit but vote extension data is
+// is useful when dealing with an ExtendedCommit but vote extension data is
 // expected to be absent.
 func stripExtensions(ec *types.ExtendedCommit) bool {
 	stripped := false

--- a/types/vote_set_test.go
+++ b/types/vote_set_test.go
@@ -528,31 +528,31 @@ func TestVoteSet_VoteExtensionsEnabled(t *testing.T) {
 		name              string
 		requireExtensions bool
 		addExtension      bool
-		exepectError      bool
+		expectError      bool
 	}{
 		{
 			name:              "no extension but expected",
 			requireExtensions: true,
 			addExtension:      false,
-			exepectError:      true,
+			expectError:      true,
 		},
 		{
 			name:              "invalid extensions but not expected",
 			requireExtensions: true,
 			addExtension:      false,
-			exepectError:      true,
+			expectError:      true,
 		},
 		{
 			name:              "no extension and not expected",
 			requireExtensions: false,
 			addExtension:      false,
-			exepectError:      false,
+			expectError:      false,
 		},
 		{
 			name:              "extension and expected",
 			requireExtensions: true,
 			addExtension:      true,
-			exepectError:      false,
+			expectError:      false,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -594,7 +594,7 @@ func TestVoteSet_VoteExtensionsEnabled(t *testing.T) {
 			}
 
 			added, err := voteSet.AddVote(vote)
-			if tc.exepectError {
+			if tc.expectError {
 				require.Error(t, err)
 				require.False(t, added)
 			} else {


### PR DESCRIPTION
- **Corrected variable names in `store.go`**:
  - `previosulyPrunedStates` → `previouslyPrunedStates`
  - `ExecTxResulst` → `ExecTxResults`
  
- **Fixed spelling issues in `kv.go`**:
  - `eventSeqSeperatorRuneAt0` → `eventSeqSeparatorRuneAt0`
  
- **Updated function documentation in `rfc-100-abci-vote-extension-propag.md` and `rfc-017-abci++-vote-extension-propag.md`**:
  - Fixed `snapshop` → `snapshot` for better documentation clarity.

- **Corrected typos in `vote_set_test.go`**:
  - `exepectError` → `expectError` to match expected test conditions.
