### PR TITLE
fix(types): use correct variable in evidence MaxBytes error message

### DIFF
--- a/types/params.go
+++ b/types/params.go
@@ -185,7 +185,7 @@ func (params ConsensusParams) ValidateBasic() error {
 	}
 	if params.Evidence.MaxBytes > maxBytes {
 		return fmt.Errorf("evidence.MaxBytesEvidence is greater than upper bound, %d > %d",
-			params.Evidence.MaxBytes, params.Block.MaxBytes)
+			params.Evidence.MaxBytes, maxBytes)
 	}
 
 	if params.Evidence.MaxBytes < 0 {


### PR DESCRIPTION
When Block.MaxBytes is set to -1 (meaning "use default max"), the validationcomputes maxBytes = MaxBlockSizeBytes (104857600). But the error messagewas printing params.Block.MaxBytes instead of maxBytes.

This led to confusing errors like:
  "evidence.MaxBytesEvidence is greater than upper bound, 200000000 > -1"

when it should say:
  "evidence.MaxBytesEvidence is greater than upper bound, 200000000 > 104857600"

Just a one-liner fix - use the computed maxBytes variable in fmt.Errorf