### PR TITLE
docs(running-in-production.md): fix broken link

### DIFF
--- a/docs/explanation/core/running-in-production.md
+++ b/docs/explanation/core/running-in-production.md
@@ -414,7 +414,7 @@ give you limited number of file descriptors.
 If you want to accept greater number of connections, you will need to increase
 these limits.
 
-[Sysctls to tune the system to be able to open more connections](https://github.com/satori-com/tcpkali/blob/master/doc/tcpkali.man.md#sysctls-to-tune-the-system-to-be-able-to-open-more-connections)
+[Sysctls to tune the system to be able to open more connections](https://github.com/nextnet-works/tcpkali/blob/master/doc/tcpkali.man.md#sysctls-to-tune-the-system-to-be-able-to-open-more-connections)
 
 The process file limits must also be increased, e.g. via `ulimit -n 8192`.
 


### PR DESCRIPTION
---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments

#### Changes

https://github.com/satori-com/tcpkali/blob/master/doc/tcpkali.man.md#sysctls-to-tune-the-system-to-be-able-to-open-more-connections 
=>
https://github.com/nextnet-works/tcpkali/blob/master/doc/tcpkali.man.md#sysctls-to-tune-the-system-to-be-able-to-open-more-connections

#### Description

"Sysctls to tune the system to be able to open more connections" link is changed to right path. 
"https://github.com/satori-com/tcpkali/blob/master/doc/tcpkali.man.md" is no longer valid, The repository is moved to "https://github.com/nextnet-works/tcpkali/blob/master/doc/tcpkali.man.md"