### PR TITLE
fix(cmd): align p2p.external_address argument when set the node P2P external address (backport #3497)

### DIFF
--- a/.changelog/unreleased/bug-fixes/3497-fix-p2p-external-address.md
+++ b/.changelog/unreleased/bug-fixes/3497-fix-p2p-external-address.md
@@ -1,0 +1,2 @@
+- `[cmd]` Align `p2p.external_address` argument to set the node P2P external address.
+  ([\#3460](https://github.com/cometbft/cometbft/issues/3460))

--- a/cmd/cometbft/commands/run_node.go
+++ b/cmd/cometbft/commands/run_node.go
@@ -62,7 +62,7 @@ func AddNodeFlags(cmd *cobra.Command) {
 		"p2p.laddr",
 		config.P2P.ListenAddress,
 		"node listen address. (0.0.0.0:0 means any interface, any port)")
-	cmd.Flags().String("p2p.external-address", config.P2P.ExternalAddress, "ip:port address to advertise to peers for them to dial")
+	cmd.Flags().String("p2p.external_address", config.P2P.ExternalAddress, "ip:port address to advertise to peers for them to dial")
 	cmd.Flags().String("p2p.seeds", config.P2P.Seeds, "comma-delimited ID@host:port seed nodes")
 	cmd.Flags().String("p2p.persistent_peers", config.P2P.PersistentPeers, "comma-delimited ID@host:port persistent peers")
 	cmd.Flags().String("p2p.unconditional_peer_ids",


### PR DESCRIPTION
* cherry pick [this commit](https://github.com/cometbft/cometbft/commit/bb2033120a944e3fd8691f7aa7231b99f29c0886) from `main/v1.x` to `v0.38.x`
* currently on all `v0.x.x` branches the flag `--p2p.external-address` is completely broken, if anyone has it set it is not working.
* Original ticket where issue was brought up/fixed: https://github.com/cometbft/cometbft/issues/3460

Note: I haven't made a PR for cometbft before so hopefully this is the way! If this is correct/allowed then I'd also like to open a backport for branch `v0.37.x`

---

#### PR checklist

- [ ] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
