### PR TITLE
feat(cmd): add key-type flag to testnet command

### DIFF
--- a/.changelog/unreleased/improvements/5129-specific-key-tesnet-cmd.md
+++ b/.changelog/unreleased/improvements/5129-specific-key-tesnet-cmd.md
@@ -1,0 +1,1 @@
+- `[cmd]` Add `---key-type` flag to the `tesnet` command to allow specifying validator key type ([\#5129](https://github.com/cometbft/cometbft/issues/5129))

--- a/cmd/cometbft/commands/testnet.go
+++ b/cmd/cometbft/commands/testnet.go
@@ -11,6 +11,8 @@ import (
 	"github.com/spf13/viper"
 
 	cfg "github.com/cometbft/cometbft/config"
+	"github.com/cometbft/cometbft/crypto/ed25519"
+	kt "github.com/cometbft/cometbft/internal/keytypes"
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
 	"github.com/cometbft/cometbft/libs/bytes"
 	"github.com/cometbft/cometbft/p2p"
@@ -75,6 +77,8 @@ func init() {
 		"P2P Port")
 	TestnetFilesCmd.Flags().BoolVar(&randomMonikers, "random-monikers", false,
 		"randomize the moniker for each generated node")
+	TestnetFilesCmd.Flags().StringVar(&keyType, "key-type", ed25519.KeyType,
+		fmt.Sprintf("private key type (one of %s)", kt.SupportedKeyTypesStr()))
 }
 
 // TestnetFilesCmd allows initialisation of files for a CometBFT testnet.


### PR DESCRIPTION
Closes #5129 

## Description

This PR adds a `--key-type` flag to the `testnet` command and allow to specify which private key type to use when generating validator keys for a testnet.


#### PR checklist

- [ ] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
