### PR TITLE
fix: Use channel-specific SendQueueCapacity in Channel.canSend()

### DIFF
--- a/p2p/transport/tcp/conn/connection.go
+++ b/p2p/transport/tcp/conn/connection.go
@@ -803,7 +803,7 @@ func (ch *stream) loadSendQueueSize() (size int) {
 // Goroutine-safe
 // Use only as a heuristic.
 func (ch *stream) canSend() bool {
-	return ch.loadSendQueueSize() < defaultSendQueueCapacity
+	return ch.loadSendQueueSize() < ch.desc.SendQueueCapacity
 }
 
 // Returns true if any PacketMsgs are pending to be sent.


### PR DESCRIPTION
Previously, the canSend() method in the Channel struct compared the current send queue size to the global defaultSendQueueCapacity constant. This approach ignored custom queue capacities set for individual channels via their ChannelDescriptor.
For example, if a channel is created with SendQueueCapacity: 10, canSend() should return true as long as there are fewer than 10 messages in the queue. Previously, since the method always compared against the default value (e.g., 1), it would return false after just one message, even though the channel could accept 9 more messages.
This commit updates canSend() to compare against ch.desc.SendQueueCapacity, ensuring that the method accurately reflects each channel's configured queue size. This change allows channels with custom capacities to function as intended and improves the flexibility and correctness of the multiplexed connection logic.