### PR TITLE
docs: Fix broken ADR links in documentation

### DIFF
--- a/.changelog/v1.0.0/summary.md
+++ b/.changelog/v1.0.0/summary.md
@@ -20,16 +20,16 @@ team, including:
    transaction dissemination mechanism, for example a standalone mempool-like
    process that can be scaled independently of the consensus engine/application.
    This requires application developers to implement their own gossip/networking
-   mechanisms. See [ADR 111](./docs/architecture/adr-111-nop-mempool.md) for
+   mechanisms. See [ADR 111](./docs/references/architecture/adr-111-nop-mempool.md) for
    details.
 5. The first officially supported release of the [data companion
-   API](./docs/architecture/adr-101-data-companion-pull-api.md).
+   API](./docs/references/architecture/adr-101-data-companion-pull-api.md).
 6. Versioning of both the Protobuf definitions _and_ RPC. By versioning our
    APIs, we aim to provide a level of commitment to API stability while
    simultaneously affording ourselves the ability to roll out substantial
    changes in non-breaking releases of CometBFT. See [ADR
-   103](./docs/architecture/adr-103-proto-versioning.md) and [ADR
-   107](./docs/architecture/adr-107-betaize-proto-versions.md).
+   103](./docs/references/architecture/adr-103-proto-versioning.md) and [ADR
+   107](./docs/references/architecture/adr-107-betaize-proto-versions.md).
 7. Moving many Go packages that are currently publicly accessible into the
    `internal` directory such that the team can roll out substantial changes in
    future without needing to worry about causing breakages in users' codebases.
@@ -37,7 +37,7 @@ team, including:
    hampered the team's ability to roll out impactful new changes to users, as
    previously such changes required a new breaking release (which currently
    takes 6 to 12 months to reach production use for many users). See [ADR
-   109](./docs/architecture/adr-109-reduce-go-api-surface.md) for more details.
+   109](./docs/references/architecture/adr-109-reduce-go-api-surface.md) for more details.
 
 None of these changes are state machine-breaking for CometBFT-based networks,
 but could be breaking for some users who depend on the Protobuf definitions type

--- a/mempool/nop_mempool.go
+++ b/mempool/nop_mempool.go
@@ -13,7 +13,7 @@ import (
 // NopMempool is a mempool that does nothing.
 //
 // The ABCI app is responsible for storing, disseminating, and proposing transactions.
-// See [ADR-111](../docs/architecture/adr-111-nop-mempool.md).
+// See [ADR-111](../docs/references/architecture/adr-111-nop-mempool.md).
 type NopMempool struct{}
 
 // errNotAllowed indicates that the operation is not allowed with `nop` mempool.


### PR DESCRIPTION
Update links to architecture decision records (ADRs) throughout the codebase to use the correct path: ./docs/references/architecture/ instead of ./docs/architecture/

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
