### PR TITLE
chore(commands): log TMHOME deprecation at info level

### DIFF
--- a/cmd/cometbft/commands/root.go
+++ b/cmd/cometbft/commands/root.go
@@ -41,7 +41,7 @@ func ParseConfig(cmd *cobra.Command) (*cfg.Config, error) {
 	} else if os.Getenv("TMHOME") != "" {
 		// XXX: Deprecated.
 		home = os.Getenv("TMHOME")
-		logger.Error("Deprecated environment variable TMHOME identified. CMTHOME should be used instead.")
+		logger.Info("Deprecated environment variable TMHOME identified. CMTHOME should be used instead.")
 	} else {
 		home, err = cmd.Flags().GetString(cli.HomeFlag)
 		if err != nil {


### PR DESCRIPTION
Change deprecation notice for TMHOME from error to info to align with the logging API (no warn level) and existing practice where deprecations are emitted as informational messages (e.g., configuration deprecations). Using error was semantically too strong and inconsistent, potentially alarming operators despite a non-fatal condition.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Log TMHOME deprecation at info level instead of error in `cmd/cometbft/commands/root.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40fe71b08b18edc7ee3deac898479e2bd8932d7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->