### PR TITLE
fix(autopool): modify recovery of `autopool` workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### BUG FIXES
 
+- `[autopool]` Fix autopool worker message handling recovery
+  ([\#5775](https://github.com/cometbft/cometbft/pull/5775))
+
 ### IMPROVEMENTS
 
 ### FEATURES

--- a/internal/autopool/pool.go
+++ b/internal/autopool/pool.go
@@ -212,13 +212,7 @@ func (p *Pool[T]) Cap() int {
 }
 
 func (w *worker[T]) run() {
-	defer func() {
-		w.pool.workersWg.Done()
-		if r := recover(); r != nil {
-			w.pool.logger.Error("Panic in pool worker", "panic", r)
-		}
-	}()
-
+	defer w.pool.workersWg.Done()
 	for {
 		select {
 		case <-w.closeCh:
@@ -236,6 +230,14 @@ func (w *worker[T]) run() {
 }
 
 func (p *Pool[T]) handleMessage(msg T) {
+	defer func() {
+		// if we panic processing a message, simply log an error and let the
+		// caller decide if we should continue processing more
+		if r := recover(); r != nil {
+			p.logger.Error("Panic handling message", "panic", r)
+		}
+	}()
+
 	now := time.Now()
 	p.receive(msg)
 	timeTaken := time.Since(now)

--- a/internal/autopool/pool_test.go
+++ b/internal/autopool/pool_test.go
@@ -277,19 +277,11 @@ func TestPool(t *testing.T) {
 
 		// ACT
 
-		// continuously push panicing messages so every worker (including
-		// ones the autoscaler spins up) hits a panic. Interleave with
-		// normal messages to keep queue pressure above the 0.6 threshold
-		// and force the scaler to keep adding workers until maxWorkers
-		// are all zombies.
+		// push enough messages to panic all workers
 		for i := 0; i < maxWorkers; i++ {
 			pool.Push(-1)
 			pool.Push(-1) // extra to catch scaled-up workers
 		}
-
-		// after processing all of the above messages, if we do not properly
-		// handle recovery in the workers, all workers will be dead and we have
-		// maxed out the scaler, leaving no workers to process messages
 
 		for i := 1; i <= normalMessages; i++ {
 			pool.Push(i)

--- a/internal/autopool/pool_test.go
+++ b/internal/autopool/pool_test.go
@@ -246,6 +246,66 @@ func TestPool(t *testing.T) {
 			"expected %d items to be consumed, got %d", totalItems, consumed.Load())
 	})
 
+	t.Run("SurvivesPanicInHandler", func(t *testing.T) {
+		const (
+			minWorkers     = 2
+			maxWorkers     = 4
+			normalMessages = 10
+		)
+
+		// ARRANGE
+		scaler := NewThroughputLatencyScaler(
+			minWorkers, maxWorkers,
+			90.0,
+			10*time.Millisecond,
+			50*time.Millisecond, // short epoch so autoscaler has a chance to react
+			logger,
+		)
+
+		var processed atomic.Int64
+
+		consumer := func(msg int) {
+			if msg < 0 {
+				panic("error")
+			}
+			processed.Add(1)
+		}
+
+		pool := New(scaler, consumer, 16, WithLogger[int](logger))
+		pool.Start()
+		defer pool.Stop()
+
+		// ACT
+
+		// continuously push panicing messages so every worker (including
+		// ones the autoscaler spins up) hits a panic. Interleave with
+		// normal messages to keep queue pressure above the 0.6 threshold
+		// and force the scaler to keep adding workers until maxWorkers
+		// are all zombies.
+		for i := 0; i < maxWorkers; i++ {
+			pool.Push(-1)
+			pool.Push(-1) // extra to catch scaled-up workers
+		}
+
+		// after processing all of the above messages, if we do not properly
+		// handle recovery in the workers, all workers will be dead and we have
+		// maxed out the scaler, leaving no workers to process messages
+
+		for i := 1; i <= normalMessages; i++ {
+			pool.Push(i)
+		}
+
+		// give the autoscaler time to scale up and exhaust all worker slots
+		time.Sleep(1 * time.Second)
+
+		// ASSERT
+		require.Eventually(t, func() bool {
+			return processed.Load() == normalMessages
+		}, 3*time.Second, 50*time.Millisecond,
+			"expected all %d messages to be processed but instead got %d",
+			normalMessages, processed.Load())
+	})
+
 	t.Run("PriorityQueueBurstAfterDrain", func(t *testing.T) {
 		// ARRANGE
 		// Given pool with priority queue


### PR DESCRIPTION
---

Modifies the behavior of an `autopool` workers panic recovery so that they the gorouitnes do not exit on panic recovery. Instead, the `recover` is deferred inside of the function handling the message, the main loop function will log the recovered error and continue handling messages now.

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `CHANGELOG.md`
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
