### PR TITLE
chore(docs,code): fix typos and spelling in docs, comments, and tests

### DIFF
--- a/docs/references/architecture/adr-106-grpc-api.md
+++ b/docs/references/architecture/adr-106-grpc-api.md
@@ -66,7 +66,7 @@ be worked out in the implementation.
 
 - `VersionService` - A simple service that aims to be quite stable over time in
   order to be utilized by clients to establish the version of the software with
-  which they are interacting (e.g. to pre-emptively determine compatibility).
+  which they are interacting (e.g. to preemptively determine compatibility).
   This could technically be part of the `NodeService`, but if the `NodeService`
   interface were to be modified, a new version of the service would need to be
   created, and all old versions would need to be maintained, since the

--- a/docs/references/architecture/adr-108-e2e-abci++.md
+++ b/docs/references/architecture/adr-108-e2e-abci++.md
@@ -330,7 +330,7 @@ To-do list:
 ## Consequences
 
 ### Positive
-- We should be able to check whether CommetBFT respects ABCI 2.0 grammar.
+- We should be able to check whether CometBFT respects ABCI 2.0 grammar.
 ### Negative
 
 ### Neutral

--- a/docs/references/architecture/tendermint-core/adr-020-block-size.md
+++ b/docs/references/architecture/tendermint-core/adr-020-block-size.md
@@ -12,7 +12,7 @@
 ## Context
 
 We currently use MaxTxs to reap txs from the mempool when proposing a block,
-but enforce MaxBytes when unmarshaling a block, so we could easily propose a
+but enforce MaxBytes when unmarshalling a block, so we could easily propose a
 block that's too large to be valid.
 
 We should just remove MaxTxs all together and stick with MaxBytes, and have a
@@ -31,9 +31,9 @@ of MaxDataBytes in addition to, or instead of, MaxBytes.
 
 MaxBytes provides a clear limit on the total size of a block that requires no
 additional calculation if you want to use it to bound resource usage, and there
-has been considerable discussions about optimizing tendermint around 1MB blocks.
+has been considerable discussions about optimizing Tendermint around 1MB blocks.
 Regardless, we need some maximum on the size of a block so we can avoid
-unmarshaling blocks that are too big during the consensus, and it seems more
+unmarshalling blocks that are too big during the consensus, and it seems more
 straightforward to provide a single fixed number for this rather than a
 computation of "MaxDataBytes + everything else you need to make room for
 (signatures, evidence, header)". MaxBytes provides a simple bound so we can

--- a/docs/references/architecture/tendermint-core/adr-023-ABCI-propose-tx.md
+++ b/docs/references/architecture/tendermint-core/adr-023-ABCI-propose-tx.md
@@ -58,7 +58,7 @@ exacerbated if the business logic for generating such transactions is
 potentially non-deterministic, as this should not even be done in
 `Begin/EndBlock`, which may, as a result, break consensus guarantees.
 
-Additinoally, this has serious implications for "watchers" - independent third parties,
+Additionally, this has serious implications for "watchers" - independent third parties,
 or even an auxiliary blockchain, responsible for ensuring that blocks recorded
 on the Root Chain are consistent with the Plasma chain's. Since, in this case,
 the Plasma chain is inconsistent with the canonical one maintained by Tendermint

--- a/docs/references/architecture/tendermint-core/adr-030-consensus-refactor.md
+++ b/docs/references/architecture/tendermint-core/adr-030-consensus-refactor.md
@@ -59,7 +59,7 @@ const (
 type Message int
 
 const (
-	MeesageUnknown Message = iota
+	MessageUnknown Message = iota
 	MessageProposal
 	MessageVotes
 	MessageDecision

--- a/docs/references/architecture/tendermint-core/adr-042-state-sync.md
+++ b/docs/references/architecture/tendermint-core/adr-042-state-sync.md
@@ -221,7 +221,7 @@ Proposed
 ### Positive
 * Safe & performant state sync design substantiated with real world implementation experience
 * General interfaces allowing application specific innovation
-* Parallizable implementation trajectory with reasonable engineering effort
+* Parallelizable implementation trajectory with reasonable engineering effort
 
 ### Negative
 * Static Scheduling lacks opportunity for real time chunk availability optimizations

--- a/docs/references/architecture/tendermint-core/adr-058-event-hashing.md
+++ b/docs/references/architecture/tendermint-core/adr-058-event-hashing.md
@@ -30,7 +30,7 @@ results are hashed into the `LastResultsHash` as follows:
 
 - Since we do not expect `BeginBlock` and `EndBlock` to contain many events,
   these will be Protobuf encoded and included in the Merkle tree as leaves.
-- `LastResultsHash` therefore is the root hash of a Merkle tree w/ 3 leafs:
+- `LastResultsHash` therefore is the root hash of a Merkle tree w/ 3 leaves:
   proto-encoded `ResponseBeginBlock#Events`, root hash of a Merkle tree build
   from `ResponseDeliverTx` responses (Log, Info and Codespace fields are
   ignored), and proto-encoded `ResponseEndBlock#Events`.

--- a/docs/references/architecture/tendermint-core/adr-062-p2p-architecture.md
+++ b/docs/references/architecture/tendermint-core/adr-062-p2p-architecture.md
@@ -136,7 +136,7 @@ Non-networked endpoints (without an IP address) are considered local, and will o
 
 A connection represents an established transport connection between two endpoints (i.e. two nodes), which can be used to exchange binary messages with logical channel IDs (corresponding to the higher-level channel IDs used in the router). Connections are set up either via `Transport.Dial()` (outbound) or `Transport.Accept()` (inbound).
 
-Once a connection is esablished, `Transport.Handshake()` must be called to perform a node handshake, exchanging node info and public keys to verify node identities. Node handshakes should not really be part of the transport layer (it's an application protocol concern), this exists for backwards-compatibility with the existing MConnection protocol which conflates the two. `NodeInfo` is part of the existing MConnection protocol, but does not appear to be documented in the specification -- refer to the Go codebase for details.
+Once a connection is established, `Transport.Handshake()` must be called to perform a node handshake, exchanging node info and public keys to verify node identities. Node handshakes should not really be part of the transport layer (it's an application protocol concern), this exists for backwards-compatibility with the existing MConnection protocol which conflates the two. `NodeInfo` is part of the existing MConnection protocol, but does not appear to be documented in the specification -- refer to the Go codebase for details.
 
 The `Connection` interface is shown below. It omits certain additions that are currently implemented for backwards compatibility with the legacy P2P stack and are planned to be removed before the final release.
 
@@ -314,7 +314,7 @@ type Channel struct {
     In          <-chan Envelope  // Inbound messages (peers to reactors).
     Out         chan<- Envelope  // outbound messages (reactors to peers)
     Error       chan<- PeerError // Peer error reporting.
-    messageType proto.Message    // Channel's message type, for e.g. unmarshaling.
+    messageType proto.Message    // Channel's message type, for e.g. unmarshalling.
 }
 
 // Close closes the channel, also closing Out and Error.

--- a/docs/references/architecture/tendermint-core/adr-077-block-retention.md
+++ b/docs/references/architecture/tendermint-core/adr-077-block-retention.md
@@ -72,7 +72,7 @@ The returned `retain_height` would be the lowest height that satisfies:
 
 - State sync snapshots: blocks since the _oldest_ available snapshot must be available for state sync nodes to catch up (oldest because a node may be restoring an old snapshot while a new snapshot was taken).
 
-- Local config: archive nodes may want to retain more or all blocks, e.g. via a local config option `min-retain-blocks`. There may also be a need to vary rentention for other nodes, e.g. sentry nodes which do not need historical blocks.
+- Local config: archive nodes may want to retain more or all blocks, e.g. via a local config option `min-retain-blocks`. There may also be a need to vary retention for other nodes, e.g. sentry nodes which do not need historical blocks.
 
 ![Cosmos SDK block retention diagram](img/block-retention.png)
 

--- a/docs/references/config/config.toml.md
+++ b/docs/references/config/config.toml.md
@@ -1326,7 +1326,7 @@ max_tx_bytes = 1048576
 
 Transactions bigger than the maximum configured size are rejected by mempool,
 this applies to both transactions submitted by clients via RPC endpoints, and
-transactions receveing from peers on the mempool protocol.
+transactions receiving from peers on the mempool protocol.
 
 ### mempool.max_txs_bytes
 The maximum size in bytes of all transactions stored in the mempool.

--- a/docs/references/rfc/rfc-100-abci-vote-extension-propag.md
+++ b/docs/references/rfc/rfc-100-abci-vote-extension-propag.md
@@ -254,7 +254,7 @@ We now briefly describe the current catch-up mechanisms in the reactors concerne
 
 Full nodes optionally run statesync just after starting, when they start from scratch.
 If statesync succeeds, an Application snapshot is installed, and CometBFT jumps from height 0 directly
-to the height the Application snapshop represents, without applying the block of any previous height.
+to the height the Application snapshot represents, without applying the block of any previous height.
 Some light blocks are received and stored in the block store for running light-client verification of
 all the skipped blocks. Light blocks are incomplete blocks, typically containing the header and the
 canonical commit but, e.g., no transactions. They are stored in the block store as "signed headers".

--- a/docs/references/rfc/tendermint-core/rfc-002-ipc-ecosystem.md
+++ b/docs/references/rfc/tendermint-core/rfc-002-ipc-ecosystem.md
@@ -78,8 +78,8 @@ two ways:
 
 - In-process direct calls (for applications written in Go and compiled against
   the Tendermint code).  This is an optimization for the common case where an
-  application is written in Go, to save on the overhead of marshaling and
-  unmarshaling requests and responses within the same process:
+  application is written in Go, to save on the overhead of marshalling and
+  unmarshalling requests and responses within the same process:
   [`abci/client/local_client.go`][local-client]
 
 - A custom remote procedure protocol built on wire-format protobuf messages
@@ -208,7 +208,7 @@ the server must lock conservatively, and no optimistic scheduling is practical.
 This would be a tedious implementation change, but should be achievable without
 breaking any of the existing interfaces. More importantly, it could potentially
 address a lot of difficult concurrency and performance problems we currently
-see anecdotally but have difficultly isolating because of how intertwined these
+see anecdotally but have difficulty isolating because of how intertwined these
 separate message streams are at runtime.
 
 TODO: Impact of ABCI++ for this topic?

--- a/docs/references/rfc/tendermint-core/rfc-008-do-not-panic.md
+++ b/docs/references/rfc/tendermint-core/rfc-008-do-not-panic.md
@@ -112,14 +112,14 @@ In **no** other situation is it acceptable for the code to panic:
 - callers of library functions should not expect panics.
 - ensuring that arbitrary go routines can't panic.
 - ensuring that there are no arbitrary panics in core production code,
-  espically code that can run at any time during the lifetime of a
+  especially code that can run at any time during the lifetime of a
   process.
 - all test code and fixture should report normal test assertions with
   a mechanism like testify's `require` assertion rather than calling
   panic directly.
 
 The goal of this increased "panic rigor" is to ensure that any escaped
-panic is reflects a fixable bug in Tendermint.
+panic reflects a fixable bug in Tendermint.
 
 ### Removing Panics
 

--- a/docs/references/rfc/tendermint-core/rfc-017-abci++-vote-extension-propag.md
+++ b/docs/references/rfc/tendermint-core/rfc-017-abci++-vote-extension-propag.md
@@ -244,7 +244,7 @@ We now briefly describe the current catch-up mechanisms in the reactors concerne
 
 Full nodes optionally run statesync just after starting, when they start from scratch.
 If statesync succeeds, an Application snapshot is installed, and Tendermint jumps from height 0 directly
-to the height the Application snapshop represents, without applying the block of any previous height.
+to the height the Application snapshot represents, without applying the block of any previous height.
 Some light blocks are received and stored in the block store for running light-client verification of
 all the skipped blocks. Light blocks are incomplete blocks, typically containing the header and the
 canonical commit but, e.g., no transactions. They are stored in the block store as "signed headers".

--- a/docs/references/rfc/tendermint-core/rfc-027-p2p-message-bandwidth-report.md
+++ b/docs/references/rfc/tendermint-core/rfc-027-p2p-message-bandwidth-report.md
@@ -8,7 +8,7 @@
 ## Abstract
 
 Node operators and application developers complain that Tendermint nodes consume
-larges amounts of network bandwidth. This RFC catalogues the major sources of bandwidth
+large amounts of network bandwidth. This RFC catalogues the major sources of bandwidth
 consumption within Tendermint and suggests modifications to Tendermint that may reduce
 bandwidth consumption for nodes.
 

--- a/docs/references/storage/README.md
+++ b/docs/references/storage/README.md
@@ -108,7 +108,7 @@ The experiments were ran in a number of different settings:
 - **Storage footprint** 
 - **RAM usage**
 - **Block processing time** (*cometbft_state_block_processing_time*) This time here indicates the time to execute `FinalizeBlock` while reconstructing the last commit from the database and sending it to the application for processing. 
-- **Block time**: Computes the time taken for 1 block based on the number of blocks procssed in 1h. Note that for small networks the validators usually keep up and thus their average block times end up being similar.
+- **Block time**: Computes the time taken for 1 block based on the number of blocks processed in 1h. Note that for small networks the validators usually keep up and thus their average block times end up being similar.
 - **Duration of individual consensus steps** (*cometbft_consensus_step_duration_seconds* aggregated by step)
 - **consensus_total_txs**
 

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -116,7 +116,7 @@ func NewSwitch(
 		unconditionalPeerIDs: make(map[nodekey.ID]struct{}),
 	}
 
-	// Ensure we have a completely undeterministic PRNG.
+	// Ensure we have a completely indeterministic PRNG.
 	sw.rng = rand.NewRand()
 
 	sw.BaseService = *service.NewBaseService(nil, "P2P Switch", sw)

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -552,7 +552,7 @@ func TestSwitchReconnectsToOutboundPersistentPeer(t *testing.T) {
 	conf.TestDialFail = true // will trigger a reconnect
 	err = sw.addOutboundPeerWithConfig(rp.Addr(), conf)
 	require.Error(t, err)
-	// DialPeerWithAddres - sw.peerConfig resets the dialer
+	// DialPeerWithAddress - sw.peerConfig resets the dialer
 	waitUntilSwitchHasAtLeastNPeers(sw, 2)
 	assert.Equal(t, 2, sw.Peers().Size())
 }

--- a/p2p/transport/tcp/conn/secret_connection.go
+++ b/p2p/transport/tcp/conn/secret_connection.go
@@ -467,7 +467,7 @@ func shareAuthSignature(sc io.ReadWriter, pubKey crypto.PubKey, signature []byte
 func incrNonce(nonce *[aeadNonceSize]byte) {
 	counter := binary.LittleEndian.Uint64(nonce[4:])
 	if counter == math.MaxUint64 {
-		// Terminates the session and makes sure the nonce would not re-used.
+		// Terminates the session and makes sure the nonce would not be reused.
 		// See https://github.com/tendermint/tendermint/issues/3531
 		panic("can't increase nonce without overflow")
 	}

--- a/rpc/client/event_test.go
+++ b/rpc/client/event_test.go
@@ -40,8 +40,8 @@ func TestHeaderEvents(t *testing.T) {
 				})
 			}
 
-			evtTyp := types.EventNewBlockHeader
-			evt, err := client.WaitForOneEvent(c, evtTyp, waitForEventTimeout)
+			evtType := types.EventNewBlockHeader
+			evt, err := client.WaitForOneEvent(c, evtType, waitForEventTimeout)
 			require.NoError(t, err)
 			require.NoError(t, err, "%d: %+v", i, err)
 			_, ok := evt.(types.EventDataNewBlockHeader)

--- a/rpc/client/helpers.go
+++ b/rpc/client/helpers.go
@@ -60,13 +60,13 @@ func WaitForHeight(c StatusClient, h int64, waiter Waiter) error {
 // when the timeout duration has expired.
 //
 // This handles subscribing and unsubscribing under the hood.
-func WaitForOneEvent(c EventsClient, evtTyp string, timeout time.Duration) (types.TMEventData, error) {
+func WaitForOneEvent(c EventsClient, evtType string, timeout time.Duration) (types.TMEventData, error) {
 	const subscriber = "helpers"
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	// register for the next event of this type
-	eventCh, err := c.Subscribe(ctx, subscriber, types.QueryForEvent(evtTyp).String())
+	eventCh, err := c.Subscribe(ctx, subscriber, types.QueryForEvent(evtType).String())
 	if err != nil {
 		return nil, ErrSubscribe{Source: err}
 	}

--- a/rpc/jsonrpc/server/http_json_handler.go
+++ b/rpc/jsonrpc/server/http_json_handler.go
@@ -47,7 +47,7 @@ func makeJSONRPCHandler(funcMap map[string]*RPCFunc, logger log.Logger) http.Han
 			// next, try to unmarshal as a single request
 			var request types.RPCRequest
 			if err := json.Unmarshal(b, &request); err != nil {
-				res := types.RPCParseError(fmt.Errorf("error unmarshaling request: %w", err))
+				res := types.RPCParseError(fmt.Errorf("error unmarshalling request: %w", err))
 				if wErr := WriteRPCResponseHTTPError(w, http.StatusInternalServerError, res); wErr != nil {
 					logger.Error("failed to write response", "err", wErr)
 				}

--- a/rpc/jsonrpc/server/rpc_func.go
+++ b/rpc/jsonrpc/server/rpc_func.go
@@ -11,7 +11,7 @@ import (
 
 // RegisterRPCFuncs adds a route for each function in the funcMap, as well as
 // general jsonrpc and websocket handlers for all functions. "result" is the
-// interface on which the result objects are registered, and is popualted with
+// interface on which the result objects are registered, and is populated with
 // every RPCResponse.
 func RegisterRPCFuncs(mux *http.ServeMux, funcMap map[string]*RPCFunc, logger log.Logger) {
 	// HTTP endpoints

--- a/rpc/jsonrpc/server/ws_handler.go
+++ b/rpc/jsonrpc/server/ws_handler.go
@@ -337,7 +337,7 @@ func (wsc *wsConnection) readRoutine() {
 			err = dec.Decode(&request)
 			if err != nil {
 				if err := wsc.WriteRPCResponse(writeCtx,
-					types.RPCParseError(fmt.Errorf("error unmarshaling request: %w", err))); err != nil {
+					types.RPCParseError(fmt.Errorf("error unmarshalling request: %w", err))); err != nil {
 					wsc.Logger.Error("Error writing RPC response", "err", err)
 				}
 				continue

--- a/spec/abci/README.md
+++ b/spec/abci/README.md
@@ -9,21 +9,21 @@ parent:
 
 ## Introduction
 
-ABCI 2.0 is a major evolution of ABCI (**A**pplication **B**lock**c**hain **I**nterface).
+ABCI 2.0 is a major evolution of ABCI (**A**application **B**lock**c**hain **I**nterface).
 ABCI is the interface between CometBFT (a state-machine
-replication engine) and the actual state machine being replicated (i.e., the Application).
+replication engine) and the actual state machine being replicated (i.e., the Aapplication).
 The API consists of a set of _methods_, each with a corresponding `Request` and `Response`
 message type.
 
 > Note: ABCI 2.0 is colloquially called ABCI++. To be precise in these documents, we will refer to the exact version of ABCI under discussion, currently 2.0.
 
-The methods are always initiated by CometBFT. The Application implements its logic
+The methods are always initiated by CometBFT. The Aapplication implements its logic
 for handling all ABCI methods.
 Thus, CometBFT always sends the `*Request` messages and receives the `*Response` messages
 in return.
 
 All ABCI messages and methods are defined in [protocol buffers](https://github.com/cometbft/cometbft/blob/main/proto/cometbft/abci/v1/types.proto).
-This allows CometBFT to run with applications written in many programming languages.
+This allows CometBFT to run with aapplications written in many programming languages.
 
 This specification is split as follows:
 
@@ -31,13 +31,13 @@ This specification is split as follows:
   needed to understand other parts of this specification.
 - [Methods](./abci++_methods.md) - complete details on all ABCI methods
   and message types.
-- [Requirements for the Application](./abci++_app_requirements.md) - formal requirements
-  on the Application's logic to ensure CometBFT properties such as liveness. These requirements define what
-  CometBFT expects from the Application; second part on managing ABCI application state and related topics.
+- [Requirements for the Aapplication](./abci++_app_requirements.md) - formal requirements
+  on the Aapplication's logic to ensure CometBFT properties such as liveness. These requirements define what
+  CometBFT expects from the Aapplication; second part on managing ABCI aapplication state and related topics.
 - [CometBFT's expected behavior](./abci++_comet_expected_behavior.md) - specification of
-  how the different ABCI methods may be called by CometBFT. This explains what the Application
+  how the different ABCI methods may be called by CometBFT. This explains what the Aapplication
   is to expect from CometBFT.
-- [Example scenarios](./abci++_example_scenarios.md) - specific scenarios showing why the Application needs to account
+- [Example scenarios](./abci++_example_scenarios.md) - specific scenarios showing why the Aapplication needs to account
 for any CometBFT's behavior prescribed by the specification.
 - [Client and Server](./abci++_client_server.md) - for those looking to implement their
-  own ABCI application servers.
+  own ABCI aapplication servers.

--- a/spec/abci/README.md
+++ b/spec/abci/README.md
@@ -9,21 +9,21 @@ parent:
 
 ## Introduction
 
-ABCI 2.0 is a major evolution of ABCI (**A**application **B**lock**c**hain **I**nterface).
+ABCI 2.0 is a major evolution of ABCI (**A**pplication **B**lock**c**hain **I**nterface).
 ABCI is the interface between CometBFT (a state-machine
-replication engine) and the actual state machine being replicated (i.e., the Aapplication).
+replication engine) and the actual state machine being replicated (i.e., the Application).
 The API consists of a set of _methods_, each with a corresponding `Request` and `Response`
 message type.
 
 > Note: ABCI 2.0 is colloquially called ABCI++. To be precise in these documents, we will refer to the exact version of ABCI under discussion, currently 2.0.
 
-The methods are always initiated by CometBFT. The Aapplication implements its logic
+The methods are always initiated by CometBFT. The Application implements its logic
 for handling all ABCI methods.
 Thus, CometBFT always sends the `*Request` messages and receives the `*Response` messages
 in return.
 
 All ABCI messages and methods are defined in [protocol buffers](https://github.com/cometbft/cometbft/blob/main/proto/cometbft/abci/v1/types.proto).
-This allows CometBFT to run with aapplications written in many programming languages.
+This allows CometBFT to run with applications written in many programming languages.
 
 This specification is split as follows:
 
@@ -31,13 +31,13 @@ This specification is split as follows:
   needed to understand other parts of this specification.
 - [Methods](./abci++_methods.md) - complete details on all ABCI methods
   and message types.
-- [Requirements for the Aapplication](./abci++_app_requirements.md) - formal requirements
-  on the Aapplication's logic to ensure CometBFT properties such as liveness. These requirements define what
-  CometBFT expects from the Aapplication; second part on managing ABCI aapplication state and related topics.
+- [Requirements for the Application](./abci++_app_requirements.md) - formal requirements
+  on the Application's logic to ensure CometBFT properties such as liveness. These requirements define what
+  CometBFT expects from the Application; second part on managing ABCI application state and related topics.
 - [CometBFT's expected behavior](./abci++_comet_expected_behavior.md) - specification of
-  how the different ABCI methods may be called by CometBFT. This explains what the Aapplication
+  how the different ABCI methods may be called by CometBFT. This explains what the Application
   is to expect from CometBFT.
-- [Example scenarios](./abci++_example_scenarios.md) - specific scenarios showing why the Aapplication needs to account
+- [Example scenarios](./abci++_example_scenarios.md) - specific scenarios showing why the Application needs to account
 for any CometBFT's behavior prescribed by the specification.
 - [Client and Server](./abci++_client_server.md) - for those looking to implement their
-  own ABCI aapplication servers.
+  own ABCI application servers.

--- a/spec/mempool/gossip/dog.md
+++ b/spec/mempool/gossip/dog.md
@@ -17,7 +17,7 @@ preserving low latency performance and ensuring robustness against Byzantine att
   transactions. If a node is not receiving enough duplicate transactions, it will request its peers
   to re-activate a previously disabled route. This ensures a steady yet controlled flow of data.
 
-The DOG protocol is built on top of the [Flood protocol](flood.md). This spec re-uses many of the
+The DOG protocol is built on top of the [Flood protocol](flood.md). This spec reuses many of the
 same types, messages, and data structures defined in Flood's spec. 
 
 **Table of contents**

--- a/spec/mempool/quint/Ledger.qnt
+++ b/spec/mempool/quint/Ledger.qnt
@@ -123,7 +123,7 @@ module Ledger{
     }
     
     // Total Order: for any two processes, entries are prefix one from another.
-    pure def ledgerOrdertInv(state: LedgerState): bool = {
+    pure def ledgerOrderedInv(state: LedgerState): bool = {
       0.to(state.height()-1).forall(h => consensusAgreementInv(state.log[h]))
     }
 
@@ -139,7 +139,7 @@ module Ledger{
     val ledgerInvariant = {
       and {
         ledgerValidityInv(_ledger),
-        ledgerOrdertInv(_ledger)
+        ledgerOrderedInv(_ledger)
       }
     }
 

--- a/spec/p2p/implementation/addressbook.md
+++ b/spec/p2p/implementation/addressbook.md
@@ -259,8 +259,8 @@ A known address becomes bad if it is stored in buckets of new addresses, and
 when connection attempts:
 
 - Have not been made over a week, i.e., `LastAttempt` is older than a week
-- Have failed 3 times and never succeeded, i.e., `LastSucess` field is unset
-- Have failed 10 times in the last week, i.e., `LastSucess` is older than a week
+- Have failed 3 times and never succeeded, i.e., `LastSuccess` field is unset
+- Have failed 10 times in the last week, i.e., `LastSuccess` is older than a week
 
 Addresses marked as *bad* are the first candidates to be removed from a bucket of
 new addresses when the bucket becomes full.

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -370,7 +370,7 @@ func TestBlockStoreSaveLoadBlock(t *testing.T) {
 }
 
 // stripExtensions removes all VoteExtension data from an ExtendedCommit. This
-// is useful when dealing with an ExendedCommit but vote extension data is
+// is useful when dealing with an ExtendedCommit but vote extension data is
 // expected to be absent.
 func stripExtensions(ec *types.ExtendedCommit) bool {
 	stripped := false


### PR DESCRIPTION
This PR corrects spelling mistakes and minor wording issues across documentation, code comments, identifiers, and tests.  
Examples of fixes include:  
- **Docs/specs**: `pre-emptively` → `preemptively`, `Additinoally` → `Additionally`, `espically` → `especially`, `snapshop` → `snapshot`.  
- **Identifiers/tests**: `ledgerOrdertInv` → `ledgerOrderedInv`, `evtTyp` → `evtType`, `NetAddresss` → `NetAddress`.  
- **P2P/RPC**: corrected error messages and comments (`unmarshaling` → `unmarshalling`, `popualted` → `populated`, `undeterministic` → `indeterministic`).  
- **Miscellaneous**: fixed typos like `LastSucess` → `LastSuccess`, `ExendedCommit` → `ExtendedCommit`, `procssed` → `processed`.  

No functional or logic changes — only documentation and spelling corrections for consistency and readability.
