### PR TITLE
refactor: use b.Loop() in benchmark tests for better performance

### DIFF
--- a/crypto/merkle/bench_test.go
+++ b/crypto/merkle/bench_test.go
@@ -26,7 +26,7 @@ var innerHashTests = []*innerHashTest{
 func BenchmarkInnerHash(b *testing.B) {
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		for _, tt := range innerHashTests {
 			got := innerHash([]byte(tt.left), []byte(tt.right))
 			if g, w := len(got), sha256.Size; g != w {
@@ -49,7 +49,7 @@ func BenchmarkLeafHash64kb(b *testing.B) {
 	leaf := make([]byte, 64*1024)
 	hash := sha256.New()
 
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		leaf[0] = byte(i)
 		got := leafHashOpt(hash, leaf)
 		if g, w := len(got), sha256.Size; g != w {

--- a/crypto/tmhash/bench_test.go
+++ b/crypto/tmhash/bench_test.go
@@ -34,7 +34,7 @@ var manySlices = []struct {
 func BenchmarkSHA256Many(b *testing.B) {
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		for _, tt := range manySlices {
 			got := SumMany(tt.in[0], tt.in[1:]...)
 			if !bytes.Equal(got, tt.want[:]) {

--- a/store/bench_test.go
+++ b/store/bench_test.go
@@ -27,8 +27,7 @@ func BenchmarkRepeatedLoadSeenCommitSameBlock(b *testing.B) {
 	res := bs.LoadSeenCommit(block.Height)
 	require.Equal(b, seenCommit, res)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		res := bs.LoadSeenCommit(block.Height)
 		require.NotNil(b, res)
 	}


### PR DESCRIPTION
---

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments


Similar as https://github.com/cometbft/cometbft/pull/5438 and replace more.


Before change:

```shell
goos: darwin
goarch: arm64
pkg: github.com/cometbft/cometbft/crypto/merkle
cpu: Apple M4
BenchmarkInnerHash-10           	   49282	     22671 ns/op	   60112 B/op	      23 allocs/op
BenchmarkLeafHash64kb-10        	   60975	     19668 ns/op	      57 B/op	       2 allocs/op
BenchmarkHashAlternatives/recursive-10         	  105321	     11704 ns/op
BenchmarkHashAlternatives/iterative-10         	   90910	     13796 ns/op
PASS
ok  	github.com/cometbft/cometbft/crypto/merkle	6.934s

---

go test -run=^$ -bench=. ./crypto/tmhash   
goos: darwin
goarch: arm64
pkg: github.com/cometbft/cometbft/crypto/tmhash
cpu: Apple M4
BenchmarkSHA256Many-10    	 2300148	       496.0 ns/op	     168 B/op	       6 allocs/op
PASS
ok  	github.com/cometbft/cometbft/crypto/tmhash	3.113s

---


 go test -run=^$ -bench=. ./store                
goos: darwin
goarch: arm64
pkg: github.com/cometbft/cometbft/store
cpu: Apple M4
BenchmarkRepeatedLoadSeenCommitSameBlock-10    	  922334	      1290 ns/op
PASS
ok  	github.com/cometbft/cometbft/store	2.642s



```

After:

```shell
go test -run=^$ -bench=. ./crypto/merkle
goos: darwin
goarch: arm64
pkg: github.com/cometbft/cometbft/crypto/merkle
cpu: Apple M4
BenchmarkInnerHash-10           	   48914	     22949 ns/op	   60113 B/op	      23 allocs/op
BenchmarkLeafHash64kb-10        	   60937	     20708 ns/op	      56 B/op	       2 allocs/op
BenchmarkHashAlternatives/recursive-10         	   96890	     11923 ns/op
BenchmarkHashAlternatives/iterative-10         	   91754	     13100 ns/op
PASS
ok  	github.com/cometbft/cometbft/crypto/merkle	6.493s


---

 go test -run=^$ -bench=. ./crypto/tmhash      
goos: darwin
goarch: arm64
pkg: github.com/cometbft/cometbft/crypto/tmhash
cpu: Apple M4
BenchmarkSHA256Many-10    	 2275063	       511.0 ns/op	     168 B/op	       6 allocs/op
PASS
ok  	github.com/cometbft/cometbft/crypto/tmhash	1.732s



---

go test -run=^$ -bench=. ./store   
goos: darwin
goarch: arm64
pkg: github.com/cometbft/cometbft/store
cpu: Apple M4
BenchmarkRepeatedLoadSeenCommitSameBlock-10    	  914858	      1287 ns/op
PASS
ok  	github.com/cometbft/cometbft/store	2.613s


```