### PR TITLE
fix: standardize POLRound naming in proposal.go

### DIFF
--- a/types/proposal.go
+++ b/types/proposal.go
@@ -155,7 +155,7 @@ func (p *Proposal) ToProto() *cmtproto.Proposal {
 	pb.Type = p.Type
 	pb.Height = p.Height
 	pb.Round = p.Round
-	pb.PolRound = p.POLRound // FIXME: names do not match
+	pb.POLRound = p.POLRound
 	pb.Timestamp = p.Timestamp
 	pb.Signature = p.Signature
 
@@ -180,7 +180,7 @@ func ProposalFromProto(pp *cmtproto.Proposal) (*Proposal, error) {
 	p.Type = pp.Type
 	p.Height = pp.Height
 	p.Round = pp.Round
-	p.POLRound = pp.PolRound // FIXME: names do not match
+	p.POLRound = pp.POLRound
 	p.Timestamp = pp.Timestamp
 	p.Signature = pp.Signature
 


### PR DESCRIPTION
### Pull Request Description
This pull request addresses a naming inconsistency in the proposal.go file by standardizing the use of POLRound. The changes ensure that the naming convention is consistent across the ToProto and ProposalFromProto functions, aligning with the existing struct definition in the Proposal type. This improves code readability and maintainability.
### Changes Made
Updated pb.PolRound to pb.POLRound in the ToProto function.
Updated pp.PolRound to pp.POLRound in the ProposalFromProto function.
### PR Checklist
[ ] Tests written/updated
[ ] Changelog entry added in .changelog (we use unclog to manage our changelog)
[ ] Updated relevant documentation (docs/ or spec/) and code comments