### PR TITLE
style: use errors.New instead of fmt.Errorf for non-formatted error

### DIFF
--- a/types/vote.go
+++ b/types/vote.go
@@ -345,7 +345,7 @@ func (vote *Vote) ValidateBasic() error {
 		// we don't know if extensions are enabled so we can only
 		// enforce the signature when extension size is not nil
 		if len(vote.ExtensionSignature) == 0 && len(vote.Extension) != 0 {
-			return fmt.Errorf("vote extension signature absent on vote with extension")
+			return errors.New("vote extension signature absent on vote with extension")
 		}
 	}
 


### PR DESCRIPTION
Replace fmt.Errorf with errors.New when no formatting is used according to the project style guide.

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace fmt.Errorf with errors.New for the "vote extension signature absent on vote with extension" error in types/vote.go.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit adc2688df4d8b7d3918420d651124efca544b0ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->