### PR TITLE
docs: Fix KVStore transaction argument and response format in quick-start tutorial

### DIFF
--- a/.changelog/unreleased/bug-fixes/4735-quick-start-docs.md
+++ b/.changelog/unreleased/bug-fixes/4735-quick-start-docs.md
@@ -1,0 +1,5 @@
+- `[docs]` Fixes the quick start transaction documentation.
+  Removes broadcast curl command with only a key specified with no value.
+  Adds explanation of the two ways the key/value arguments can be formatted.
+  Fixes the explanation of the response to correctly specify the value format as base64 instead of hex.
+  ([\#4735](https://github.com/cometbft/cometbft/issues/4735))

--- a/docs/tutorials/quick-start.md
+++ b/docs/tutorials/quick-start.md
@@ -63,31 +63,19 @@ curl -s localhost:26657/status
 
 ### Sending Transactions
 
-With the KVstore app running, we can send transactions:
-
-```sh
-curl -s 'localhost:26657/broadcast_tx_commit?tx="abcd"'
-```
-
-and check that it worked with:
-
-```sh
-curl -s 'localhost:26657/abci_query?data="abcd"'
-```
-
-We can send transactions with a key and value too:
+With the KVstore app running, we can send transactions with a key and value:
 
 ```sh
 curl -s 'localhost:26657/broadcast_tx_commit?tx="name=satoshi"'
 ```
 
-and query the key:
+and check that it worked by querying the key:
 
 ```sh
 curl -s 'localhost:26657/abci_query?data="name"'
 ```
 
-where the value is returned in hex.
+where the value is returned in base64.
 
 ## Cluster of Nodes
 

--- a/docs/tutorials/quick-start.md
+++ b/docs/tutorials/quick-start.md
@@ -63,10 +63,10 @@ curl -s localhost:26657/status
 
 ### Sending Transactions
 
-With the KVstore app running, we can send transactions with a key and value:
+With the KVstore app running, we can send transactions with a key and value, in either `key=value` or `key:value` format.
 
 ```sh
-curl -s 'localhost:26657/broadcast_tx_commit?tx="name=satoshi"'
+curl -s 'localhost:26657/broadcast_tx_commit?tx="name=satoshi"' # or ?tx="name:satoshi"
 ```
 
 and check that it worked by querying the key:


### PR DESCRIPTION
Fixes https://github.com/cometbft/cometbft/issues/4735 and incorporates [CreeptoGengar](https://github.com/CreeptoGengar)'s changes in https://github.com/cometbft/cometbft/pull/5120.

Fixes the quick start transaction documentation:
- Removes broadcast `curl` command with only a key specified with no value
- Adds explanation of the two ways the key/value arguments can be formatted 
- Fixes the explanation of the response to correctly specify the value format as `base64` instead of `hex` 

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
