### PR TITLE
refactor: use t.TempDir() instead of os.MkdirTemp

### DIFF
--- a/config/toml_test.go
+++ b/config/toml_test.go
@@ -25,9 +25,7 @@ func TestEnsureRoot(t *testing.T) {
 	require := require.New(t)
 
 	// setup temp dir for test
-	tmpDir, err := os.MkdirTemp("", "config-test")
-	require.NoError(err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	// create root dir
 	config.EnsureRoot(tmpDir)

--- a/internal/autofile/autofile_test.go
+++ b/internal/autofile/autofile_test.go
@@ -23,11 +23,7 @@ func TestSIGHUP(t *testing.T) {
 	})
 
 	// First, create a temporary directory and move into it
-	dir, err := os.MkdirTemp("", "sighup_test")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 	err = os.Chdir(dir)
 	require.NoError(t, err)
 
@@ -48,9 +44,7 @@ func TestSIGHUP(t *testing.T) {
 	require.NoError(t, err)
 
 	// Move into a different temporary directory
-	otherDir, err := os.MkdirTemp("", "sighup_test_other")
-	require.NoError(t, err)
-	defer os.RemoveAll(otherDir)
+	otherDir := t.TempDir()
 	err = os.Chdir(otherDir)
 	require.NoError(t, err)
 

--- a/internal/autofile/group_test.go
+++ b/internal/autofile/group_test.go
@@ -124,9 +124,7 @@ func TestRotateFile(t *testing.T) {
 		}
 	}()
 
-	dir, err := os.MkdirTemp("", "rotate_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	err = os.Chdir(dir)
 	require.NoError(t, err)
 

--- a/internal/consensus/wal_test.go
+++ b/internal/consensus/wal_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -35,9 +34,7 @@ const (
 func TestWALTruncate(t *testing.T) {
 	const numBlocks = 60
 
-	walDir, err := os.MkdirTemp("", "wal")
-	require.NoError(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 
 	walFile := filepath.Join(walDir, "wal")
 
@@ -255,9 +252,8 @@ func TestWALEncoder(t *testing.T) {
 }
 
 func TestWALWrite(t *testing.T) {
-	walDir, err := os.MkdirTemp("", "wal")
-	require.NoError(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
+
 	walFile := filepath.Join(walDir, "wal")
 
 	wal, err := NewWAL(walFile)
@@ -323,9 +319,7 @@ func TestWALSearchForEndHeight(t *testing.T) {
 }
 
 func TestWALPeriodicSync(t *testing.T) {
-	walDir, err := os.MkdirTemp("", "wal")
-	require.NoError(t, err)
-	defer os.RemoveAll(walDir)
+	walDir := t.TempDir()
 
 	walFile := filepath.Join(walDir, "wal")
 	wal, err := NewWAL(walFile, autofile.GroupCheckDuration(1*time.Millisecond))

--- a/internal/os/os_test.go
+++ b/internal/os/os_test.go
@@ -38,12 +38,10 @@ func TestCopyFile(t *testing.T) {
 }
 
 func TestEnsureDir(t *testing.T) {
-	tmp, err := os.MkdirTemp("", "ensure-dir")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	// Should be possible to create a new directory.
-	err = EnsureDir(filepath.Join(tmp, "dir"), 0o755)
+	err := EnsureDir(filepath.Join(tmp, "dir"), 0o755)
 	require.NoError(t, err)
 	require.DirExists(t, filepath.Join(tmp, "dir"))
 
@@ -74,11 +72,7 @@ func TestEnsureDir(t *testing.T) {
 // the origin is positively a non-directory and that it is ready for copying.
 // See https://github.com/tendermint/tendermint/issues/6427
 func TestTrickedTruncation(t *testing.T) {
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "pwn_truncate")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(tmpDir)
+	tmpDir := t.TempDir()
 
 	originalWALPath := filepath.Join(tmpDir, "wal")
 	originalWALContent := []byte("I AM BECOME DEATH, DESTROYER OF ALL WORLDS!")

--- a/libs/os/os_test.go
+++ b/libs/os/os_test.go
@@ -42,12 +42,10 @@ func TestCopyFile(t *testing.T) {
 }
 
 func TestEnsureDir(t *testing.T) {
-	tmp, err := os.MkdirTemp("", "ensure-dir")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	// Should be possible to create a new directory.
-	err = EnsureDir(filepath.Join(tmp, "dir"), 0o755)
+	err := EnsureDir(filepath.Join(tmp, "dir"), 0o755)
 	require.NoError(t, err)
 	require.DirExists(t, filepath.Join(tmp, "dir"))
 
@@ -78,11 +76,7 @@ func TestEnsureDir(t *testing.T) {
 // the origin is positively a non-directory and that it is ready for copying.
 // See https://github.com/tendermint/tendermint/issues/6427
 func TestTrickedTruncation(t *testing.T) {
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "pwn_truncate")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(tmpDir)
+	tmpDir := t.TempDir()
 
 	originalWALPath := filepath.Join(tmpDir, "wal")
 	originalWALContent := []byte("I AM BECOME DEATH, DESTROYER OF ALL WORLDS!")

--- a/p2p/pex/pex_reactor_test.go
+++ b/p2p/pex/pex_reactor_test.go
@@ -72,9 +72,7 @@ func TestPEXReactorRunning(t *testing.T) {
 	switches := make([]*p2p.Switch, n)
 
 	// directory to store address books
-	dir, err := os.MkdirTemp("", "pex_reactor")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	books := make([]AddrBook, n)
 	logger := log.TestingLogger()
@@ -206,9 +204,7 @@ func TestPEXReactorAddrsMessageAbuse(t *testing.T) {
 
 func TestCheckSeeds(t *testing.T) {
 	// directory to store address books
-	dir, err := os.MkdirTemp("", "pex_reactor")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// 1. test creating peer with no seeds works
 	peerSwitch := testCreateDefaultPeer(dir, 0)
@@ -249,9 +245,7 @@ func TestCheckSeeds(t *testing.T) {
 
 func TestPEXReactorUsesSeedsIfNeeded(t *testing.T) {
 	// directory to store address books
-	dir, err := os.MkdirTemp("", "pex_reactor")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// 1. create seed
 	seed := testCreateSeed(dir, 0, []*na.NetAddr{}, []*na.NetAddr{})
@@ -269,9 +263,7 @@ func TestPEXReactorUsesSeedsIfNeeded(t *testing.T) {
 
 func TestConnectionSpeedForPeerReceivedFromSeed(t *testing.T) {
 	// directory to store address books
-	dir, err := os.MkdirTemp("", "pex_reactor")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	var id int
 	var knownAddrs []*na.NetAddr
@@ -313,9 +305,7 @@ func TestConnectionSpeedForPeerReceivedFromSeed(t *testing.T) {
 
 func TestPEXReactorSeedMode(t *testing.T) {
 	// directory to store address books
-	dir, err := os.MkdirTemp("", "pex_reactor")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	pexRConfig := &ReactorConfig{SeedMode: true, SeedDisconnectWaitPeriod: 100 * time.Millisecond}
 	pexR, book := createReactor(pexRConfig)
@@ -323,7 +313,7 @@ func TestPEXReactorSeedMode(t *testing.T) {
 
 	sw := createSwitchAndAddReactors(pexR)
 	sw.SetAddrBook(book)
-	err = sw.Start()
+	err := sw.Start()
 	require.NoError(t, err)
 	defer sw.Stop() //nolint:errcheck // ignore for tests
 
@@ -352,9 +342,7 @@ func TestPEXReactorSeedMode(t *testing.T) {
 
 func TestPEXReactorDoesNotDisconnectFromPersistentPeerInSeedMode(t *testing.T) {
 	// directory to store address books
-	dir, err := os.MkdirTemp("", "pex_reactor")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	pexRConfig := &ReactorConfig{SeedMode: true, SeedDisconnectWaitPeriod: 1 * time.Millisecond}
 	pexR, book := createReactor(pexRConfig)
@@ -362,7 +350,7 @@ func TestPEXReactorDoesNotDisconnectFromPersistentPeerInSeedMode(t *testing.T) {
 
 	sw := createSwitchAndAddReactors(pexR)
 	sw.SetAddrBook(book)
-	err = sw.Start()
+	err := sw.Start()
 	require.NoError(t, err)
 	defer sw.Stop() //nolint:errcheck // ignore for tests
 
@@ -389,10 +377,6 @@ func TestPEXReactorDoesNotDisconnectFromPersistentPeerInSeedMode(t *testing.T) {
 }
 
 func TestPEXReactorDialsPeerUpToMaxAttemptsInSeedMode(t *testing.T) {
-	// directory to store address books
-	dir, err := os.MkdirTemp("", "pex_reactor")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	pexR, book := createReactor(&ReactorConfig{SeedMode: true})
 	defer teardownReactor(book)
@@ -404,7 +388,7 @@ func TestPEXReactorDialsPeerUpToMaxAttemptsInSeedMode(t *testing.T) {
 	peer := mock.NewPeer(nil)
 	addr := peer.SocketAddr()
 
-	err = book.AddAddress(addr, addr)
+	err := book.AddAddress(addr, addr)
 	require.NoError(t, err)
 
 	assert.True(t, book.HasAddress(addr))
@@ -426,9 +410,7 @@ func TestPEXReactorSeedModeFlushStop(t *testing.T) {
 	switches := make([]*p2p.Switch, n)
 
 	// directory to store address books
-	dir, err := os.MkdirTemp("", "pex_reactor")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	books := make([]AddrBook, n)
 	logger := log.TestingLogger()
@@ -466,7 +448,7 @@ func TestPEXReactorSeedModeFlushStop(t *testing.T) {
 	reactor := switches[0].Reactors()["pex"].(*Reactor)
 	peerID := switches[1].NodeInfo().ID()
 
-	err = switches[1].DialPeerWithAddress(switches[0].NetAddr())
+	err := switches[1].DialPeerWithAddress(switches[0].NetAddr())
 	require.NoError(t, err)
 
 	// sleep up to a second while waiting for the peer to send us a message.

--- a/rpc/core/env_test.go
+++ b/rpc/core/env_test.go
@@ -271,11 +271,7 @@ func TestCleanup(t *testing.T) {
 		// creating a directory and a sub-directory; then we'll set the parent
 		// directory's permissions to read-only, so that os.RemoveAll() will fail.
 
-		parentDir, err := os.MkdirTemp("", "parentDir")
-		if err != nil {
-			t.Fatalf("creating test parent directory: %s", err)
-		}
-		defer os.RemoveAll(parentDir)
+		parentDir := t.TempDir()
 
 		var (
 			gFilePath = filepath.Join(parentDir, "genesis.json")
@@ -294,7 +290,7 @@ func TestCleanup(t *testing.T) {
 			t.Fatalf("changing test parent directory permissions: %s", err)
 		}
 
-		err = env.Cleanup()
+		err := env.Cleanup()
 		if err == nil {
 			t.Fatalf("expected an error, got nil")
 		}
@@ -438,11 +434,7 @@ func TestMkChunksDir(t *testing.T) {
 }
 
 func TestWriteChunk(t *testing.T) {
-	cDir, err := os.MkdirTemp("", _chunksDir)
-	if err != nil {
-		t.Fatalf("creating test chunks directory: %s", err)
-	}
-	defer os.RemoveAll(cDir)
+	cDir := t.TempDir()
 
 	var (
 		chunk    = []byte("test-chunk")

--- a/scripts/metricsgen/metricsgen_test.go
+++ b/scripts/metricsgen/metricsgen_test.go
@@ -227,11 +227,7 @@ func TestParseMetricsStruct(t *testing.T) {
 	}
 	for _, testCase := range metricsTests {
 		t.Run(testCase.name, func(t *testing.T) {
-			dir, err := os.MkdirTemp(os.TempDir(), "metricsdir")
-			if err != nil {
-				t.Fatalf("unable to create directory: %v", err)
-			}
-			defer os.Remove(dir)
+			dir := t.TempDir()
 			f, err := os.Create(filepath.Join(dir, "metrics.go"))
 			if err != nil {
 				t.Fatalf("unable to open file: %v", err)
@@ -272,11 +268,7 @@ func TestParseAliasedMetric(t *testing.T) {
 				m mymetrics.Gauge
 			}
 			`
-	dir, err := os.MkdirTemp(os.TempDir(), "metricsdir")
-	if err != nil {
-		t.Fatalf("unable to create directory: %v", err)
-	}
-	defer os.Remove(dir)
+	dir := t.TempDir()
 	f, err := os.Create(filepath.Join(dir, "metrics.go"))
 	if err != nil {
 		t.Fatalf("unable to open file: %v", err)


### PR DESCRIPTION
https://pkg.go.dev/testing#B.TempDir
