### PR TITLE
chore (fix): build script issues for Alpine + Go 1.17+

### DIFF
--- a/scripts/proto-gen.sh
+++ b/scripts/proto-gen.sh
@@ -3,7 +3,7 @@
 # Update the generated code for protocol buffers in the CometBFT repository.
 # This must be run from inside a CometBFT working directory.
 #
-set -euo pipefail
+set -eu
 
 # Work from the root of the repository.
 cd "$(git rev-parse --show-toplevel)"
@@ -11,9 +11,9 @@ cd "$(git rev-parse --show-toplevel)"
 # Run inside Docker to install the correct versions of the required tools
 # without polluting the local system.
 docker run --rm -i -v "$PWD":/w --workdir=/w golang:1.20-alpine sh <<"EOF"
-apk add git make
+apk add --no-cache git make
 
-go install github.com/bufbuild/buf/cmd/buf
+go install github.com/bufbuild/buf/cmd/buf@latest
 go install github.com/cosmos/gogoproto/protoc-gen-gogofaster@latest
 make proto-gen
 EOF


### PR DESCRIPTION
fixed a couple of problems that were breaking builds in minimal environments:

* switched `set -euo pipefail` → `set -eu` since `pipefail` isn’t supported in `/bin/sh` (Alpine uses `ash`).
* changed `apk add git make` → `apk add --no-cache git make` to avoid leaving behind cache files in the container.
* updated `go install github.com/bufbuild/buf/cmd/buf` → `go install github.com/bufbuild/buf/cmd/buf@latest` because Go 1.17+ requires an explicit version when installing outside a module.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
