### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"reflect"
 	"runtime/debug"
+	"slices"
 	"time"
 
 	"github.com/cosmos/gogoproto/proto"
@@ -418,12 +419,7 @@ func (p *peer) Set(key string, data any) {
 
 // HasChannel returns whether the peer reported implementing this channel.
 func (p *peer) HasChannel(chID byte) bool {
-	for _, ch := range p.channels {
-		if ch == chID {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(p.channels, chID)
 }
 
 func (p *peer) SetRemovalFailed() {

--- a/state/indexer/block/kv/kv.go
+++ b/state/indexer/block/kv/kv.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -344,7 +345,7 @@ func (idx *BlockerIndexer) Search(ctx context.Context, q *query.Query) ([]int64,
 
 	// for all other conditions
 	for i, c := range conditions {
-		if intInSlice(i, skipIndexes) {
+		if slices.Contains(skipIndexes, i) {
 			continue
 		}
 

--- a/state/indexer/block/kv/util.go
+++ b/state/indexer/block/kv/util.go
@@ -23,16 +23,6 @@ type HeightInfo struct {
 	onlyHeightEq    bool
 }
 
-func intInSlice(a int, list []int) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-
-	return false
-}
-
 func int64FromBytes(bz []byte) int64 {
 	v, _ := binary.Varint(bz)
 	return v

--- a/state/txindex/kv/kv.go
+++ b/state/txindex/kv/kv.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -536,7 +537,7 @@ func (txi *TxIndex) Search(ctx context.Context, q *query.Query, pagSettings txin
 
 	// for all other conditions
 	for i, c := range conditions {
-		if intInSlice(i, skipIndexes) {
+		if slices.Contains(skipIndexes, i) {
 			continue
 		}
 

--- a/state/txindex/kv/utils.go
+++ b/state/txindex/kv/utils.go
@@ -22,16 +22,6 @@ type HeightInfo struct {
 	onlyHeightEq    bool
 }
 
-// IntInSlice returns true if a is found in the list.
-func intInSlice(a int, list []int) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-	return false
-}
-
 func ParseEventSeqFromEventKey(key []byte) (int64, error) {
 	var (
 		compositeKey, typ, eventValue string

--- a/state/txindex/kv/utils_test.go
+++ b/state/txindex/kv/utils_test.go
@@ -1,14 +1,15 @@
 package kv
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestIntInSlice(t *testing.T) {
-	assert.True(t, intInSlice(1, []int{1, 2, 3}))
-	assert.False(t, intInSlice(4, []int{1, 2, 3}))
-	assert.True(t, intInSlice(0, []int{0}))
-	assert.False(t, intInSlice(0, []int{}))
+	assert.True(t, slices.Contains([]int{1, 2, 3}, 1))
+	assert.False(t, slices.Contains([]int{1, 2, 3}, 4))
+	assert.True(t, slices.Contains([]int{0}, 0))
+	assert.False(t, slices.Contains([]int{}, 0))
 }


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.


#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
