### PR TITLE
fix(rpc): context cancel() leak in (*Environment).Subscribe

### DIFF
--- a/rpc/core/events.go
+++ b/rpc/core/events.go
@@ -69,8 +69,9 @@ func (env *Environment) Subscribe(ctx *rpctypes.Context, query string) (*ctypes.
 					resp        = rpctypes.NewRPCSuccessResponse(subscriptionID, resultEvent)
 				)
 				writeCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-				defer cancel()
-				if err := ctx.WSConn.WriteRPCResponse(writeCtx, resp); err != nil {
+				err := ctx.WSConn.WriteRPCResponse(writeCtx, resp)
+				cancel()
+				if err != nil {
 					env.Logger.Info("Can't write response (slow client)",
 						"to", addr, "subscriptionID", subscriptionID, "err", err)
 


### PR DESCRIPTION
Fix a memory leak in the (rpc) `Subscribe` method where `context.CancelFunc` was being deferred (`defer cancel()`) inside a long-running `for` loop. The more event publishes (and number of subscribed clients), the more `defer cancel()` accumulates until the clients unsubscribe or disconnect which could eventually leading to an OOM crash.