### PR TITLE
Fix typos and wording across docs, specs, and comments

### DIFF
--- a/docs/references/architecture/tendermint-core/adr-042-state-sync.md
+++ b/docs/references/architecture/tendermint-core/adr-042-state-sync.md
@@ -221,7 +221,7 @@ Proposed
 ### Positive
 * Safe & performant state sync design substantiated with real world implementation experience
 * General interfaces allowing application specific innovation
-* Parallizable implementation trajectory with reasonable engineering effort
+* Parallelizable implementation trajectory with reasonable engineering effort
 
 ### Negative
 * Static Scheduling lacks opportunity for real time chunk availability optimizations

--- a/docs/references/rfc/rfc-100-abci-vote-extension-propag.md
+++ b/docs/references/rfc/rfc-100-abci-vote-extension-propag.md
@@ -254,7 +254,7 @@ We now briefly describe the current catch-up mechanisms in the reactors concerne
 
 Full nodes optionally run statesync just after starting, when they start from scratch.
 If statesync succeeds, an Application snapshot is installed, and CometBFT jumps from height 0 directly
-to the height the Application snapshop represents, without applying the block of any previous height.
+to the height the Application snapshot represents, without applying the block of any previous height.
 Some light blocks are received and stored in the block store for running light-client verification of
 all the skipped blocks. Light blocks are incomplete blocks, typically containing the header and the
 canonical commit but, e.g., no transactions. They are stored in the block store as "signed headers".

--- a/proto/tendermint/state/types.proto
+++ b/proto/tendermint/state/types.proto
@@ -13,7 +13,7 @@ import "google/protobuf/timestamp.proto";
 
 // LegacyABCIResponses retains the responses
 // of the legacy ABCI calls during block processing.
-// Note ReponseDeliverTx is renamed to ExecTxResult but they are semantically the same
+// Note ResponseDeliverTx is renamed to ExecTxResult but they are semantically the same
 // Kept for backwards compatibility for versions prior to v0.38
 message LegacyABCIResponses {
   repeated tendermint.abci.ExecTxResult deliver_txs = 1;

--- a/spec/light-client/accountability/Synopsis.md
+++ b/spec/light-client/accountability/Synopsis.md
@@ -9,7 +9,7 @@
 - this specification focuses on safety, so timeouts are modelled with
    with non-determinism
 
-- the proposer function is non-determinstic, no fairness is assumed
+- the proposer function is non-deterministic, no fairness is assumed
 
 - the messages by the faulty processes are injected right in the initial states
 

--- a/spec/light-client/supervisor/supervisor_001_draft.md
+++ b/spec/light-client/supervisor/supervisor_001_draft.md
@@ -515,7 +515,7 @@ func InitLightClient (initData LCInitData) (LightStore, Error) {
             newBlock := current
         }
         else {
-            // [LC-SUMBIT-EVIDENCE.1]
+            // [LC-SUBMIT-EVIDENCE.1]
             submitEvidence(Evidences);
             return(nil, ErrorAttack);
         }

--- a/spec/p2p/implementation/addressbook.md
+++ b/spec/p2p/implementation/addressbook.md
@@ -259,8 +259,8 @@ A known address becomes bad if it is stored in buckets of new addresses, and
 when connection attempts:
 
 - Have not been made over a week, i.e., `LastAttempt` is older than a week
-- Have failed 3 times and never succeeded, i.e., `LastSucess` field is unset
-- Have failed 10 times in the last week, i.e., `LastSucess` is older than a week
+- Have failed 3 times and never succeeded, i.e., `LastSuccess` field is unset
+- Have failed 10 times in the last week, i.e., `LastSuccess` is older than a week
 
 Addresses marked as *bad* are the first candidates to be removed from a bucket of
 new addresses when the bucket becomes full.

--- a/state/store.go
+++ b/state/store.go
@@ -407,7 +407,7 @@ func (store dbStore) PruneStates(from int64, to int64, evidenceThresholdHeight i
 //------------------------------------------------------------------------
 
 // TxResultsHash returns the root hash of a Merkle tree of
-// ExecTxResulst responses (see ABCIResults.Hash)
+// ExecTxResults responses (see ABCIResults.Hash)
 //
 // See merkle.SimpleHashFromByteSlices
 func TxResultsHash(txResults []*abci.ExecTxResult) []byte {

--- a/test/loadtime/payload/payload.go
+++ b/test/loadtime/payload/payload.go
@@ -53,7 +53,7 @@ func NewBytes(p *Payload) ([]byte, error) {
 	return append([]byte(keyPrefix), h...), nil
 }
 
-// FromBytes extracts a paylod from the byte representation of the payload.
+// FromBytes extracts a payload from the byte representation of the payload.
 // FromBytes leaves the padding untouched, returning it to the caller to handle
 // or discard per their preference.
 func FromBytes(b []byte) (*Payload, error) {

--- a/types/errors/sanity.go
+++ b/types/errors/sanity.go
@@ -19,7 +19,7 @@ type (
 		Reason string
 	}
 
-	// ErrWrongField is returned every time a value does not pass a validaty check, accompanied with error
+	// ErrWrongField is returned every time a value does not pass a validity check, accompanied with error
 	ErrWrongField struct {
 		Field string
 		Err   error


### PR DESCRIPTION

- Corrects spelling and phrasing in Markdown specs and docs (e.g., “Parallelizable”, “snapshot”, “deterministic”, “submit”, “LastSuccess”).
- Updates proto comment note about `ResponseDeliverTx`.
- Fixes Go comments: pluralization of `ExecTxResults`, “payload”, “validity”.


