### PR TITLE
fix: check for nil sender before sending DOG HaveTx message

### DIFF
--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -272,7 +272,7 @@ func (memR *Reactor) TryAddTx(tx types.Tx, sender p2p.Peer) (*abcicli.ReqRes, er
 		switch {
 		case errors.Is(err, ErrTxInCache):
 			memR.Logger.Debug("Tx already exists in cache", "tx", txKey.Hash(), "sender", senderID)
-			if memR.redundancyControl != nil {
+			if memR.redundancyControl != nil && sender != nil {
 				memR.redundancyControl.incDuplicateTxs()
 				if memR.redundancyControl.isHaveTxBlocked() {
 					return nil, err

--- a/mempool/reactor_test.go
+++ b/mempool/reactor_test.go
@@ -857,6 +857,20 @@ func TestDOGTestRedundancyCalculation(t *testing.T) {
 	require.Equal(t, redundancy, reactors[0].redundancyControl.upperBound)
 }
 
+func TestDOGTestDuplicateTransactionFromRPC(t *testing.T) {
+	config := cfg.TestConfig()
+	config.Mempool.DOGProtocolEnabled = true
+	reactors, _ := makeAndConnectReactors(config, 1, nil)
+
+	txs := newUniqueTxs(1)
+
+	_, err := reactors[0].TryAddTx(txs[0], nil)
+	require.NoError(t, err)
+
+	_, err = reactors[0].TryAddTx(txs[0], nil)
+	require.ErrorIs(t, err, ErrTxInCache)
+}
+
 func BenchmarkCurrentRedundancy(b *testing.B) {
 	config := &cfg.MempoolConfig{
 		DOGTargetRedundancy: 1.0,


### PR DESCRIPTION
Duplicate Tx from RPC causes nil pointer exception in DOG protocol when sending HaveTx.
---
Closes https://github.com/cometbft/cometbft/issues/5159

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
