### PR TITLE
refactor: unify the error handling methods in the db package that are different from the project style & remove deprecated of package io/ioutil

### DIFF
--- a/db/pebbledb.go
+++ b/db/pebbledb.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"path/filepath"
 
@@ -56,7 +57,7 @@ func (pDB *pebbleDB) Get(key []byte) ([]byte, error) {
 
 	value, closer, err := pDB.db.Get(key)
 	if err != nil {
-		if err == pebble.ErrNotFound {
+		if errors.Is(err, pebble.ErrNotFound) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("fetching value from the DB for key %X: %w", key, err)

--- a/db/prefixdb.go
+++ b/db/prefixdb.go
@@ -270,8 +270,7 @@ func (pDB *prefixDB) Print() error {
 
 	itr, err := pDB.Iterator(nil, nil)
 	if err != nil {
-		const format = "creating a prefixed DB namespace iterator for debug printing: %w"
-		return fmt.Errorf(format, err)
+		return fmt.Errorf("creating a prefixed DB namespace iterator for debug printing: %w", err)
 	}
 	defer itr.Close()
 
@@ -572,8 +571,7 @@ func (it *prefixDBIterator) Valid() bool {
 		keyTooShort = len(key) < prefixLen
 	)
 	if keyTooShort || !bytes.Equal(key[:prefixLen], it.prefix) {
-		const format = "received invalid key from backend: %X (expected prefix %X)"
-		it.err = fmt.Errorf(format, key, it.prefix)
+		it.err = fmt.Errorf("received invalid key from backend: %X (expected prefix %X)", key, it.prefix)
 
 		return false
 	}

--- a/test/e2e/pkg/grammar/grammar-auto/lexer/lexer.go
+++ b/test/e2e/pkg/grammar/grammar-auto/lexer/lexer.go
@@ -2,8 +2,7 @@
 package lexer
 
 import (
-	// "fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"unicode"
 
@@ -124,7 +123,7 @@ If the input file is a normal text file NewFile treats all text in the inputfile
 as input text.
 */
 func NewFile(fname string) *Lexer {
-	buf, err := ioutil.ReadFile(fname)
+	buf, err := os.ReadFile(fname)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
1. unify the error handling methods in the db package that are different from the project style
2. remove deprecated of package io/ioutil