### PR TITLE
fix(store):  Properly prune extended commits

### DIFF
--- a/.changelog/unreleased/bug-fixes/5275-pruning-ext-commit-fix.md
+++ b/.changelog/unreleased/bug-fixes/5275-pruning-ext-commit-fix.md
@@ -1,0 +1,2 @@
+- `[store]` Prune extended commits properly
+  ([5275](https://github.com/cometbft/cometbft/issues/5275)

--- a/store/store.go
+++ b/store/store.go
@@ -531,6 +531,13 @@ func (bs *BlockStore) PruneBlocks(height int64, state sm.State) (uint64, int64, 
 			}
 			bs.blockCommitCache.Remove(h)
 		}
+		if h < evidencePoint {
+			if err := batch.Delete(bs.dbKeyLayout.CalcExtCommitKey(h)); err != nil {
+				return 0, -1, ErrDBOpt{Err: err}
+			}
+			bs.blockExtendedCommitCache.Remove(h)
+		}
+
 		if err := batch.Delete(bs.dbKeyLayout.CalcSeenCommitKey(h)); err != nil {
 			return 0, -1, ErrDBOpt{Err: err}
 		}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -665,7 +665,9 @@ func TestPruningService(t *testing.T) {
 		require.NotNil(t, bs.LoadBlockMeta(1100))
 		require.Nil(t, bs.LoadBlockMeta(1099))
 		require.NotNil(t, bs.LoadBlockCommit(1100))
+		require.NotNil(t, bs.LoadBlockExtendedCommit(1100))
 		require.Nil(t, bs.LoadBlockCommit(1099))
+		require.Nil(t, bs.LoadBlockExtendedCommit(1099))
 		for i := int64(1); i < 1200; i++ {
 			block, meta = bs.LoadBlock(i)
 			require.Nil(t, block)
@@ -706,7 +708,9 @@ func TestPruningService(t *testing.T) {
 		require.NotNil(t, bs.LoadBlockMeta(1100))
 		require.Nil(t, bs.LoadBlockMeta(1099))
 		require.NotNil(t, bs.LoadBlockCommit(1100))
+		require.NotNil(t, bs.LoadBlockExtendedCommit(1100))
 		require.Nil(t, bs.LoadBlockCommit(1099))
+		require.Nil(t, bs.LoadBlockExtendedCommit(1099))
 		t.Log("Done pruning up until 1300")
 	case <-time.After(5 * time.Second):
 		require.Fail(t, "timed out waiting for pruning run to complete")


### PR DESCRIPTION
Closes #5275 


    This should be back ported all the way to 0.38. Note that in v1 and 0.38 there is no blockCommitCache so that part should be left out. 
---

#### PR checklist

- [ ] Tests written/updated
- [ x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
