### PR TITLE
fix(docs): replace non-existent DefaultValidatorConfig with DefaultConfig

### DIFF
--- a/docs/guides/go-built-in.md
+++ b/docs/guides/go-built-in.md
@@ -607,7 +607,7 @@ This is a huge blob of code, so let's break it down into pieces.
 First, we use [viper](https://github.com/spf13/viper) to load the CometBFT configuration files, which we will generate later:
 
 ```go
-config := cfg.DefaultValidatorConfig()
+config := cfg.DefaultConfig()
 
 config.SetRoot(homeDir)
 


### PR DESCRIPTION
Fixes incorrect method name in code example. 

The documentation was using cfg.DefaultValidatorConfig() which doesn't exist in the codebase. 

Replaced  it with cfg.DefaultConfig() to match the actual working code shown earlier in the guide.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace `cfg.DefaultValidatorConfig()` with `cfg.DefaultConfig()` in `docs/guides/go-built-in.md` code sample.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a282e63f84929d2eed1001ae9f5c741653d7581d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->