### PR TITLE
Update consensus.md

### DIFF
--- a/spec/consensus/consensus.md
+++ b/spec/consensus/consensus.md
@@ -150,7 +150,7 @@ Upon entering `Prevote`, each validator broadcasts its prevote vote.
 
 - First, if the validator is locked on a block since `LastLockRound`
   but now has a PoLC for something else at round `PoLC-Round` where
-  `LastLockRound < PoLC-Round < R`, then it unlocks.
+  `LastLockRound <= PoLC-Round < R`, then it unlocks.
 - If the validator is still locked on a block, it prevotes that.
 - Else, if the proposed block from `Propose(H,R)` is good, it
   prevotes that.


### PR DESCRIPTION
The spec (https://arxiv.org/pdf/1807.04938) mentions that LastLockedRound can be less than or equal to PoLC_Round, not just strictly less than.


---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
