### PR TITLE
fix(light): the validator with the lowest proposer priority is not guaranteed to have been the proposer of the previous block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### DEPENDENCIES
 
 ### BUG FIXES
+- `[light]` the validator with the lowest proposer priority is not guaranteed to have been the proposer of the previous block ([\#5279](https://github.com/cometbft/cometbft/pull/5279))
 
 ### IMPROVEMENTS
 -  `[mempool]` perf(mempool/cache): Optimize LRUTxCache.Remove to reduce lock contention and map access

--- a/light/provider/http/http.go
+++ b/light/provider/http/http.go
@@ -83,7 +83,7 @@ func (p *http) LightBlock(ctx context.Context, height int64) (*types.LightBlock,
 		}
 	}
 
-	vs, err := p.validatorSet(ctx, &sh.Height, sh.Header.ProposerAddress)
+	vs, err := p.validatorSet(ctx, &sh.Height, sh.ProposerAddress)
 	if err != nil {
 		return nil, err
 	}

--- a/light/provider/http/http.go
+++ b/light/provider/http/http.go
@@ -83,7 +83,7 @@ func (p *http) LightBlock(ctx context.Context, height int64) (*types.LightBlock,
 		}
 	}
 
-	vs, err := p.validatorSet(ctx, &sh.Height)
+	vs, err := p.validatorSet(ctx, &sh.Height, sh.Header.ProposerAddress)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +107,7 @@ func (p *http) ReportEvidence(ctx context.Context, ev types.Evidence) error {
 	return err
 }
 
-func (p *http) validatorSet(ctx context.Context, height *int64) (*types.ValidatorSet, error) {
+func (p *http) validatorSet(ctx context.Context, height *int64, proposerAddress types.Address) (*types.ValidatorSet, error) {
 	// Since the malicious node could report a massive number of pages, making us
 	// spend a considerable time iterating, we restrict the number of pages here.
 	// => 10000 validators max
@@ -168,7 +168,7 @@ OUTER_LOOP:
 		}
 	}
 
-	valSet, err := types.ValidatorSetFromExistingValidators(vals)
+	valSet, err := types.ValidatorSetFromExistingValidators(vals, proposerAddress)
 	if err != nil {
 		return nil, provider.ErrBadLightBlock{Reason: err}
 	}

--- a/test/e2e/runner/evidence.go
+++ b/test/e2e/runner/evidence.go
@@ -69,7 +69,7 @@ func InjectEvidence(ctx context.Context, r *rand.Rand, testnet *e2e.Testnet, amo
 		return err
 	}
 
-	valSet, err := types.ValidatorSetFromExistingValidators(valRes.Validators, blockRes.Block.Header.ProposerAddress)
+	valSet, err := types.ValidatorSetFromExistingValidators(valRes.Validators, blockRes.Block.ProposerAddress)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/runner/evidence.go
+++ b/test/e2e/runner/evidence.go
@@ -69,7 +69,7 @@ func InjectEvidence(ctx context.Context, r *rand.Rand, testnet *e2e.Testnet, amo
 		return err
 	}
 
-	valSet, err := types.ValidatorSetFromExistingValidators(valRes.Validators)
+	valSet, err := types.ValidatorSetFromExistingValidators(valRes.Validators, blockRes.Block.Header.ProposerAddress)
 	if err != nil {
 		return err
 	}

--- a/types/validator_set_test.go
+++ b/types/validator_set_test.go
@@ -1366,7 +1366,7 @@ func TestNewValidatorSetFromExistingValidators(t *testing.T) {
 	newValSet := NewValidatorSet(valSet.Validators)
 	assert.NotEqual(t, valSet, newValSet)
 
-	existingValSet, err := ValidatorSetFromExistingValidators(valSet.Validators)
+	existingValSet, err := ValidatorSetFromExistingValidators(valSet.Validators, valSet.Proposer.Address)
 	assert.NoError(t, err)
 	assert.Equal(t, valSet, existingValSet)
 	assert.Equal(t, valSet.CopyIncrementProposerPriority(3), existingValSet.CopyIncrementProposerPriority(3))


### PR DESCRIPTION
### Problem

The validator with the lowest proposer priority in the validator set is not necessarily the previous proposer.

### Example

Take a look at [Initia mainnet](https://rpc.initia.xyz/) blocks 1846549 and 1846550:

- The priority of validator `FA593C7759CD64CF7BD339E8F8E6A30201097348` increased from `-17172236` to `-16276454`.
- The priority of validator `82DB4159D2BA84EA02B269815FB87BC022AFA9FF` changed from `14744743` to `-16034753`.

Despite this, `82DB4159D2BA84EA02B269815FB87BC022AFA9FF` was the proposer, even though `FA593C7759CD64CF7BD339E8F8E6A30201097348` had a lower priority value.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Correct proposer determination and validator-set handling, add proposer-priority hash and signature caching for faster light verification, enforce vote-extension rules, refine block/tx sizing, and update indexer/e2e/build tooling.
> 
> - **Consensus/Validators**:
>   - Fix proposer inference: do not assume lowest `ProposerPriority` is prior proposer; require proposer exists in set; add `ValidatorSet.ProposerPriorityHash` and pass proposer to `ValidatorSetFromExistingValidators`.
>   - Move/clarify validation errors and checks; improve averaging/priority logic.
> - **Light Client/Verification**:
>   - Add signature cache and new `VerifyCommitLight(AllSignatures)/WithCache` APIs; improve batch/single verification paths and errors.
> - **Vote Extensions**:
>   - Enforce extensions only for non-nil precommits; validate presence/absence strictly; extend e2e to vary extension sizes.
> - **Sizing/Encoding**:
>   - Use protobuf-computed tx sizes; refine `MaxDataBytes`, part/commit size math; add `Proposal.ValidateBlockSize`.
> - **Indexer**:
>   - Support big int/float query bounds; add logger injection; optimize psql via bulk inserts; query fixes.
> - **Events/RPC/E2E/Build**:
>   - Minor event-bus tweaks; new infra (DigitalOcean), Prometheus config, Docker/Go upgrades, and extensive e2e/test updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e970e54bf7dd30297c17b2be6152c5a58dcdc6d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->