### PR TITLE
fix(consensus): adaptiveSync ingestion

### DIFF
--- a/consensus/errors.go
+++ b/consensus/errors.go
@@ -26,9 +26,10 @@ var (
 
 // Ingestion errors
 var (
-	ErrValidation      = errors.New("validation error")
-	ErrAlreadyIncluded = errors.New("block already included")
-	ErrHeightGap       = errors.New("height gap invariant violated")
+	ErrValidation        = errors.New("validation error")
+	ErrAlreadyIncluded   = errors.New("block already included")
+	ErrHeightGap         = errors.New("height gap invariant violated")
+	ErrConsensusShutdown = errors.New("consensus shutdown")
 )
 
 type ErrConsensusMessageNotRecognized struct {

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -99,6 +99,7 @@ type State struct {
 	// msgs from ourself, or by timeouts
 	peerMsgQueue     chan msgInfo
 	internalMsgQueue chan msgInfo
+	ingestBlockQueue chan *ingestVerifiedBlockRequest
 	timeoutTicker    TimeoutTicker
 
 	// information about about added votes and block parts are written on this channel
@@ -157,6 +158,7 @@ func NewState(
 		txNotifier:       txNotifier,
 		peerMsgQueue:     make(chan msgInfo, msgQueueSize),
 		internalMsgQueue: make(chan msgInfo, msgQueueSize),
+		ingestBlockQueue: make(chan *ingestVerifiedBlockRequest, 1),
 		timeoutTicker:    NewTimeoutTicker(),
 		statsMsgQueue:    make(chan msgInfo, msgQueueSize),
 		done:             make(chan struct{}),
@@ -825,6 +827,20 @@ func (cs *State) receiveRoutine(maxSteps int) {
 			}
 		}
 
+		// potential verified blocks have priority over consensus messages
+		// todo: we might want to skip a verified block if all pre-commits are almost received
+		// (means the node lags by <=1 block)
+		select {
+		case req := <-cs.ingestBlockQueue:
+			cs.handleIngestVerifiedBlockRequest(req)
+			continue
+		case <-cs.Quit():
+			onExit(cs)
+			return
+		default:
+			// don't block && go to another select{}
+		}
+
 		rs := cs.RoundState
 		var mi msgInfo
 
@@ -842,25 +858,15 @@ func (cs *State) receiveRoutine(maxSteps int) {
 			// handles proposals, block parts, votes
 			// may generate internal events (votes, complete proposals, 2/3 majorities)
 			cs.handleMsg(mi)
-
 		case mi = <-cs.internalMsgQueue:
 			cs.Logger.Debug("Received message from cs.internalMsgQueue", "peer_id", mi.PeerID)
 
-			writeWal := true
-
-			// avoid writing WAL for ingested verified blocks coming from blocksync
-			if _, ok := mi.Msg.(*ingestVerifiedBlockRequest); ok {
-				writeWal = false
-			}
-
-			if writeWal {
-				// NOTE: fsync
-				if err := cs.wal.WriteSync(mi); err != nil {
-					panic(fmt.Errorf(
-						"failed to write %v msg to consensus WAL; check your file system and restart the node: %w",
-						mi, err,
-					))
-				}
+			// NOTE: fsync
+			if err := cs.wal.WriteSync(mi); err != nil {
+				panic(fmt.Errorf(
+					"failed to write %v msg to consensus WAL; check your file system and restart the node: %w",
+					mi, err,
+				))
 			}
 
 			if _, ok := mi.Msg.(*VoteMessage); ok {
@@ -873,7 +879,6 @@ func (cs *State) receiveRoutine(maxSteps int) {
 
 			// handles proposals, block parts, votes
 			cs.handleMsg(mi)
-
 		case ti := <-cs.timeoutTicker.Chan(): // tockChan:
 			if err := cs.wal.Write(ti); err != nil {
 				cs.Logger.Error("failed writing to WAL", "err", err)
@@ -882,7 +887,6 @@ func (cs *State) receiveRoutine(maxSteps int) {
 			// if the timeout is relevant to the rs
 			// go to the next step
 			cs.handleTimeout(ti, rs)
-
 		case <-cs.Quit():
 			onExit(cs)
 			return
@@ -967,9 +971,6 @@ func (cs *State) handleMsg(mi msgInfo) {
 		// TODO: If rs.Height == vote.Height && rs.Round < vote.Round,
 		// the peer is sending us CatchupCommit precommits.
 		// We could make note of this and help filter in broadcastHasVoteMessage().
-
-	case *ingestVerifiedBlockRequest:
-		cs.handleIngestVerifiedBlockRequest(msg)
 	default:
 		cs.Logger.Error("unknown msg type", "type", fmt.Sprintf("%T", msg))
 		return

--- a/consensus/state_ingest.go
+++ b/consensus/state_ingest.go
@@ -174,39 +174,45 @@ func (ic *IngestCandidate) commitVoting(chainID string, vals *types.ValidatorSet
 // It uses the underlying internalQueue to ensure SERIAL state-machine processing inside the main receiveRoutine.
 // See handleIngestVerifiedBlock for the actual implementation and error handling.
 func (cs *State) IngestVerifiedBlock(ic IngestCandidate) (err error) {
-	logger := cs.Logger.With("height", ic.Height())
-	logger.Info("ingesting verified block")
+	height := ic.Height()
 
 	defer func() {
 		if err != nil {
-			logger.Info("failed to ingest verified block", "err", err)
+			cs.Logger.Info("Failed to ingest verified block", "height", height, "err", err)
 		} else {
-			logger.Info("ingested verified block")
+			cs.Logger.Info("Ingested verified block", "height", height)
 		}
 	}()
 
-	// register response channel so we can receive from receiveRoutine
-	ch := make(chan ingestVerifiedBlockResponse, 1)
-	defer close(ch)
+	// create a chan, so we can receive from receiveRoutine
+	responseCh := make(chan ingestVerifiedBlockResponse, 1)
+	defer close(responseCh)
 
-	req := &ingestVerifiedBlockRequest{
+	cs.ingestBlockQueue <- &ingestVerifiedBlockRequest{
 		IngestCandidate: ic,
 		sentAt:          time.Now(),
-		response:        ch,
+		response:        responseCh,
 	}
 
-	cs.sendInternalMessage(msgInfo{Msg: req})
-
 	select {
+	case res := <-responseCh:
+		return res.err
 	case <-cs.Quit():
 		return fmt.Errorf("consensus shutdown")
-	case res := <-req.response:
-		return res.err
 	}
 }
 
 // note the outcome of this call is NOT relevant to statsMsgQueue
 func (cs *State) handleIngestVerifiedBlockRequest(req *ingestVerifiedBlockRequest) {
+	cs.mtx.Lock()
+	defer cs.mtx.Unlock()
+
+	cs.Logger.Info(
+		"Ingesting verified block",
+		"height", req.Height(),
+		"queue_dur", time.Since(req.sentAt).String(),
+	)
+
 	err := cs.ingestBlock(req.IngestCandidate)
 
 	req.response <- ingestVerifiedBlockResponse{err: err}

--- a/consensus/state_ingest.go
+++ b/consensus/state_ingest.go
@@ -174,7 +174,15 @@ func (ic *IngestCandidate) commitVoting(chainID string, vals *types.ValidatorSet
 // It uses the underlying internalQueue to ensure SERIAL state-machine processing inside the main receiveRoutine.
 // See handleIngestVerifiedBlock for the actual implementation and error handling.
 func (cs *State) IngestVerifiedBlock(ic IngestCandidate) (err error) {
-	height := ic.Height()
+	var (
+		height = ic.Height()
+		quit   = cs.Quit()
+		req    = &ingestVerifiedBlockRequest{
+			IngestCandidate: ic,
+			sentAt:          time.Now(),
+			response:        make(chan ingestVerifiedBlockResponse, 1),
+		}
+	)
 
 	defer func() {
 		if err != nil {
@@ -184,21 +192,22 @@ func (cs *State) IngestVerifiedBlock(ic IngestCandidate) (err error) {
 		}
 	}()
 
-	// create a chan, so we can receive from receiveRoutine
-	responseCh := make(chan ingestVerifiedBlockResponse, 1)
-	defer close(responseCh)
-
-	cs.ingestBlockQueue <- &ingestVerifiedBlockRequest{
-		IngestCandidate: ic,
-		sentAt:          time.Now(),
-		response:        responseCh,
+	// send to the main routine
+	select {
+	case cs.ingestBlockQueue <- req:
+		// ok, move on
+	case <-quit:
+		return ErrConsensusShutdown
 	}
 
+	// wait
 	select {
-	case res := <-responseCh:
+	case res := <-req.response:
+		// let the chan leak in other cases (that's fine for shutdown)
+		close(req.response)
 		return res.err
-	case <-cs.Quit():
-		return fmt.Errorf("consensus shutdown")
+	case <-quit:
+		return ErrConsensusShutdown
 	}
 }
 


### PR DESCRIPTION
Moved verified blocks ingestion from the consensus message queue into a separate queue that has a higher priority. IngestCandidate is skipped from WAL on purpose as it's neither a WAL entry nor a p2p consensus message

---

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `CHANGELOG.md`
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
