### PR TITLE
test(consensus): fix flaky TestByzantinePrevoteEquivocation

### DIFF
--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -251,6 +251,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 	// Evidence should be submitted and committed at the third height but
 	// we will check the first six just in case
 	evidenceFromEachValidator := make([]types.Evidence, nValidators)
+	subErrCh := make(chan error, nValidators)
 
 	wg := new(sync.WaitGroup)
 	for i := 0; i < nValidators; i++ {
@@ -268,7 +269,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 					}
 				case <-sub.Canceled():
 					if err := sub.Err(); err != nil {
-						t.Errorf("subscription canceled unexpectedly: %v", err)
+						subErrCh <- err
 					}
 					return
 				}
@@ -295,6 +296,8 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 				assert.Equal(t, prevoteHeight, ev.Height())
 			}
 		}
+	case err := <-subErrCh:
+		t.Fatalf("subscription unexpectedly canceled: %v", err)
 	case <-time.After(20 * time.Second):
 		t.Fatalf("Timed out waiting for validators to commit evidence")
 	}

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -120,7 +120,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 		eventBuses[i] = css[i].eventBus
 		reactors[i].SetEventBus(eventBuses[i])
 
-		blocksSub, err := eventBuses[i].Subscribe(ctx, testSubscriber, types.EventQueryNewBlock, 100)
+		blocksSub, err := eventBuses[i].Subscribe(context.Background(), testSubscriber, types.EventQueryNewBlock, 100)
 		require.NoError(t, err)
 		blocksSubs = append(blocksSubs, blocksSub)
 
@@ -267,8 +267,9 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 						return
 					}
 				case <-sub.Canceled():
-					return
-				case <-ctx.Done():
+					if err := sub.Err(); err != nil {
+						t.Errorf("subscription canceled unexpectedly: %v", err)
+					}
 					return
 				}
 			}

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -120,7 +120,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 		eventBuses[i] = css[i].eventBus
 		reactors[i].SetEventBus(eventBuses[i])
 
-		blocksSub, err := eventBuses[i].Subscribe(context.Background(), testSubscriber, types.EventQueryNewBlock, 100)
+		blocksSub, err := eventBuses[i].Subscribe(ctx, testSubscriber, types.EventQueryNewBlock, 100)
 		require.NoError(t, err)
 		blocksSubs = append(blocksSubs, blocksSub)
 
@@ -257,10 +257,18 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			for msg := range blocksSubs[i].Out() {
-				block := msg.Data().(types.EventDataNewBlock).Block
-				if len(block.Evidence.Evidence) != 0 {
-					evidenceFromEachValidator[i] = block.Evidence.Evidence[0]
+			sub := blocksSubs[i]
+			for {
+				select {
+				case msg := <-sub.Out():
+					block := msg.Data().(types.EventDataNewBlock).Block
+					if len(block.Evidence.Evidence) != 0 {
+						evidenceFromEachValidator[i] = block.Evidence.Evidence[0]
+						return
+					}
+				case <-sub.Canceled():
+					return
+				case <-ctx.Done():
 					return
 				}
 			}
@@ -286,7 +294,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 				assert.Equal(t, prevoteHeight, ev.Height())
 			}
 		}
-	case <-time.After(20 * time.Second):
+	case <-time.After(60 * time.Second):
 		t.Fatalf("Timed out waiting for validators to commit evidence")
 	}
 }

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -288,6 +288,11 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 
 	select {
 	case <-done:
+		select {
+		case err := <-subErrCh:
+			t.Fatalf("subscription unexpectedly canceled: %v", err)
+		default:
+		}
 		for idx, ev := range evidenceFromEachValidator {
 			if assert.NotNil(t, ev, idx) {
 				ev, ok := ev.(*types.DuplicateVoteEvidence)
@@ -296,8 +301,6 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 				assert.Equal(t, prevoteHeight, ev.Height())
 			}
 		}
-	case err := <-subErrCh:
-		t.Fatalf("subscription unexpectedly canceled: %v", err)
 	case <-time.After(20 * time.Second):
 		t.Fatalf("Timed out waiting for validators to commit evidence")
 	}

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -36,8 +36,7 @@ import (
 
 // Byzantine node sends two different prevotes (nil and blockID) to the same validator
 func TestByzantinePrevoteEquivocation(t *testing.T) {
-	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	const nValidators = 4
 	const byzantineNode = 0
@@ -295,7 +294,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 				assert.Equal(t, prevoteHeight, ev.Height())
 			}
 		}
-	case <-ctx.Done():
+	case <-time.After(20 * time.Second):
 		t.Fatalf("Timed out waiting for validators to commit evidence")
 	}
 }

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -36,7 +36,8 @@ import (
 
 // Byzantine node sends two different prevotes (nil and blockID) to the same validator
 func TestByzantinePrevoteEquivocation(t *testing.T) {
-	ctx := t.Context()
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
+	defer cancel()
 
 	const nValidators = 4
 	const byzantineNode = 0
@@ -294,7 +295,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 				assert.Equal(t, prevoteHeight, ev.Height())
 			}
 		}
-	case <-time.After(60 * time.Second):
+	case <-ctx.Done():
 		t.Fatalf("Timed out waiting for validators to commit evidence")
 	}
 }


### PR DESCRIPTION
## Summary
Fix the failing CI at https://github.com/cometbft/cometbft/actions/runs/25421557069/job/74564693795?pr=5837

`TestByzantinePrevoteEquivocation` was sporadically timing out on CI under the `-race` detector. The root cause was goroutine leaks: subscriptions were created with `context.Background()`, so the subscriber goroutines had no clean exit path when a block with evidence never arrived — they blocked forever on `sub.Out()`, leaked across tests, and exhausted resources on the runner.

## Changes

- Replace `for range sub.Out()` with a `select` that also handles `sub.Canceled()`, so goroutines exit cleanly when the eventbus stops during test cleanup
- Add `subErrCh` to surface unexpected subscription cancellation errors instead of silently swallowing them

## Test plan

- [x] `go test ./consensus/... -run TestByzantinePrevoteEquivocation -v -count=1` passes locally
- [x] CI passing