### PR TITLE
fix: remove duplicate WithDBKeyLayout parameter in blockStore initial…

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -348,7 +348,7 @@ func NewNodeWithCliParams(ctx context.Context,
 		DBKeyLayout:          config.Storage.ExperimentalKeyLayout,
 	})
 
-	blockStore := store.NewBlockStore(blockStoreDB, store.WithMetrics(bstMetrics), store.WithCompaction(config.Storage.Compact, config.Storage.CompactionInterval), store.WithDBKeyLayout(config.Storage.ExperimentalKeyLayout), store.WithDBKeyLayout(config.Storage.ExperimentalKeyLayout))
+	blockStore := store.NewBlockStore(blockStoreDB, store.WithMetrics(bstMetrics), store.WithCompaction(config.Storage.Compact, config.Storage.CompactionInterval), store.WithDBKeyLayout(config.Storage.ExperimentalKeyLayout))
 	logger.Info("Blockstore version", "version", blockStore.GetVersion())
 
 	// The key will be deleted if it existed.


### PR DESCRIPTION

The parameter `store.WithDBKeyLayout(config.Storage.ExperimentalKeyLayout)` was accidentally duplicated in the `NewBlockStore` constructor call. 

While functionally harmless (the latter instance would simply override the former in Go's option pattern), this duplication creates code redundancy and maintenance ambiguity. 


---

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
