### PR TITLE
feat(abci): indicate lock-free calls via ctx

### DIFF
--- a/abci/client/client.go
+++ b/abci/client/client.go
@@ -14,6 +14,8 @@ const (
 	echoRetryIntervalSeconds = 1
 )
 
+type lockFreeCallCtxKey struct{}
+
 //go:generate ../../scripts/mockery_generate.sh Client
 
 // Client defines the interface for an ABCI client.
@@ -129,4 +131,14 @@ func waitGroup1() (wg *sync.WaitGroup) {
 	wg = &sync.WaitGroup{}
 	wg.Add(1)
 	return
+}
+
+// LockFreeContext indicates that the caller expects the call NOT to acquire the lock.
+func LockFreeContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, lockFreeCallCtxKey{}, true)
+}
+
+// IsLockFreeContext checks for LockFreeContext.
+func IsLockFreeContext(ctx context.Context) bool {
+	return ctx.Value(lockFreeCallCtxKey{}) != nil
 }

--- a/abci/client/local_client.go
+++ b/abci/client/local_client.go
@@ -93,15 +93,11 @@ func (app *localClient) Info(ctx context.Context, req *types.RequestInfo) (*type
 }
 
 func (app *localClient) CheckTx(ctx context.Context, req *types.RequestCheckTx) (*types.ResponseCheckTx, error) {
-	app.mtx.Lock()
-	defer app.mtx.Unlock()
+	if !IsLockFreeContext(ctx) {
+		app.mtx.Lock()
+		defer app.mtx.Unlock()
+	}
 
-	return app.Application.CheckTx(ctx, req)
-}
-
-// CheckTxUnlocked calls CheckTx without acquiring the mutex lock.
-// This is used by AppMempool which handles its own concurrency.
-func (app *localClient) CheckTxUnlocked(ctx context.Context, req *types.RequestCheckTx) (*types.ResponseCheckTx, error) {
 	return app.Application.CheckTx(ctx, req)
 }
 

--- a/mempool/app_mempool.go
+++ b/mempool/app_mempool.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	client "github.com/cometbft/cometbft/abci/client"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/libs/log"
@@ -32,9 +33,8 @@ type AppMempoolClient interface {
 	// InsertTx inserts a tx into app-side mempool
 	InsertTx(ctx context.Context, req *abci.RequestInsertTx) (*abci.ResponseInsertTx, error)
 
-	// CheckTxUnlocked expects the application to check the transaction, inserting if successful.
-	// NOTE: Comet will not lock this method; it is expected the application side will acquire all necessary locks for successful checking.
-	CheckTxUnlocked(ctx context.Context, req *abci.RequestCheckTx) (*abci.ResponseCheckTx, error)
+	// CheckTx checks a tx against the application
+	CheckTx(ctx context.Context, req *abci.RequestCheckTx) (*abci.ResponseCheckTx, error)
 
 	// ReapTxs reaps txs from app-side mempool
 	ReapTxs(ctx context.Context, req *abci.RequestReapTxs) (*abci.ResponseReapTxs, error)
@@ -231,11 +231,18 @@ func (m *AppMempool) FlushAppConn() error {
 	return nil
 }
 
-// CheckTx calls the appliction's CheckTx method.
+// CheckTx calls ABCI.CheckTx
+// This type of mempool assumes ABCI.CheckTx is safe to call LOCK-FREE.
+// It's a responsibility of application to handle concurrency safely.
 func (m *AppMempool) CheckTx(tx types.Tx, callback func(res *abci.ResponseCheckTx), _ TxInfo) error {
 	if err := m.guardTx(tx); err != nil {
 		return err
 	}
+
+	var (
+		ctx = client.LockFreeContext(m.ctx)
+		req = &abci.RequestCheckTx{Tx: tx}
+	)
 
 	go func() {
 		defer func() {
@@ -244,7 +251,7 @@ func (m *AppMempool) CheckTx(tx types.Tx, callback func(res *abci.ResponseCheckT
 			}
 		}()
 
-		res, err := m.app.CheckTxUnlocked(m.ctx, &abci.RequestCheckTx{Tx: tx})
+		res, err := m.app.CheckTx(ctx, req)
 		if err != nil {
 			// note that other ABCI methods panic if err is not nil
 			m.logger.Error("AppMempool.CheckTx: error inserting tx", "error", err, "tx", txHash(tx))

--- a/mempool/app_mempool_test.go
+++ b/mempool/app_mempool_test.go
@@ -23,7 +23,7 @@ func TestAppMempool(t *testing.T) {
 		added := atomic.Uint64{}
 
 		// Given app
-		app := newMockAppMempoolClient(t)
+		app := abcimock.NewClient(t)
 		app.
 			On("InsertTx", mock.Anything, mock.Anything).
 			Return(func(_ context.Context, req *abci.RequestInsertTx) (*abci.ResponseInsertTx, error) {
@@ -145,7 +145,7 @@ func TestAppMempool(t *testing.T) {
 		// Given app
 		allMempoolTxs := [][]byte{}
 
-		app := newMockAppMempoolClient(t)
+		app := abcimock.NewClient(t)
 		app.
 			On("ReapTxs", mock.Anything, mock.Anything).
 			Return(func(_ context.Context, _ *abci.RequestReapTxs) (*abci.ResponseReapTxs, error) {
@@ -189,7 +189,7 @@ func TestAppMempool_UsesConfigValues(t *testing.T) {
 		cfg.ReapInterval = 10 * time.Millisecond // short for fast test
 
 		var receivedReq *abci.RequestReapTxs
-		app := newMockAppMempoolClient(t)
+		app := abcimock.NewClient(t)
 		app.On("ReapTxs", mock.Anything, mock.MatchedBy(func(req *abci.RequestReapTxs) bool {
 			receivedReq = req
 			return true
@@ -216,7 +216,7 @@ func TestAppMempool_UsesConfigValues(t *testing.T) {
 		cfg.Type = config.MempoolTypeApp
 		cfg.SeenCacheSize = 3 // small cache to test eviction
 
-		app := newMockAppMempoolClient(t)
+		app := abcimock.NewClient(t)
 		app.On("InsertTx", mock.Anything, mock.Anything).
 			Return(&abci.ResponseInsertTx{Code: abci.CodeTypeOK}, nil)
 		app.On("CheckTx", mock.Anything, mock.Anything).
@@ -240,17 +240,4 @@ func TestAppMempool_UsesConfigValues(t *testing.T) {
 		// tx1 was evicted - should succeed now
 		require.NoError(t, m.InsertTx(types.Tx("tx1")))
 	})
-}
-
-// mockAppMempoolClient wraps abcimock.Client to implement AppMempoolClient
-type mockAppMempoolClient struct {
-	*abcimock.Client
-}
-
-func (m *mockAppMempoolClient) CheckTxUnlocked(ctx context.Context, req *abci.RequestCheckTx) (*abci.ResponseCheckTx, error) {
-	return m.CheckTx(ctx, req)
-}
-
-func newMockAppMempoolClient(t *testing.T) *mockAppMempoolClient {
-	return &mockAppMempoolClient{Client: abcimock.NewClient(t)}
 }

--- a/mempool/app_reactor_test.go
+++ b/mempool/app_reactor_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	abcimock "github.com/cometbft/cometbft/abci/client/mocks"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/libs/log"
@@ -193,7 +194,7 @@ type appReactorNode struct {
 	t    *testing.T
 	name string
 
-	app     *mockAppMempoolClient
+	app     *abcimock.Client
 	mempool *AppMempool
 	reactor *AppReactor
 	sw      *p2p.Switch
@@ -208,7 +209,7 @@ type appReactorNode struct {
 func newAppReactorNode(t *testing.T, name string) *appReactorNode {
 	config := config.TestConfig()
 	logger := log.TestingLogger().With("name", name)
-	app := newMockAppMempoolClient(t)
+	app := abcimock.NewClient(t)
 
 	mempool := NewAppMempool(
 		config.Mempool,

--- a/proxy/app_conn.go
+++ b/proxy/app_conn.go
@@ -31,18 +31,10 @@ type AppConnMempool interface {
 	Error() error
 
 	CheckTx(context.Context, *types.RequestCheckTx) (*types.ResponseCheckTx, error)
-	CheckTxUnlocked(context.Context, *types.RequestCheckTx) (*types.ResponseCheckTx, error)
 	CheckTxAsync(context.Context, *types.RequestCheckTx) (*abcicli.ReqRes, error)
 	InsertTx(context.Context, *types.RequestInsertTx) (*types.ResponseInsertTx, error)
 	ReapTxs(context.Context, *types.RequestReapTxs) (*types.ResponseReapTxs, error)
 	Flush(context.Context) error
-}
-
-// checkTxUnlocker is an optional interface that clients can implement to
-// support unlocked CheckTx calls. This is used by localClient to bypass
-// the mutex lock when AppMempool handles its own concurrency.
-type checkTxUnlocker interface {
-	CheckTxUnlocked(context.Context, *types.RequestCheckTx) (*types.ResponseCheckTx, error)
 }
 
 type AppConnQuery interface {
@@ -150,14 +142,6 @@ func (app *appConnMempool) Flush(ctx context.Context) error {
 
 func (app *appConnMempool) CheckTx(ctx context.Context, req *types.RequestCheckTx) (*types.ResponseCheckTx, error) {
 	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "check_tx", "type", "sync"))()
-	return app.appConn.CheckTx(ctx, req)
-}
-
-func (app *appConnMempool) CheckTxUnlocked(ctx context.Context, req *types.RequestCheckTx) (*types.ResponseCheckTx, error) {
-	defer addTimeSample(app.metrics.MethodTimingSeconds.With("method", "check_tx", "type", "sync"))()
-	if unlocker, ok := app.appConn.(checkTxUnlocker); ok {
-		return unlocker.CheckTxUnlocked(ctx, req)
-	}
 	return app.appConn.CheckTx(ctx, req)
 }
 

--- a/proxy/mocks/app_conn_mempool.go
+++ b/proxy/mocks/app_conn_mempool.go
@@ -77,36 +77,6 @@ func (_m *AppConnMempool) CheckTxAsync(_a0 context.Context, _a1 *types.RequestCh
 	return r0, r1
 }
 
-// CheckTxUnlocked provides a mock function with given fields: _a0, _a1
-func (_m *AppConnMempool) CheckTxUnlocked(_a0 context.Context, _a1 *types.RequestCheckTx) (*types.ResponseCheckTx, error) {
-	ret := _m.Called(_a0, _a1)
-
-	if len(ret) == 0 {
-		panic("no return value specified for CheckTxUnlocked")
-	}
-
-	var r0 *types.ResponseCheckTx
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *types.RequestCheckTx) (*types.ResponseCheckTx, error)); ok {
-		return rf(_a0, _a1)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, *types.RequestCheckTx) *types.ResponseCheckTx); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*types.ResponseCheckTx)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, *types.RequestCheckTx) error); ok {
-		r1 = rf(_a0, _a1)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // Error provides a mock function with no fields
 func (_m *AppConnMempool) Error() error {
 	ret := _m.Called()


### PR DESCRIPTION
**Context**

To support `rpc.BroadcastTxSync()` while leveraging Krakatoa on the EVM, we added `client.CheckTxUnlocked()`.

I feel that this API can be expressed in a concise and idiomatic way. This PR replaces checkTxUnlocked with ctx key:

```go
ctx = client.LockFreeContext(ctx)
app.CheckTx(ctx, req)
```
---

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `CHANGELOG.md`
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
