### PR TITLE
docs: Fix broken link to configuration.md in state-sync documentation

### DIFF
--- a/docs/explanation/core/state-sync.md
+++ b/docs/explanation/core/state-sync.md
@@ -36,7 +36,7 @@ Let's break down the settings:
 - `trust_period`: Trust period is the period in which headers can be verified.
   > :warning: This value should be significantly smaller than the unbonding period.
 
-For other settings, visit the [Configuration](./configuration) page.
+For other settings, visit the [Configuration](./configuration.md) page.
 
 If you need to get the information you need from publicly exposed RPCs, you 
 can use `curl` and [`jq`][jq].


### PR DESCRIPTION
Fixed a broken link to the configuration page in docs/explanation/core/state-sync.md. The link now correctly points to the existing configuration.md file, allowing users to easily access additional configuration information.


---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
