### PR TITLE
fix: regex syntax in dist.sh script

### DIFF
--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -6,7 +6,7 @@ set -e
 
 # Get the version from the environment, or try to figure it out.
 if [ -z $VERSION ]; then
-	VERSION=$(awk -F\" 'CMTSemVer =/ { print $2; exit }' < version/version.go)
+	VERSION=$(awk -F\" '/CMTSemVer =/ { print $2; exit }' < version/version.go)
 fi
 if [ -z "$VERSION" ]; then
     echo "Please specify a version."


### PR DESCRIPTION
Corrects the regular expression syntax in the dist.sh script by adding proper delimiters to the awk command pattern. This ensures proper version extraction from version.go file.