### PR TITLE
feat(mempool): Add transaction cache statistics tracking and metrics

### DIFF
--- a/mempool/cache.go
+++ b/mempool/cache.go
@@ -2,6 +2,7 @@ package mempool
 
 import (
 	"container/list"
+	"sync/atomic"
 
 	cmtsync "github.com/cometbft/cometbft/libs/sync"
 	"github.com/cometbft/cometbft/types"
@@ -28,6 +29,24 @@ type TxCache interface {
 	Has(tx types.Tx) bool
 }
 
+// CacheStats provides statistics about cache operations
+type CacheStats interface {
+	// Hits returns the number of cache hits
+	Hits() uint64
+
+	// Misses returns the number of cache misses
+	Misses() uint64
+
+	// Evictions returns the number of cache evictions
+	Evictions() uint64
+
+	// Size returns the current number of items in the cache
+	Size() int
+
+	// ResetStats resets all statistics counters to zero
+	ResetStats()
+}
+
 var _ TxCache = (*LRUTxCache)(nil)
 
 // LRUTxCache maintains a thread-safe LRU cache of raw transactions. The cache
@@ -39,11 +58,29 @@ type LRUTxCache struct {
 	list     *list.List
 }
 
+// StatsLRUTxCache extends LRUTxCache with statistics tracking
+type StatsLRUTxCache struct {
+	LRUTxCache
+	hits      atomic.Uint64
+	misses    atomic.Uint64
+	evictions atomic.Uint64
+}
+
+var _ TxCache = (*StatsLRUTxCache)(nil)
+var _ CacheStats = (*StatsLRUTxCache)(nil)
+
 func NewLRUTxCache(cacheSize int) *LRUTxCache {
 	return &LRUTxCache{
 		size:     cacheSize,
 		cacheMap: make(map[types.TxKey]*list.Element, cacheSize),
 		list:     list.New(),
+	}
+}
+
+// NewStatsLRUTxCache creates a new LRU cache with statistics tracking
+func NewStatsLRUTxCache(cacheSize int) *StatsLRUTxCache {
+	return &StatsLRUTxCache{
+		LRUTxCache: *NewLRUTxCache(cacheSize),
 	}
 }
 
@@ -60,6 +97,12 @@ func (c *LRUTxCache) Reset() {
 
 	clear(c.cacheMap)
 	c.list.Init()
+}
+
+// Reset resets the cache to an empty state and clears statistics.
+func (c *StatsLRUTxCache) Reset() {
+	c.LRUTxCache.Reset()
+	c.ResetStats()
 }
 
 func (c *LRUTxCache) Push(tx types.Tx) bool {
@@ -89,6 +132,38 @@ func (c *LRUTxCache) Push(tx types.Tx) bool {
 	return true
 }
 
+// Push adds a transaction to the cache with statistics tracking
+func (c *StatsLRUTxCache) Push(tx types.Tx) bool {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	key := tx.Key()
+
+	moved, ok := c.cacheMap[key]
+	if ok {
+		c.list.MoveToBack(moved)
+		c.hits.Add(1)
+		return false
+	}
+
+	c.misses.Add(1)
+
+	if c.list.Len() >= c.size {
+		front := c.list.Front()
+		if front != nil {
+			frontKey := front.Value.(types.TxKey)
+			delete(c.cacheMap, frontKey)
+			c.list.Remove(front)
+			c.evictions.Add(1)
+		}
+	}
+
+	e := c.list.PushBack(key)
+	c.cacheMap[key] = e
+
+	return true
+}
+
 func (c *LRUTxCache) Remove(tx types.Tx) {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
@@ -108,6 +183,49 @@ func (c *LRUTxCache) Has(tx types.Tx) bool {
 
 	_, ok := c.cacheMap[tx.Key()]
 	return ok
+}
+
+// Has checks if a transaction is in the cache with statistics tracking
+func (c *StatsLRUTxCache) Has(tx types.Tx) bool {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	_, ok := c.cacheMap[tx.Key()]
+	if ok {
+		c.hits.Add(1)
+	} else {
+		c.misses.Add(1)
+	}
+	return ok
+}
+
+// Hits returns the number of cache hits
+func (c *StatsLRUTxCache) Hits() uint64 {
+	return c.hits.Load()
+}
+
+// Misses returns the number of cache misses
+func (c *StatsLRUTxCache) Misses() uint64 {
+	return c.misses.Load()
+}
+
+// Evictions returns the number of cache evictions
+func (c *StatsLRUTxCache) Evictions() uint64 {
+	return c.evictions.Load()
+}
+
+// Size returns the current number of items in the cache
+func (c *StatsLRUTxCache) Size() int {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	return c.list.Len()
+}
+
+// ResetStats resets all statistics counters to zero
+func (c *StatsLRUTxCache) ResetStats() {
+	c.hits.Store(0)
+	c.misses.Store(0)
+	c.evictions.Store(0)
 }
 
 // NopTxCache defines a no-op raw transaction cache.

--- a/mempool/metrics.gen.go
+++ b/mempool/metrics.gen.go
@@ -108,19 +108,49 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Name:      "redundancy",
 			Help:      "Redundancy level.",
 		}, labels).With(labelsAndValues...),
+		CacheHits: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "cache_hits",
+			Help:      "Number of cache hits.",
+		}, labels).With(labelsAndValues...),
+		CacheMisses: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "cache_misses",
+			Help:      "Number of cache misses.",
+		}, labels).With(labelsAndValues...),
+		CacheEvictions: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "cache_evictions",
+			Help:      "Number of cache evictions.",
+		}, labels).With(labelsAndValues...),
+		CacheSize: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "cache_size",
+			Help:      "Current number of transactions in the cache.",
+		}, labels).With(labelsAndValues...),
+		CacheHitRatio: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "cache_hit_ratio",
+			Help:      "Ratio of cache hits to total lookups (hits + misses).",
+		}, labels).With(labelsAndValues...),
 	}
 }
 
 func NopMetrics() *Metrics {
 	return &Metrics{
-		Size:                      discard.NewGauge(),
-		SizeBytes:                 discard.NewGauge(),
-		LaneSize:                  discard.NewGauge(),
-		LaneBytes:                 discard.NewGauge(),
-		TxLifeSpan:                discard.NewHistogram(),
-		TxSizeBytes:               discard.NewHistogram(),
+		Size:                     discard.NewGauge(),
+		SizeBytes:                discard.NewGauge(),
+		LaneSize:                 discard.NewGauge(),
+		LaneBytes:                discard.NewGauge(),
+		TxLifeSpan:               discard.NewHistogram(),
+		TxSizeBytes:              discard.NewHistogram(),
 		FailedTxs:                 discard.NewCounter(),
-		RejectedTxs:               discard.NewCounter(),
+		RejectedTxs:              discard.NewCounter(),
 		EvictedTxs:                discard.NewCounter(),
 		RecheckTimes:              discard.NewCounter(),
 		AlreadyReceivedTxs:        discard.NewCounter(),
@@ -128,5 +158,10 @@ func NopMetrics() *Metrics {
 		RecheckDurationSeconds:    discard.NewGauge(),
 		DisabledRoutes:            discard.NewGauge(),
 		Redundancy:                discard.NewGauge(),
+		CacheHits:                discard.NewCounter(),
+		CacheMisses:              discard.NewCounter(),
+		CacheEvictions:           discard.NewCounter(),
+		CacheSize:                discard.NewGauge(),
+		CacheHitRatio:            discard.NewGauge(),
 	}
 }

--- a/mempool/metrics.go
+++ b/mempool/metrics.go
@@ -76,4 +76,24 @@ type Metrics struct {
 
 	// Redundancy level.
 	Redundancy metrics.Gauge
+
+	// Cache hit count - number of times a transaction was found in the cache
+	// metrics:Number of cache hits.
+	CacheHits metrics.Counter
+
+	// Cache miss count - number of times a transaction was not found in the cache
+	// metrics:Number of cache misses.
+	CacheMisses metrics.Counter
+
+	// Cache eviction count - number of times a transaction was evicted from the cache
+	// metrics:Number of cache evictions.
+	CacheEvictions metrics.Counter
+
+	// Current cache size - number of transactions currently in the cache
+	// metrics:Current number of transactions in the cache.
+	CacheSize metrics.Gauge
+
+	// Cache hit ratio - ratio of cache hits to total cache lookups
+	// metrics:Ratio of cache hits to total lookups (hits + misses).
+	CacheHitRatio metrics.Gauge
 }


### PR DESCRIPTION
## Description
This PR adds a new feature to track and expose statistics for the transaction cache in the mempool. It introduces a new StatsLRUTxCache implementation that extends the existing LRUTxCache with the ability to track hits, misses, evictions, and size metrics. These statistics are exposed through Prometheus metrics, allowing node operators to monitor cache performance and optimize cache size based on actual usage patterns.
The new metrics include:
- cache_hits: Number of cache hits
- cache_misses: Number of cache misses
- cache_evictions: Number of cache evictions
- cache_size: Current number of transactions in the cache
- cache_hit_ratio: Ratio of cache hits to total lookups
This enhancement will help operators better understand mempool performance and make informed decisions about cache configuration.
#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
