### PR TITLE
Private Validator Ephemeral Port Exhaustion (DoS)

### DIFF
--- a/privval/socket_listeners.go
+++ b/privval/socket_listeners.go
@@ -78,7 +78,7 @@ func (ln *TCPListener) Accept() (net.Conn, error) {
 	timeoutConn := newTimeoutConn(tc, ln.timeoutReadWrite)
 	secretConn, err := p2pconn.MakeSecretConnection(timeoutConn, ln.secretConnKey)
 	if err != nil {
-		tc.Close()
+		_ = tc.Close()
 		return nil, err
 	}
 
@@ -134,7 +134,7 @@ func (ln *UnixListener) Accept() (net.Conn, error) {
 
 	tc, err := ln.AcceptUnix()
 	if err != nil {
-		tc.Close()
+		_ = tc.Close()
 		return nil, err
 	}
 

--- a/privval/socket_listeners.go
+++ b/privval/socket_listeners.go
@@ -78,6 +78,7 @@ func (ln *TCPListener) Accept() (net.Conn, error) {
 	timeoutConn := newTimeoutConn(tc, ln.timeoutReadWrite)
 	secretConn, err := p2pconn.MakeSecretConnection(timeoutConn, ln.secretConnKey)
 	if err != nil {
+		tc.Close()
 		return nil, err
 	}
 
@@ -133,6 +134,7 @@ func (ln *UnixListener) Accept() (net.Conn, error) {
 
 	tc, err := ln.AcceptUnix()
 	if err != nil {
+		tc.Close()
 		return nil, err
 	}
 

--- a/privval/socket_listeners.go
+++ b/privval/socket_listeners.go
@@ -134,7 +134,6 @@ func (ln *UnixListener) Accept() (net.Conn, error) {
 
 	tc, err := ln.AcceptUnix()
 	if err != nil {
-		_ = tc.Close()
 		return nil, err
 	}
 


### PR DESCRIPTION
## Ephemeral Port Exhaustion of `priv_validator_laddr`

While conducting automated security scanning on our Cosmos based infrastructure we noticed after some time the `priv_validator_laddr` would stop accepting new connections. On investigation it appears that the connection is not properly closed after a failed connection attempt eventually exhausting all ephemeral ports. It appears the method `MakeSecretConnection` doesn't close the connection and leaves it in a `CLOSE_WAIT` state.

## Steps to Reproduce

The following script connects to the `priv_validator_laddr` and disconnects. After ~2000 requests the port will stop accepting new connections and the service will require restarting to free the ports. 

```python
#!/usr/bin/env python3
import socket

ip_address = '10.10.10.10'
priv_val_port = 1234
runs = 10000


def tcp_probe(ip, port, timeout=2):
    """Connect to priv_val_port and immediately close the connection"""
    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
    s.settimeout(timeout)
    try:
        if s.connect_ex((ip, port)) == 0:
            return True
        else:
            return False
    finally:
        s.close()


def main():
    for i in range(runs):
        connected = tcp_probe(ip_address, priv_val_port)
        if connected:
            print(f"Completed probe {i+1}/{runs}")
        else:
            print(f"Probe failed {i+1}/{runs}")


main()

```

The ports are left in a `CLOSE_WAIT` state which can be viewed with `netstat -anp | grep CLOSE_WAIT` and do not clear until the service is restarted.

## Proposed Solution

In the event of an error during the call to `MakeSecretConnection` call `tc.Close()`.
