### PR TITLE
docs: fix incorrect benchmark comment in store/bench_test.go

### DIFF
--- a/store/bench_test.go
+++ b/store/bench_test.go
@@ -10,9 +10,8 @@ import (
 	cmttime "github.com/cometbft/cometbft/types/time"
 )
 
-// TestLoadBlockExtendedCommit tests loading the extended commit for a previously
-// saved block. The load method should return nil when only a commit was saved and
-// return the extended commit otherwise.
+// BenchmarkRepeatedLoadSeenCommitSameBlock benchmarks the performance of repeatedly 
+// loading the same seen commit for a block.
 func BenchmarkRepeatedLoadSeenCommitSameBlock(b *testing.B) {
 	state, bs, _, _, cleanup, _ := makeStateAndBlockStoreAndIndexers()
 	defer cleanup()


### PR DESCRIPTION
Fixed incorrect comment for BenchmarkRepeatedLoadSeenCommitSameBlock function in store/bench_test.go. The previous comment was describing a different test (TestLoadBlockExtendedCommit) that doesn't exist in this file. Updated the comment to accurately describe the current benchmark function.

Changes made:
- Replaced incorrect test description with appropriate benchmark description
- Aligned comment with actual function implementation
