### PR TITLE
fix: typos and improve consistency in documentation

### DIFF
--- a/docs/references/architecture/adr-106-grpc-api.md
+++ b/docs/references/architecture/adr-106-grpc-api.md
@@ -66,7 +66,7 @@ be worked out in the implementation.
 
 - `VersionService` - A simple service that aims to be quite stable over time in
   order to be utilized by clients to establish the version of the software with
-  which they are interacting (e.g. to pre-emptively determine compatibility).
+  which they are interacting (e.g. to preemptively determine compatibility).
   This could technically be part of the `NodeService`, but if the `NodeService`
   interface were to be modified, a new version of the service would need to be
   created, and all old versions would need to be maintained, since the

--- a/docs/references/architecture/tendermint-core/adr-077-block-retention.md
+++ b/docs/references/architecture/tendermint-core/adr-077-block-retention.md
@@ -72,7 +72,7 @@ The returned `retain_height` would be the lowest height that satisfies:
 
 - State sync snapshots: blocks since the _oldest_ available snapshot must be available for state sync nodes to catch up (oldest because a node may be restoring an old snapshot while a new snapshot was taken).
 
-- Local config: archive nodes may want to retain more or all blocks, e.g. via a local config option `min-retain-blocks`. There may also be a need to vary rentention for other nodes, e.g. sentry nodes which do not need historical blocks.
+- Local config: archive nodes may want to retain more or all blocks, e.g. via a local config option `min-retain-blocks`. There may also be a need to vary retention for other nodes, e.g. sentry nodes which do not need historical blocks.
 
 ![Cosmos SDK block retention diagram](img/block-retention.png)
 

--- a/p2p/transport/tcp/conn/secret_connection.go
+++ b/p2p/transport/tcp/conn/secret_connection.go
@@ -467,7 +467,7 @@ func shareAuthSignature(sc io.ReadWriter, pubKey crypto.PubKey, signature []byte
 func incrNonce(nonce *[aeadNonceSize]byte) {
 	counter := binary.LittleEndian.Uint64(nonce[4:])
 	if counter == math.MaxUint64 {
-		// Terminates the session and makes sure the nonce would not re-used.
+		// Terminates the session and makes sure the nonce would not reused.
 		// See https://github.com/tendermint/tendermint/issues/3531
 		panic("can't increase nonce without overflow")
 	}

--- a/spec/mempool/gossip/dog.md
+++ b/spec/mempool/gossip/dog.md
@@ -17,7 +17,7 @@ preserving low latency performance and ensuring robustness against Byzantine att
   transactions. If a node is not receiving enough duplicate transactions, it will request its peers
   to re-activate a previously disabled route. This ensures a steady yet controlled flow of data.
 
-The DOG protocol is built on top of the [Flood protocol](flood.md). This spec re-uses many of the
+The DOG protocol is built on top of the [Flood protocol](flood.md). This spec reuses many of the
 same types, messages, and data structures defined in Flood's spec. 
 
 **Table of contents**


### PR DESCRIPTION


---


**Description:**  
This pull request corrects several minor typos and improves wording consistency across documentation and code comments.  
- Fixed spelling errors such as "re-used" → "reused", "pre-emptively" → "preemptively", and "rentention" → "retention".
- Updated comments and documentation for clarity and uniformity.


---