### PR TITLE
chore: add interface implementation assertions for all `PrivValidator` implementations

### DIFF
--- a/privval/file.go
+++ b/privval/file.go
@@ -156,6 +156,8 @@ func (lss *FilePVLastSignState) Save() {
 
 // -------------------------------------------------------------------------------
 
+var _ types.PrivValidator = (*FilePV)(nil)
+
 // FilePV implements PrivValidator using data persisted to disk
 // to prevent double signing.
 // NOTE: the directories containing pv.Key.filePath and pv.LastSignState.filePath must already exist.

--- a/privval/retry_signer_client.go
+++ b/privval/retry_signer_client.go
@@ -40,6 +40,8 @@ func (sc *RetrySignerClient) WaitForConnection(maxWait time.Duration) error {
 // --------------------------------------------------------
 // Implement PrivValidator
 
+var _ types.PrivValidator = (*RetrySignerClient)(nil)
+
 func (sc *RetrySignerClient) Ping() error {
 	return sc.next.Ping()
 }


### PR DESCRIPTION
Saw that we weren't making assertions while digging through the `privval` code