### PR TITLE
docs: fix broken link to vote structure in abci++_methods.md

### DIFF
--- a/spec/abci/abci++_methods.md
+++ b/spec/abci/abci++_methods.md
@@ -544,7 +544,7 @@ then _p_ locks _v_  and sends a Precommit message in the following way
    populates the other fields in [CanonicalVoteExtension](../core/data_structures.md#canonicalvoteextension),
    and signs the populated data structure.
 5. _p_ constructs and signs the [CanonicalVote](../core/data_structures.md#canonicalvote) structure.
-6. _p_ constructs the Precommit message (i.e. [Vote](../core/data_structures.md#vote) structure)
+6. _p_ constructs the Precommit message (i.e. [Vote](../../spec/core/data_structures.md#vote) structure)
    using [CanonicalVoteExtension](../core/data_structures.md#canonicalvoteextension)
    and [CanonicalVote](../core/data_structures.md#canonicalvote).
 7. _p_ broadcasts the Precommit message.


### PR DESCRIPTION


Description:  
This pull request updates the link to the Vote structure in the abci++_methods.md file. The previous link pointed to an incorrect location, and it has now been corrected to reference the appropriate section in the spec directory. This change ensures that documentation links are accurate and improve navigation for developers and readers. No other content was modified.

