### PR TITLE
refactor: use b.Loop() to simplify the code and improve performance

### DIFF
--- a/types/proposal_test.go
+++ b/types/proposal_test.go
@@ -97,14 +97,14 @@ func TestProposalVerifySignature(t *testing.T) {
 }
 
 func BenchmarkProposalWriteSignBytes(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		ProposalSignBytes("test_chain_id", pbp)
 	}
 }
 
 func BenchmarkProposalSign(b *testing.B) {
 	privVal := NewMockPV()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		err := privVal.SignProposal("test_chain_id", pbp)
 		if err != nil {
 			b.Error(err)
@@ -119,7 +119,7 @@ func BenchmarkProposalVerifySignature(b *testing.B) {
 	pubKey, err := privVal.GetPubKey()
 	require.NoError(b, err)
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		pubKey.VerifySignature(ProposalSignBytes("test_chain_id", pbp), testProposal.Signature)
 	}
 }

--- a/types/validator_set_test.go
+++ b/types/validator_set_test.go
@@ -198,7 +198,7 @@ func TestIncrementProposerPriorityPositiveTimes(t *testing.T) {
 }
 
 func BenchmarkValidatorSetCopy(b *testing.B) {
-	b.StopTimer()
+
 	vset := NewValidatorSet([]*Validator{})
 	for i := 0; i < 1000; i++ {
 		privKey := ed25519.GenPrivKey()
@@ -209,9 +209,8 @@ func BenchmarkValidatorSetCopy(b *testing.B) {
 			panic("Failed to add validator")
 		}
 	}
-	b.StartTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		vset.Copy()
 	}
 }
@@ -1601,9 +1600,8 @@ func BenchmarkUpdates(b *testing.B) {
 	for j := 0; j < m; j++ {
 		newValList[j] = newValidator([]byte(fmt.Sprintf("v%d", j+l)), 1000)
 	}
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		// Add m validators to valSetCopy
 		valSetCopy := valSet.Copy()
 		assert.NoError(b, valSetCopy.UpdateWithChangeSet(newValList))

--- a/types/vote_set_test.go
+++ b/types/vote_set_test.go
@@ -134,7 +134,7 @@ func Benchmark_2_3_Maj(b *testing.B) {
 	}
 	blockPartsTotal := uint32(123)
 	blockPartSetHeader := PartSetHeader{blockPartsTotal, crypto.CRandBytes(32)}
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		voteSet, _, privValidators := randVoteSet(height, round, cmtproto.PrevoteType, 100, 1, false)
 		for i := int32(0); i < int32(100); i += 4 {
 			pubKey, _ := privValidators[i].GetPubKey()


### PR DESCRIPTION




#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments



These changes use b.Loop() to simplify the code and improve performance

Supported by Go Team, more info: https://go.dev/blog/testing-b-loop

More info can see https://go.dev/issue/73137.

Before:


```shell
go test -run=^$ -bench=. ./types -timeout=1h             
goos: darwin
goarch: arm64
pkg: github.com/cometbft/cometbft/types
cpu: Apple M4
BenchmarkEventBus/10Clients1Query1Event-10         	 3788924	       310.3 ns/op	     416 B/op	       3 allocs/op
BenchmarkEventBus/100Clients-10                    	 3767460	       316.6 ns/op	     416 B/op	       3 allocs/op
BenchmarkEventBus/1000Clients-10                   	   16606	     66811 ns/op	     544 B/op	       6 allocs/op
BenchmarkEventBus/10ClientsRandQueries1Event-10    	  754050	      1527 ns/op	    1312 B/op	      24 allocs/op
BenchmarkEventBus/100Clients#01-10                 	  511202	      2306 ns/op	    1952 B/op	      39 allocs/op
BenchmarkEventBus/1000Clients#01-10                	  457266	      2531 ns/op	    1952 B/op	      39 allocs/op
BenchmarkEventBus/10ClientsRandQueriesRandEvents-10         	 3649645	       327.0 ns/op	     417 B/op	       3 allocs/op
BenchmarkEventBus/100Clients#02-10                          	 2947570	       346.2 ns/op	     426 B/op	       3 allocs/op
BenchmarkEventBus/1000Clients#02-10                         	  737244	      1460 ns/op	     718 B/op	      10 allocs/op
BenchmarkEventBus/10Clients1QueryRandEvents-10              	 3672014	       322.4 ns/op	     416 B/op	       3 allocs/op
BenchmarkEventBus/100Clients#03-10                          	 3715051	       322.8 ns/op	     416 B/op	       3 allocs/op
BenchmarkEventBus/1000Clients#03-10                         	  207978	      5357 ns/op	     544 B/op	       6 allocs/op
BenchmarkMakePartSet/nParts=1-10                            	   55294	     20497 ns/op
BenchmarkMakePartSet/nParts=2-10                            	   29437	     40110 ns/op
BenchmarkMakePartSet/nParts=3-10                            	   20059	     59683 ns/op
BenchmarkMakePartSet/nParts=4-10                            	   15042	     79628 ns/op
BenchmarkMakePartSet/nParts=5-10                            	   12037	     99587 ns/op
BenchmarkProposalWriteSignBytes-10                          	 4153146	       290.1 ns/op
BenchmarkProposalSign-10                                    	   99568	     11996 ns/op
BenchmarkProposalVerifySignature-10                         	 4080648	       293.9 ns/op
BenchmarkValidatorSetCopy-10                                	   59730	     19908 ns/op
BenchmarkUpdates-10                                         	    1306	    909655 ns/op
Benchmark_2_3_Maj-10                                        	     241	   5133499 ns/op
PASS
ok  	github.com/cometbft/cometbft/types	35.253s
```



after:

```shell
go test -run=^$ -bench=. ./types -timeout=1h  
goos: darwin
goarch: arm64
pkg: github.com/cometbft/cometbft/types
cpu: Apple M4
BenchmarkEventBus/10Clients1Query1Event-10         	 3789516	       313.8 ns/op	     416 B/op	       3 allocs/op
BenchmarkEventBus/100Clients-10                    	 3773624	       318.5 ns/op	     416 B/op	       3 allocs/op
BenchmarkEventBus/1000Clients-10                   	   16605	     72004 ns/op	     544 B/op	       6 allocs/op
BenchmarkEventBus/10ClientsRandQueries1Event-10    	  673412	      1728 ns/op	    1440 B/op	      27 allocs/op
BenchmarkEventBus/100Clients#01-10                 	  501636	      2356 ns/op	    1952 B/op	      39 allocs/op
BenchmarkEventBus/1000Clients#01-10                	  450982	      2539 ns/op	    1952 B/op	      39 allocs/op
BenchmarkEventBus/10ClientsRandQueriesRandEvents-10         	 3622975	       328.3 ns/op	     416 B/op	       3 allocs/op
BenchmarkEventBus/100Clients#02-10                          	 3437947	       338.0 ns/op	     425 B/op	       3 allocs/op
BenchmarkEventBus/1000Clients#02-10                         	  157407	      6593 ns/op	    2052 B/op	      41 allocs/op
BenchmarkEventBus/10Clients1QueryRandEvents-10              	 3715688	       321.9 ns/op	     416 B/op	       3 allocs/op
BenchmarkEventBus/100Clients#03-10                          	 3714166	       322.3 ns/op	     416 B/op	       3 allocs/op
BenchmarkEventBus/1000Clients#03-10                         	  194089	      5703 ns/op	     543 B/op	       5 allocs/op
BenchmarkMakePartSet/nParts=1-10                            	   55609	     20132 ns/op
BenchmarkMakePartSet/nParts=2-10                            	   30139	     39803 ns/op
BenchmarkMakePartSet/nParts=3-10                            	   20073	     59629 ns/op
BenchmarkMakePartSet/nParts=4-10                            	   15074	     79577 ns/op
BenchmarkMakePartSet/nParts=5-10                            	   12037	     99553 ns/op
BenchmarkProposalWriteSignBytes-10                          	 4253791	       282.7 ns/op
BenchmarkProposalSign-10                                    	   99486	     12026 ns/op
BenchmarkProposalVerifySignature-10                         	 4208140	       288.5 ns/op
BenchmarkValidatorSetCopy-10                                	   59937	     19850 ns/op
BenchmarkUpdates-10                                         	    1312	    904521 ns/op
Benchmark_2_3_Maj-10                                        	     240	   4960945 ns/op
PASS
ok  	github.com/cometbft/cometbft/types	34.504s
```