### PR TITLE
refactor(all): replacing []byte(fmt.Sprintf...) by fmt.Appendf(nil, ...)

### DIFF
--- a/abci/example/kvstore/helpers.go
+++ b/abci/example/kvstore/helpers.go
@@ -65,12 +65,12 @@ func NewRandomTxs(n int) [][]byte {
 
 // NewTxFromID creates a new transaction using the given ID.
 func NewTxFromID(i int) []byte {
-	return []byte(fmt.Sprintf("%d=%d", i, i))
+	return fmt.Appendf(nil, "%d=%d", i, i)
 }
 
 // MakeValSetChangeTx creates a transaction to add/remove/update a validator.
 // To remove, set power to 0.
 func MakeValSetChangeTx(v types.ValidatorUpdate) []byte {
 	pubStr := base64.StdEncoding.EncodeToString(v.PubKeyBytes)
-	return []byte(fmt.Sprintf("%s%s!%s!%d", ValidatorPrefix, v.PubKeyType, pubStr, v.Power))
+	return fmt.Appendf(nil, "%s%s!%s!%d", ValidatorPrefix, v.PubKeyType, pubStr, v.Power)
 }

--- a/internal/evidence/pool.go
+++ b/internal/evidence/pool.go
@@ -692,7 +692,7 @@ func bE(h int64) string {
 }
 
 func keySuffix(evidence types.Evidence) []byte {
-	return []byte(fmt.Sprintf("%s/%X", bE(evidence.Height()), evidence.Hash()))
+	return fmt.Appendf(nil, "%s/%X", bE(evidence.Height()), evidence.Hash())
 }
 
 // ---------------------

--- a/internal/tempfile/tempfile_test.go
+++ b/internal/tempfile/tempfile_test.go
@@ -132,7 +132,7 @@ func TestWriteFileAtomicManyDuplicates(t *testing.T) {
 		fname := "/tmp/" + atomicWriteFilePrefix + fileRand
 		firstAtomicFileBytes, err := os.ReadFile(fname)
 		require.NoError(t, err, "Error reading first atomic file")
-		require.Equal(t, []byte(fmt.Sprintf(testString, i)), firstAtomicFileBytes,
+		require.Equal(t, fmt.Appendf(nil, testString, i), firstAtomicFileBytes,
 			"atomic write file %d was overwritten", i)
 	}
 

--- a/internal/test/validator.go
+++ b/internal/test/validator.go
@@ -47,7 +47,7 @@ func GenesisValidatorSet(nVals int) ([]types.GenesisValidator, map[string]types.
 	vals := make([]types.GenesisValidator, nVals)
 	privVals := make(map[string]types.PrivValidator, nVals)
 	for i := 0; i < nVals; i++ {
-		secret := []byte(fmt.Sprintf("test%d", i))
+		secret := fmt.Appendf(nil, "test%d", i)
 		pk := ed25519.GenPrivKeyFromSecret(secret)
 		valAddr := pk.PubKey().Address()
 		vals[i] = types.GenesisValidator{

--- a/libs/bytes/bytes.go
+++ b/libs/bytes/bytes.go
@@ -58,11 +58,11 @@ func (bz HexBytes) String() string {
 func (bz HexBytes) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 'p':
-		if _, err := s.Write([]byte(fmt.Sprintf("%p", bz))); err != nil {
+		if _, err := s.Write(fmt.Appendf(nil, "%p", bz)); err != nil {
 			panic(err)
 		}
 	default:
-		if _, err := s.Write([]byte(fmt.Sprintf("%X", []byte(bz)))); err != nil {
+		if _, err := s.Write(fmt.Appendf(nil, "%X", []byte(bz))); err != nil {
 			panic(err)
 		}
 	}

--- a/light/store/db/db_test.go
+++ b/light/store/db/db_test.go
@@ -24,7 +24,7 @@ func TestV1LBKey(t *testing.T) {
 	const prefix = "v1"
 
 	sprintf := func(h int64) []byte {
-		return []byte(fmt.Sprintf("lb/%s/%020d", prefix, h))
+		return fmt.Appendf(nil, "lb/%s/%020d", prefix, h)
 	}
 
 	cases := []struct {

--- a/proxy/app_conn_test.go
+++ b/proxy/app_conn_test.go
@@ -45,7 +45,7 @@ func TestEcho(t *testing.T) {
 
 	for i := 0; i < 1000; i++ {
 		_, err = proxy.CheckTx(context.Background(), &abci.CheckTxRequest{
-			Tx:   []byte(fmt.Sprintf("echo-%v", i)),
+			Tx:   fmt.Appendf(nil, "echo-%v", i),
 			Type: abci.CHECK_TX_TYPE_CHECK,
 		})
 		if err != nil {

--- a/rpc/jsonrpc/types/types_test.go
+++ b/rpc/jsonrpc/types/types_test.go
@@ -59,7 +59,7 @@ func TestUnmarshallResponses(t *testing.T) {
 	for _, tt := range responseTests {
 		response := &RPCResponse{}
 		err := json.Unmarshal(
-			[]byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":%v,"result":{"Value":"hello"}}`, tt.expected)),
+			fmt.Appendf(nil, `{"jsonrpc":"2.0","id":%v,"result":{"Value":"hello"}}`, tt.expected),
 			response,
 		)
 		require.NoError(t, err)

--- a/scripts/wal2json/main.go
+++ b/scripts/wal2json/main.go
@@ -50,7 +50,7 @@ func main() {
 
 		if err == nil {
 			if endMsg, ok := msg.Msg.(cs.EndHeightMessage); ok {
-				_, err = os.Stdout.Write([]byte(fmt.Sprintf("ENDHEIGHT %d\n", endMsg.Height)))
+				_, err = os.Stdout.Write(fmt.Appendf(nil, "ENDHEIGHT %d\n", endMsg.Height))
 			}
 		}
 

--- a/state/compatibility_test.go
+++ b/state/compatibility_test.go
@@ -27,7 +27,7 @@ import (
 // Compatibility test across different state proto versions
 
 func calcABCIResponsesKey(height int64) []byte {
-	return []byte(fmt.Sprintf("abciResponsesKey:%v", height))
+	return fmt.Appendf(nil, "abciResponsesKey:%v", height)
 }
 
 var lastABCIResponseKey = []byte("lastABCIResponseKey")

--- a/state/txindex/kv/kv.go
+++ b/state/txindex/kv/kv.go
@@ -1055,17 +1055,17 @@ func extractEventSeqFromKey(key []byte) string {
 }
 
 func keyForEvent(key string, value string, result *abci.TxResult, eventSeq int64) []byte {
-	return []byte(fmt.Sprintf("%s/%s/%d/%d%s",
+	return fmt.Appendf(nil, "%s/%s/%d/%d%s",
 		key,
 		value,
 		result.Height,
 		result.Index,
 		eventSeqSeparator+strconv.FormatInt(eventSeq, 10),
-	))
+	)
 }
 
 func keyForHeight(result *abci.TxResult) []byte {
-	return []byte(fmt.Sprintf("%s/%d/%d/%d%s",
+	return fmt.Appendf(nil, "%s/%d/%d/%d%s",
 		types.TxHeightKey,
 		result.Height,
 		result.Height,
@@ -1073,7 +1073,7 @@ func keyForHeight(result *abci.TxResult) []byte {
 		// Added to facilitate having the eventSeq in event keys
 		// Otherwise queries break expecting 5 entries
 		eventSeqSeparator+"0",
-	))
+	)
 }
 
 func startKeyForCondition(c syntax.Condition, height int64) []byte {

--- a/state/txindex/kv/kv_test.go
+++ b/state/txindex/kv/kv_test.go
@@ -463,12 +463,12 @@ func TestTxSearchDeprecatedIndexing(t *testing.T) {
 	rawBytes, err := proto.Marshal(txResult2)
 	require.NoError(t, err)
 
-	depKey := []byte(fmt.Sprintf("%s/%s/%d/%d",
+	depKey := fmt.Appendf(nil, "%s/%s/%d/%d",
 		"sender",
 		"addr1",
 		txResult2.Height,
 		txResult2.Index,
-	))
+	)
 
 	err = b.Set(depKey, hash2)
 	require.NoError(t, err)

--- a/statesync/snapshots.go
+++ b/statesync/snapshots.go
@@ -30,7 +30,7 @@ type snapshot struct {
 func (s *snapshot) Key() snapshotKey {
 	// Hash.Write() never returns an error.
 	hasher := sha256.New()
-	hasher.Write([]byte(fmt.Sprintf("%v:%v:%v", s.Height, s.Format, s.Chunks)))
+	hasher.Write(fmt.Appendf(nil, "%v:%v:%v", s.Height, s.Format, s.Chunks))
 	hasher.Write(s.Hash)
 	hasher.Write(s.Metadata)
 	var key snapshotKey

--- a/test/e2e/app/app.go
+++ b/test/e2e/app/app.go
@@ -662,7 +662,7 @@ func (app *Application) PrepareProposal(
 			panic("unable to marshall extended commit")
 		}
 		extCommitHex := hex.EncodeToString(extCommitBytes)
-		extTx := []byte(fmt.Sprintf("%s%d|%s", extTxPrefix, sum, extCommitHex))
+		extTx := fmt.Appendf(nil, "%s%d|%s", extTxPrefix, sum, extCommitHex)
 		extTxLen := cmttypes.ComputeProtoSizeForTxs([]cmttypes.Tx{extTx})
 		app.logger.Info("preparing proposal with special transaction from vote extensions", "extTxLen", extTxLen)
 		if extTxLen > req.MaxTxBytes {
@@ -781,7 +781,7 @@ func (app *Application) ExtendVote(_ context.Context, req *abci.ExtendVoteReques
 	}
 
 	// Replay protection mechanism consists of: (a) the randomness of the extension (nonce), and (b) including the height
-	nonRpExt := []byte(fmt.Sprintf("%d|", req.Height))
+	nonRpExt := fmt.Appendf(nil, "%d|", req.Height)
 
 	nonRpExt = slices.Concat(nonRpExt, ext[:extLen])
 

--- a/test/e2e/pkg/grammar/grammar-auto/parser/parser.go
+++ b/test/e2e/pkg/grammar/grammar-auto/parser/parser.go
@@ -4,6 +4,7 @@ package parser
 import (
 	"bytes"
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 
@@ -859,9 +860,7 @@ func (p *parser) ntAdd(nt symbols.NT, j int) {
 			p.dscAdd(l, j, j)
 			failed = false
 		} else {
-			for k, v := range first[l] {
-				expected[k] = v
-			}
+			maps.Copy(expected, first[l])
 		}
 	}
 	if failed {

--- a/test/e2e/pkg/grammar/grammar-auto/parser/parser.go
+++ b/test/e2e/pkg/grammar/grammar-auto/parser/parser.go
@@ -4,7 +4,6 @@ package parser
 import (
 	"bytes"
 	"fmt"
-	"maps"
 	"sort"
 	"strings"
 
@@ -860,7 +859,9 @@ func (p *parser) ntAdd(nt symbols.NT, j int) {
 			p.dscAdd(l, j, j)
 			failed = false
 		} else {
-			maps.Copy(expected, first[l])
+			for k, v := range first[l] {
+				expected[k] = v
+			}
 		}
 	}
 	if failed {

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -517,7 +517,7 @@ func UpdateConfigStateSync(node *e2e.Node, height int64, hash []byte) error {
 	if err != nil {
 		return err
 	}
-	bz = regexp.MustCompile(`(?m)^trust_height =.*`).ReplaceAll(bz, []byte(fmt.Sprintf(`trust_height = %v`, height)))
-	bz = regexp.MustCompile(`(?m)^trust_hash =.*`).ReplaceAll(bz, []byte(fmt.Sprintf(`trust_hash = "%X"`, hash)))
+	bz = regexp.MustCompile(`(?m)^trust_height =.*`).ReplaceAll(bz, fmt.Appendf(nil, `trust_height = %v`, height))
+	bz = regexp.MustCompile(`(?m)^trust_hash =.*`).ReplaceAll(bz, fmt.Appendf(nil, `trust_hash = "%X"`, hash))
 	return os.WriteFile(cfgPath, bz, 0o644) //nolint:gosec
 }

--- a/types/validator_set_test.go
+++ b/types/validator_set_test.go
@@ -30,8 +30,8 @@ func TestValidatorSetBasic(t *testing.T) {
 	assert.Panics(t, func() { vset.IncrementProposerPriority(1) })
 
 	assert.EqualValues(t, vset, vset.Copy())
-	assert.False(t, vset.HasAddress([]byte("some val")))
-	idx, val := vset.GetByAddress([]byte("some val"))
+	assert.False(t, vset.HasAddress(fmt.Appendf(nil, "some val")))
+	idx, val := vset.GetByAddress(fmt.Appendf(nil, "some val"))
 	assert.EqualValues(t, -1, idx)
 	assert.Nil(t, val)
 	addr, val := vset.GetByIndex(-100)
@@ -1635,7 +1635,7 @@ func BenchmarkUpdates(b *testing.B) {
 	// Init with n validators
 	vs := make([]*Validator, n)
 	for j := 0; j < n; j++ {
-		vs[j] = newValidator([]byte(fmt.Sprintf("v%d", j)), 100)
+		vs[j] = newValidator(fmt.Appendf(nil, "v%d", j), 100)
 	}
 	valSet := NewValidatorSet(vs)
 	l := len(valSet.Validators)
@@ -1643,7 +1643,7 @@ func BenchmarkUpdates(b *testing.B) {
 	// Make m new validators
 	newValList := make([]*Validator, m)
 	for j := 0; j < m; j++ {
-		newValList[j] = newValidator([]byte(fmt.Sprintf("v%d", j+l)), 1000)
+		newValList[j] = newValidator(fmt.Appendf(nil, "v%d", j+l), 1000)
 	}
 	b.ResetTimer()
 


### PR DESCRIPTION
---

#### PR checklist

replacing `[]byte(fmt.Sprintf...)` by `fmt.Appendf(nil, ...)`, added in go1.19;


- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
