### PR TITLE
ci(testapp-docker): release two images, not one

### DIFF
--- a/.github/workflows/testapp-docker.yml
+++ b/.github/workflows/testapp-docker.yml
@@ -76,7 +76,9 @@ jobs:
 
       - name: Capture Image Digest
         id: capture-digest
-        run: echo "digest_${{ matrix.arch }}=${{ steps.build.outputs.digest }}" >> $GITHUB_ENV
+        run: |
+          echo "digest_${{ matrix.arch }}=${{ steps.build.outputs.digest }}" >> $GITHUB_ENV
+          echo "::set-output name=digest_${{ matrix.arch }}::${{ steps.build.outputs.digest }}"
 
   merge:
     runs-on: ubuntu-latest
@@ -85,6 +87,11 @@ jobs:
     steps:
       - name: Get sanitized Docker tag
         run: echo "DOCKER_TAG=$(echo ${{ needs.build-image-at-tag.outputs.version }} | sed 's/[^a-zA-Z0-9\.]/-/g')" >> $GITHUB_ENV
+
+      - name: Debug Output Digests
+        run: |
+          echo "AMD64 Digest: ${{ needs.build-image-at-tag.outputs.digest_amd64 }}"
+          echo "ARM64 Digest: ${{ needs.build-image-at-tag.outputs.digest_arm64 }}"
 
       - name: Login to DockerHub
         if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/testapp-docker.yml
+++ b/.github/workflows/testapp-docker.yml
@@ -11,52 +11,99 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+"   # e.g. v0.37.0-beta.1, v0.38.0-beta.10
       - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"      # e.g. v0.37.0-rc1, v0.38.0-rc10
 
+env:
+  ORG: cometbft
+  IMAGE_NAME: e2e-node
+
 jobs:
-  build:
+  build-image-at-tag:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-24.04
-            arch: linux/amd64
+            platform: linux/amd64
+            arch: amd64
           - os: ubuntu-24.04-arm
-            arch: linux/arm64
+            platform: linux/arm64
+            arch: arm64
     runs-on: ${{ matrix.os }}
+    outputs:
+      digest_amd64: ${{ steps.capture-digest.outputs.digest_amd64 }}
+      digest_arm64: ${{ steps.capture-digest.outputs.digest_arm64 }}
+      version: ${{ steps.get-version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
-      - name: Prepare
-        id: prep
-        run: |
-          DOCKER_IMAGE=cometbft/e2e-node
-          VERSION=noop
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/}
-          elif [[ $GITHUB_REF == refs/heads/* ]]; then
-            VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
-            if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
-              VERSION=latest
-            fi
-          fi
-          TAGS="${DOCKER_IMAGE}:${VERSION}"
-          if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-            TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION}"
-          fi
-          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+        with:
+          fetch-depth: 0
 
-      - name: Set up Docker Build
-        uses: docker/setup-buildx-action@v3.9.0
+      - name: Get version
+        id: get-version
+        run: |
+          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            echo "version=latest" >> $GITHUB_ENV
+            echo "::set-output name=version::latest"
+          elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            tag_name="${GITHUB_REF#refs/tags/}"
+            echo "version=$tag_name" >> $GITHUB_ENV
+            echo "::set-output name=version::$tag_name"
+          else
+            echo "Unknown version"
+            exit 1
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
         if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/login-action@v3.3.0
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Publish to Docker Hub
-        uses: docker/build-push-action@v6.14.0
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@v6
         with:
+          platforms: ${{ matrix.platform }}
           context: .
           file: ./test/e2e/docker/Dockerfile
-          platforms: ${{ matrix.arch }}
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.prep.outputs.tags }}
+          tags: |
+            ${{ env.ORG }}/${{ env.IMAGE_NAME }}:${{ steps.get-version.outputs.version }}
+          push: true
+          outputs: type=image,name=${{ env.ORG }}/${{ env.IMAGE_NAME }},digest=true
+
+      - name: Capture Image Digest
+        id: capture-digest
+        run: echo "digest_${{ matrix.arch }}=${{ steps.build.outputs.digest }}" >> $GITHUB_ENV
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build-image-at-tag
+    steps:
+      - name: Get sanitized Docker tag
+        run: echo "DOCKER_TAG=$(echo ${{ needs.build-image-at-tag.outputs.version }} | sed 's/[^a-zA-Z0-9\.]/-/g')" >> $GITHUB_ENV
+
+      - name: Login to DockerHub
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create Multi-Arch Manifest
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ env.ORG }}/${{ env.IMAGE_NAME }}:${{ env.DOCKER_TAG }} \
+            ${{ env.ORG }}/${{ env.IMAGE_NAME }}@${{ needs.build-image-at-tag.outputs.digest_amd64 }} \
+            ${{ env.ORG }}/${{ env.IMAGE_NAME }}@${{ needs.build-image-at-tag.outputs.digest_arm64 }}
+
+      - name: Tag and Push Latest (if applicable)
+        if: github.ref == 'refs/heads/main'
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ env.ORG }}/${{ env.IMAGE_NAME }}:latest \
+            ${{ env.ORG }}/${{ env.IMAGE_NAME }}@${{ needs.build-image-at-tag.outputs.digest_amd64 }} \
+            ${{ env.ORG }}/${{ env.IMAGE_NAME }}@${{ needs.build-image-at-tag.outputs.digest_arm64 }}


### PR DESCRIPTION
Previously, we would only push a single arm64 image. Evidence: https://hub.docker.com/r/cometbft/e2e-node/tags