### PR TITLE
fix: typos across the codebase

### DIFF
--- a/consensus/replay_file.go
+++ b/consensus/replay_file.go
@@ -143,7 +143,7 @@ func (pb *playback) replayReset(count int, newStepSub types.Subscription) error 
 	pb.fp = fp
 	pb.dec = NewWALDecoder(fp)
 	count = pb.count - count
-	fmt.Printf("Reseting from %d to %d\n", pb.count, count)
+	fmt.Printf("Resetting from %d to %d\n", pb.count, count)
 	pb.count = 0
 	pb.cs = newCS
 	var msg *TimedWALMessage

--- a/crypto/merkle/proof.go
+++ b/crypto/merkle/proof.go
@@ -12,7 +12,7 @@ import (
 const (
 	// MaxAunts is the maximum number of aunts that can be included in a Proof.
 	// This corresponds to a tree of size 2^100, which should be sufficient for all conceivable purposes.
-	// This maximum helps prevent Denial-of-Service attacks by limitting the size of the proofs.
+	// This maximum helps prevent Denial-of-Service attacks by limiting the size of the proofs.
 	MaxAunts = 100
 )
 

--- a/crypto/merkle/proof_op.go
+++ b/crypto/merkle/proof_op.go
@@ -115,7 +115,7 @@ func (prt *ProofRuntime) VerifyValue(proof *cmtcrypto.ProofOps, root []byte, key
 	return prt.Verify(proof, root, keypath, [][]byte{value})
 }
 
-// TODO In the long run we'll need a method of classifcation of ops,
+// TODO In the long run we'll need a method of classification of ops,
 // whether existence or absence or perhaps a third?
 func (prt *ProofRuntime) VerifyAbsence(proof *cmtcrypto.ProofOps, root []byte, keypath string) (err error) {
 	return prt.Verify(proof, root, keypath, nil)

--- a/light/detector.go
+++ b/light/detector.go
@@ -251,7 +251,7 @@ func (c *Client) handleConflictingHeaders(
 	// and generate evidence against the primary that we can send to the witness
 	commonBlock, trustedBlock := witnessTrace[0], witnessTrace[len(witnessTrace)-1]
 	evidenceAgainstPrimary := newLightClientAttackEvidence(primaryBlock, trustedBlock, commonBlock)
-	c.logger.Error("ATTEMPTED ATTACK DETECTED. Sending evidence againt primary by witness", "ev", evidenceAgainstPrimary,
+	c.logger.Error("ATTEMPTED ATTACK DETECTED. Sending evidence against primary by witness", "ev", evidenceAgainstPrimary,
 		"primary", c.primary, "witness", supportingWitness)
 	c.sendEvidence(ctx, evidenceAgainstPrimary, supportingWitness)
 

--- a/p2p/conn/secret_connection_test.go
+++ b/p2p/conn/secret_connection_test.go
@@ -120,7 +120,7 @@ func TestSecretConnectionReadWrite(t *testing.T) {
 	// A helper that will run with (fooConn, fooWrites, fooReads) and vice versa
 	genNodeRunner := func(id string, nodeConn kvstoreConn, nodeWrites []string, nodeReads *[]string) async.Task {
 		return func(_ int) (interface{}, bool, error) {
-			// Initiate cryptographic private key and secret connection trhough nodeConn.
+			// Initiate cryptographic private key and secret connection through nodeConn.
 			nodePrvKey := ed25519.GenPrivKey()
 			nodeSecretConn, err := MakeSecretConnection(nodeConn, nodePrvKey)
 			if err != nil {

--- a/p2p/node_info.go
+++ b/p2p/node_info.go
@@ -95,7 +95,7 @@ type DefaultNodeInfo struct {
 	Other   DefaultNodeInfoOther `json:"other"`   // other application specific data
 }
 
-// DefaultNodeInfoOther is the misc. applcation specific data
+// DefaultNodeInfoOther is the misc. application specific data
 type DefaultNodeInfoOther struct {
 	TxIndex    string `json:"tx_index"`
 	RPCAddress string `json:"rpc_address"`

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -232,7 +232,7 @@ func (p *peer) IsOutbound() bool {
 	return p.outbound
 }
 
-// IsPersistent returns true if the peer is persitent, false otherwise.
+// IsPersistent returns true if the peer is persistent, false otherwise.
 func (p *peer) IsPersistent() bool {
 	return p.persistent
 }

--- a/p2p/transport.go
+++ b/p2p/transport.go
@@ -81,7 +81,7 @@ type transportLifecycle interface {
 }
 
 // ConnFilterFunc to be implemented by filter hooks after a new connection has
-// been established. The set of exisiting connections is passed along together
+// been established. The set of existing connections is passed along together
 // with all resolved IPs for the new connection.
 type ConnFilterFunc func(ConnSet, net.Conn, []net.IP) error
 

--- a/spec/consensus/proposer-based-timestamp/pbts_001_draft.md
+++ b/spec/consensus/proposer-based-timestamp/pbts_001_draft.md
@@ -21,7 +21,7 @@ In CometBFT, the first version of how time is computed and stored in a block wor
 1. **Liveness.** The liveness of the protocol:
    1. does not depend on clock synchronization,
    1. depends on bounded message delays.
-1. **Relation to real time.** There is no clock synchronizaton, which implies that there is **no relation** between the computed block `time` and real time.
+1. **Relation to real time.** There is no clock synchronization, which implies that there is **no relation** between the computed block `time` and real time.
 1. **Aggregate signatures.** As the `precommit` messages contain the local times, all these `precommit` messages typically differ in the time field, which **prevents** the use of aggregate signatures.
 
 ## Suggested Proposer-Based Time

--- a/state/store_test.go
+++ b/state/store_test.go
@@ -270,7 +270,7 @@ func TestLastFinalizeBlockResponses(t *testing.T) {
 		require.NoError(t, err)
 		// check to see if the saved response height is the same as the loaded height.
 		assert.Equal(t, lastResponse, response1)
-		// use an incorret height to make sure the state store errors.
+		// use an incorrect height to make sure the state store errors.
 		_, err = stateStore.LoadLastFinalizeBlockResponse(height + 1)
 		assert.Error(t, err)
 		// check if the abci response didnt save in the abciresponses.

--- a/statesync/syncer.go
+++ b/statesync/syncer.go
@@ -491,7 +491,7 @@ func (s *syncer) verifyApp(snapshot *snapshot, appVersion uint64) error {
 	// sanity check that the app version in the block matches the application's own record
 	// of its version
 	if resp.AppVersion != appVersion {
-		// An error here most likely means that the app hasn't inplemented state sync
+		// An error here most likely means that the app hasn't implemented state sync
 		// or the Info call correctly
 		return fmt.Errorf("app version mismatch. Expected: %d, got: %d",
 			appVersion, resp.AppVersion)

--- a/types/validation.go
+++ b/types/validation.go
@@ -242,7 +242,7 @@ func verifyCommitBatch(
 			continue
 		}
 
-		// If the vals and commit have a 1-to-1 correspondance we can retrieve
+		// If the vals and commit have a 1-to-1 correspondence we can retrieve
 		// them by index else we need to retrieve them by address
 		if lookUpByIndex {
 			val = vals.Validators[idx]


### PR DESCRIPTION


Description:
- Corrects spelling in comments, log messages, and docs/tests.
- Examples: limitting → limiting, classification, against, through, application, persistent, existing, incorrect, implemented, correspondence.
