### PR TITLE
Document errors that trigger panic in Switch.acceptRoutine

### DIFF
--- a/spec/p2p/implementation/switch.md
+++ b/spec/p2p/implementation/switch.md
@@ -129,7 +129,11 @@ Errors of `ErrRejected` or `ErrFilterTimeout` types are ignored,
 an `ErrTransportClosed` causes the accepted routine to be interrupted,
 while other errors cause the routine to panic.
 
-> TODO: which errors can cause the routine to panic?
+Errors that cause the routine to panic (i.e., errors returned by `Accept` that are not `ErrRejected`, `ErrFilterTimeout`, or `ErrTransportClosed`) include:
+
+- Listener accept errors propagated by the transport (e.g., `net.OpError`) from `MultiplexTransport.acceptPeers` via `acceptc`
+- IP resolution failures during connection filtering (e.g., `net.AddrError`, `net.DNSError`, or other resolver errors) returned by `resolveIPs` in `MultiplexTransport.filterConn`
+- Any other unexpected error surfaced by `MultiplexTransport.Accept` that does not match the handled types above
 
 ## Add peer
 


### PR DESCRIPTION
This updates spec/p2p/implementation/switch.md to replace the TODO about which Accept errors cause the acceptRoutine to panic. Based on the implementation, any error returned by Transport.Accept that is not ErrRejected, ErrFilterTimeout, or ErrTransportClosed will trigger a panic. Examples include net.Listener.Accept errors (e.g., net.OpError) and IP resolution failures in filterConn (e.g., net.AddrError, net.DNSError), plus any other unexpected errors. This clarifies behavior and aligns the spec with the current code
