### PR TITLE
feat: simplified Loop using slices.Contains

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -340,10 +341,8 @@ func (cfg BaseConfig) validateProxyApp() error {
 	}
 
 	// proxy is a static application.
-	for _, proxyApp := range proxyAppList {
-		if cfg.ProxyApp == proxyApp {
-			return nil
-		}
+	if slices.Contains(proxyAppList, cfg.ProxyApp) {
+		return nil
 	}
 
 	// proxy is a network address.

--- a/internal/strings/string.go
+++ b/internal/strings/string.go
@@ -2,17 +2,13 @@ package strings
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 )
 
 // StringInSlice returns true if a is found the list.
 func StringInSlice(a string, list []string) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(list, a)
 }
 
 // SplitAndTrim slices s into all subslices separated by sep and returns a

--- a/libs/pubsub/query/query.go
+++ b/libs/pubsub/query/query.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"math/big"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -150,12 +151,7 @@ func (c condition) findAttr(event types.Event) ([]string, bool) {
 
 // matchesAny reports whether c matches at least one of the given events.
 func (c condition) matchesAny(events []types.Event) bool {
-	for _, event := range events {
-		if c.matchesEvent(event) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(events, c.matchesEvent)
 }
 
 // matchesEvent reports whether c matches the given event.
@@ -172,12 +168,7 @@ func (c condition) matchesEvent(event types.Event) bool {
 	}
 
 	// At this point, we have candidate values.
-	for _, v := range vs {
-		if c.match(v) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(vs, c.match)
 }
 
 func compileCondition(cond syntax.Condition) (condition, error) {

--- a/libs/pubsub/query/syntax/parser.go
+++ b/libs/pubsub/query/syntax/parser.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"slices"
 	"strings"
 	"time"
 )
@@ -197,10 +198,8 @@ func (p *Parser) require(tokens ...Token) error {
 		return fmt.Errorf("offset %d: %w", p.scanner.Pos(), err)
 	}
 	got := p.scanner.Token()
-	for _, tok := range tokens {
-		if tok == got {
-			return nil
-		}
+	if slices.Contains(tokens, got) {
+		return nil
 	}
 	return fmt.Errorf("offset %d: got %v, wanted %s", p.scanner.Pos(), got, tokLabel(tokens))
 }

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"reflect"
 	"runtime/debug"
+	"slices"
 	"time"
 
 	"github.com/cosmos/gogoproto/proto"
@@ -418,12 +419,7 @@ func (p *peer) Set(key string, data any) {
 
 // HasChannel returns whether the peer reported implementing this channel.
 func (p *peer) HasChannel(chID byte) bool {
-	for _, ch := range p.channels {
-		if ch == chID {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(p.channels, chID)
 }
 
 func (p *peer) SetRemovalFailed() {

--- a/p2p/pex/known_address.go
+++ b/p2p/pex/known_address.go
@@ -1,6 +1,7 @@
 package pex
 
 import (
+	"slices"
 	"time"
 
 	"github.com/cometbft/cometbft/p2p/internal/nodekey"
@@ -67,12 +68,10 @@ func (ka *knownAddress) isBanned() bool {
 }
 
 func (ka *knownAddress) addBucketRef(bucketIdx int) int {
-	for _, bucket := range ka.Buckets {
-		if bucket == bucketIdx {
-			// TODO refactor to return error?
-			// log.Warn(Fmt("Bucket already exists in ka.Buckets: %v", ka))
-			return -1
-		}
+	if slices.Contains(ka.Buckets, bucketIdx) {
+		// TODO refactor to return error?
+		// log.Warn(Fmt("Bucket already exists in ka.Buckets: %v", ka))
+		return -1
 	}
 	ka.Buckets = append(ka.Buckets, bucketIdx)
 	return len(ka.Buckets)

--- a/state/indexer/block/kv/util.go
+++ b/state/indexer/block/kv/util.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"slices"
 	"strconv"
 
 	"github.com/google/orderedcode"
@@ -24,13 +25,7 @@ type HeightInfo struct {
 }
 
 func intInSlice(a int, list []int) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(list, a)
 }
 
 func int64FromBytes(bz []byte) int64 {

--- a/state/txindex/kv/utils.go
+++ b/state/txindex/kv/utils.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math/big"
+	"slices"
 
 	"github.com/google/orderedcode"
 
@@ -24,12 +25,7 @@ type HeightInfo struct {
 
 // IntInSlice returns true if a is found in the list.
 func intInSlice(a int, list []int) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(list, a)
 }
 
 func ParseEventSeqFromEventKey(key []byte) (int64, error) {


### PR DESCRIPTION
---

#### PR checklist

go 1.23 support `slices`, the code is more simplified and readable.
check all && omit auto generated code
```
lfgtwo/cometbft/libs/pubsub/query/query.go:153:2: Loop can be simplified using slices.ContainsFunc
lfgtwo/cometbft/libs/pubsub/query/query.go:175:2: Loop can be simplified using slices.ContainsFunc
lfgtwo/cometbft/p2p/pex/known_address.go:70:2: Loop can be simplified using slices.Contains
lfgtwo/cometbft/state/indexer/block/kv/util.go:27:2: Loop can be simplified using slices.Contains
lfgtwo/cometbft/state/txindex/kv/utils.go:27:2: Loop can be simplified using slices.Contains
lfgtwo/cometbft/test/e2e/pkg/grammar/grammar-auto/lexer/lexer.go:266:2: Loop can be simplified using slices.Contains
lfgtwo/cometbft/test/e2e/pkg/grammar/grammar-auto/lexer/lexer.go:275:2: Loop can be simplified using slices.Contains
lfgtwo/cometbft/test/e2e/pkg/grammar/grammar-auto/parser/bsr/bsr.go:539:4: Loop can be simplified using slices.ContainsFunc
lfgtwo/cometbft/test/e2e/pkg/grammar/grammar-auto/parser/parser.go:946:2: Loop can be simplified using slices.Contains
lfgtwo/cometbft/test/e2e/pkg/grammar/grammar-auto/parser/parser.go:1003:2: Loop can be simplified using slices.Contains
```

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
