### PR TITLE
fix: Add Private Key Length Validation to Ed25519 Sign Method

### DIFF
--- a/crypto/ed25519/ed25519.go
+++ b/crypto/ed25519/ed25519.go
@@ -89,8 +89,11 @@ func (privKey PrivKey) Bytes() []byte {
 // If these conditions aren't met, Sign will panic or produce an
 // incorrect signature.
 func (privKey PrivKey) Sign(msg []byte) ([]byte, error) {
-	signatureBytes := ed25519.Sign(ed25519.PrivateKey(privKey), msg)
-	return signatureBytes, nil
+    if len(privKey) != PrivateKeySize {
+	return nil, fmt.Errorf("invalid private key size: got %d, want %d", len(privKey), PrivateKeySize)
+    }
+    signatureBytes := ed25519.Sign(ed25519.PrivateKey(privKey), msg)
+    return signatureBytes, nil
 }
 
 // PubKey gets the corresponding public key from the private key.


### PR DESCRIPTION


**Description:**  
This pull request adds an explicit length check for the Ed25519 private key in the `Sign` method.  
If the key length is invalid, the method now returns a clear error instead of risking a panic or producing an incorrect signature.  
