### PR TITLE
chore: remove unused min func

### DIFF
--- a/test/e2e/runner/benchmark.go
+++ b/test/e2e/runner/benchmark.go
@@ -218,10 +218,3 @@ func extractTestnetStats(intervals []time.Duration) testnetStats {
 		min:  min,
 	}
 }
-
-func min(a, b int64) int64 {
-	if a > b {
-		return b
-	}
-	return a
-}


### PR DESCRIPTION
Go 1.21 adds built-in functions min and max.   https://tip.golang.org/doc/go1.21
Therefore, we can directly remove our own implementations and use the built-in function with the same names. 

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
