### PR TITLE
fix: Fix incorrect nil return value

### DIFF
--- a/rpc/jsonrpc/jsonrpc_test.go
+++ b/rpc/jsonrpc/jsonrpc_test.go
@@ -259,7 +259,7 @@ func echoViaWS(cl *client.WSClient, val string) (string, error) {
 
 	msg := <-cl.ResponsesCh
 	if msg.Error != nil {
-		return "", err
+		return "", msg.Error
 	}
 	result := new(ResultEcho)
 	err = json.Unmarshal(msg.Result, result)


### PR DESCRIPTION


Because err has been checked before and returned as != nil, err here must be nil, and msg.Error should actually be returned
