### PR TITLE
fix: do multistage builds for e2e-node

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,4 +3,3 @@ test/e2e/build
 test/e2e/networks
 test/logs
 test/p2p/data
-.git

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -2,8 +2,6 @@
 # Stage 1: Build environment - compiles the application and test node
 FROM cometbft/cometbft-db-testing:v1.0.4 AS build
 
-
-# Set the working directory for the build stage
 WORKDIR /src/cometbft
 
 # Copy Go module files and download dependencies
@@ -16,9 +14,7 @@ COPY . .
 
 # Set build options to include specific features and databases
 ENV COMETBFT_BUILD_OPTIONS=badgerdb,rocksdb,clock_skew,bls12381,secp256k1eth
-# Build the CometBFT binary
 RUN make build
-# Build the test node application
 RUN cd test/e2e && make node
 
 # Stage 2: Final image - minimal runtime environment

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -1,35 +1,33 @@
-# We need to build in a Linux environment to support C libraries, e.g. RocksDB.
-# We use Debian instead of Alpine, so that we can use binary database packages
-# instead of spending time compiling them.
-FROM cometbft/cometbft-db-testing:v1.0.4
+FROM cometbft/cometbft-db-testing:v1.0.4 AS build
 
 RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
-
-# For latency emulation, install iproute2, which includes tc.
 RUN apt-get -qq install -y iputils-ping iproute2 >/dev/null
 
-# Set up build directory /src/cometbft
-ENV COMETBFT_BUILD_OPTIONS=badgerdb,rocksdb,clock_skew,bls12381,secp256k1eth
 WORKDIR /src/cometbft
 
-# Fetch dependencies separately (for layer caching)
 COPY go.mod go.sum api/go.mod api/go.sum ./
 RUN go mod download
 
-# Build CometBFT and install into /usr/bin/cometbft
 COPY . .
-RUN make build && cp build/cometbft /usr/bin/cometbft
-COPY test/e2e/docker/entrypoint* /usr/bin/
-RUN cd test/e2e && make node && cp build/node /usr/bin/app
 
-# Set up runtime directory. We don't use a separate runtime image since we need
-# e.g. leveldb and rocksdb which are already installed in the build image.
+ENV COMETBFT_BUILD_OPTIONS=badgerdb,rocksdb,clock_skew,bls12381,secp256k1eth
+RUN make build
+RUN cd test/e2e && make node
+
+FROM debian:bookworm-slim
+
 WORKDIR /cometbft
 VOLUME /cometbft
 ENV CMTHOME=/cometbft
 ENV GORACE="halt_on_error=1"
 
+COPY --from=build /usr/local/lib/librocksdb.so* /lib/
+
+COPY --from=build /src/cometbft/test/e2e/docker/entrypoint* /usr/bin/
+COPY --from=build /src/cometbft/build/cometbft /usr/bin/cometbft
+COPY --from=build /src/cometbft/test/e2e/build/node /usr/bin/app
+
 EXPOSE 26656 26657 26660 6060
+
 ENTRYPOINT ["/usr/bin/entrypoint"]
 CMD ["node"]
-STOPSIGNAL SIGTERM

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -2,10 +2,6 @@
 # Stage 1: Build environment - compiles the application and test node
 FROM cometbft/cometbft-db-testing:v1.0.4 AS build
 
-# Update system packages and install network utilities
-# -qq flag reduces output verbosity, >/dev/null suppresses output
-RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
-RUN apt-get -qq install -y iputils-ping iproute2 >/dev/null
 
 # Set the working directory for the build stage
 WORKDIR /src/cometbft
@@ -27,6 +23,10 @@ RUN cd test/e2e && make node
 
 # Stage 2: Final image - minimal runtime environment
 FROM debian:bookworm-slim AS runtime
+
+# Update system packages and install network utilities
+RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
+RUN apt-get -qq install -y iputils-ping iproute2 >/dev/null
 
 WORKDIR /cometbft
 VOLUME /cometbft

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -1,33 +1,59 @@
+# Multi-stage build Dockerfile for CometBFT end-to-end testing
+# Stage 1: Build environment - compiles the application and test node
 FROM cometbft/cometbft-db-testing:v1.0.4 AS build
 
+# Update system packages and install network utilities
+# -qq flag reduces output verbosity, >/dev/null suppresses output
 RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
 RUN apt-get -qq install -y iputils-ping iproute2 >/dev/null
 
+# Set the working directory for the build stage
 WORKDIR /src/cometbft
 
+# Copy Go module files and download dependencies
+# This is done before copying the rest of the code to leverage Docker's build cache
 COPY go.mod go.sum api/go.mod api/go.sum ./
 RUN go mod download
 
+# Copy the entire codebase into the container
 COPY . .
 
+# Set build options to include specific features and databases
 ENV COMETBFT_BUILD_OPTIONS=badgerdb,rocksdb,clock_skew,bls12381,secp256k1eth
+# Build the CometBFT binary
 RUN make build
+# Build the test node application
 RUN cd test/e2e && make node
 
-FROM debian:bookworm-slim
+# Stage 2: Final image - minimal runtime environment
+FROM debian:bookworm-slim AS runtime
 
 WORKDIR /cometbft
 VOLUME /cometbft
 ENV CMTHOME=/cometbft
+
+# Configure Go race detector to halt on error
 ENV GORACE="halt_on_error=1"
 
+# Copy RocksDB shared libraries from the build stage
 COPY --from=build /usr/local/lib/librocksdb.so* /lib/
 
+# Copy executables from the build stage
+# - entrypoint script for container initialization
+# - cometbft binary for the blockchain node
+# - app binary for the test application
 COPY --from=build /src/cometbft/test/e2e/docker/entrypoint* /usr/bin/
 COPY --from=build /src/cometbft/build/cometbft /usr/bin/cometbft
 COPY --from=build /src/cometbft/test/e2e/build/node /usr/bin/app
 
+# Expose ports:
+# - 26656: P2P communication between nodes
+# - 26657: RPC server for API requests
+# - 26660: ABCI server for application communication
+# - 6060: Prometheus metrics endpoint
 EXPOSE 26656 26657 26660 6060
 
+# Set the entrypoint script to initialize the container
 ENTRYPOINT ["/usr/bin/entrypoint"]
+# Default command to run when container starts (can be overridden)
 CMD ["node"]

--- a/test/e2e/docker/Dockerfile.debug
+++ b/test/e2e/docker/Dockerfile.debug
@@ -2,32 +2,35 @@
 # Stage 1: Build environment - compiles the application and test node with debugging support
 FROM cometbft/cometbft-db-testing:v1.0.4 AS build
 
-
-# Set up build directory /src/cometbft
-ENV COMETBFT_BUILD_OPTIONS=badgerdb,rocksdb,nostrip,clock_skew,bls12381,secp256k1eth
 WORKDIR /src/cometbft
 
-# Fetch dependencies separately (for layer caching)
-COPY go.mod go.sum ./
+# Copy Go module files and download dependencies
+# This is done before copying the rest of the code to leverage Docker's build cache
+COPY go.mod go.sum api/go.mod api/go.sum ./
 RUN go mod download
 
-# Build CometBFT and install into /usr/bin/cometbft
+# Copy the entire codebase into the container
 COPY . .
-RUN echo $COMETBFT_BUILD_OPTION && make build
+
+# Set build options to include specific features and databases
+ENV COMETBFT_BUILD_OPTIONS=badgerdb,rocksdb,clock_skew,bls12381,secp256k1eth,nostrip
+RUN make build
 RUN cd test/e2e && make node
 
 # Stage 2: Final image - runtime environment with debugging support
 FROM debian:bookworm-slim AS runtime
 
-# Install required packages for debugging
+# Update system packages and install network utilities
 RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
+RUN apt-get -qq install -y iputils-ping iproute2 >/dev/null
 RUN apt-get -qq install -y zsh vim golang >/dev/null
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
-# Set up runtime directory
 WORKDIR /cometbft
 VOLUME /cometbft
 ENV CMTHOME=/cometbft
+
+# Configure Go race detector to halt on error
 ENV GORACE="halt_on_error=1"
 
 # Copy RocksDB shared libraries from the build stage
@@ -37,6 +40,9 @@ COPY --from=build /usr/local/lib/librocksdb.so* /lib/
 RUN cp /root/go/bin/dlv /usr/bin/dlv
 
 # Copy executables from the build stage
+# - entrypoint script for container initialization
+# - cometbft binary for the blockchain node
+# - app binary for the test application
 COPY --from=build /src/cometbft/test/e2e/docker/entrypoint-delve /usr/bin/entrypoint-builtin
 COPY --from=build /src/cometbft/build/cometbft /usr/bin/cometbft
 COPY --from=build /src/cometbft/test/e2e/build/node /usr/bin/app
@@ -49,3 +55,4 @@ COPY --from=build /src/cometbft/test/e2e/build/node /usr/bin/app
 # - 2345, 2346: Delve debugger ports
 EXPOSE 26656 26657 26660 6060 2345 2346
 STOPSIGNAL SIGTERM
+

--- a/test/e2e/docker/Dockerfile.debug
+++ b/test/e2e/docker/Dockerfile.debug
@@ -1,8 +1,8 @@
-# We need to build in a Linux environment to support C libraries, e.g. RocksDB.
-# We use Debian instead of Alpine, so that we can use binary database packages
-# instead of spending time compiling them.
-FROM cometbft/cometbft-db-testing:v1.0.4
+# Multi-stage build Dockerfile for CometBFT debug end-to-end testing
+# Stage 1: Build environment - compiles the application and test node with debugging support
+FROM cometbft/cometbft-db-testing:v1.0.4 AS build
 
+# Update system packages and install debugging tools
 RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
 RUN apt-get -qq install -y zsh vim >/dev/null
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
@@ -17,16 +17,38 @@ RUN go mod download
 
 # Build CometBFT and install into /usr/bin/cometbft
 COPY . .
-RUN echo $COMETBFT_BUILD_OPTION && make build && cp build/cometbft /usr/bin/cometbft
-COPY test/e2e/docker/entrypoint-delve  /usr/bin/entrypoint-builtin
-RUN cd test/e2e && make node && cp build/node /usr/bin/app
+RUN echo $COMETBFT_BUILD_OPTION && make build
+RUN cd test/e2e && make node
 
-# Set up runtime directory. We don't use a separate runtime image since we need
-# e.g. leveldb and rocksdb which are already installed in the build image.
+# Stage 2: Final image - runtime environment with debugging support
+FROM debian:bookworm-slim AS runtime
+
+# Install required packages for debugging
+RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
+RUN apt-get -qq install -y zsh vim >/dev/null
+
+# Set up runtime directory
 WORKDIR /cometbft
 VOLUME /cometbft
 ENV CMTHOME=/cometbft
 ENV GORACE="halt_on_error=1"
 
+# Copy RocksDB shared libraries from the build stage
+COPY --from=build /usr/local/lib/librocksdb.so* /lib/
+
+# Copy debugging tools from the build stage
+COPY --from=build /go/bin/dlv /usr/bin/dlv
+
+# Copy executables from the build stage
+COPY --from=build /src/cometbft/test/e2e/docker/entrypoint-delve /usr/bin/entrypoint-builtin
+COPY --from=build /src/cometbft/build/cometbft /usr/bin/cometbft
+COPY --from=build /src/cometbft/test/e2e/build/node /usr/bin/app
+
+# Expose ports:
+# - 26656: P2P communication between nodes
+# - 26657: RPC server for API requests
+# - 26660: ABCI server for application communication
+# - 6060: Prometheus metrics endpoint
+# - 2345, 2346: Delve debugger ports
 EXPOSE 26656 26657 26660 6060 2345 2346
 STOPSIGNAL SIGTERM

--- a/test/e2e/docker/Dockerfile.debug
+++ b/test/e2e/docker/Dockerfile.debug
@@ -18,12 +18,12 @@ RUN make build
 RUN cd test/e2e && make node
 
 # Stage 2: Final image - runtime environment with debugging support
-FROM debian:bookworm-slim AS runtime
+FROM golang:1.23 AS runtime
 
 # Update system packages and install network utilities
 RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
 RUN apt-get -qq install -y iputils-ping iproute2 >/dev/null
-RUN apt-get -qq install -y zsh vim golang >/dev/null
+RUN apt-get -qq install -y zsh vim >/dev/null
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
 WORKDIR /cometbft
@@ -35,9 +35,6 @@ ENV GORACE="halt_on_error=1"
 
 # Copy RocksDB shared libraries from the build stage
 COPY --from=build /usr/local/lib/librocksdb.so* /lib/
-
-# Move dlv to /usr/bin for easier access
-RUN cp /root/go/bin/dlv /usr/bin/dlv
 
 # Copy executables from the build stage
 # - entrypoint script for container initialization
@@ -55,4 +52,3 @@ COPY --from=build /src/cometbft/test/e2e/build/node /usr/bin/app
 # - 2345, 2346: Delve debugger ports
 EXPOSE 26656 26657 26660 6060 2345 2346
 STOPSIGNAL SIGTERM
-

--- a/test/e2e/docker/Dockerfile.debug
+++ b/test/e2e/docker/Dockerfile.debug
@@ -2,10 +2,6 @@
 # Stage 1: Build environment - compiles the application and test node with debugging support
 FROM cometbft/cometbft-db-testing:v1.0.4 AS build
 
-# Update system packages and install debugging tools
-RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
-RUN apt-get -qq install -y zsh vim >/dev/null
-RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
 # Set up build directory /src/cometbft
 ENV COMETBFT_BUILD_OPTIONS=badgerdb,rocksdb,nostrip,clock_skew,bls12381,secp256k1eth
@@ -25,7 +21,8 @@ FROM debian:bookworm-slim AS runtime
 
 # Install required packages for debugging
 RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
-RUN apt-get -qq install -y zsh vim >/dev/null
+RUN apt-get -qq install -y zsh vim golang >/dev/null
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
 # Set up runtime directory
 WORKDIR /cometbft
@@ -36,8 +33,8 @@ ENV GORACE="halt_on_error=1"
 # Copy RocksDB shared libraries from the build stage
 COPY --from=build /usr/local/lib/librocksdb.so* /lib/
 
-# Copy debugging tools from the build stage
-COPY --from=build /go/bin/dlv /usr/bin/dlv
+# Move dlv to /usr/bin for easier access
+RUN cp /root/go/bin/dlv /usr/bin/dlv
 
 # Copy executables from the build stage
 COPY --from=build /src/cometbft/test/e2e/docker/entrypoint-delve /usr/bin/entrypoint-builtin


### PR DESCRIPTION
---

I removed .git from the .dockerignore because it's used during building. Doing multistage builds should keep it out of the runtime build. Open to alternative ideas.

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
