### PR TITLE
fix: client error handling in `killTMOnClientError`

### DIFF
--- a/proxy/multi_app_conn.go
+++ b/proxy/multi_app_conn.go
@@ -169,22 +169,24 @@ func (app *multiAppConn) killTMOnClientError() {
 		}
 	}
 
-	select {
-	case <-app.consensusConnClient.Quit():
-		if err := app.consensusConnClient.Error(); err != nil {
-			killFn(connConsensus, err, app.Logger)
-		}
-	case <-app.mempoolConnClient.Quit():
-		if err := app.mempoolConnClient.Error(); err != nil {
-			killFn(connMempool, err, app.Logger)
-		}
-	case <-app.queryConnClient.Quit():
-		if err := app.queryConnClient.Error(); err != nil {
-			killFn(connQuery, err, app.Logger)
-		}
-	case <-app.snapshotConnClient.Quit():
-		if err := app.snapshotConnClient.Error(); err != nil {
-			killFn(connSnapshot, err, app.Logger)
+	for {
+		select {
+		case <-app.consensusConnClient.Quit():
+			if err := app.consensusConnClient.Error(); err != nil {
+				killFn(connConsensus, err, app.Logger)
+			}
+		case <-app.mempoolConnClient.Quit():
+			if err := app.mempoolConnClient.Error(); err != nil {
+				killFn(connMempool, err, app.Logger)
+			}
+		case <-app.queryConnClient.Quit():
+			if err := app.queryConnClient.Error(); err != nil {
+				killFn(connQuery, err, app.Logger)
+			}
+		case <-app.snapshotConnClient.Quit():
+			if err := app.snapshotConnClient.Error(); err != nil {
+				killFn(connSnapshot, err, app.Logger)
+			}
 		}
 	}
 }


### PR DESCRIPTION
tThe current `select` statement only handles the first closed client, ignoring others.
replacing it with a `for { select {} }` loop ensures all client errors are properly handled, making the behavior more reliable.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
