### PR TITLE
blocksync: improve Peers erroneously removed during playback

### DIFF
--- a/blocksync/pool.go
+++ b/blocksync/pool.go
@@ -881,6 +881,7 @@ OUTER_LOOP:
 					bpr.Logger.Debug("Retrying block request(s) after timeout", "height", bpr.height, "peer", bpr.peerID, "secondPeerID", bpr.secondPeerID)
 					bpr.reset(bpr.peerID)
 					bpr.reset(bpr.secondPeerID)
+					retryTimer.Stop()
 					continue OUTER_LOOP
 				}
 			case peerID := <-bpr.redoCh:


### PR DESCRIPTION
## Summary

Peers erroneously removed during playback — modified `blocksync/pool.go`.

Refs #5135

## Changes

- blocksync/pool.go (+1)

## Rationale

Applied fix for Peers erroneously removed during playback in `pool.go`, where the affected behavior originates.

## Scope

1 file(s) modified. Changes isolated to listed files.

## Risk

limited to blocksync/pool.go.

## Validation

Basic lint and formatting checks passed.