### PR TITLE
feat(libs): restore os and rand, add deprecation notices

### DIFF
--- a/.changelog/unreleased/improvements/4986-restore-os-and-rand-packages.md
+++ b/.changelog/unreleased/improvements/4986-restore-os-and-rand-packages.md
@@ -1,0 +1,1 @@
+The libs/os and libs/rand packages were previously moved to internal/, making them inaccessible to external consumers. We restored them to libs/ while marking them as deprecated to provide a transition period before removal in a future release.

--- a/libs/os/os.go
+++ b/libs/os/os.go
@@ -1,0 +1,126 @@
+// Package os provides utility functions for OS-level interactions.
+//
+// Deprecated: This package will be removed in a future release. Users should migrate
+// off this package as its functionality will no longer be part of the exported interface.
+package os
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/cometbft/cometbft/libs/log"
+)
+
+type logger interface {
+	Info(msg string, keyvals ...any)
+}
+
+// TrapSignal catches the SIGTERM/SIGINT and executes cb function. After that it exits
+// with code 0.
+// Deprecated: This function will be removed in a future release. Do not use.
+func TrapSignal(logger logger, cb func()) {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		for sig := range c {
+			logger.Info("signal trapped", "msg", log.NewLazySprintf("captured %v, exiting...", sig))
+			if cb != nil {
+				cb()
+			}
+			os.Exit(0)
+		}
+	}()
+}
+
+// Kill the running process by sending itself SIGTERM.
+// Deprecated: This function will be removed in a future release. Do not use.
+func Kill() error {
+	p, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		return err
+	}
+	return p.Signal(syscall.SIGTERM)
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func Exit(s string) {
+	fmt.Println(s)
+	os.Exit(1)
+}
+
+// EnsureDir ensures the given directory exists, creating it if necessary.
+// Errors if the path already exists as a non-directory.
+// Deprecated: This function will be removed in a future release. Do not use.
+func EnsureDir(dir string, mode os.FileMode) error {
+	err := os.MkdirAll(dir, mode)
+	if err != nil {
+		return fmt.Errorf("could not create directory %q: %w", dir, err)
+	}
+	return nil
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func FileExists(filePath string) bool {
+	_, err := os.Stat(filePath)
+	return !os.IsNotExist(err)
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func ReadFile(filePath string) ([]byte, error) {
+	return os.ReadFile(filePath)
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func MustReadFile(filePath string) []byte {
+	fileBytes, err := os.ReadFile(filePath)
+	if err != nil {
+		Exit(fmt.Sprintf("MustReadFile failed: %v", err))
+		return nil
+	}
+	return fileBytes
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func WriteFile(filePath string, contents []byte, mode os.FileMode) error {
+	return os.WriteFile(filePath, contents, mode)
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func MustWriteFile(filePath string, contents []byte, mode os.FileMode) {
+	err := WriteFile(filePath, contents, mode)
+	if err != nil {
+		Exit(fmt.Sprintf("MustWriteFile failed: %v", err))
+	}
+}
+
+// CopyFile copies a file. It truncates the destination file if it exists.
+// Deprecated: This function will be removed in a future release. Do not use.
+func CopyFile(src, dst string) error {
+	srcfile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcfile.Close()
+
+	info, err := srcfile.Stat()
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		return errors.New("cannot read from directories")
+	}
+
+	// create new file, truncate if exists and apply same permissions as the original one
+	dstfile, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	defer dstfile.Close()
+
+	_, err = io.Copy(dstfile, srcfile)
+	return err
+}

--- a/libs/os/os_test.go
+++ b/libs/os/os_test.go
@@ -1,0 +1,116 @@
+// Package os provides utility functions for OS-level interactions.
+//
+// Deprecated: This package will be removed in a future release. Users should migrate
+// off this package as its functionality will no longer be part of the exported interface.
+package os
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopyFile(t *testing.T) {
+	tmpfile, err := os.CreateTemp("", "example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+	content := []byte("hello world")
+	if _, err := tmpfile.Write(content); err != nil {
+		t.Fatal(err)
+	}
+
+	copyfile := tmpfile.Name() + ".copy"
+	if err := CopyFile(tmpfile.Name(), copyfile); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(copyfile); os.IsNotExist(err) {
+		t.Fatal("copy should exist")
+	}
+	data, err := os.ReadFile(copyfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(data, content) {
+		t.Fatalf("copy file content differs: expected %v, got %v", content, data)
+	}
+	os.Remove(copyfile)
+}
+
+func TestEnsureDir(t *testing.T) {
+	tmp, err := os.MkdirTemp("", "ensure-dir")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmp)
+
+	// Should be possible to create a new directory.
+	err = EnsureDir(filepath.Join(tmp, "dir"), 0o755)
+	require.NoError(t, err)
+	require.DirExists(t, filepath.Join(tmp, "dir"))
+
+	// Should succeed on existing directory.
+	err = EnsureDir(filepath.Join(tmp, "dir"), 0o755)
+	require.NoError(t, err)
+
+	// Should fail on file.
+	err = os.WriteFile(filepath.Join(tmp, "file"), []byte{}, 0o644)
+	require.NoError(t, err)
+	err = EnsureDir(filepath.Join(tmp, "file"), 0o755)
+	require.Error(t, err)
+
+	// Should allow symlink to dir.
+	err = os.Symlink(filepath.Join(tmp, "dir"), filepath.Join(tmp, "linkdir"))
+	require.NoError(t, err)
+	err = EnsureDir(filepath.Join(tmp, "linkdir"), 0o755)
+	require.NoError(t, err)
+
+	// Should error on symlink to file.
+	err = os.Symlink(filepath.Join(tmp, "file"), filepath.Join(tmp, "linkfile"))
+	require.NoError(t, err)
+	err = EnsureDir(filepath.Join(tmp, "linkfile"), 0o755)
+	require.Error(t, err)
+}
+
+// Ensure that using CopyFile does not truncate the destination file before
+// the origin is positively a non-directory and that it is ready for copying.
+// See https://github.com/tendermint/tendermint/issues/6427
+func TestTrickedTruncation(t *testing.T) {
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "pwn_truncate")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpDir)
+
+	originalWALPath := filepath.Join(tmpDir, "wal")
+	originalWALContent := []byte("I AM BECOME DEATH, DESTROYER OF ALL WORLDS!")
+	if err := os.WriteFile(originalWALPath, originalWALContent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// 1. Sanity check.
+	readWAL, err := os.ReadFile(originalWALPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(readWAL, originalWALContent) {
+		t.Fatalf("Cannot proceed as the content does not match\nGot:  %q\nWant: %q", readWAL, originalWALContent)
+	}
+
+	// 2. Now cause the truncation of the original file.
+	// It is absolutely legal to invoke os.Open on a directory.
+	if err := CopyFile(tmpDir, originalWALPath); err == nil {
+		t.Fatal("Expected an error")
+	}
+
+	// 3. Check the WAL's content
+	reReadWAL, err := os.ReadFile(originalWALPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(reReadWAL, originalWALContent) {
+		t.Fatalf("Oops, the WAL's content was changed :(\nGot:  %q\nWant: %q", reReadWAL, originalWALContent)
+	}
+}

--- a/libs/rand/random.go
+++ b/libs/rand/random.go
@@ -1,0 +1,377 @@
+// Package rand provides a pseudo-random number generator seeded with OS randomness.
+//
+// Deprecated: This package will be removed in a future release. Users should migrate
+// off this package, as its functionality will no longer be part of the exported interface.
+package rand
+
+import (
+	crand "crypto/rand"
+	mrand "math/rand"
+	"time"
+
+	cmtsync "github.com/cometbft/cometbft/libs/sync"
+)
+
+const (
+	strChars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" // 62 characters
+)
+
+// Rand is a prng, that is seeded with OS randomness.
+// The OS randomness is obtained from crypto/rand, however none of the provided
+// methods are suitable for cryptographic usage.
+// They all utilize math/rand's prng internally.
+//
+// All of the methods here are suitable for concurrent use.
+// This is achieved by using a mutex lock on all of the provided methods.
+// Deprecated: This struct will be removed in a future release. Do not use.
+type Rand struct {
+	cmtsync.Mutex
+	rand *mrand.Rand
+}
+
+var grand *Rand
+
+func init() {
+	grand = NewRand()
+	grand.init()
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func NewRand() *Rand {
+	rand := &Rand{}
+	rand.init()
+	return rand
+}
+
+// Make a new stdlib rand source. Its up to the caller to ensure
+// that the rand source is not called in parallel.
+// The failure mode of calling the returned rand multiple times in parallel is
+// repeated values across threads.
+// Deprecated: This function will be removed in a future release. Do not use.
+func NewStdlibRand() *mrand.Rand {
+	// G404: Use of weak random number generator (math/rand instead of crypto/rand)
+	//nolint:gosec
+	return mrand.New(mrand.NewSource(newSeed()))
+}
+
+func newSeed() int64 {
+	bz := cRandBytes(8)
+	var seed uint64
+	for i := 0; i < 8; i++ {
+		seed |= uint64(bz[i])
+		seed <<= 8
+	}
+	return int64(seed)
+}
+
+func (r *Rand) init() {
+	r.reset(newSeed())
+}
+
+func (r *Rand) reset(seed int64) {
+	// G404: Use of weak random number generator (math/rand instead of crypto/rand)
+	//nolint:gosec
+	r.rand = mrand.New(mrand.NewSource(seed))
+}
+
+// ----------------------------------------
+// Global functions
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func Seed(seed int64) {
+	grand.Seed(seed)
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func Str(length int) string {
+	return grand.Str(length)
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func Uint16() uint16 {
+	return grand.Uint16()
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func Uint32() uint32 {
+	return grand.Uint32()
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func Uint64() uint64 {
+	return grand.Uint64()
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func Uint() uint {
+	return grand.Uint()
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func Int16() int16 {
+	return grand.Int16()
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func Int32() int32 {
+	return grand.Int32()
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func Int64() int64 {
+	return grand.Int64()
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func Int() int {
+	return grand.Int()
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func Int31() int32 {
+	return grand.Int31()
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func Int31n(n int32) int32 {
+	return grand.Int31n(n)
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func Int63() int64 {
+	return grand.Int63()
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func Int63n(n int64) int64 {
+	return grand.Int63n(n)
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func Bool() bool {
+	return grand.Bool()
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func Float32() float32 {
+	return grand.Float32()
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func Float64() float64 {
+	return grand.Float64()
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func Time() time.Time {
+	return grand.Time()
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func Bytes(n int) []byte {
+	return grand.Bytes(n)
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func Intn(n int) int {
+	return grand.Intn(n)
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func Perm(n int) []int {
+	return grand.Perm(n)
+}
+
+// ----------------------------------------
+// Rand methods
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func (r *Rand) Seed(seed int64) {
+	r.Lock()
+	r.reset(seed)
+	r.Unlock()
+}
+
+// Str constructs a random alphanumeric string of given length.
+// Deprecated: This function will be removed in a future release. Do not use.
+func (r *Rand) Str(length int) string {
+	if length <= 0 {
+		return ""
+	}
+
+	chars := []byte{}
+MAIN_LOOP:
+	for {
+		val := r.Int63()
+		for i := 0; i < 10; i++ {
+			v := int(val & 0x3f) // rightmost 6 bits
+			if v >= 62 {         // only 62 characters in strChars
+				val >>= 6
+				continue
+			}
+			chars = append(chars, strChars[v])
+			if len(chars) == length {
+				break MAIN_LOOP
+			}
+			val >>= 6
+		}
+	}
+
+	return string(chars)
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func (r *Rand) Uint16() uint16 {
+	return uint16(r.Uint32() & (1<<16 - 1))
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func (r *Rand) Uint32() uint32 {
+	r.Lock()
+	u32 := r.rand.Uint32()
+	r.Unlock()
+	return u32
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func (r *Rand) Uint64() uint64 {
+	return uint64(r.Uint32())<<32 + uint64(r.Uint32())
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func (r *Rand) Uint() uint {
+	r.Lock()
+	i := r.rand.Int()
+	r.Unlock()
+	return uint(i)
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func (r *Rand) Int16() int16 {
+	return int16(r.Uint32() & (1<<16 - 1))
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func (r *Rand) Int32() int32 {
+	return int32(r.Uint32())
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func (r *Rand) Int64() int64 {
+	return int64(r.Uint64())
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func (r *Rand) Int() int {
+	r.Lock()
+	i := r.rand.Int()
+	r.Unlock()
+	return i
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func (r *Rand) Int31() int32 {
+	r.Lock()
+	i31 := r.rand.Int31()
+	r.Unlock()
+	return i31
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func (r *Rand) Int31n(n int32) int32 {
+	r.Lock()
+	i31n := r.rand.Int31n(n)
+	r.Unlock()
+	return i31n
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func (r *Rand) Int63() int64 {
+	r.Lock()
+	i63 := r.rand.Int63()
+	r.Unlock()
+	return i63
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func (r *Rand) Int63n(n int64) int64 {
+	r.Lock()
+	i63n := r.rand.Int63n(n)
+	r.Unlock()
+	return i63n
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func (r *Rand) Float32() float32 {
+	r.Lock()
+	f32 := r.rand.Float32()
+	r.Unlock()
+	return f32
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func (r *Rand) Float64() float64 {
+	r.Lock()
+	f64 := r.rand.Float64()
+	r.Unlock()
+	return f64
+}
+
+// Deprecated: This function will be removed in a future release. Do not use.
+func (r *Rand) Time() time.Time {
+	return time.Unix(int64(r.Uint64()), 0)
+}
+
+// Bytes returns n random bytes generated from the internal
+// prng.
+// Deprecated: This function will be removed in a future release. Do not use.
+func (r *Rand) Bytes(n int) []byte {
+	// cRandBytes isn't guaranteed to be fast so instead
+	// use random bytes generated from the internal PRNG
+	bs := make([]byte, n)
+	for i := 0; i < len(bs); i++ {
+		bs[i] = byte(r.Int() & 0xFF)
+	}
+	return bs
+}
+
+// Intn returns, as an int, a uniform pseudo-random number in the range [0, n).
+// It panics if n <= 0.
+// Deprecated: This function will be removed in a future release. Do not use.
+func (r *Rand) Intn(n int) int {
+	r.Lock()
+	i := r.rand.Intn(n)
+	r.Unlock()
+	return i
+}
+
+// Bool returns a uniformly random boolean.
+// Deprecated: This function will be removed in a future release. Do not use.
+func (r *Rand) Bool() bool {
+	// See https://github.com/golang/go/issues/23804#issuecomment-365370418
+	// for reasoning behind computing like this
+	return r.Int63()%2 == 0
+}
+
+// Perm returns a pseudo-random permutation of n integers in [0, n).
+// Deprecated: This function will be removed in a future release. Do not use.
+func (r *Rand) Perm(n int) []int {
+	r.Lock()
+	perm := r.rand.Perm(n)
+	r.Unlock()
+	return perm
+}
+
+// NOTE: This relies on the os's random number generator.
+// For real security, we should salt that with some seed.
+// See github.com/cometbft/cometbft/crypto for a more secure reader.
+// This function is thread safe, see:
+// https://stackoverflow.com/questions/75685374/is-golang-crypto-rand-thread-safe
+func cRandBytes(numBytes int) []byte {
+	b := make([]byte, numBytes)
+	_, err := crand.Read(b)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/libs/rand/random_test.go
+++ b/libs/rand/random_test.go
@@ -1,0 +1,139 @@
+package rand
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRandStr(t *testing.T) {
+	l := 243
+	s := Str(l)
+	assert.Len(t, s, l)
+}
+
+func TestRandBytes(t *testing.T) {
+	l := 243
+	b := Bytes(l)
+	assert.Len(t, b, l)
+}
+
+func TestRandIntn(t *testing.T) {
+	n := 243
+	for i := 0; i < 100; i++ {
+		x := Intn(n)
+		assert.Less(t, x, n)
+	}
+}
+
+// Test to make sure that we never call math.rand().
+// We do this by ensuring that outputs are deterministic.
+func TestDeterminism(t *testing.T) {
+	var firstOutput string
+
+	for i := 0; i < 100; i++ {
+		output := testThemAll()
+		if i == 0 {
+			firstOutput = output
+		} else if firstOutput != output {
+			t.Errorf("run #%d's output was different from first run.\nfirst: %v\nlast: %v",
+				i, firstOutput, output)
+		}
+	}
+}
+
+func testThemAll() string {
+	// Such determinism.
+	grand.reset(1)
+
+	// Use it.
+	out := new(bytes.Buffer)
+	perm := Perm(10)
+	blob, err := json.Marshal(perm)
+	if err != nil {
+		log.Fatalf("couldn't unmarshal perm: %v", err)
+	}
+	fmt.Fprintf(out, "perm: %s\n", blob)
+	fmt.Fprintf(out, "randInt: %d\n", Int())
+	fmt.Fprintf(out, "randUint: %d\n", Uint())
+	fmt.Fprintf(out, "randIntn: %d\n", Intn(97))
+	fmt.Fprintf(out, "randInt31: %d\n", Int31())
+	fmt.Fprintf(out, "randInt32: %d\n", Int32())
+	fmt.Fprintf(out, "randInt63: %d\n", Int63())
+	fmt.Fprintf(out, "randInt64: %d\n", Int64())
+	fmt.Fprintf(out, "randUint32: %d\n", Uint32())
+	fmt.Fprintf(out, "randUint64: %d\n", Uint64())
+	return out.String()
+}
+
+func TestRngConcurrencySafety(_ *testing.T) {
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			_ = Uint64()
+			<-time.After(time.Millisecond * time.Duration(Intn(100)))
+			_ = Perm(3)
+		}()
+	}
+	wg.Wait()
+}
+
+// Makes a new stdlib random instance 100 times concurrently.
+// Ensures that it is concurrent safe to create rand instances, and call independent rand
+// sources in parallel.
+func TestStdlibRngConcurrencySafety(_ *testing.T) {
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r := NewStdlibRand()
+			_ = r.Uint64()
+			<-time.After(time.Millisecond * time.Duration(Intn(100)))
+			_ = r.Perm(3)
+		}()
+	}
+	wg.Wait()
+}
+
+func BenchmarkRandBytes10B(b *testing.B) {
+	benchmarkRandBytes(b, 10)
+}
+
+func BenchmarkRandBytes100B(b *testing.B) {
+	benchmarkRandBytes(b, 100)
+}
+
+func BenchmarkRandBytes1KiB(b *testing.B) {
+	benchmarkRandBytes(b, 1024)
+}
+
+func BenchmarkRandBytes10KiB(b *testing.B) {
+	benchmarkRandBytes(b, 10*1024)
+}
+
+func BenchmarkRandBytes100KiB(b *testing.B) {
+	benchmarkRandBytes(b, 100*1024)
+}
+
+func BenchmarkRandBytes1MiB(b *testing.B) {
+	b.Helper()
+	benchmarkRandBytes(b, 1024*1024)
+}
+
+func benchmarkRandBytes(b *testing.B, n int) {
+	b.Helper()
+	for i := 0; i < b.N; i++ {
+		_ = Bytes(n)
+	}
+	b.ReportAllocs()
+}


### PR DESCRIPTION
Closes #4986 

Summary
Restores libs/os and libs/rand from internal/ to temporarily maintain backward compatibility. Adds deprecation notices to indicate their removal in a future release.

Changes
- Restored libs/os and libs/rand from internal/ (just did a copy)
- Added Deprecated: comments to both packages (only added comments)

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
