### PR TITLE
docs: fixed dead link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ heartfelt emoji.
 
 If the issue would benefit from thorough discussion, maintainers may request
 that you create a [Request For
-Comment](https://github.com/cometbft/cometbft/tree/main/docs/rfc) in the
+Comment](https://github.com/cometbft/cometbft/tree/main/docs/references/rfc) in the
 CometBFT repo. Discussion at the RFC stage will build collective
 understanding of the dimensions of the problems and help structure conversations
 around trade-offs.


### PR DESCRIPTION
found a broken RFC link in `CONTRIBUTING.md` and updated it to the current path in the CometBFT repo.


---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update the RFC link in `CONTRIBUTING.md` to point to `docs/references/rfc`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe0afcf73172f6c3f27286fbd9ab6f8fea6aeb0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->