### PR TITLE
docs(RELEASES.md): fix broken link

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -18,7 +18,7 @@ case).
 As non-breaking changes land on `main`, they should also be backported to
 these backport branches.
 
-We use Mergify's [backport feature](https://mergify.io/features/backports) to
+We use Mergify's [backport feature](https://docs.mergify.com/workflow/actions/backport/) to
 automatically backport to the needed branch. There should be a label for any
 backport branch that you'll be targeting. To notify the bot to backport a pull
 request, mark the pull request with the label corresponding to the correct


### PR DESCRIPTION
The link to Mergify's "backport" article is outdated so i replaced it with new one. 

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
