### PR TITLE
fix(mempool): allow CheckTx retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 - `[mempool]` Add app mempool & related ABCI methods, InsertTx and ReapTxs.
   ([\#5790](https://github.com/cometbft/cometbft/pull/5790))
+- `[mempool]` Allow CheckTx retries for BroadcastTxSync
+  ([\#5802](https://github.com/cometbft/cometbft/pull/5802))
 
 ### STATE-BREAKING
 

--- a/config/config.go
+++ b/config/config.go
@@ -1005,6 +1005,8 @@ type MempoolConfig struct {
 	ReapMaxGas uint64 `mapstructure:"reap_max_gas"`
 	// App mempool only: interval between ReapTxs calls when streaming txs from app.
 	ReapInterval time.Duration `mapstructure:"reap_interval"`
+	// App mempool only: delay after which a tx is forgotten for ABCI.CheckTx
+	CheckTxRetryDelay time.Duration `mapstructure:"check_tx_retry_delay"`
 }
 
 // DefaultMempoolConfig returns a default configuration for the CometBFT mempool
@@ -1024,10 +1026,11 @@ func DefaultMempoolConfig() *MempoolConfig {
 		ExperimentalMaxGossipConnectionsToNonPersistentPeers: 0,
 		ExperimentalMaxGossipConnectionsToPersistentPeers:    0,
 		// App mempool defaults
-		SeenCacheSize: 100_000,
-		ReapMaxBytes:  0,
-		ReapMaxGas:    0,
-		ReapInterval:  500 * time.Millisecond,
+		SeenCacheSize:     100_000,
+		ReapMaxBytes:      0,
+		ReapMaxGas:        0,
+		ReapInterval:      500 * time.Millisecond,
+		CheckTxRetryDelay: 5 * time.Second,
 	}
 }
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -492,6 +492,8 @@ reap_max_bytes = {{ .Mempool.ReapMaxBytes }}
 reap_max_gas = {{ .Mempool.ReapMaxGas }}
 # App mempool only: interval between ReapTxs calls when streaming txs from app.
 reap_interval = "{{ .Mempool.ReapInterval }}"
+# App mempool only: delay after which a tx is forgotten for ABCI.CheckTx
+check_tx_retry_delay = "{{ .Mempool.CheckTxRetryDelay }}"
 
 #######################################################
 ###         State Sync Configuration Options        ###

--- a/internal/guard/guard.go
+++ b/internal/guard/guard.go
@@ -1,56 +1,179 @@
+// Package guard provides a thread-safe dedup utility designed to prevent
+// repeated processing of already "observed" items. Use-case example:
+// avoiding handling already seen mempool txs.
 package guard
 
 import (
+	"sync"
 	"time"
 
-	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/hashicorp/golang-lru/v2/simplelru"
 )
 
+// Guard is a thread-safe LRU dedup cache with optional TTL before removal.
 type Guard[K comparable] struct {
-	lru *lru.Cache[K, bool]
+	lru         *simplelru.LRU[K, *entry]
+	mu          sync.Mutex
+	ttlRemovals map[K]struct{}
+	doneCh      chan struct{}
+	doneOnce    sync.Once
 }
 
+type entry struct {
+	expiresAt time.Time
+}
+
+const defaultCleanInterval = 2 * time.Second
+
+// New Guard constructor.
 func New[K comparable](capacity int) *Guard[K] {
+	return NewWithInterval[K](capacity, defaultCleanInterval)
+}
+
+// New Guard constructor with custom check interval.
+func NewWithInterval[K comparable](capacity int, cleanInterval time.Duration) *Guard[K] {
 	if capacity <= 0 {
 		panic("capacity must be greater than 0")
 	}
 
-	cache, _ := lru.New[K, bool](capacity)
-
-	return &Guard[K]{
-		lru: cache,
+	if cleanInterval <= 0 {
+		panic("cleanInterval must be greater than 0")
 	}
+
+	ttlRemovals := map[K]struct{}{}
+
+	lru, _ := simplelru.NewLRU(
+		capacity,
+		func(key K, _ *entry) { delete(ttlRemovals, key) },
+	)
+
+	g := &Guard[K]{
+		lru:         lru,
+		doneCh:      make(chan struct{}),
+		ttlRemovals: ttlRemovals,
+	}
+
+	go func() {
+		ticker := time.NewTicker(cleanInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				g.removeExpired()
+			case <-g.doneCh:
+				return
+			}
+		}
+	}()
+
+	return g
+}
+
+// Close closes the guard.
+func (g *Guard[K]) Close() {
+	g.doneOnce.Do(func() {
+		g.mu.Lock()
+		defer g.mu.Unlock()
+
+		close(g.doneCh)
+	})
 }
 
 // Guard guards the item against duplicates.
-// Returns true if the item was added to the guard, false if it was already present.
+// Doesn't have a TTL besides LRU eviction.
+// Returns true if the key was added, false if it was already present.
 func (g *Guard[K]) Guard(key K) (added bool) {
-	found, _ := g.lru.ContainsOrAdd(key, true)
+	g.mu.Lock()
+	defer g.mu.Unlock()
 
-	return !found
+	if e, exists := g.lru.Peek(key); exists {
+		if !e.expired() {
+			// exists and not expired -> guard!
+			return false
+		}
+		// lazy removal
+		g.lru.Remove(key)
+	}
+
+	// add new entry
+	g.lru.Add(key, &entry{})
+
+	return true
 }
 
+// Has checks if the key is already guarded.
 func (g *Guard[K]) Has(key K) bool {
-	return g.lru.Contains(key)
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	e, exists := g.lru.Peek(key)
+	if !exists {
+		return false
+	}
+
+	// lazy removal
+	if e.expired() {
+		g.lru.Remove(key)
+		return false
+	}
+
+	return true
 }
 
+// Forget removes the key from the guard.
 func (g *Guard[K]) Forget(key K) (present bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
 	return g.lru.Remove(key)
 }
 
+// ForgetAfter removes the key from the guard after a duration.
 func (g *Guard[K]) ForgetAfter(key K, duration time.Duration) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
 	if duration <= 0 {
-		g.Forget(key)
+		g.lru.Remove(key)
 		return
 	}
 
-	// todo async way w/o many goroutines
-	go func() {
-		time.Sleep(duration)
-		g.Forget(key)
-	}()
+	if e, ok := g.lru.Peek(key); ok {
+		// access by pointer to avoid .Add call
+		e.expiresAt = time.Now().Add(duration)
+		g.ttlRemovals[key] = struct{}{}
+	}
 }
 
+// Purge purges the guard.
 func (g *Guard[K]) Purge() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
 	g.lru.Purge()
+}
+
+func (g *Guard[K]) removeExpired() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	for key := range g.ttlRemovals {
+		e, exists := g.lru.Peek(key)
+		if !exists {
+			continue
+		}
+
+		if e.expired() {
+			g.lru.Remove(key)
+		}
+	}
+}
+
+func (e *entry) expired() bool {
+	if e.expiresAt.IsZero() {
+		return false
+	}
+
+	return time.Now().After(e.expiresAt)
 }

--- a/internal/guard/guard.go
+++ b/internal/guard/guard.go
@@ -1,0 +1,56 @@
+package guard
+
+import (
+	"time"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+)
+
+type Guard[K comparable] struct {
+	lru *lru.Cache[K, bool]
+}
+
+func New[K comparable](capacity int) *Guard[K] {
+	if capacity <= 0 {
+		panic("capacity must be greater than 0")
+	}
+
+	cache, _ := lru.New[K, bool](capacity)
+
+	return &Guard[K]{
+		lru: cache,
+	}
+}
+
+// Guard guards the item against duplicates.
+// Returns true if the item was added to the guard, false if it was already present.
+func (g *Guard[K]) Guard(key K) (added bool) {
+	found, _ := g.lru.ContainsOrAdd(key, true)
+
+	return !found
+}
+
+func (g *Guard[K]) Has(key K) bool {
+	return g.lru.Contains(key)
+}
+
+func (g *Guard[K]) Forget(key K) (present bool) {
+	return g.lru.Remove(key)
+}
+
+func (g *Guard[K]) ForgetAfter(key K, duration time.Duration) {
+	if duration <= 0 {
+		g.Forget(key)
+		return
+	}
+
+	// todo async way w/o many goroutines
+	go func() {
+		time.Sleep(duration)
+		g.Forget(key)
+	}()
+}
+
+func (g *Guard[K]) Purge() {
+	g.lru.Purge()
+}

--- a/internal/guard/guard.go
+++ b/internal/guard/guard.go
@@ -121,14 +121,6 @@ func (g *Guard[K]) Has(key K) bool {
 	return true
 }
 
-// Forget removes the key from the guard.
-func (g *Guard[K]) Forget(key K) (present bool) {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-
-	return g.lru.Remove(key)
-}
-
 // ForgetAfter removes the key from the guard after a duration.
 func (g *Guard[K]) ForgetAfter(key K, duration time.Duration) {
 	g.mu.Lock()
@@ -144,14 +136,6 @@ func (g *Guard[K]) ForgetAfter(key K, duration time.Duration) {
 		e.expiresAt = time.Now().Add(duration)
 		g.ttlRemovals[key] = struct{}{}
 	}
-}
-
-// Purge purges the guard.
-func (g *Guard[K]) Purge() {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-
-	g.lru.Purge()
 }
 
 func (g *Guard[K]) removeExpired() {

--- a/internal/guard/guard_test.go
+++ b/internal/guard/guard_test.go
@@ -1,0 +1,200 @@
+package guard
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGuard(t *testing.T) {
+	t.Run("New", func(t *testing.T) {
+		t.Run("construct", func(t *testing.T) {
+			g := New[string](10)
+			require.NotNil(t, g)
+			assert.NotNil(t, g.lru)
+		})
+
+		t.Run("zeroCapacity", func(t *testing.T) {
+			assert.PanicsWithValue(t, "capacity must be greater than 0", func() { New[string](0) })
+		})
+
+		t.Run("negativeCapacity", func(t *testing.T) {
+			assert.PanicsWithValue(t, "capacity must be greater than 0", func() { New[string](-1) })
+		})
+	})
+
+	t.Run("Guard", func(t *testing.T) {
+		t.Run("happyPath", func(t *testing.T) {
+			// ARRANGE
+			g := New[string](10)
+			item := "item-1"
+
+			// ACT #1
+			added := g.Guard(item)
+
+			// ASSERT #1
+			assert.True(t, added)
+			assert.True(t, g.Has(item))
+
+			// ACT #2
+			added2 := g.Guard(item)
+
+			// ASSERT #2
+			assert.False(t, added2, "item should exist on second call")
+		})
+
+		t.Run("differentItems", func(t *testing.T) {
+			// ARRANGE
+			g := New[string](10)
+
+			// ACT
+			firstA := g.Guard("a")
+			firstB := g.Guard("b")
+			secondA := g.Guard("a")
+
+			// ASSERT
+			assert.True(t, firstA)
+			assert.True(t, firstB)
+			assert.False(t, secondA)
+		})
+
+		t.Run("eviction", func(t *testing.T) {
+			// ARRANGE
+			g := New[string](2)
+
+			// ACT
+			g.Guard("a")
+			g.Guard("b")
+			g.Guard("c")
+
+			// ASSERT
+			assert.False(t, g.Has("a"))
+			assert.True(t, g.Has("b"))
+			assert.True(t, g.Has("c"))
+		})
+	})
+
+	t.Run("Has", func(t *testing.T) {
+		t.Run("notPresent", func(t *testing.T) {
+			// ARRANGE
+			g := New[string](10)
+
+			// ACT + ASSERT
+			assert.False(t, g.Has("missing"))
+		})
+
+		t.Run("present", func(t *testing.T) {
+			// ARRANGE
+			g := New[string](10)
+			item := "present"
+			g.Guard(item)
+
+			// ACT + ASSERT
+			assert.True(t, g.Has(item))
+		})
+	})
+
+	t.Run("Remove", func(t *testing.T) {
+		t.Run("happyPath", func(t *testing.T) {
+			// ARRANGE
+			g := New[string](10)
+			item := "item"
+			g.Guard(item)
+
+			// ACT
+			present := g.Forget(item)
+
+			// ASSERT
+			assert.True(t, present)
+			assert.False(t, g.Has(item))
+		})
+
+		t.Run("notPresent", func(t *testing.T) {
+			// ARRANGE
+			g := New[string](10)
+
+			// ACT
+			present := g.Forget("missing")
+
+			// ASSERT
+			assert.False(t, present)
+		})
+	})
+
+	t.Run("RemoveAfter", func(t *testing.T) {
+		t.Run("zeroDuration", func(t *testing.T) {
+			// ARRANGE
+			g := New[string](10)
+			item := "now"
+			g.Guard(item)
+
+			// ACT
+			g.ForgetAfter(item, 0)
+
+			// ASSERT
+			assert.False(t, g.Has(item))
+		})
+
+		t.Run("negativeDuration", func(t *testing.T) {
+			// ARRANGE
+			g := New[string](10)
+			item := "negative"
+			g.Guard(item)
+
+			// ACT
+			g.ForgetAfter(item, -time.Second)
+
+			// ASSERT
+			assert.False(t, g.Has(item))
+		})
+
+		t.Run("asyncRemoval", func(t *testing.T) {
+			// ARRANGE
+			g := New[string](10)
+			item := "later"
+			g.Guard(item)
+
+			// ACT
+			g.ForgetAfter(item, 50*time.Millisecond)
+
+			// ASSERT #1: still present immediately after the call
+			assert.True(t, g.Has(item))
+
+			// ASSERT #2: removed after the duration elapses
+			check := func() bool {
+				return !g.Has(item)
+			}
+
+			require.Eventually(t, check, time.Second, 10*time.Millisecond)
+		})
+	})
+
+	t.Run("Reset", func(t *testing.T) {
+		t.Run("happyPath", func(t *testing.T) {
+			// ARRANGE
+			g := New[string](10)
+			for i := 0; i < 5; i++ {
+				g.Guard("item-" + strconv.Itoa(i))
+			}
+
+			// ACT
+			g.Purge()
+
+			// ASSERT
+			for i := 0; i < 5; i++ {
+				assert.False(t, g.Has("item-"+strconv.Itoa(i)))
+			}
+		})
+
+		t.Run("noop", func(t *testing.T) {
+			// ARRANGE
+			g := New[string](10)
+
+			// ACT + ASSERT
+			assert.NotPanics(t, func() { g.Purge() })
+		})
+	})
+}

--- a/internal/guard/guard_test.go
+++ b/internal/guard/guard_test.go
@@ -5,50 +5,56 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGuard(t *testing.T) {
+	makeGuard := func(t *testing.T, capacity int) *Guard[string] {
+		t.Helper()
+
+		g := New[string](capacity)
+		t.Cleanup(g.Close)
+
+		return g
+	}
+
 	t.Run("New", func(t *testing.T) {
 		t.Run("construct", func(t *testing.T) {
-			g := New[string](10)
+			g := makeGuard(t, 10)
 			require.NotNil(t, g)
-			assert.NotNil(t, g.lru)
-		})
 
-		t.Run("zeroCapacity", func(t *testing.T) {
-			assert.PanicsWithValue(t, "capacity must be greater than 0", func() { New[string](0) })
-		})
-
-		t.Run("negativeCapacity", func(t *testing.T) {
-			assert.PanicsWithValue(t, "capacity must be greater than 0", func() { New[string](-1) })
+			require.PanicsWithValue(t, "capacity must be greater than 0", func() {
+				makeGuard(t, 0)
+			})
+			require.PanicsWithValue(t, "capacity must be greater than 0", func() {
+				makeGuard(t, -1)
+			})
 		})
 	})
 
 	t.Run("Guard", func(t *testing.T) {
 		t.Run("happyPath", func(t *testing.T) {
 			// ARRANGE
-			g := New[string](10)
+			g := makeGuard(t, 10)
 			item := "item-1"
 
 			// ACT #1
 			added := g.Guard(item)
 
 			// ASSERT #1
-			assert.True(t, added)
-			assert.True(t, g.Has(item))
+			require.True(t, added)
+			require.True(t, g.Has(item))
 
 			// ACT #2
 			added2 := g.Guard(item)
 
 			// ASSERT #2
-			assert.False(t, added2, "item should exist on second call")
+			require.False(t, added2, "item should exist on second call")
 		})
 
 		t.Run("differentItems", func(t *testing.T) {
 			// ARRANGE
-			g := New[string](10)
+			g := makeGuard(t, 10)
 
 			// ACT
 			firstA := g.Guard("a")
@@ -56,14 +62,14 @@ func TestGuard(t *testing.T) {
 			secondA := g.Guard("a")
 
 			// ASSERT
-			assert.True(t, firstA)
-			assert.True(t, firstB)
-			assert.False(t, secondA)
+			require.True(t, firstA)
+			require.True(t, firstB)
+			require.False(t, secondA)
 		})
 
 		t.Run("eviction", func(t *testing.T) {
 			// ARRANGE
-			g := New[string](2)
+			g := makeGuard(t, 2)
 
 			// ACT
 			g.Guard("a")
@@ -71,36 +77,36 @@ func TestGuard(t *testing.T) {
 			g.Guard("c")
 
 			// ASSERT
-			assert.False(t, g.Has("a"))
-			assert.True(t, g.Has("b"))
-			assert.True(t, g.Has("c"))
+			require.False(t, g.Has("a"))
+			require.True(t, g.Has("b"))
+			require.True(t, g.Has("c"))
 		})
 	})
 
 	t.Run("Has", func(t *testing.T) {
 		t.Run("notPresent", func(t *testing.T) {
 			// ARRANGE
-			g := New[string](10)
+			g := makeGuard(t, 10)
 
 			// ACT + ASSERT
-			assert.False(t, g.Has("missing"))
+			require.False(t, g.Has("missing"))
 		})
 
 		t.Run("present", func(t *testing.T) {
 			// ARRANGE
-			g := New[string](10)
+			g := makeGuard(t, 10)
 			item := "present"
 			g.Guard(item)
 
 			// ACT + ASSERT
-			assert.True(t, g.Has(item))
+			require.True(t, g.Has(item))
 		})
 	})
 
-	t.Run("Remove", func(t *testing.T) {
+	t.Run("Forget", func(t *testing.T) {
 		t.Run("happyPath", func(t *testing.T) {
 			// ARRANGE
-			g := New[string](10)
+			g := makeGuard(t, 10)
 			item := "item"
 			g.Guard(item)
 
@@ -108,26 +114,26 @@ func TestGuard(t *testing.T) {
 			present := g.Forget(item)
 
 			// ASSERT
-			assert.True(t, present)
-			assert.False(t, g.Has(item))
+			require.True(t, present)
+			require.False(t, g.Has(item))
 		})
 
 		t.Run("notPresent", func(t *testing.T) {
 			// ARRANGE
-			g := New[string](10)
+			g := makeGuard(t, 10)
 
 			// ACT
 			present := g.Forget("missing")
 
 			// ASSERT
-			assert.False(t, present)
+			require.False(t, present)
 		})
 	})
 
-	t.Run("RemoveAfter", func(t *testing.T) {
+	t.Run("ForgetAfter", func(t *testing.T) {
 		t.Run("zeroDuration", func(t *testing.T) {
 			// ARRANGE
-			g := New[string](10)
+			g := makeGuard(t, 10)
 			item := "now"
 			g.Guard(item)
 
@@ -135,12 +141,12 @@ func TestGuard(t *testing.T) {
 			g.ForgetAfter(item, 0)
 
 			// ASSERT
-			assert.False(t, g.Has(item))
+			require.False(t, g.Has(item))
 		})
 
 		t.Run("negativeDuration", func(t *testing.T) {
 			// ARRANGE
-			g := New[string](10)
+			g := makeGuard(t, 10)
 			item := "negative"
 			g.Guard(item)
 
@@ -148,20 +154,20 @@ func TestGuard(t *testing.T) {
 			g.ForgetAfter(item, -time.Second)
 
 			// ASSERT
-			assert.False(t, g.Has(item))
+			require.False(t, g.Has(item))
 		})
 
-		t.Run("asyncRemoval", func(t *testing.T) {
+		t.Run("delayedRemovalAccess", func(t *testing.T) {
 			// ARRANGE
-			g := New[string](10)
+			g := makeGuard(t, 10)
 			item := "later"
 			g.Guard(item)
 
 			// ACT
-			g.ForgetAfter(item, 50*time.Millisecond)
+			g.ForgetAfter(item, 100*time.Millisecond)
 
 			// ASSERT #1: still present immediately after the call
-			assert.True(t, g.Has(item))
+			require.True(t, g.Has(item))
 
 			// ASSERT #2: removed after the duration elapses
 			check := func() bool {
@@ -170,12 +176,37 @@ func TestGuard(t *testing.T) {
 
 			require.Eventually(t, check, time.Second, 10*time.Millisecond)
 		})
+
+		t.Run("delayedRemovalAsync", func(t *testing.T) {
+			// ARRANGE
+			g := NewWithInterval[string](10, 50*time.Millisecond)
+			t.Cleanup(g.Close)
+
+			item := "later"
+			g.Guard(item)
+
+			// ACT
+			g.ForgetAfter(item, 10*time.Millisecond)
+
+			// ASSERT #1: still present immediately after the call
+			require.False(t, g.Guard(item))
+			require.True(t, g.Has(item))
+
+			// ASSERT #2: removed in a goroutine after the duration elapses
+			time.Sleep(100 * time.Millisecond)
+
+			g.mu.Lock()
+			_, ok := g.lru.Peek(item)
+			g.mu.Unlock()
+
+			require.False(t, ok)
+		})
 	})
 
-	t.Run("Reset", func(t *testing.T) {
+	t.Run("Purge", func(t *testing.T) {
 		t.Run("happyPath", func(t *testing.T) {
 			// ARRANGE
-			g := New[string](10)
+			g := makeGuard(t, 10)
 			for i := 0; i < 5; i++ {
 				g.Guard("item-" + strconv.Itoa(i))
 			}
@@ -185,16 +216,16 @@ func TestGuard(t *testing.T) {
 
 			// ASSERT
 			for i := 0; i < 5; i++ {
-				assert.False(t, g.Has("item-"+strconv.Itoa(i)))
+				require.False(t, g.Has("item-"+strconv.Itoa(i)))
 			}
 		})
 
 		t.Run("noop", func(t *testing.T) {
 			// ARRANGE
-			g := New[string](10)
+			g := makeGuard(t, 10)
 
 			// ACT + ASSERT
-			assert.NotPanics(t, func() { g.Purge() })
+			require.NotPanics(t, func() { g.Purge() })
 		})
 	})
 }

--- a/internal/guard/guard_test.go
+++ b/internal/guard/guard_test.go
@@ -1,7 +1,6 @@
 package guard
 
 import (
-	"strconv"
 	"testing"
 	"time"
 
@@ -103,33 +102,6 @@ func TestGuard(t *testing.T) {
 		})
 	})
 
-	t.Run("Forget", func(t *testing.T) {
-		t.Run("happyPath", func(t *testing.T) {
-			// ARRANGE
-			g := makeGuard(t, 10)
-			item := "item"
-			g.Guard(item)
-
-			// ACT
-			present := g.Forget(item)
-
-			// ASSERT
-			require.True(t, present)
-			require.False(t, g.Has(item))
-		})
-
-		t.Run("notPresent", func(t *testing.T) {
-			// ARRANGE
-			g := makeGuard(t, 10)
-
-			// ACT
-			present := g.Forget("missing")
-
-			// ASSERT
-			require.False(t, present)
-		})
-	})
-
 	t.Run("ForgetAfter", func(t *testing.T) {
 		t.Run("zeroDuration", func(t *testing.T) {
 			// ARRANGE
@@ -200,32 +172,6 @@ func TestGuard(t *testing.T) {
 			g.mu.Unlock()
 
 			require.False(t, ok)
-		})
-	})
-
-	t.Run("Purge", func(t *testing.T) {
-		t.Run("happyPath", func(t *testing.T) {
-			// ARRANGE
-			g := makeGuard(t, 10)
-			for i := 0; i < 5; i++ {
-				g.Guard("item-" + strconv.Itoa(i))
-			}
-
-			// ACT
-			g.Purge()
-
-			// ASSERT
-			for i := 0; i < 5; i++ {
-				require.False(t, g.Has("item-"+strconv.Itoa(i)))
-			}
-		})
-
-		t.Run("noop", func(t *testing.T) {
-			// ARRANGE
-			g := makeGuard(t, 10)
-
-			// ACT + ASSERT
-			require.NotPanics(t, func() { g.Purge() })
 		})
 	})
 }

--- a/mempool/app_mempool.go
+++ b/mempool/app_mempool.go
@@ -223,10 +223,6 @@ func (m *AppMempool) reapTxs(ctx context.Context, channel chan<- types.Txs) {
 
 			// avoid receiving these txs again from other peers.
 			for _, tx := range txs {
-				if m.guard.Has(tx.Key()) {
-					continue
-				}
-
 				m.guard.Guard(tx.Key())
 			}
 		}

--- a/mempool/app_mempool.go
+++ b/mempool/app_mempool.go
@@ -46,7 +46,8 @@ type AppMempoolClient interface {
 // AppMempoolOpt is the option for AppMempool
 type AppMempoolOpt func(*AppMempool)
 
-// CheckTxRetryDelay is the delay after which a tx is forgotten if it returns a non-retryable error code
+// CheckTxRetryDelay is the base delay before a failed tx is evicted from the seen cache.
+// Retryable errors use CheckTxRetryDelay/10; non-retryable errors use the full value.
 const CheckTxRetryDelay = 5 * time.Second
 
 var _ Mempool = &AppMempool{}

--- a/mempool/app_mempool.go
+++ b/mempool/app_mempool.go
@@ -106,7 +106,7 @@ func (m *AppMempool) InsertTx(tx types.Tx) error {
 		return wrapErrCode("unable to insert tx", code, err)
 	case codeRetry(code):
 		// drop tx from seen cache (to retry later), but still return the error
-		m.guard.Forget(tx.Key())
+		m.forgetTx(tx, true)
 		fallthrough
 	case code != abci.CodeTypeOK:
 		m.metrics.RejectedTxs.Add(1)

--- a/mempool/app_mempool.go
+++ b/mempool/app_mempool.go
@@ -8,6 +8,7 @@ import (
 	client "github.com/cometbft/cometbft/abci/client"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/config"
+	"github.com/cometbft/cometbft/internal/guard"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/types"
 	"github.com/pkg/errors"
@@ -24,8 +25,13 @@ type AppMempool struct {
 	config  *config.MempoolConfig
 	metrics *Metrics
 	app     AppMempoolClient
-	seen    TxCache
-	logger  log.Logger
+
+	// cache to avoid receiving the same txs from other peers.
+	// supports TTL eviction policy.
+	guard             *guard.Guard[types.TxKey]
+	checkTxRetryDelay time.Duration
+
+	logger log.Logger
 }
 
 // AppMempoolClient is the interface for the app-side mempool.
@@ -46,9 +52,6 @@ type AppMempoolClient interface {
 // AppMempoolOpt is the option for AppMempool
 type AppMempoolOpt func(*AppMempool)
 
-// CheckTxRetryDelay is the delay after which a tx is forgotten if it returns a non-retryable error code
-const CheckTxRetryDelay = 5 * time.Second
-
 var _ Mempool = &AppMempool{}
 
 var (
@@ -65,26 +68,23 @@ func WithAMLogger(logger log.Logger) AppMempoolOpt {
 	return func(m *AppMempool) { m.logger = logger }
 }
 
-func NewAppMempool(
-	config *config.MempoolConfig,
-	app AppMempoolClient,
-	opts ...AppMempoolOpt,
-) *AppMempool {
-	// cache to avoid receiving the same txs from other peers.
-	// we should add TTL w/ eviction policy.
-	seen := NewLRUTxCache(config.SeenCacheSize)
-
+func NewAppMempool(config *config.MempoolConfig, app AppMempoolClient, opts ...AppMempoolOpt) *AppMempool {
 	m := &AppMempool{
-		ctx:     context.Background(),
-		config:  config,
-		app:     app,
-		seen:    seen,
-		metrics: NopMetrics(),
-		logger:  log.NewNopLogger(),
+		ctx:               context.Background(),
+		config:            config,
+		app:               app,
+		guard:             guard.New[types.TxKey](config.SeenCacheSize),
+		checkTxRetryDelay: config.CheckTxRetryDelay,
+		metrics:           NopMetrics(),
+		logger:            log.NewNopLogger(),
 	}
 
 	for _, opt := range opts {
 		opt(m)
+	}
+
+	if m.checkTxRetryDelay <= 0 {
+		panic("mempool.CheckTxRetryDelay must be positive")
 	}
 
 	return m
@@ -106,7 +106,7 @@ func (m *AppMempool) InsertTx(tx types.Tx) error {
 		return wrapErrCode("unable to insert tx", code, err)
 	case codeRetry(code):
 		// drop tx from seen cache (to retry later), but still return the error
-		m.seen.Remove(tx)
+		m.guard.Forget(tx.Key())
 		fallthrough
 	case code != abci.CodeTypeOK:
 		m.metrics.RejectedTxs.Add(1)
@@ -132,8 +132,7 @@ func (m *AppMempool) guardTx(tx types.Tx) error {
 		}
 	}
 
-	pushed := m.seen.Push(tx)
-	if !pushed {
+	if !m.guard.Guard(tx.Key()) {
 		m.metrics.AlreadyReceivedTxs.Add(1)
 		return ErrSeenTx
 	}
@@ -143,15 +142,12 @@ func (m *AppMempool) guardTx(tx types.Tx) error {
 
 // forgetTx forgets a tx after a delay (blocking)
 func (m *AppMempool) forgetTx(tx types.Tx, retryable bool) {
-	delay := CheckTxRetryDelay
+	delay := m.checkTxRetryDelay
 	if retryable {
 		delay /= 10
 	}
 
-	time.Sleep(delay)
-	m.seen.Remove(tx)
-
-	m.logger.Debug("Deleted tx from seen cache", "tx", txHash(tx), "retryable", retryable)
+	m.guard.ForgetAfter(tx.Key(), delay)
 }
 
 func (m *AppMempool) insertTx(tx types.Tx) (uint32, error) {
@@ -227,11 +223,11 @@ func (m *AppMempool) reapTxs(ctx context.Context, channel chan<- types.Txs) {
 
 			// avoid receiving these txs again from other peers.
 			for _, tx := range txs {
-				if m.seen.Has(tx) {
+				if m.guard.Has(tx.Key()) {
 					continue
 				}
 
-				m.seen.Push(tx)
+				m.guard.Guard(tx.Key())
 			}
 		}
 	}

--- a/mempool/app_mempool.go
+++ b/mempool/app_mempool.go
@@ -46,6 +46,9 @@ type AppMempoolClient interface {
 // AppMempoolOpt is the option for AppMempool
 type AppMempoolOpt func(*AppMempool)
 
+// CheckTxRetryDelay is the delay after which a tx is forgotten if it returns a non-retryable error code
+const CheckTxRetryDelay = 5 * time.Second
+
 var _ Mempool = &AppMempool{}
 
 var (
@@ -136,6 +139,19 @@ func (m *AppMempool) guardTx(tx types.Tx) error {
 	}
 
 	return nil
+}
+
+// forgetTx forgets a tx after a delay (blocking)
+func (m *AppMempool) forgetTx(tx types.Tx, retryable bool) {
+	delay := CheckTxRetryDelay
+	if retryable {
+		delay /= 10
+	}
+
+	time.Sleep(delay)
+	m.seen.Remove(tx)
+
+	m.logger.Debug("Deleted tx from seen cache", "tx", txHash(tx), "retryable", retryable)
 }
 
 func (m *AppMempool) insertTx(tx types.Tx) (uint32, error) {
@@ -234,6 +250,7 @@ func (m *AppMempool) FlushAppConn() error {
 // CheckTx calls ABCI.CheckTx
 // This type of mempool assumes ABCI.CheckTx is safe to call LOCK-FREE.
 // It's a responsibility of application to handle concurrency safely.
+// Used only by RPC.BroadcastTxAsync and RPC.BroadcastTxSync.
 func (m *AppMempool) CheckTx(tx types.Tx, callback func(res *abci.ResponseCheckTx), _ TxInfo) error {
 	if err := m.guardTx(tx); err != nil {
 		return err
@@ -258,11 +275,21 @@ func (m *AppMempool) CheckTx(tx types.Tx, callback func(res *abci.ResponseCheckT
 			return
 		}
 
-		// App mempool doesn't execute the tx, so we ALWAYS return an empty response here.
+		// app mempool doesn't execute the tx, so we ALWAYS return an empty response here.
 		// This will most likely break many clients. Clients should rely on app-specific
 		// broadcasting endpoints (think of eth_sendRawTransaction, etc...).
 		if callback != nil {
 			callback(res)
+		}
+
+		// handle (non)retryable errors:
+		// allow RPC requests to be retryable while keeping DDoS vector small.
+		//
+		// - if app returns a retryable error code -> forget after a small delay
+		// - if app returns a non-retryable error code -> forget after a bigger delay
+		// - if a tx comes from other peers via m.InsertTx() -> it won't be cleaned (guardTx).
+		if res.Code != abci.CodeTypeOK {
+			m.forgetTx(tx, codeRetry(res.Code))
 		}
 	}()
 

--- a/mempool/app_mempool_test.go
+++ b/mempool/app_mempool_test.go
@@ -72,7 +72,7 @@ func TestAppMempool(t *testing.T) {
 		require.ErrorIs(t, err4, ErrEmptyTx)
 
 		require.ErrorContains(t, err5, "invalid code: (code=32000)")
-		require.False(t, m.seen.Has(txs[3]), "should be removed from seen cache")
+		require.False(t, m.guard.Has(txs[3].Key()), "should be removed from seen cache")
 
 		require.Equal(t, uint64(2), added.Load())
 
@@ -101,14 +101,14 @@ func TestAppMempool(t *testing.T) {
 					tx:   tx("fail-retryable"),
 					assert: func(t *testing.T, res *abci.ResponseCheckTx) {
 						require.Equal(t, abci.CodeTypeRetry, res.Code)
-						require.True(t, m.seen.Has(tx("fail-retryable")))
+						require.True(t, m.guard.Has(tx("fail-retryable").Key()))
 
 						// eventually the tx should be forgotten
 						check := func() bool {
-							return !m.seen.Has(tx("fail-retryable"))
+							return !m.guard.Has(tx("fail-retryable").Key())
 						}
 
-						require.Eventually(t, check, CheckTxRetryDelay, time.Millisecond*50)
+						require.Eventually(t, check, m.checkTxRetryDelay, time.Millisecond*50)
 					},
 				},
 				{

--- a/mempool/app_mempool_test.go
+++ b/mempool/app_mempool_test.go
@@ -22,7 +22,7 @@ func TestAppMempool(t *testing.T) {
 
 	t.Run("InsertTx", func(t *testing.T) {
 		// ARRANGE
-		added := atomic.Uint64{}
+		wasInserted := atomic.Uint64{}
 
 		// Given app
 		app := abcimock.NewClient(t)
@@ -36,7 +36,7 @@ func TestAppMempool(t *testing.T) {
 					return &abci.ResponseInsertTx{Code: codeFail}, nil
 				}
 
-				added.Add(1)
+				wasInserted.Add(1)
 				return &abci.ResponseInsertTx{Code: abci.CodeTypeOK}, nil
 			})
 		app.
@@ -72,9 +72,14 @@ func TestAppMempool(t *testing.T) {
 		require.ErrorIs(t, err4, ErrEmptyTx)
 
 		require.ErrorContains(t, err5, "invalid code: (code=32000)")
-		require.False(t, m.guard.Has(txs[3].Key()), "should be removed from seen cache")
+		require.Equal(t, uint64(2), wasInserted.Load())
 
-		require.Equal(t, uint64(2), added.Load())
+		// retryable txs are forgotten asynchronously via guard.ForgetAfter(),
+		// so the seen-cache entry clears shortly after the call returns.
+		retryableForgotten := func() bool {
+			return !m.guard.Has(txs[3].Key())
+		}
+		require.Eventually(t, retryableForgotten, m.checkTxRetryDelay, 50*time.Millisecond)
 
 		t.Run("CheckTx", func(t *testing.T) {
 			for _, tt := range []struct {

--- a/mempool/app_mempool_test.go
+++ b/mempool/app_mempool_test.go
@@ -18,6 +18,8 @@ import (
 func TestAppMempool(t *testing.T) {
 	tx := func(v string) types.Tx { return types.Tx(v) }
 
+	const codeFail = uint32(123)
+
 	t.Run("InsertTx", func(t *testing.T) {
 		// ARRANGE
 		added := atomic.Uint64{}
@@ -27,9 +29,11 @@ func TestAppMempool(t *testing.T) {
 		app.
 			On("InsertTx", mock.Anything, mock.Anything).
 			Return(func(_ context.Context, req *abci.RequestInsertTx) (*abci.ResponseInsertTx, error) {
-				if string(req.Tx) == "fail" {
-					t.Logf("returning retryable error")
+				if string(req.Tx) == "fail-retryable" {
 					return &abci.ResponseInsertTx{Code: abci.CodeTypeRetry}, nil
+				}
+				if string(req.Tx) == "fail" {
+					return &abci.ResponseInsertTx{Code: codeFail}, nil
 				}
 
 				added.Add(1)
@@ -38,8 +42,11 @@ func TestAppMempool(t *testing.T) {
 		app.
 			On("CheckTx", mock.Anything, mock.Anything).
 			Return(func(_ context.Context, req *abci.RequestCheckTx) (*abci.ResponseCheckTx, error) {
-				if string(req.Tx) == "fail" {
+				if string(req.Tx) == "fail-retryable" {
 					return &abci.ResponseCheckTx{Code: abci.CodeTypeRetry}, nil
+				}
+				if string(req.Tx) == "fail" {
+					return &abci.ResponseCheckTx{Code: codeFail}, nil
 				}
 				return &abci.ResponseCheckTx{Code: abci.CodeTypeOK}, nil
 			})
@@ -48,7 +55,7 @@ func TestAppMempool(t *testing.T) {
 		m := NewAppMempool(config.DefaultMempoolConfig(), app)
 
 		// Given txs
-		txs := []types.Tx{tx("tx1"), tx("tx2"), tx(""), tx("fail")}
+		txs := []types.Tx{tx("tx1"), tx("tx2"), tx(""), tx("fail-retryable")}
 
 		// ACT
 		err1 := m.InsertTx(txs[0])
@@ -86,7 +93,22 @@ func TestAppMempool(t *testing.T) {
 					name: "fail",
 					tx:   tx("fail"),
 					assert: func(t *testing.T, res *abci.ResponseCheckTx) {
+						require.Equal(t, codeFail, res.Code)
+					},
+				},
+				{
+					name: "fail-retryable",
+					tx:   tx("fail-retryable"),
+					assert: func(t *testing.T, res *abci.ResponseCheckTx) {
 						require.Equal(t, abci.CodeTypeRetry, res.Code)
+						require.True(t, m.seen.Has(tx("fail-retryable")))
+
+						// eventually the tx should be forgotten
+						check := func() bool {
+							return !m.seen.Has(tx("fail-retryable"))
+						}
+
+						require.Eventually(t, check, CheckTxRetryDelay, time.Millisecond*50)
 					},
 				},
 				{


### PR DESCRIPTION
Fixed a UX hiccup: `RPC.BroadcastTxSync()` calls `appMempool.CheckTx()` that limited retries. With Krakatoa's mempool that meant you couldn't resubmit a cosmos tx if your balance was low, for example. 

This PR drops the tx hash from the "seen cache" after a delay, letting you resubmit while still protecting the node from DoS.

Closes STACK-2402

---

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `CHANGELOG.md`
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
