### PR TITLE
docs: Fix broken link to ADR-106 in architecture README

### DIFF
--- a/docs/references/architecture/README.md
+++ b/docs/references/architecture/README.md
@@ -51,7 +51,7 @@ numbering our ADRs from 100 onwards.
 - [ADR-103: Protobuf definition versioning](adr-103-proto-versioning.md)
 - [ADR-104: State sync from local snapshot](adr-104-out-of-band-state-sync.md)
 - [ADR-105: Refactor list of senders in mempool](adr-105-refactor-mempool-senders.md)
-- [ADR-106: gRPC API](adr-106-grpc-api)
+- [ADR-106: gRPC API](adr-106-grpc-api.md)
 - [ADR-107: Rename protobuf versions of 0.x releases to pre-v1 betas](adr-107-betaize-proto-versions.md)
 - [ADR-109: Reduce CometBFT Go API Surface Area](adr-109-reduce-go-api-surface.md)
 - [ADR-111: `nop` Mempool](adr-111-nop-mempool.md)


### PR DESCRIPTION
Corrected the link to ADR-106 in docs/references/architecture/README.md by adding the missing .md extension. This ensures the link properly points to the existing adr-106-grpc-api.md file and resolves the previous "Cannot find file" error.


---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
