### PR TITLE
chore(golangci-lint): remove unsupported formatters from config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,8 +47,6 @@ issues:
     - path: _test\.go
       linters:
         - gocritic
-        - gofmt
-        - goimport
         - gosec
         - noctx
         - paralleltest
@@ -56,8 +54,6 @@ issues:
         - tparallel
     - path: \.pb\.go
       linters:
-        - gofmt
-        - goimports
         - govet
         - stylecheck
   max-same-issues: 10000


### PR DESCRIPTION
Removed `gofmt`, `goimport`, and `goimports` from `.golangci.yml` because they are now considered formatters, not linters. Without these changes, golangci-lint fails with errors. Locally tested per the [official migration guide](https://golangci-lint.run/product/migration-guide/).
