### PR TITLE
chore: remove tag from individual builds

### DIFF
--- a/.github/workflows/testapp-docker.yml
+++ b/.github/workflows/testapp-docker.yml
@@ -77,10 +77,9 @@ jobs:
           platforms: ${{ matrix.platform }}
           context: .
           file: ./test/e2e/docker/Dockerfile
-          tags: |
-            ${{ env.ORG }}/${{ env.IMAGE_NAME }}:${{ steps.get-version.outputs.version }}
+          tags: ""
           push: true
-          outputs: type=image,name=${{ env.ORG }}/${{ env.IMAGE_NAME }},digest=true
+          outputs: type=image,name=${{ env.ORG }}/${{ env.IMAGE_NAME }},push=true,digest=true
 
       - name: Capture Image Digest
         id: capture-digest


### PR DESCRIPTION
---

Since in a later step we are creating a multi arch build, my understanding is that tagging each build independently can cause a race condition on dockerhub's side.

Since we are seeing single architecture builds on dockerhub, this will hopefully fix it.

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
