### PR TITLE
fix(test): prevent "address already in use" error in dockertest

### DIFF
--- a/state/indexer/sink/psql/psql_test.go
+++ b/state/indexer/sink/psql/psql_test.go
@@ -39,7 +39,6 @@ var (
 const (
 	user     = "postgres"
 	password = "secret"
-	port     = "5432"
 	dsn      = "postgres://%s:%s@localhost:%s/%s?sslmode=disable"
 	dbName   = "postgres"
 	chainID  = "test-chainID"
@@ -68,7 +67,6 @@ func TestMain(m *testing.M) {
 			"POSTGRES_DB=" + dbName,
 			"listen_addresses = '*'",
 		},
-		ExposedPorts: []string{port},
 	}, func(config *docker.HostConfig) {
 		// set AutoRemove to true so that stopped container goes away by itself
 		config.AutoRemove = true
@@ -90,7 +88,7 @@ func TestMain(m *testing.M) {
 
 	// Connect to the database, clear any leftover data, and install the
 	// indexing schema.
-	conn := fmt.Sprintf(dsn, user, password, resource.GetPort(port+"/tcp"), dbName)
+	conn := fmt.Sprintf(dsn, user, password, resource.GetPort("5432/tcp"), dbName)
 	var db *sql.DB
 
 	if err := pool.Retry(func() error {


### PR DESCRIPTION
---
Closes https://github.com/cometbft/cometbft/issues/5149

This fixes an issue where 5432 port is conflicting with a port already in use (presumably from another test)

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
