### PR TITLE
chore: misleading error return in boundary check

### DIFF
--- a/internal/indexer/indexer_utils.go
+++ b/internal/indexer/indexer_utils.go
@@ -78,7 +78,7 @@ func CheckBounds(ranges indexer.QueryRange, v interface{}) (bool, error) {
 				return false, err
 			}
 			if cmp == -1 || (isFloat && cmp == 0 && !ranges.IncludeLowerBound) {
-				return false, err
+				return false, nil
 			}
 		}
 		if upperBound != nil {
@@ -87,7 +87,7 @@ func CheckBounds(ranges indexer.QueryRange, v interface{}) (bool, error) {
 				return false, err
 			}
 			if cmp == 1 || (isFloat && cmp == 0 && !ranges.IncludeUpperBound) {
-				return false, err
+				return false, nil
 			}
 		}
 
@@ -98,7 +98,7 @@ func CheckBounds(ranges indexer.QueryRange, v interface{}) (bool, error) {
 				return false, err
 			}
 			if cmp == -1 || (cmp == 0 && isFloat && !ranges.IncludeLowerBound) {
-				return false, err
+				return false, nil
 			}
 		}
 		if upperBound != nil {
@@ -107,7 +107,7 @@ func CheckBounds(ranges indexer.QueryRange, v interface{}) (bool, error) {
 				return false, err
 			}
 			if cmp == 1 || (cmp == 0 && isFloat && !ranges.IncludeUpperBound) {
-				return false, err
+				return false, nil
 			}
 		}
 


### PR DESCRIPTION
noticed that the function was returning `(false, err)` even though `err` is always `nil` at this point. this could give the impression that an error was possible here when it actually isn’t.

updated the code to return `(false, nil)` instead, which makes it clear that hitting the boundary is not an error case.


#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
