### PR TITLE
refactor: remove redundant nil check before len() in detectDivergence

### DIFF
--- a/light/detector.go
+++ b/light/detector.go
@@ -25,7 +25,7 @@ import (
 // If there are no conflicting headers, the light client deems the verified target header
 // trusted and saves it to the trusted store.
 func (c *Client) detectDivergence(ctx context.Context, primaryTrace []*types.LightBlock, now time.Time) error {
-	if primaryTrace == nil || len(primaryTrace) < 2 {
+	if len(primaryTrace) < 2 {
 		return ErrNilOrSinglePrimaryTrace
 	}
 	var (


### PR DESCRIPTION
This commit removes an unnecessary nil check on the primaryTrace slice in the detectDivergence function. In Go, calling len() on a nil slice is safe and returns 0, so the explicit nil check is redundant. This change improves code clarity