### PR TITLE
fix(rpc/test): misuse wrong err variable

### DIFF
--- a/rpc/jsonrpc/jsonrpc_test.go
+++ b/rpc/jsonrpc/jsonrpc_test.go
@@ -259,7 +259,7 @@ func echoViaWS(cl *client.WSClient, val string) (string, error) {
 
 	msg := <-cl.ResponsesCh
 	if msg.Error != nil {
-		return "", err
+		return "", msg.Error
 	}
 	result := new(ResultEcho)
 	err = json.Unmarshal(msg.Result, result)
@@ -396,7 +396,7 @@ func TestWSNewWSRPCFunc(t *testing.T) {
 
 	msg := <-cl.ResponsesCh
 	if msg.Error != nil {
-		t.Fatal(err)
+		t.Fatal(msg.Error)
 	}
 	result := new(ResultEcho)
 	err = json.Unmarshal(msg.Result, result)
@@ -426,7 +426,7 @@ func TestWSNewWSRPCFuncV1(t *testing.T) {
 
 	msg := <-cl.ResponsesCh
 	if msg.Error != nil {
-		t.Fatal(err)
+		t.Fatal(msg.Error)
 	}
 	result := new(ResultEcho)
 	err = json.Unmarshal(msg.Result, result)
@@ -454,7 +454,7 @@ func TestWSHandlesArrayParams(t *testing.T) {
 
 	msg := <-cl.ResponsesCh
 	if msg.Error != nil {
-		t.Fatalf("%+v", err)
+		t.Fatalf("%+v", msg.Error)
 	}
 	result := new(ResultEcho)
 	err = json.Unmarshal(msg.Result, result)
@@ -482,7 +482,7 @@ func TestWSHandlesArrayParamsV1(t *testing.T) {
 
 	msg := <-cl.ResponsesCh
 	if msg.Error != nil {
-		t.Fatalf("%+v", err)
+		t.Fatalf("%+v", msg.Error)
 	}
 	result := new(ResultEcho)
 	err = json.Unmarshal(msg.Result, result)


### PR DESCRIPTION
`err` has been checked before with `require.NoError(t, err)`, actually we are not aim to check `err` but `msg.Error` :)