### PR TITLE
fix: correct typos in comments and error messages

### DIFF
--- a/abci/server/socket_server.go
+++ b/abci/server/socket_server.go
@@ -167,7 +167,7 @@ func (s *SocketServer) handleRequests(closeConn chan error, conn io.Reader, resp
 	defer func() {
 		// make sure to recover from any app-related panics to allow proper socket cleanup.
 		// In the case of a panic, we do not notify the client by passing an exception so
-		// presume that the client is still running and retying to connect
+		// presume that the client is still running and retrying to connect
 		r := recover()
 		if r != nil {
 			const size = 64 << 10

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -869,7 +869,7 @@ func getSwitchIndex(switches []*p2p.Switch, peer p2p.Peer) int {
 			return i
 		}
 	}
-	panic("didnt find peer in switches")
+	panic("didn't find peer in switches")
 }
 
 //-------------------------------------------------------------------------------

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -576,7 +576,7 @@ OUTER_LOOP:
 		if blockStoreBase > 0 && 0 < prs.Height && prs.Height < rs.Height && prs.Height >= blockStoreBase {
 			heightLogger := logger.With("height", prs.Height)
 
-			// if we never received the commit message from the peer, the block parts wont be initialized
+			// if we never received the commit message from the peer, the block parts won't be initialized
 			if prs.ProposalBlockParts == nil {
 				blockMeta := conR.conS.blockStore.LoadBlockMeta(prs.Height)
 				if blockMeta == nil {

--- a/consensus/wal.go
+++ b/consensus/wal.go
@@ -335,7 +335,7 @@ func IsDataCorruptionError(err error) bool {
 	return ok
 }
 
-// DataCorruptionError is an error that occures if data on disk was corrupted.
+// DataCorruptionError is an error that occurs if data on disk was corrupted.
 type DataCorruptionError struct {
 	cause error
 }

--- a/docs/references/architecture/tendermint-core/adr-077-block-retention.md
+++ b/docs/references/architecture/tendermint-core/adr-077-block-retention.md
@@ -72,7 +72,7 @@ The returned `retain_height` would be the lowest height that satisfies:
 
 - State sync snapshots: blocks since the _oldest_ available snapshot must be available for state sync nodes to catch up (oldest because a node may be restoring an old snapshot while a new snapshot was taken).
 
-- Local config: archive nodes may want to retain more or all blocks, e.g. via a local config option `min-retain-blocks`. There may also be a need to vary rentention for other nodes, e.g. sentry nodes which do not need historical blocks.
+- Local config: archive nodes may want to retain more or all blocks, e.g. via a local config option `min-retain-blocks`. There may also be a need to vary retention for other nodes, e.g. sentry nodes which do not need historical blocks.
 
 ![Cosmos SDK block retention diagram](img/block-retention.png)
 

--- a/libs/math/fraction.go
+++ b/libs/math/fraction.go
@@ -27,7 +27,7 @@ func (fr Fraction) String() string {
 func ParseFraction(f string) (Fraction, error) {
 	o := strings.Split(f, "/")
 	if len(o) != 2 {
-		return Fraction{}, errors.New("incorrect formating: should have a single slash i.e. \"1/3\"")
+		return Fraction{}, errors.New("incorrect formatting: should have a single slash i.e. \"1/3\"")
 	}
 	numerator, err := strconv.ParseUint(o[0], 10, 64)
 	if err != nil {

--- a/light/detector.go
+++ b/light/detector.go
@@ -287,7 +287,7 @@ func (c *Client) handleConflictingHeaders(
 }
 
 // examineConflictingHeaderAgainstTrace takes a trace from one provider and a divergent header that
-// it has received from another and preforms verifySkipping at the heights of each of the intermediate
+// it has received from another and performs verifySkipping at the heights of each of the intermediate
 // headers in the trace until it reaches the divergentHeader. 1 of 2 things can happen.
 //
 //  1. The light client verifies a header that is different to the intermediate header in the trace. This

--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -512,7 +512,7 @@ func TestSerialReap(t *testing.T) {
 	// Reap again.  We should get the same amount
 	reapCheck(1000)
 
-	// Commit from the conensus AppConn
+	// Commit from the consensus AppConn
 	commitRange(0, 500)
 	updateRange(0, 500)
 

--- a/proxy/app_conn.go
+++ b/proxy/app_conn.go
@@ -221,7 +221,7 @@ func (app *appConnSnapshot) ApplySnapshotChunk(ctx context.Context, req *types.R
 }
 
 // addTimeSample returns a function that, when called, adds an observation to m.
-// The observation added to m is the number of seconds ellapsed since addTimeSample
+// The observation added to m is the number of seconds elapsed since addTimeSample
 // was initially called. addTimeSample is meant to be called in a defer to calculate
 // the amount of time a function takes to complete.
 func addTimeSample(m metrics.Histogram) func() {

--- a/types/evidence.go
+++ b/types/evidence.go
@@ -297,7 +297,7 @@ func (l *LightClientAttackEvidence) GetByzantineValidators(commonVals *Validator
 	return validators
 }
 
-// ConflictingHeaderIsInvalid takes a trusted header and matches it againt a conflicting header
+// ConflictingHeaderIsInvalid takes a trusted header and matches it against a conflicting header
 // to determine whether the conflicting header was the product of a valid state transition
 // or not. If it is then all the deterministic fields of the header should be the same.
 // If not, it is an invalid header and constitutes a lunatic attack.

--- a/types/validator.go
+++ b/types/validator.go
@@ -138,7 +138,7 @@ func (v *Validator) Bytes() []byte {
 	return bz
 }
 
-// ToProto converts Valiator to protobuf
+// ToProto converts Validator to protobuf
 func (v *Validator) ToProto() (*cmtproto.Validator, error) {
 	if v == nil {
 		return nil, errors.New("nil validator")


### PR DESCRIPTION

This PR fixes minor spelling errors across multiple files to improve code readability and consistency.

- **`abci/server/socket_server.go`**: Fixed "retying" → "retrying" in comment
- **`consensus/common_test.go`**: Fixed "didnt" → "didn't" in panic message  
- **`consensus/reactor.go`**: Fixed "wont" → "won't" in comment
- **`consensus/wal.go`**: Fixed "occures" → "occurs" in comment
- **`docs/references/architecture/tendermint-core/adr-077-block-retention.md`**: Fixed "rentention" → "retention"
- **`libs/math/fraction.go`**: Fixed "formating" → "formatting" in error message
- **`light/detector.go`**: Fixed "preforms" → "performs" in comment
- **`mempool/clist_mempool_test.go`**: Fixed "conensus" → "consensus" in comment
- **`proxy/app_conn.go`**: Fixed "ellapsed" → "elapsed" in comment
- **`types/evidence.go`**: Fixed "againt" → "against" in comment
- **`types/validator.go`**: Fixed "Valiator" → "Validator" in comment

