### PR TITLE
abci/server: remove unused request/response counters in socket server

### DIFF
--- a/abci/server/socket_server.go
+++ b/abci/server/socket_server.go
@@ -161,7 +161,6 @@ func (s *SocketServer) waitForClose(closeConn chan error, connID int) {
 
 // Read requests from conn and deal with them
 func (s *SocketServer) handleRequests(closeConn chan error, conn io.Reader, responses chan<- *types.Response) {
-	var count int
 	bufReader := bufio.NewReader(conn)
 
 	defer func() {
@@ -195,7 +194,6 @@ func (s *SocketServer) handleRequests(closeConn chan error, conn io.Reader, resp
 			return
 		}
 		s.appMtx.Lock()
-		count++
 		resp, err := s.handleRequest(context.TODO(), req)
 		if err != nil {
 			// any error either from the application or because of an unknown request
@@ -307,7 +305,6 @@ func (s *SocketServer) handleRequest(ctx context.Context, req *types.Request) (*
 
 // Pull responses from 'responses' and write them to conn.
 func (s *SocketServer) handleResponses(closeConn chan error, conn io.Writer, responses <-chan *types.Response) {
-	var count int
 	bufWriter := bufio.NewWriter(conn)
 	for {
 		res := <-responses
@@ -330,6 +327,5 @@ func (s *SocketServer) handleResponses(closeConn chan error, conn io.Writer, res
 		if e, ok := res.Value.(*types.Response_Exception); ok {
 			closeConn <- errors.New(e.Exception.Error)
 		}
-		count++
 	}
 }


### PR DESCRIPTION
Removed unused count variables and count++ increments in abci/server/socket_server.go within handleRequests and handleResponses.
Rationale: These counters were never read, not wired to metrics or logging, and have no protocol impact. Keeping them is misleading and may trigger static-analysis concerns. The gRPC server has no analogous counters.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove unused `count` variables and increments from `handleRequests` and `handleResponses` in `abci/server/socket_server.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4cff1cef300ecf33f5ba6662c9fbfae5d59a397. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->