### PR TITLE
docs: fix broken links

### DIFF
--- a/light/doc.go
+++ b/light/doc.go
@@ -118,7 +118,7 @@ as a wrapper, which verifies all the headers, using a light client connected to
 some other node.
 
 See
-https://docs.cometbft.com/v0.38.x/core/light-client.html
+https://docs.cometbft.com/v0.38/core/light-client
 for usage example.
 Or see
 https://github.com/cometbft/cometbft/tree/v0.38.x/spec/consensus/light-client

--- a/rpc/core/abci.go
+++ b/rpc/core/abci.go
@@ -11,7 +11,7 @@ import (
 )
 
 // ABCIQuery queries the application for some information.
-// More: https://docs.cometbft.com/v0.38.x/rpc/#/ABCI/abci_query
+// More: https://docs.cometbft.com/v0.38/spec/rpc/#abciquery
 func (env *Environment) ABCIQuery(
 	_ *rpctypes.Context,
 	path string,
@@ -33,7 +33,7 @@ func (env *Environment) ABCIQuery(
 }
 
 // ABCIInfo gets some info about the application.
-// More: https://docs.cometbft.com/v0.38.x/rpc/#/ABCI/abci_info
+// More: https://docs.cometbft.com/v0.38/spec/rpc/#abciinfo
 func (env *Environment) ABCIInfo(_ *rpctypes.Context) (*ctypes.ResultABCIInfo, error) {
 	resInfo, err := env.ProxyAppQuery.Info(context.TODO(), proxy.RequestInfo)
 	if err != nil {

--- a/rpc/core/blocks.go
+++ b/rpc/core/blocks.go
@@ -136,7 +136,7 @@ func (env *Environment) Block(_ *rpctypes.Context, heightPtr *int64) (*ctypes.Re
 }
 
 // BlockByHash gets block by hash.
-// More: https://docs.cometbft.com/v0.38.x/rpc/#/Info/block_by_hash
+// More: https://docs.cometbft.com/v0.38/spec/rpc/#blockbyhash
 func (env *Environment) BlockByHash(_ *rpctypes.Context, hash []byte) (*ctypes.ResultBlock, error) {
 	block := env.BlockStore.LoadBlockByHash(hash)
 	if block == nil {

--- a/rpc/core/consensus.go
+++ b/rpc/core/consensus.go
@@ -14,7 +14,7 @@ import (
 // validators are sorted by their voting power - this is the canonical order
 // for the validators in the set as used in computing their Merkle root.
 //
-// More: https://docs.cometbft.com/v0.38.x/rpc/#/Info/validators
+// More: https://docs.cometbft.com/v0.38/spec/rpc/#validators
 func (env *Environment) Validators(
 	_ *rpctypes.Context,
 	heightPtr *int64,
@@ -95,7 +95,7 @@ func (env *Environment) GetConsensusState(*rpctypes.Context) (*ctypes.ResultCons
 
 // ConsensusParams gets the consensus parameters at the given block height.
 // If no height is provided, it will fetch the latest consensus params.
-// More: https://docs.cometbft.com/v0.38.x/rpc/#/Info/consensus_params
+// More: https://docs.cometbft.com/v0.38/spec/rpc/#consensusparams
 func (env *Environment) ConsensusParams(
 	_ *rpctypes.Context,
 	heightPtr *int64,

--- a/rpc/core/health.go
+++ b/rpc/core/health.go
@@ -7,7 +7,7 @@ import (
 
 // Health gets node health. Returns empty result (200 OK) on success, no
 // response - in case of an error.
-// More: https://docs.cometbft.com/v0.38.x/rpc/#/Info/health
+// More: https://docs.cometbft.com/v0.38/spec/rpc/#health
 func (env *Environment) Health(*rpctypes.Context) (*ctypes.ResultHealth, error) {
 	return &ctypes.ResultHealth{}, nil
 }

--- a/rpc/core/mempool.go
+++ b/rpc/core/mempool.go
@@ -171,7 +171,7 @@ func (env *Environment) NumUnconfirmedTxs(*rpctypes.Context) (*ctypes.ResultUnco
 
 // CheckTx checks the transaction without executing it. The transaction won't
 // be added to the mempool either.
-// More: https://docs.cometbft.com/v0.38.x/rpc/#/Tx/check_tx
+// More: https://docs.cometbft.com/v0.38/spec/rpc/#checktx
 func (env *Environment) CheckTx(_ *rpctypes.Context, tx types.Tx) (*ctypes.ResultCheckTx, error) {
 	res, err := env.ProxyAppMempool.CheckTx(context.TODO(), &abci.RequestCheckTx{Tx: tx})
 	if err != nil {

--- a/rpc/core/net.go
+++ b/rpc/core/net.go
@@ -11,7 +11,7 @@ import (
 )
 
 // NetInfo returns network info.
-// More: https://docs.cometbft.com/v0.38.x/rpc/#/Info/net_info
+// More: https://docs.cometbft.com/v0.38/spec/rpc/#netinfo
 func (env *Environment) NetInfo(*rpctypes.Context) (*ctypes.ResultNetInfo, error) {
 	peersList := env.P2PPeers.Peers().List()
 	peers := make([]ctypes.Peer, 0, len(peersList))
@@ -95,7 +95,7 @@ func (env *Environment) UnsafeDialPeers(
 }
 
 // Genesis returns genesis file.
-// More: https://docs.cometbft.com/v0.38.x/rpc/#/Info/genesis
+// More: https://docs.cometbft.com/v0.38/spec/rpc/#genesis
 func (env *Environment) Genesis(*rpctypes.Context) (*ctypes.ResultGenesis, error) {
 	if len(env.genChunks) > 1 {
 		return nil, errors.New("genesis response is large, please use the genesis_chunked API instead")


### PR DESCRIPTION
1. broken https://docs.cometbft.com/v0.38.x/core/light-client.html
correct https://docs.cometbft.com/v0.38/core/light-client
2. broken https://docs.cometbft.com/v0.38/core/light-client
correct https://docs.cometbft.com/v0.38/spec/rpc/#abciquery
3. broken https://docs.cometbft.com/v0.38.x/rpc/#/ABCI/abci_info
correct https://docs.cometbft.com/v0.38/spec/rpc/#abciinfo
4. broken https://docs.cometbft.com/v0.38.x/rpc/#/Info/block_by_hash
correct https://docs.cometbft.com/v0.38/spec/rpc/#blockbyhash
5. broken https://docs.cometbft.com/v0.38.x/rpc/#/Info/validators
correct https://docs.cometbft.com/v0.38/spec/rpc/#validators
6. broken https://docs.cometbft.com/v0.38.x/rpc/#/Info/consensus_params
correct https://docs.cometbft.com/v0.38/spec/rpc/#consensusparams
7. broken https://docs.cometbft.com/v0.38.x/rpc/#/Info/health
correct https://docs.cometbft.com/v0.38/spec/rpc/#health
8. broken https://docs.cometbft.com/v0.38.x/rpc/#/Tx/check_tx
correct https://docs.cometbft.com/v0.38/spec/rpc/#checktx
9. broken https://docs.cometbft.com/v0.38.x/rpc/#/Info/net_info
correct https://docs.cometbft.com/v0.38/spec/rpc/#netinfo
10. broken https://docs.cometbft.com/v0.38.x/rpc/#/Info/genesis
correct https://docs.cometbft.com/v0.38/spec/rpc/#genesis