### PR TITLE
fix: add missing ReportConflictingVotes method to EvidencePool mock

### DIFF
--- a/state/mocks/evidence_pool.go
+++ b/state/mocks/evidence_pool.go
@@ -85,6 +85,11 @@ func (_m *EvidencePool) Update(_a0 state.State, evList types.EvidenceList) {
 	_m.Called(_a0, evList)
 }
 
+// ReportConflictingVotes provides a mock function with given fields: voteA, voteB
+func (_m *EvidencePool) ReportConflictingVotes(voteA, voteB *types.Vote) {
+	_m.Called(voteA, voteB)
+}
+
 // NewEvidencePool creates a new instance of EvidencePool. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewEvidencePool(t interface {


### PR DESCRIPTION
The EvidencePool mock was missing the ReportConflictingVotes method that is
present in the actual EvidencePool interface used by consensus. This method
is required for handling conflicting votes and creating duplicate vote evidence.

This fix ensures the mock properly implements all methods from the EvidencePool
interface, preventing compilation errors and runtime issues when the mock is
used in tests that call ReportConflictingVotes.

- Add ReportConflictingVotes(voteA, voteB *types.Vote) method to mock
- Follow same pattern as other mock methods
- Maintain consistency with actual EvidencePool interface