### PR TITLE
fix(db): correct parameter order in setWithOpts error message

### DIFF
--- a/db/pebbledb.go
+++ b/db/pebbledb.go
@@ -134,7 +134,7 @@ func (pDB *pebbleDB) setWithOpts(
 
 	err := pDB.db.Set(key, value, writeOpts)
 	if err != nil {
-		return fmt.Errorf("setting (k,v)=( %X , %X ) to DB: %w", value, key, err)
+		return fmt.Errorf("setting (k,v)=( %X , %X ) to DB: %w", key, value, err)
 	}
 
 	return nil


### PR DESCRIPTION
#### Description:

This PR fixes an inconsistent error message in the DB package's `setWithOpts` function.

The key-value pair's parameters were passed in the opposite order (`value, key`) from their labels (`k,v`), which causes confusion when debugging.

#### Changes:
- Corrected the order of parameters passed to the `fmt.Errorf` function to match the labeled format `(k,v)`.

#### Impact:
- Error messages now accurately reflect the correct key-value pairing.

#### Example:
```go
// Before
return fmt.Errorf("setting (k,v)=( %X , %X ) to DB: %w", value, key, err)

// After
return fmt.Errorf("setting (k,v)=( %X , %X ) to DB: %w", key, value, err)
```