### PR TITLE
docs: Fix KVStore transaction format in quick-start tutorial

### DIFF
--- a/.changelog/unreleased/bug-fixes/4735-kvstore-docs.md
+++ b/.changelog/unreleased/bug-fixes/4735-kvstore-docs.md
@@ -1,0 +1,3 @@
+- `[docs]` Fix documentation in quick-start guide to correctly describe how
+  KVstore transactions should be formatted
+  ([\#4735](https://github.com/cometbft/cometbft/issues/4735))

--- a/docs/tutorials/quick-start.md
+++ b/docs/tutorials/quick-start.md
@@ -66,28 +66,24 @@ curl -s localhost:26657/status
 With the KVstore app running, we can send transactions:
 
 ```sh
-curl -s 'localhost:26657/broadcast_tx_commit?tx="abcd"'
-```
-
-and check that it worked with:
-
-```sh
-curl -s 'localhost:26657/abci_query?data="abcd"'
-```
-
-We can send transactions with a key and value too:
-
-```sh
 curl -s 'localhost:26657/broadcast_tx_commit?tx="name=satoshi"'
 ```
 
-and query the key:
+and check that it worked with:
 
 ```sh
 curl -s 'localhost:26657/abci_query?data="name"'
 ```
 
 where the value is returned in hex.
+
+The KVstore app accepts transactions in the format `key=value` or `key:value`. For example:
+
+```sh
+curl -s 'localhost:26657/broadcast_tx_commit?tx="name:satoshi"'
+```
+
+Both will work the same way, storing the key-value pair in the KVstore.
 
 ## Cluster of Nodes
 


### PR DESCRIPTION
Fixes #4735

Corrects the KVStore example documentation to properly reflect that transactions must be in key=value or key:value format. The previous example incorrectly suggested that plain values without separators would work.

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
