### PR TITLE
docs: fix typos

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -138,6 +138,6 @@ retract (
 	v0.38.4
 	// a breaking change was introduced
 	v0.38.3
-	// superseeded by v0.38.3 because of ASA-2024-001
+	// superseded by v0.38.3 because of ASA-2024-001
 	[v0.38.0, v0.38.2]
 )

--- a/test/e2e/docker/entrypoint-delve
+++ b/test/e2e/docker/entrypoint-delve
@@ -4,7 +4,7 @@
 rm -rf /var/run/privval.sock /var/run/app.sock
 
 # dlv won't run the app until you connect to it with a client.
-# Once the app is run, the signer will try only a few times before stopping, so don't take long to let commet run as well.
+# Once the app is run, the signer will try only a few times before stopping, so don't take long to let cometbft run as well.
 dlv --headless --listen=:2345 --log --log-output=debugger,debuglineerr,gdbwire,lldbout,rpc --accept-multiclient --api-version=2 exec /usr/bin/app -- /cometbft/config/app.toml &
 
 sleep 30


### PR DESCRIPTION
### Description

Fix `superseeded` to `superseded`.
Fix `commet` to `cometbft`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects typos in a go.mod retract comment and an e2e Docker entrypoint comment (superseeded→superseded, commet→cometbft).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ab5d2801e715dc5129dfd6ce6fd86f02228d79e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->