### PR TITLE
refactor(all): simplify length calculations using min/max functions

### DIFF
--- a/internal/blocksync/pool_test.go
+++ b/internal/blocksync/pool_test.go
@@ -97,10 +97,7 @@ func makePeers(numPeers int, minHeight, maxHeight int64) testPeers {
 	for i := 0; i < numPeers; i++ {
 		peerID := p2p.ID(cmtrand.Str(12))
 		height := minHeight + cmtrand.Int63n(maxHeight-minHeight)
-		base := minHeight + int64(i)
-		if base > height {
-			base = height
-		}
+		base := min(minHeight+int64(i), height)
 		peers[peerID] = &testPeer{peerID, base, height, make(chan inputData, 10), false}
 	}
 	return peers

--- a/internal/consensus/pbts_test.go
+++ b/internal/consensus/pbts_test.go
@@ -149,10 +149,7 @@ func (p *pbtsTestHarness) observedValidatorProposerHeight(t *testing.T, previous
 
 	ensureNewRound(p.roundCh, p.currentHeight, p.currentRound)
 
-	timeout := cmttime.Until(previousBlockTime.Add(ensureTimeout))
-	if timeout < ensureTimeout {
-		timeout = ensureTimeout
-	}
+	timeout := max(cmttime.Until(previousBlockTime.Add(ensureTimeout)), ensureTimeout)
 	ensureProposalWithTimeout(p.ensureProposalCh, p.currentHeight, p.currentRound, nil, timeout)
 
 	rs := p.observedState.GetRoundState()

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -2659,10 +2659,7 @@ func (cs *State) updatePrivValidatorPubKey() error {
 func (cs *State) checkDoubleSigningRisk(height int64) error {
 	if cs.privValidator != nil && cs.privValidatorPubKey != nil && cs.config.DoubleSignCheckHeight > 0 && height > 0 {
 		valAddr := cs.privValidatorPubKey.Address()
-		doubleSignCheckHeight := cs.config.DoubleSignCheckHeight
-		if doubleSignCheckHeight > height {
-			doubleSignCheckHeight = height
-		}
+		doubleSignCheckHeight := min(cs.config.DoubleSignCheckHeight, height)
 
 		for i := int64(1); i < doubleSignCheckHeight; i++ {
 			lastCommit := cs.blockStore.LoadSeenCommit(height - i)

--- a/internal/flowrate/flowrate.go
+++ b/internal/flowrate/flowrate.go
@@ -159,10 +159,7 @@ func (m *Monitor) Status() Status {
 			s.CurRate = round(m.rEMA)
 			if s.BytesRem > 0 {
 				if tRate := 0.8*m.rEMA + 0.2*rAvg; tRate > 0 {
-					ns := float64(s.BytesRem) / tRate * 1e9
-					if ns > float64(timeRemLimit) {
-						ns = float64(timeRemLimit)
-					}
+					ns := min(float64(s.BytesRem)/tRate*1e9, float64(timeRemLimit))
 					s.TimeRem = clockRound(time.Duration(ns))
 				}
 			}

--- a/internal/keytypes/keytypes.go
+++ b/internal/keytypes/keytypes.go
@@ -2,7 +2,7 @@ package keytypes
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/cometbft/cometbft/crypto"
@@ -57,9 +57,7 @@ func SupportedKeyTypesStr() string {
 	for k := range keyTypes {
 		keyTypesSlice = append(keyTypesSlice, fmt.Sprintf("%q", k))
 	}
-	sort.Slice(keyTypesSlice, func(i, j int) bool {
-		return keyTypesSlice[i] < keyTypesSlice[j]
-	})
+	slices.Sort(keyTypesSlice)
 	return strings.Join(keyTypesSlice, ", ")
 }
 
@@ -69,9 +67,7 @@ func ListSupportedKeyTypes() []string {
 	for k := range keyTypes {
 		keyTypesSlice = append(keyTypesSlice, k)
 	}
-	sort.Slice(keyTypesSlice, func(i, j int) bool {
-		return keyTypesSlice[i] < keyTypesSlice[j]
-	})
+	slices.Sort(keyTypesSlice)
 	return keyTypesSlice
 }
 

--- a/libs/metrics/teststat/populate.go
+++ b/libs/metrics/teststat/populate.go
@@ -40,10 +40,7 @@ import (
 func PopulateNormalHistogram(h metrics.Histogram, seed int) {
 	r := rand.New(rand.NewSource(int64(seed))) //nolint:gosec
 	for i := 0; i < Count; i++ {
-		sample := r.NormFloat64()*float64(Stdev) + float64(Mean)
-		if sample < 0 {
-			sample = 0
-		}
+		sample := max(r.NormFloat64()*float64(Stdev)+float64(Mean), 0)
 		h.Observe(sample)
 	}
 }

--- a/state/txindex/kv/kv.go
+++ b/state/txindex/kv/kv.go
@@ -587,12 +587,7 @@ func (txi *TxIndex) Search(ctx context.Context, q *query.Query, pagSettings txin
 
 		// Calculate pagination start and end indices
 		startIndex := (pagSettings.Page - 1) * pagSettings.PerPage
-		endIndex := startIndex + pagSettings.PerPage
-
-		// Apply pagination limits
-		if endIndex > len(hashKeys) {
-			endIndex = len(hashKeys)
-		}
+		endIndex := min(startIndex+pagSettings.PerPage, len(hashKeys))
 		if startIndex >= len(hashKeys) {
 			return []*abci.TxResult{}, 0, nil
 		}


### PR DESCRIPTION
---

#### PR checklist

since currently cometbft support Go 1.23, use built in `min/max` to simplify some length cal.

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
