### PR TITLE
fix: update nodekey.ID to use type alias instead of declaration

### DIFF
--- a/crypto/secp256k1/secp256k1.go
+++ b/crypto/secp256k1/secp256k1.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
-	"golang.org/x/crypto/ripemd160" //nolint: staticcheck // necessary for Bitcoin address format
+	"golang.org/x/crypto/ripemd160" //nolint: gosec,staticcheck // necessary for Bitcoin address format
 
 	"github.com/cometbft/cometbft/crypto"
 	cmtjson "github.com/cometbft/cometbft/libs/json"

--- a/crypto/secp256k1/secp256k1.go
+++ b/crypto/secp256k1/secp256k1.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
-	"golang.org/x/crypto/ripemd160" //nolint: gosec,staticcheck // necessary for Bitcoin address format
+	"golang.org/x/crypto/ripemd160" //nolint: staticcheck // necessary for Bitcoin address format
 
 	"github.com/cometbft/cometbft/crypto"
 	cmtjson "github.com/cometbft/cometbft/libs/json"

--- a/internal/blocksync/pool_test.go
+++ b/internal/blocksync/pool_test.go
@@ -95,7 +95,7 @@ func (ps testPeers) stop() {
 func makePeers(numPeers int, minHeight, maxHeight int64) testPeers {
 	peers := make(testPeers, numPeers)
 	for i := 0; i < numPeers; i++ {
-		peerID := p2p.ID(cmtrand.Str(12))
+		peerID := cmtrand.Str(12)
 		height := minHeight + cmtrand.Int63n(maxHeight-minHeight)
 		base := minHeight + int64(i)
 		if base > height {
@@ -235,7 +235,7 @@ func TestBlockPoolTimeout(t *testing.T) {
 func TestBlockPoolRemovePeer(t *testing.T) {
 	peers := make(testPeers, 10)
 	for i := 0; i < 10; i++ {
-		peerID := p2p.ID(strconv.Itoa(i + 1))
+		peerID := strconv.Itoa(i + 1)
 		height := int64(i + 1)
 		peers[peerID] = &testPeer{peerID, 0, height, make(chan inputData), false}
 	}
@@ -259,10 +259,10 @@ func TestBlockPoolRemovePeer(t *testing.T) {
 	assert.EqualValues(t, 10, pool.MaxPeerHeight())
 
 	// remove not-existing peer
-	assert.NotPanics(t, func() { pool.RemovePeer(p2p.ID("Superman")) })
+	assert.NotPanics(t, func() { pool.RemovePeer("Superman") })
 
 	// remove peer with biggest height
-	pool.RemovePeer(p2p.ID("10"))
+	pool.RemovePeer("10")
 	assert.EqualValues(t, 9, pool.MaxPeerHeight())
 
 	// remove all peers
@@ -292,9 +292,9 @@ func TestBlockPoolMaliciousNode(t *testing.T) {
 	//   This takes a couple of minutes to complete, so we don't run it.
 	const initialHeight = 7
 	peers := testPeers{
-		p2p.ID("good"):  &testPeer{p2p.ID("good"), 1, initialHeight, make(chan inputData), false},
-		p2p.ID("bad"):   &testPeer{p2p.ID("bad"), 1, initialHeight + MaliciousLie, make(chan inputData), true},
-		p2p.ID("good1"): &testPeer{p2p.ID("good1"), 1, initialHeight, make(chan inputData), false},
+		"good":  &testPeer{"good", 1, initialHeight, make(chan inputData), false},
+		"bad":   &testPeer{"bad", 1, initialHeight + MaliciousLie, make(chan inputData), true},
+		"good1": &testPeer{"good1", 1, initialHeight, make(chan inputData), false},
 	}
 	errorsCh := make(chan peerError, 3)
 	requestsCh := make(chan BlockRequest)
@@ -407,9 +407,9 @@ func TestBlockPoolMaliciousNodeMaxInt64(t *testing.T) {
 	// lowering the height was not accounted for.
 	const initialHeight = 7
 	peers := testPeers{
-		p2p.ID("good"):  &testPeer{p2p.ID("good"), 1, initialHeight, make(chan inputData), false},
-		p2p.ID("bad"):   &testPeer{p2p.ID("bad"), 1, math.MaxInt64, make(chan inputData), true},
-		p2p.ID("good1"): &testPeer{p2p.ID("good1"), 1, initialHeight, make(chan inputData), false},
+		"good":  &testPeer{"good", 1, initialHeight, make(chan inputData), false},
+		"bad":   &testPeer{"bad", 1, math.MaxInt64, make(chan inputData), true},
+		"good1": &testPeer{"good1", 1, initialHeight, make(chan inputData), false},
 	}
 	errorsCh := make(chan peerError, 3)
 	requestsCh := make(chan BlockRequest)
@@ -440,7 +440,7 @@ func TestBlockPoolMaliciousNodeMaxInt64(t *testing.T) {
 
 		// Report the lower height
 		peers["bad"].height = initialHeight
-		pool.SetPeerRange(p2p.ID("bad"), 1, initialHeight)
+		pool.SetPeerRange("bad", 1, initialHeight)
 
 		ticker := time.NewTicker(1 * time.Second) // Speed of new block creation
 		defer ticker.Stop()

--- a/internal/consensus/msgs.go
+++ b/internal/consensus/msgs.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cometbft/cometbft/internal/bits"
 	cstypes "github.com/cometbft/cometbft/internal/consensus/types"
 	cmtmath "github.com/cometbft/cometbft/libs/math"
-	"github.com/cometbft/cometbft/p2p"
 	"github.com/cometbft/cometbft/types"
 	cmterrors "github.com/cometbft/cometbft/types/errors"
 )
@@ -338,7 +337,7 @@ func WALFromProto(msg *cmtcons.WALMessage) (WALMessage, error) {
 		}
 		msgInfo := msgInfo{
 			Msg:    walMsg,
-			PeerID: p2p.ID(msg.MsgInfo.PeerID),
+			PeerID: msg.MsgInfo.PeerID,
 		}
 
 		if msg.MsgInfo.ReceiveTime != nil {

--- a/internal/consensus/msgs.go
+++ b/internal/consensus/msgs.go
@@ -281,7 +281,7 @@ func WALToProto(msg WALMessage) (*cmtcons.WALMessage, error) {
 			Sum: &cmtcons.WALMessage_MsgInfo{
 				MsgInfo: &cmtcons.MsgInfo{
 					Msg:         cm,
-					PeerID:      string(msg.PeerID),
+					PeerID:      msg.PeerID,
 					ReceiveTime: rtp,
 				},
 			},

--- a/internal/consensus/msgs_test.go
+++ b/internal/consensus/msgs_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cometbft/cometbft/crypto/merkle"
 	"github.com/cometbft/cometbft/internal/bits"
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
-	"github.com/cometbft/cometbft/p2p"
 	"github.com/cometbft/cometbft/types"
 	cmttime "github.com/cometbft/cometbft/types/time"
 )
@@ -255,7 +254,7 @@ func TestWALMsgProto(t *testing.T) {
 				Round:  1,
 				Part:   &parts,
 			},
-			PeerID: p2p.ID("string"),
+			PeerID: "string",
 		}, &cmtcons.WALMessage{
 			Sum: &cmtcons.WALMessage_MsgInfo{
 				MsgInfo: &cmtcons.MsgInfo{
@@ -278,7 +277,7 @@ func TestWALMsgProto(t *testing.T) {
 				Round:  1,
 				Part:   &parts,
 			},
-			PeerID: p2p.ID("string"),
+			PeerID: "string",
 		}, &cmtcons.WALMessage{
 			Sum: &cmtcons.WALMessage_MsgInfo{
 				MsgInfo: &cmtcons.MsgInfo{
@@ -302,7 +301,7 @@ func TestWALMsgProto(t *testing.T) {
 				Round:  1,
 				Part:   &parts,
 			},
-			PeerID: p2p.ID("string"),
+			PeerID: "string",
 		}, &cmtcons.WALMessage{
 			Sum: &cmtcons.WALMessage_MsgInfo{
 				MsgInfo: &cmtcons.MsgInfo{

--- a/internal/consensus/reactor.go
+++ b/internal/consensus/reactor.go
@@ -337,7 +337,7 @@ func (conR *Reactor) Receive(e p2p.Envelope) {
 			ps.ApplyProposalPOLMessage(msg)
 		case *BlockPartMessage:
 			ps.SetHasProposalBlockPart(msg.Height, msg.Round, int(msg.Part.Index))
-			conR.Metrics.BlockParts.With("peer_id", string(e.Src.ID())).Add(1)
+			conR.Metrics.BlockParts.With("peer_id", e.Src.ID()).Add(1)
 			conR.conS.peerMsgQueue <- msgInfo{msg, e.Src.ID(), time.Time{}}
 		default:
 			conR.Logger.Error(fmt.Sprintf("Unknown message type %v", reflect.TypeOf(msg)))

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	noSender    = p2p.ID("")
+	noSender    = ""
 	defaultLane = "default"
 )
 

--- a/mempool/mocks/mempool.go
+++ b/mempool/mocks/mempool.go
@@ -8,8 +8,6 @@ import (
 
 	mock "github.com/stretchr/testify/mock"
 
-	nodekey "github.com/cometbft/cometbft/p2p"
-
 	types "github.com/cometbft/cometbft/types"
 
 	v2 "github.com/cometbft/cometbft/api/cometbft/abci/v2"
@@ -21,7 +19,7 @@ type Mempool struct {
 }
 
 // CheckTx provides a mock function with given fields: tx, sender
-func (_m *Mempool) CheckTx(tx types.Tx, sender nodekey.ID) (*abcicli.ReqRes, error) {
+func (_m *Mempool) CheckTx(tx types.Tx, sender string) (*abcicli.ReqRes, error) {
 	ret := _m.Called(tx, sender)
 
 	if len(ret) == 0 {
@@ -30,10 +28,10 @@ func (_m *Mempool) CheckTx(tx types.Tx, sender nodekey.ID) (*abcicli.ReqRes, err
 
 	var r0 *abcicli.ReqRes
 	var r1 error
-	if rf, ok := ret.Get(0).(func(types.Tx, nodekey.ID) (*abcicli.ReqRes, error)); ok {
+	if rf, ok := ret.Get(0).(func(types.Tx, string) (*abcicli.ReqRes, error)); ok {
 		return rf(tx, sender)
 	}
-	if rf, ok := ret.Get(0).(func(types.Tx, nodekey.ID) *abcicli.ReqRes); ok {
+	if rf, ok := ret.Get(0).(func(types.Tx, string) *abcicli.ReqRes); ok {
 		r0 = rf(tx, sender)
 	} else {
 		if ret.Get(0) != nil {
@@ -41,7 +39,7 @@ func (_m *Mempool) CheckTx(tx types.Tx, sender nodekey.ID) (*abcicli.ReqRes, err
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(types.Tx, nodekey.ID) error); ok {
+	if rf, ok := ret.Get(1).(func(types.Tx, string) error); ok {
 		r1 = rf(tx, sender)
 	} else {
 		r1 = ret.Error(1)
@@ -97,23 +95,23 @@ func (_m *Mempool) FlushAppConn() error {
 }
 
 // GetSenders provides a mock function with given fields: txKey
-func (_m *Mempool) GetSenders(txKey types.TxKey) ([]nodekey.ID, error) {
+func (_m *Mempool) GetSenders(txKey types.TxKey) ([]string, error) {
 	ret := _m.Called(txKey)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetSenders")
 	}
 
-	var r0 []nodekey.ID
+	var r0 []string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(types.TxKey) ([]nodekey.ID, error)); ok {
+	if rf, ok := ret.Get(0).(func(types.TxKey) ([]string, error)); ok {
 		return rf(txKey)
 	}
-	if rf, ok := ret.Get(0).(func(types.TxKey) []nodekey.ID); ok {
+	if rf, ok := ret.Get(0).(func(types.TxKey) []string); ok {
 		r0 = rf(txKey)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]nodekey.ID)
+			r0 = ret.Get(0).([]string)
 		}
 	}
 

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -349,7 +349,7 @@ func (memR *Reactor) broadcastTxRoutine(peer p2p.Peer) {
 		}
 	}()
 
-	iter := NewBlockingIterator(ctx, memR.mempool, string(peer.ID()))
+	iter := NewBlockingIterator(ctx, memR.mempool, peer.ID())
 	for {
 		// In case of both next.NextWaitChan() and peer.Quit() are variable at the same time
 		if !memR.IsRunning() || !peer.IsRunning() {

--- a/node/setup.go
+++ b/node/setup.go
@@ -459,7 +459,7 @@ func createTransport(
 			// ABCI query for ID filtering.
 			func(_ p2p.IPeerSet, p p2p.Peer) error {
 				res, err := proxyApp.Query().Query(context.TODO(), &abci.QueryRequest{
-					Path: fmt.Sprintf("/p2p/filter/id/%s", p.ID()),
+					Path: "/p2p/filter/id/" + p.ID(),
 				})
 				if err != nil {
 					return err

--- a/p2p/internal/nodeinfo/nodeinfo.go
+++ b/p2p/internal/nodeinfo/nodeinfo.go
@@ -218,7 +218,7 @@ func (info Default) ToProto() *tmp2p.DefaultNodeInfo {
 		App:   info.ProtocolVersion.App,
 	}
 
-	dni.DefaultNodeID = string(info.DefaultNodeID)
+	dni.DefaultNodeID = info.DefaultNodeID
 	dni.ListenAddr = info.ListenAddr
 	dni.Network = info.Network
 	dni.Version = info.Version
@@ -243,7 +243,7 @@ func DefaultFromToProto(pb *tmp2p.DefaultNodeInfo) (Default, error) {
 			Block: pb.ProtocolVersion.Block,
 			App:   pb.ProtocolVersion.App,
 		},
-		DefaultNodeID: nodekey.ID(pb.DefaultNodeID),
+		DefaultNodeID: pb.DefaultNodeID,
 		ListenAddr:    pb.ListenAddr,
 		Network:       pb.Network,
 		Version:       pb.Version,

--- a/p2p/internal/nodekey/nodekey.go
+++ b/p2p/internal/nodekey/nodekey.go
@@ -42,7 +42,7 @@ func (nk *NodeKey) PubKey() crypto.PubKey {
 // PubKeyToID returns the ID corresponding to the given PubKey.
 // It's the hex-encoding of the pubKey.Address().
 func PubKeyToID(pubKey crypto.PubKey) ID {
-	return ID(hex.EncodeToString(pubKey.Address()))
+	return hex.EncodeToString(pubKey.Address())
 }
 
 // LoadOrGen attempts to load the NodeKey from the given filePath. If

--- a/p2p/internal/nodekey/nodekey.go
+++ b/p2p/internal/nodekey/nodekey.go
@@ -13,7 +13,7 @@ import (
 )
 
 // ID is a hex-encoded crypto.Address.
-type ID string
+type ID = string
 
 // IDByteLength is the length of a crypto.Address. Currently only 20.
 // TODO: support other length addresses ?

--- a/p2p/mocks/peer.go
+++ b/p2p/mocks/peer.go
@@ -102,18 +102,18 @@ func (_m *Peer) HasChannel(chID byte) bool {
 }
 
 // ID provides a mock function with no fields
-func (_m *Peer) ID() p2p.ID {
+func (_m *Peer) ID() string {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for ID")
 	}
 
-	var r0 p2p.ID
-	if rf, ok := ret.Get(0).(func() p2p.ID); ok {
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
 		r0 = rf()
 	} else {
-		r0 = ret.Get(0).(p2p.ID)
+		r0 = ret.Get(0).(string)
 	}
 
 	return r0

--- a/p2p/netaddr/netaddr.go
+++ b/p2p/netaddr/netaddr.go
@@ -76,11 +76,11 @@ func NewFromString(addr string) (*NetAddr, error) {
 	}
 
 	// get ID
-	if err := ValidateID(nodekey.ID(spl[0])); err != nil {
+	if err := ValidateID(spl[0]); err != nil {
 		return nil, ErrInvalid{addrWithoutProtocol, err}
 	}
 	var id nodekey.ID
-	id, addrWithoutProtocol = nodekey.ID(spl[0]), spl[1]
+	id, addrWithoutProtocol = spl[0], spl[1]
 
 	// get host and port
 	host, portStr, err := net.SplitHostPort(addrWithoutProtocol)
@@ -149,7 +149,7 @@ func NewFromProto(pb tmp2p.NetAddress) (*NetAddr, error) {
 		return nil, ErrInvalid{Addr: pb.IP, Err: ErrInvalidPort{pb.Port}}
 	}
 	return &NetAddr{
-		ID:   nodekey.ID(pb.ID),
+		ID:   pb.ID,
 		IP:   ip,
 		Port: uint16(pb.Port),
 	}, nil
@@ -182,7 +182,7 @@ func AddrsToProtos(nas []*NetAddr) []tmp2p.NetAddress {
 // ToProto converts an Addr to Protobuf.
 func (na *NetAddr) ToProto() tmp2p.NetAddress {
 	return tmp2p.NetAddress{
-		ID:   string(na.ID),
+		ID:   na.ID,
 		IP:   na.IP.String(),
 		Port: uint32(na.Port),
 	}
@@ -281,7 +281,7 @@ func (na *NetAddr) Valid() error {
 // HasID returns true if the address has an ID.
 // NOTE: It does not check whether the ID is valid or not.
 func (na *NetAddr) HasID() bool {
-	return string(na.ID) != ""
+	return na.ID != ""
 }
 
 // Local returns true if it is a local address.
@@ -412,7 +412,7 @@ func ValidateID(id nodekey.ID) error {
 	if len(id) == 0 {
 		return ErrNoIP
 	}
-	idBytes, err := hex.DecodeString(string(id))
+	idBytes, err := hex.DecodeString(id)
 	if err != nil {
 		return err
 	}

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -468,11 +468,11 @@ func (p *peer) eventLoop() {
 			for _, s := range state.StreamStates {
 				totalSendQueueSize += s.SendQueueSize
 			}
-			p.metrics.RecvRateLimiterDelay.With("peer_id", string(p.ID())).
+			p.metrics.RecvRateLimiterDelay.With("peer_id", p.ID()).
 				Add(state.RecvRateLimiterDelay.Seconds())
-			p.metrics.SendRateLimiterDelay.With("peer_id", string(p.ID())).
+			p.metrics.SendRateLimiterDelay.With("peer_id", p.ID()).
 				Add(state.SendRateLimiterDelay.Seconds())
-			p.metrics.PeerPendingSendBytes.With("peer_id", string(p.ID())).Set(float64(totalSendQueueSize))
+			p.metrics.PeerPendingSendBytes.With("peer_id", p.ID()).Set(float64(totalSendQueueSize))
 
 			// Report per peer, per message total bytes, since the last interval
 			func() {

--- a/p2p/pex/addrbook.go
+++ b/p2p/pex/addrbook.go
@@ -203,7 +203,7 @@ func (a *addrBook) AddPrivateIDs(ids []string) {
 	defer a.mtx.Unlock()
 
 	for _, id := range ids {
-		a.privateIDs[nodekey.ID(id)] = struct{}{}
+		a.privateIDs[id] = struct{}{}
 	}
 }
 

--- a/p2p/pex/addrbook_test.go
+++ b/p2p/pex/addrbook_test.go
@@ -411,7 +411,7 @@ func testCreatePrivateAddrs(t *testing.T, numAddrs int) ([]*na.NetAddr, []string
 
 	private := make([]string, numAddrs)
 	for i, addr := range addrs {
-		private[i] = string(addr.ID)
+		private[i] = addr.ID
 	}
 	return addrs, private
 }

--- a/p2p/pex/addrbook_test.go
+++ b/p2p/pex/addrbook_test.go
@@ -202,7 +202,7 @@ func randIPv4Address(t *testing.T) *na.NetAddr {
 			cmtrand.Intn(255),
 		)
 		port := cmtrand.Intn(65535-1) + 1
-		id := nodekey.ID(hex.EncodeToString(cmtrand.Bytes(nodekey.IDByteLength)))
+		id := hex.EncodeToString(cmtrand.Bytes(nodekey.IDByteLength))
 		idAddr := na.IDAddrString(id, fmt.Sprintf("%v:%v", ip, port))
 		addr, err := na.NewFromString(idAddr)
 		require.NoError(t, err)

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -216,7 +216,7 @@ func (r *Reactor) AddPeer(p Peer) {
 
 // RemovePeer implements Reactor by resetting peer's requests info.
 func (r *Reactor) RemovePeer(p Peer, _ any) {
-	id := string(p.ID())
+	id := p.ID()
 	r.requestsSent.Delete(id)
 	r.lastReceivedRequests.Delete(id)
 }
@@ -248,7 +248,7 @@ func (r *Reactor) Receive(e p2p.Envelope) {
 		// If we're a seed and this is an inbound peer,
 		// respond once and disconnect.
 		if r.config.SeedMode && !e.Src.IsOutbound() {
-			id := string(e.Src.ID())
+			id := e.Src.ID()
 			v := r.lastReceivedRequests.Get(id)
 			if v != nil {
 				// FlushStop/StopPeer are already
@@ -298,7 +298,7 @@ func (r *Reactor) Receive(e p2p.Envelope) {
 
 // enforces a minimum amount of time between requests.
 func (r *Reactor) receiveRequest(src Peer) error {
-	id := string(src.ID())
+	id := src.ID()
 	v := r.lastReceivedRequests.Get(id)
 	if v == nil {
 		// initialize with empty time
@@ -332,7 +332,7 @@ func (r *Reactor) receiveRequest(src Peer) error {
 // RequestAddrs asks peer for more addresses if we do not already have a
 // request out for this peer.
 func (r *Reactor) RequestAddrs(p Peer) {
-	id := string(p.ID())
+	id := p.ID()
 	if r.requestsSent.Has(id) {
 		return
 	}
@@ -348,7 +348,7 @@ func (r *Reactor) RequestAddrs(p Peer) {
 // request for this peer and deletes the open request.
 // If there's no open request for the src peer, it returns an error.
 func (r *Reactor) ReceiveAddrs(addrs []*na.NetAddr, src Peer) error {
-	id := string(src.ID())
+	id := src.ID()
 	if !r.requestsSent.Has(id) {
 		return ErrUnsolicitedList
 	}

--- a/p2p/pex/pex_reactor_test.go
+++ b/p2p/pex/pex_reactor_test.go
@@ -154,7 +154,7 @@ func TestPEXReactorRequestMessageAbuse(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, book.HasAddress(peerAddr))
 
-	id := string(peer.ID())
+	id := peer.ID()
 
 	// first time creates the entry
 	r.Receive(p2p.Envelope{ChannelID: PexChannel, Src: peer, Message: &tmp2p.PexRequest{}})
@@ -184,7 +184,7 @@ func TestPEXReactorAddrsMessageAbuse(t *testing.T) {
 	p2p.AddPeerToSwitchPeerSet(sw, peer)
 	assert.True(t, sw.Peers().Has(peer.ID()))
 
-	id := string(peer.ID())
+	id := peer.ID()
 
 	// request addrs from the peer
 	r.RequestAddrs(peer)
@@ -473,7 +473,7 @@ func TestPEXReactorSeedModeFlushStop(t *testing.T) {
 	// this isn't perfect since it's possible the peer sends us a msg and we FlushStop
 	// before this loop catches it. but non-deterministically it works pretty well.
 	for i := 0; i < 1000; i++ {
-		v := reactor.lastReceivedRequests.Get(string(peerID))
+		v := reactor.lastReceivedRequests.Get(peerID)
 		if v != nil {
 			break
 		}
@@ -499,7 +499,7 @@ func TestPEXReactorDoesNotAddPrivatePeersToAddrBook(t *testing.T) {
 	peer := p2p.CreateRandomPeer(false)
 
 	pexR, book := createReactor(&ReactorConfig{})
-	book.AddPrivateIDs([]string{string(peer.NodeInfo().ID())})
+	book.AddPrivateIDs([]string{peer.NodeInfo().ID()})
 	defer teardownReactor(book)
 
 	// we have to send a request to receive responses

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -652,7 +652,7 @@ func TestSwitchAcceptRoutine(t *testing.T) {
 		peer := newRemoteTCPPeer()
 		peer.Start()
 		unconditionalPeers[i] = peer
-		unconditionalPeerIDs[i] = string(peer.ID())
+		unconditionalPeerIDs[i] = peer.ID()
 	}
 
 	// make switch
@@ -965,7 +965,7 @@ func (rp *remoteTCPPeer) ID() nodekey.ID {
 
 func (rp *remoteTCPPeer) Start() {
 	id := nodekey.PubKeyToID(rp.privKey.PubKey())
-	addr, err := na.NewFromString(string(id) + "@127.0.0.1:0")
+	addr, err := na.NewFromString(id + "@127.0.0.1:0")
 	if err != nil {
 		panic(err)
 	}

--- a/rpc/core/net.go
+++ b/rpc/core/net.go
@@ -24,7 +24,7 @@ func (env *Environment) NetInfo(*rpctypes.Context) (*ctypes.ResultNetInfo, error
 		nodeInfo, ok := peer.NodeInfo().(p2p.NodeInfoDefault)
 		if !ok {
 			err = ErrInvalidNodeType{
-				PeerID:   string(peer.ID()),
+				PeerID:   peer.ID(),
 				Expected: fmt.Sprintf("%T", p2p.NodeInfoDefault{}),
 				Actual:   fmt.Sprintf("%T", peer.NodeInfo()),
 			}

--- a/scripts/metricsgen/metricsgen.go
+++ b/scripts/metricsgen/metricsgen.go
@@ -168,7 +168,7 @@ func ParseMetricsDir(dir string, structName string) (TemplateData, error) {
 
 	// Grab the package name.
 	var pkgName string
-	var pkg *ast.Package // nolint:staticcheck
+	var pkg *ast.Package //nolint:staticcheck
 	// TODO(thane): Figure out a more readable way of implementing this.
 
 	for pkgName, pkg = range d { //nolint:revive

--- a/scripts/metricsgen/metricsgen.go
+++ b/scripts/metricsgen/metricsgen.go
@@ -168,7 +168,7 @@ func ParseMetricsDir(dir string, structName string) (TemplateData, error) {
 
 	// Grab the package name.
 	var pkgName string
-	var pkg *ast.Package
+	var pkg *ast.Package // nolint:staticcheck
 	// TODO(thane): Figure out a more readable way of implementing this.
 
 	for pkgName, pkg = range d { //nolint:revive

--- a/scripts/metricsgen/metricsgen.go
+++ b/scripts/metricsgen/metricsgen.go
@@ -168,7 +168,7 @@ func ParseMetricsDir(dir string, structName string) (TemplateData, error) {
 
 	// Grab the package name.
 	var pkgName string
-	var pkg *ast.Package //nolint:staticcheck
+	var pkg *ast.Package
 	// TODO(thane): Figure out a more readable way of implementing this.
 
 	for pkgName, pkg = range d { //nolint:revive

--- a/statesync/chunks_test.go
+++ b/statesync/chunks_test.go
@@ -314,9 +314,9 @@ func TestChunkQueue_GetSender(t *testing.T) {
 	queue, teardown := setupChunkQueue(t)
 	defer teardown()
 
-	_, err := queue.Add(&chunk{Height: 3, Format: 1, Index: 0, Chunk: []byte{1}, Sender: p2p.ID("a")})
+	_, err := queue.Add(&chunk{Height: 3, Format: 1, Index: 0, Chunk: []byte{1}, Sender: "a"})
 	require.NoError(t, err)
-	_, err = queue.Add(&chunk{Height: 3, Format: 1, Index: 1, Chunk: []byte{2}, Sender: p2p.ID("b")})
+	_, err = queue.Add(&chunk{Height: 3, Format: 1, Index: 1, Chunk: []byte{2}, Sender: "b"})
 	require.NoError(t, err)
 
 	assert.EqualValues(t, "a", queue.GetSender(0))
@@ -350,7 +350,7 @@ func TestChunkQueue_Next(t *testing.T) {
 	}()
 
 	assert.Empty(t, chNext)
-	_, err := queue.Add(&chunk{Height: 3, Format: 1, Index: 1, Chunk: []byte{3, 1, 1}, Sender: p2p.ID("b")})
+	_, err := queue.Add(&chunk{Height: 3, Format: 1, Index: 1, Chunk: []byte{3, 1, 1}, Sender: "b"})
 	require.NoError(t, err)
 	select {
 	case <-chNext:
@@ -358,17 +358,17 @@ func TestChunkQueue_Next(t *testing.T) {
 	default:
 	}
 
-	_, err = queue.Add(&chunk{Height: 3, Format: 1, Index: 0, Chunk: []byte{3, 1, 0}, Sender: p2p.ID("a")})
+	_, err = queue.Add(&chunk{Height: 3, Format: 1, Index: 0, Chunk: []byte{3, 1, 0}, Sender: "a"})
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		&chunk{Height: 3, Format: 1, Index: 0, Chunk: []byte{3, 1, 0}, Sender: p2p.ID("a")},
+		&chunk{Height: 3, Format: 1, Index: 0, Chunk: []byte{3, 1, 0}, Sender: "a"},
 		<-chNext)
 	assert.Equal(t,
-		&chunk{Height: 3, Format: 1, Index: 1, Chunk: []byte{3, 1, 1}, Sender: p2p.ID("b")},
+		&chunk{Height: 3, Format: 1, Index: 1, Chunk: []byte{3, 1, 1}, Sender: "b"},
 		<-chNext)
 
-	_, err = queue.Add(&chunk{Height: 3, Format: 1, Index: 4, Chunk: []byte{3, 1, 4}, Sender: p2p.ID("e")})
+	_, err = queue.Add(&chunk{Height: 3, Format: 1, Index: 4, Chunk: []byte{3, 1, 4}, Sender: "e"})
 	require.NoError(t, err)
 	select {
 	case <-chNext:
@@ -376,19 +376,19 @@ func TestChunkQueue_Next(t *testing.T) {
 	default:
 	}
 
-	_, err = queue.Add(&chunk{Height: 3, Format: 1, Index: 2, Chunk: []byte{3, 1, 2}, Sender: p2p.ID("c")})
+	_, err = queue.Add(&chunk{Height: 3, Format: 1, Index: 2, Chunk: []byte{3, 1, 2}, Sender: "c"})
 	require.NoError(t, err)
-	_, err = queue.Add(&chunk{Height: 3, Format: 1, Index: 3, Chunk: []byte{3, 1, 3}, Sender: p2p.ID("d")})
+	_, err = queue.Add(&chunk{Height: 3, Format: 1, Index: 3, Chunk: []byte{3, 1, 3}, Sender: "d"})
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		&chunk{Height: 3, Format: 1, Index: 2, Chunk: []byte{3, 1, 2}, Sender: p2p.ID("c")},
+		&chunk{Height: 3, Format: 1, Index: 2, Chunk: []byte{3, 1, 2}, Sender: "c"},
 		<-chNext)
 	assert.Equal(t,
-		&chunk{Height: 3, Format: 1, Index: 3, Chunk: []byte{3, 1, 3}, Sender: p2p.ID("d")},
+		&chunk{Height: 3, Format: 1, Index: 3, Chunk: []byte{3, 1, 3}, Sender: "d"},
 		<-chNext)
 	assert.Equal(t,
-		&chunk{Height: 3, Format: 1, Index: 4, Chunk: []byte{3, 1, 4}, Sender: p2p.ID("e")},
+		&chunk{Height: 3, Format: 1, Index: 4, Chunk: []byte{3, 1, 4}, Sender: "e"},
 		<-chNext)
 
 	_, ok := <-chNext

--- a/statesync/reactor_test.go
+++ b/statesync/reactor_test.go
@@ -52,7 +52,7 @@ func TestReactor_Receive_ChunkRequest(t *testing.T) {
 
 			// Mock peer to store response, if found
 			peer := &p2pmocks.Peer{}
-			peer.On("ID").Return(p2p.ID("id"))
+			peer.On("ID").Return("id")
 			var response *ssproto.ChunkResponse
 			if tc.expectResponse != nil {
 				peer.On("Send", mock.MatchedBy(func(i any) bool {
@@ -143,7 +143,7 @@ func TestReactor_Receive_SnapshotsRequest(t *testing.T) {
 			responses := []*ssproto.SnapshotsResponse{}
 			peer := &p2pmocks.Peer{}
 			if len(tc.expectResponses) > 0 {
-				peer.On("ID").Return(p2p.ID("id"))
+				peer.On("ID").Return("id")
 				peer.On("Send", mock.MatchedBy(func(i any) bool {
 					e, ok := i.(p2p.Envelope)
 					return ok && e.ChannelID == SnapshotChannel

--- a/statesync/snapshots_test.go
+++ b/statesync/snapshots_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/cometbft/cometbft/p2p"
 	p2pmocks "github.com/cometbft/cometbft/p2p/mocks"
 )
 
@@ -39,7 +38,7 @@ func TestSnapshot_Key(t *testing.T) {
 
 func TestSnapshotPool_Add(t *testing.T) {
 	peer := &p2pmocks.Peer{}
-	peer.On("ID").Return(p2p.ID("id"))
+	peer.On("ID").Return("id")
 
 	// Adding to the pool should work
 	pool := newSnapshotPool()
@@ -54,7 +53,7 @@ func TestSnapshotPool_Add(t *testing.T) {
 
 	// Adding again from a different peer should return false
 	otherPeer := &p2pmocks.Peer{}
-	otherPeer.On("ID").Return(p2p.ID("other"))
+	otherPeer.On("ID").Return("other")
 	added, err = pool.Add(peer, &snapshot{
 		Height: 1,
 		Format: 1,
@@ -74,9 +73,9 @@ func TestSnapshotPool_GetPeer(t *testing.T) {
 
 	s := &snapshot{Height: 1, Format: 1, Chunks: 1, Hash: []byte{1}}
 	peerA := &p2pmocks.Peer{}
-	peerA.On("ID").Return(p2p.ID("a"))
+	peerA.On("ID").Return("a")
 	peerB := &p2pmocks.Peer{}
-	peerB.On("ID").Return(p2p.ID("b"))
+	peerB.On("ID").Return("b")
 
 	_, err := pool.Add(peerA, s)
 	require.NoError(t, err)
@@ -91,9 +90,9 @@ func TestSnapshotPool_GetPeer(t *testing.T) {
 	for !seenA || !seenB {
 		peer := pool.GetPeer(s)
 		switch peer.ID() {
-		case p2p.ID("a"):
+		case "a":
 			seenA = true
-		case p2p.ID("b"):
+		case "b":
 			seenB = true
 		}
 	}
@@ -108,9 +107,9 @@ func TestSnapshotPool_GetPeers(t *testing.T) {
 
 	s := &snapshot{Height: 1, Format: 1, Chunks: 1, Hash: []byte{1}}
 	peerA := &p2pmocks.Peer{}
-	peerA.On("ID").Return(p2p.ID("a"))
+	peerA.On("ID").Return("a")
 	peerB := &p2pmocks.Peer{}
-	peerB.On("ID").Return(p2p.ID("b"))
+	peerB.On("ID").Return("b")
 
 	_, err := pool.Add(peerA, s)
 	require.NoError(t, err)
@@ -146,7 +145,7 @@ func TestSnapshotPool_Ranked_Best(t *testing.T) {
 	for i := len(expectSnapshots) - 1; i >= 0; i-- {
 		for _, peerID := range expectSnapshots[i].peers {
 			peer := &p2pmocks.Peer{}
-			peer.On("ID").Return(p2p.ID(peerID))
+			peer.On("ID").Return(peerID)
 			_, err := pool.Add(peer, expectSnapshots[i].snapshot)
 			require.NoError(t, err)
 		}
@@ -171,7 +170,7 @@ func TestSnapshotPool_Ranked_Best(t *testing.T) {
 func TestSnapshotPool_Reject(t *testing.T) {
 	pool := newSnapshotPool()
 	peer := &p2pmocks.Peer{}
-	peer.On("ID").Return(p2p.ID("id"))
+	peer.On("ID").Return("id")
 
 	snapshots := []*snapshot{
 		{Height: 2, Format: 2, Chunks: 1, Hash: []byte{1, 2}},
@@ -199,7 +198,7 @@ func TestSnapshotPool_Reject(t *testing.T) {
 func TestSnapshotPool_RejectFormat(t *testing.T) {
 	pool := newSnapshotPool()
 	peer := &p2pmocks.Peer{}
-	peer.On("ID").Return(p2p.ID("id"))
+	peer.On("ID").Return("id")
 
 	snapshots := []*snapshot{
 		{Height: 2, Format: 2, Chunks: 1, Hash: []byte{1, 2}},
@@ -229,9 +228,9 @@ func TestSnapshotPool_RejectPeer(t *testing.T) {
 	pool := newSnapshotPool()
 
 	peerA := &p2pmocks.Peer{}
-	peerA.On("ID").Return(p2p.ID("a"))
+	peerA.On("ID").Return("a")
 	peerB := &p2pmocks.Peer{}
-	peerB.On("ID").Return(p2p.ID("b"))
+	peerB.On("ID").Return("b")
 
 	s1 := &snapshot{Height: 1, Format: 1, Chunks: 1, Hash: []byte{1}}
 	s2 := &snapshot{Height: 2, Format: 1, Chunks: 1, Hash: []byte{2}}
@@ -269,9 +268,9 @@ func TestSnapshotPool_RemovePeer(t *testing.T) {
 	pool := newSnapshotPool()
 
 	peerA := &p2pmocks.Peer{}
-	peerA.On("ID").Return(p2p.ID("a"))
+	peerA.On("ID").Return("a")
 	peerB := &p2pmocks.Peer{}
-	peerB.On("ID").Return(p2p.ID("b"))
+	peerB.On("ID").Return("b")
 
 	s1 := &snapshot{Height: 1, Format: 1, Chunks: 1, Hash: []byte{1}}
 	s2 := &snapshot{Height: 2, Format: 1, Chunks: 1, Hash: []byte{2}}

--- a/statesync/syncer.go
+++ b/statesync/syncer.go
@@ -381,8 +381,8 @@ func (s *syncer) applyChunks(chunks *chunkQueue) error {
 		// Reject any senders as requested by the app
 		for _, sender := range resp.RejectSenders {
 			if sender != "" {
-				s.snapshots.RejectPeer(p2p.ID(sender))
-				err := chunks.DiscardSender(p2p.ID(sender))
+				s.snapshots.RejectPeer(sender)
+				err := chunks.DiscardSender(sender)
 				if err != nil {
 					return fmt.Errorf("failed to reject sender: %w", err)
 				}

--- a/statesync/syncer.go
+++ b/statesync/syncer.go
@@ -362,7 +362,7 @@ func (s *syncer) applyChunks(chunks *chunkQueue) error {
 		resp, err := s.conn.ApplySnapshotChunk(context.TODO(), &abci.ApplySnapshotChunkRequest{
 			Index:  chunk.Index,
 			Chunk:  chunk.Chunk,
-			Sender: string(chunk.Sender),
+			Sender: chunk.Sender,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to apply chunk %v: %w", chunk.Index, err)

--- a/statesync/syncer_test.go
+++ b/statesync/syncer_test.go
@@ -597,7 +597,7 @@ func TestSyncer_applyChunks_RejectSenders(t *testing.T) {
 				Index: 2, Chunk: []byte{2}, Sender: "c",
 			}).Once().Return(&abci.ApplySnapshotChunkResponse{
 				Result:        tc.result,
-				RejectSenders: []string{string(peerB.ID())},
+				RejectSenders: []string{peerB.ID()},
 			}, nil)
 
 			// On retry, the last chunk will be tried again, so we just accept it then.

--- a/statesync/syncer_test.go
+++ b/statesync/syncer_test.go
@@ -47,7 +47,7 @@ func setupOfferSyncer() (*syncer, *proxymocks.AppConnSnapshot) {
 // Sets up a simple peer mock with an ID.
 func simplePeer(id string) *p2pmocks.Peer {
 	peer := &p2pmocks.Peer{}
-	peer.On("ID").Return(p2p.ID(id))
+	peer.On("ID").Return(id)
 	return peer
 }
 
@@ -101,7 +101,7 @@ func TestSyncer_SyncAny(t *testing.T) {
 
 	// Adding a couple of peers should trigger snapshot discovery messages
 	peerA := &p2pmocks.Peer{}
-	peerA.On("ID").Return(p2p.ID("a"))
+	peerA.On("ID").Return("a")
 	peerA.On("Send", mock.MatchedBy(func(i any) bool {
 		e, ok := i.(p2p.Envelope)
 		if !ok {
@@ -114,7 +114,7 @@ func TestSyncer_SyncAny(t *testing.T) {
 	peerA.AssertExpectations(t)
 
 	peerB := &p2pmocks.Peer{}
-	peerB.On("ID").Return(p2p.ID("b"))
+	peerB.On("ID").Return("b")
 	peerB.On("Send", mock.MatchedBy(func(i any) bool {
 		e, ok := i.(p2p.Envelope)
 		if !ok {


### PR DESCRIPTION
---

Update `nodekey.ID` to be `type ID = string` instead of `type ID string`.

For some reason mockery attempts to use the internal path when regenerating mocks when the modules path is update to `github.com/cometbft/cometbft/v2`.

This change make mockery use string instead of the internal type. I am unsure why it uses the public type in the v1 implementation.

Long term solution is likely to update mockery, but this fixes it for now at the cost of reduction in type strictness.

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
