### PR TITLE
consensus: handle abci: Consensus Deadlock Caused by Proposer Vote

### DIFF
--- a/consensus/state_ingest.go
+++ b/consensus/state_ingest.go
@@ -200,7 +200,6 @@ func (cs *State) IngestVerifiedBlock(ic IngestCandidate) (err error) {
 
 	// register response channel so we can receive from receiveRoutine
 	ch := make(chan ingestVerifiedBlockResponse, 1)
-	defer close(ch)
 
 	req := &ingestVerifiedBlockRequest{
 		IngestCandidate: ic,


### PR DESCRIPTION
## Summary

abci: Consensus Deadlock Caused by Proposer Vote Extension Verification Failure — modified `consensus/state_ingest.go`.

Refs #5204

## Changes

- consensus/state_ingest.go (-1)

## Rationale

Applied fix for abci: Consensus Deadlock Caused by Proposer Vote Extension Verification Failure in `state_ingest.go`, where the affected behavior originates.

## Scope

1 file(s) modified. Changes isolated to listed files.

## Risk

limited to consensus/state_ingest.go.

## Validation

Basic lint and formatting checks passed.