### PR TITLE
test(consensus): fix cs.GetRoundState deadlock after ensureNewProposal

### DIFF
--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -581,7 +581,7 @@ func ensureNewTimeout(timeoutCh <-chan cmtpubsub.Message, height int64, round in
 		"Timeout expired while waiting for NewTimeout event")
 }
 
-func ensureNewProposal(proposalCh <-chan cmtpubsub.Message, height int64, round int32) {
+func ensureNewProposal(proposalCh <-chan cmtpubsub.Message, height int64, round int32) types.BlockID {
 	select {
 	case <-time.After(ensureTimeout):
 		panic("Timeout expired while waiting for NewProposal event")
@@ -597,7 +597,9 @@ func ensureNewProposal(proposalCh <-chan cmtpubsub.Message, height int64, round 
 		if proposalEvent.Round != round {
 			panic(fmt.Sprintf("expected round %v, got %v", round, proposalEvent.Round))
 		}
+		return proposalEvent.BlockID
 	}
+	panic("unreachable")
 }
 
 func ensureNewValidBlock(validBlockCh <-chan cmtpubsub.Message, height int64, round int32) {

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -582,6 +582,7 @@ func ensureNewTimeout(timeoutCh <-chan cmtpubsub.Message, height int64, round in
 }
 
 func ensureNewProposal(proposalCh <-chan cmtpubsub.Message, height int64, round int32) types.BlockID {
+	var blockID types.BlockID
 	select {
 	case <-time.After(ensureTimeout):
 		panic("Timeout expired while waiting for NewProposal event")
@@ -597,9 +598,9 @@ func ensureNewProposal(proposalCh <-chan cmtpubsub.Message, height int64, round 
 		if proposalEvent.Round != round {
 			panic(fmt.Sprintf("expected round %v, got %v", round, proposalEvent.Round))
 		}
-		return proposalEvent.BlockID
+		blockID = proposalEvent.BlockID
 	}
-	panic("unreachable")
+	return blockID
 }
 
 func ensureNewValidBlock(validBlockCh <-chan cmtpubsub.Message, height int64, round int32) {

--- a/consensus/replay_test.go
+++ b/consensus/replay_test.go
@@ -442,9 +442,8 @@ func setupChainWithChangingValidators(t *testing.T, name string, nBlocks int) (*
 	startTestRound(css[0], height, round)
 	incrementHeight(vss...)
 	ensureNewRound(newRoundCh, height, 0)
-	ensureNewProposal(proposalCh, height, round)
-	rs := css[0].GetRoundState()
-	signAddVotes(css[0], cmtproto.PrecommitType, rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header(), true, vss[1:nVals]...)
+	blockID1 := ensureNewProposal(proposalCh, height, round)
+	signAddVotes(css[0], cmtproto.PrecommitType, blockID1.Hash, blockID1.PartSetHeader, true, vss[1:nVals]...)
 	ensureNewRound(newRoundCh, height+1, 0)
 
 	// HEIGHT 2
@@ -474,9 +473,8 @@ func setupChainWithChangingValidators(t *testing.T, name string, nBlocks int) (*
 	if err := css[0].SetProposalAndBlock(proposal, propBlock, propBlockParts, "some peer"); err != nil {
 		t.Fatal(err)
 	}
-	ensureNewProposal(proposalCh, height, round)
-	rs = css[0].GetRoundState()
-	signAddVotes(css[0], cmtproto.PrecommitType, rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header(), true, vss[1:nVals]...)
+	blockID2 := ensureNewProposal(proposalCh, height, round)
+	signAddVotes(css[0], cmtproto.PrecommitType, blockID2.Hash, blockID2.PartSetHeader, true, vss[1:nVals]...)
 	ensureNewRound(newRoundCh, height+1, 0)
 
 	// HEIGHT 3
@@ -506,9 +504,8 @@ func setupChainWithChangingValidators(t *testing.T, name string, nBlocks int) (*
 	if err := css[0].SetProposalAndBlock(proposal, propBlock, propBlockParts, "some peer"); err != nil {
 		t.Fatal(err)
 	}
-	ensureNewProposal(proposalCh, height, round)
-	rs = css[0].GetRoundState()
-	signAddVotes(css[0], cmtproto.PrecommitType, rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header(), true, vss[1:nVals]...)
+	blockID3 := ensureNewProposal(proposalCh, height, round)
+	signAddVotes(css[0], cmtproto.PrecommitType, blockID3.Hash, blockID3.PartSetHeader, true, vss[1:nVals]...)
 	ensureNewRound(newRoundCh, height+1, 0)
 
 	// HEIGHT 4
@@ -565,18 +562,17 @@ func setupChainWithChangingValidators(t *testing.T, name string, nBlocks int) (*
 	if err := css[0].SetProposalAndBlock(proposal, propBlock, propBlockParts, "some peer"); err != nil {
 		t.Fatal(err)
 	}
-	ensureNewProposal(proposalCh, height, round)
+	blockID4 := ensureNewProposal(proposalCh, height, round)
 
 	removeValidatorTx2 := kvstore.MakeValSetChangeTx(newVal2ABCI, 0)
 	err = assertMempool(css[0].txNotifier).CheckTx(removeValidatorTx2, nil, mempool.TxInfo{})
 	assert.Nil(t, err)
 
-	rs = css[0].GetRoundState()
 	for i := 0; i < nVals+1; i++ {
 		if i == selfIndex {
 			continue
 		}
-		signAddVotes(css[0], cmtproto.PrecommitType, rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header(), true, newVss[i])
+		signAddVotes(css[0], cmtproto.PrecommitType, blockID4.Hash, blockID4.PartSetHeader, true, newVss[i])
 	}
 
 	ensureNewRound(newRoundCh, height+1, 0)
@@ -589,13 +585,12 @@ func setupChainWithChangingValidators(t *testing.T, name string, nBlocks int) (*
 	newVss[newVssIdx].VotingPower = 25
 	sort.Sort(ValidatorStubsByPower(newVss))
 	selfIndex = valIndexFn(0)
-	ensureNewProposal(proposalCh, height, round)
-	rs = css[0].GetRoundState()
+	blockID5 := ensureNewProposal(proposalCh, height, round)
 	for i := 0; i < nVals+1; i++ {
 		if i == selfIndex {
 			continue
 		}
-		signAddVotes(css[0], cmtproto.PrecommitType, rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header(), true, newVss[i])
+		signAddVotes(css[0], cmtproto.PrecommitType, blockID5.Hash, blockID5.PartSetHeader, true, newVss[i])
 	}
 	ensureNewRound(newRoundCh, height+1, 0)
 
@@ -626,13 +621,12 @@ func setupChainWithChangingValidators(t *testing.T, name string, nBlocks int) (*
 	if err := css[0].SetProposalAndBlock(proposal, propBlock, propBlockParts, "some peer"); err != nil {
 		t.Fatal(err)
 	}
-	ensureNewProposal(proposalCh, height, round)
-	rs = css[0].GetRoundState()
+	blockID6 := ensureNewProposal(proposalCh, height, round)
 	for i := 0; i < nVals+3; i++ {
 		if i == selfIndex {
 			continue
 		}
-		signAddVotes(css[0], cmtproto.PrecommitType, rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header(), true, newVss[i])
+		signAddVotes(css[0], cmtproto.PrecommitType, blockID6.Hash, blockID6.PartSetHeader, true, newVss[i])
 	}
 	ensureNewRound(newRoundCh, height+1, 0)
 

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -381,8 +381,7 @@ func TestStateFullRound1(t *testing.T) {
 
 	ensureNewRound(newRoundCh, height, round)
 
-	ensureNewProposal(propCh, height, round)
-	propBlockHash := cs.GetRoundState().ProposalBlock.Hash()
+	propBlockHash := ensureNewProposal(propCh, height, round).Hash
 
 	ensurePrevote(voteCh, height, round) // wait for prevote
 	validatePrevote(t, cs, round, vss[0], propBlockHash)

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -1450,11 +1450,10 @@ func TestProcessProposalAccept(t *testing.T) {
 			startTestRound(cs1, cs1.Height, round)
 			ensureNewRound(newRoundCh, height, round)
 
-			ensureNewProposal(proposalCh, height, round)
-			rs := cs1.GetRoundState()
+			blockID := ensureNewProposal(proposalCh, height, round)
 			var prevoteHash cmtbytes.HexBytes
 			if !testCase.expectedNilPrevote {
-				prevoteHash = rs.ProposalBlock.Hash()
+				prevoteHash = blockID.Hash
 			}
 			ensurePrevoteMatch(t, voteCh, height, round, prevoteHash)
 		})
@@ -1508,20 +1507,20 @@ func TestExtendVoteCalledWhenEnabled(t *testing.T) {
 
 			startTestRound(cs1, cs1.Height, round)
 			ensureNewRound(newRoundCh, height, round)
-			ensureNewProposal(proposalCh, height, round)
+			proposalBlockID := ensureNewProposal(proposalCh, height, round)
 
 			m.AssertNotCalled(t, "ExtendVote", mock.Anything, mock.Anything)
 
-			rs := cs1.GetRoundState()
-
 			blockID := types.BlockID{
-				Hash:          rs.ProposalBlock.Hash(),
-				PartSetHeader: rs.ProposalBlockParts.Header(),
+				Hash:          proposalBlockID.Hash,
+				PartSetHeader: proposalBlockID.PartSetHeader,
 			}
 			signAddVotes(cs1, cmtproto.PrevoteType, blockID.Hash, blockID.PartSetHeader, false, vss[1:]...)
 			ensurePrevoteMatch(t, voteCh, height, round, blockID.Hash)
 
 			ensurePrecommit(voteCh, height, round)
+
+			rs := cs1.GetRoundState()
 
 			if testCase.enabled {
 				m.AssertCalled(t, "ExtendVote", context.TODO(), &abci.RequestExtendVote{
@@ -1590,17 +1589,18 @@ func TestVerifyVoteExtensionNotCalledOnAbsentPrecommit(t *testing.T) {
 
 	startTestRound(cs1, cs1.Height, round)
 	ensureNewRound(newRoundCh, height, round)
-	ensureNewProposal(proposalCh, height, round)
-	rs := cs1.GetRoundState()
+	proposalBlockID := ensureNewProposal(proposalCh, height, round)
 
 	blockID := types.BlockID{
-		Hash:          rs.ProposalBlock.Hash(),
-		PartSetHeader: rs.ProposalBlockParts.Header(),
+		Hash:          proposalBlockID.Hash,
+		PartSetHeader: proposalBlockID.PartSetHeader,
 	}
 	signAddVotes(cs1, cmtproto.PrevoteType, blockID.Hash, blockID.PartSetHeader, false, vss...)
 	ensurePrevoteMatch(t, voteCh, height, round, blockID.Hash)
 
 	ensurePrecommit(voteCh, height, round)
+
+	rs := cs1.GetRoundState()
 
 	m.AssertCalled(t, "ExtendVote", context.TODO(), &abci.RequestExtendVote{
 		Height:             height,
@@ -1675,12 +1675,10 @@ func TestPrepareProposalReceivesVoteExtensions(t *testing.T) {
 
 	startTestRound(cs1, height, round)
 	ensureNewRound(newRoundCh, height, round)
-	ensureNewProposal(proposalCh, height, round)
-
-	rs := cs1.GetRoundState()
+	proposalBlockID := ensureNewProposal(proposalCh, height, round)
 	blockID := types.BlockID{
-		Hash:          rs.ProposalBlock.Hash(),
-		PartSetHeader: rs.ProposalBlockParts.Header(),
+		Hash:          proposalBlockID.Hash,
+		PartSetHeader: proposalBlockID.PartSetHeader,
 	}
 	signAddVotes(cs1, cmtproto.PrevoteType, blockID.Hash, blockID.PartSetHeader, false, vss[1:]...)
 
@@ -1777,8 +1775,7 @@ func TestFinalizeBlockCalled(t *testing.T) {
 
 			startTestRound(cs1, cs1.Height, round)
 			ensureNewRound(newRoundCh, height, round)
-			ensureNewProposal(proposalCh, height, round)
-			rs := cs1.GetRoundState()
+			proposalBlockID := ensureNewProposal(proposalCh, height, round)
 
 			blockID := types.BlockID{}
 			nextRound := round + 1
@@ -1787,13 +1784,13 @@ func TestFinalizeBlockCalled(t *testing.T) {
 				nextRound = 0
 				nextHeight = height + 1
 				blockID = types.BlockID{
-					Hash:          rs.ProposalBlock.Hash(),
-					PartSetHeader: rs.ProposalBlockParts.Header(),
+					Hash:          proposalBlockID.Hash,
+					PartSetHeader: proposalBlockID.PartSetHeader,
 				}
 			}
 
 			signAddVotes(cs1, cmtproto.PrevoteType, blockID.Hash, blockID.PartSetHeader, false, vss[1:]...)
-			ensurePrevoteMatch(t, voteCh, height, round, rs.ProposalBlock.Hash())
+			ensurePrevoteMatch(t, voteCh, height, round, proposalBlockID.Hash)
 
 			signAddVotes(cs1, cmtproto.PrecommitType, blockID.Hash, blockID.PartSetHeader, true, vss[1:]...)
 			ensurePrecommit(voteCh, height, round)
@@ -1894,12 +1891,11 @@ func TestVoteExtensionEnableHeight(t *testing.T) {
 
 			startTestRound(cs1, cs1.Height, round)
 			ensureNewRound(newRoundCh, height, round)
-			ensureNewProposal(proposalCh, height, round)
-			rs := cs1.GetRoundState()
+			proposalBlockID := ensureNewProposal(proposalCh, height, round)
 
 			// sign all of the votes
-			signAddVotes(cs1, cmtproto.PrevoteType, rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header(), false, vss[1:]...)
-			ensurePrevoteMatch(t, voteCh, height, round, rs.ProposalBlock.Hash())
+			signAddVotes(cs1, cmtproto.PrevoteType, proposalBlockID.Hash, proposalBlockID.PartSetHeader, false, vss[1:]...)
+			ensurePrevoteMatch(t, voteCh, height, round, proposalBlockID.Hash)
 
 			var ext []byte
 			if testCase.hasExtension {
@@ -1907,7 +1903,7 @@ func TestVoteExtensionEnableHeight(t *testing.T) {
 			}
 
 			for _, vs := range vss[1:] {
-				vote, err := vs.signVote(cmtproto.PrecommitType, rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header(), ext, testCase.hasExtension)
+				vote, err := vs.signVote(cmtproto.PrecommitType, proposalBlockID.Hash, proposalBlockID.PartSetHeader, ext, testCase.hasExtension)
 				require.NoError(t, err)
 				addVotes(cs1, vote)
 			}
@@ -2194,10 +2190,9 @@ func TestStartNextHeightCorrectlyAfterTimeout(t *testing.T) {
 	startTestRound(cs1, height, round)
 	ensureNewRound(newRoundCh, height, round)
 
-	ensureNewProposal(proposalCh, height, round)
-	rs := cs1.GetRoundState()
-	theBlockHash := rs.ProposalBlock.Hash()
-	theBlockParts := rs.ProposalBlockParts.Header()
+	blockID := ensureNewProposal(proposalCh, height, round)
+	theBlockHash := blockID.Hash
+	theBlockParts := blockID.PartSetHeader
 
 	ensurePrevote(voteCh, height, round)
 	validatePrevote(t, cs1, round, vss[0], theBlockHash)
@@ -2225,7 +2220,7 @@ func TestStartNextHeightCorrectlyAfterTimeout(t *testing.T) {
 	cs1.txNotifier.(*fakeTxNotifier).Notify()
 
 	ensureNewTimeout(timeoutProposeCh, height+1, round, cs1.config.Propose(round).Nanoseconds())
-	rs = cs1.GetRoundState()
+	rs := cs1.GetRoundState()
 	assert.False(
 		t,
 		rs.TriggeredTimeoutPrecommit,
@@ -2256,10 +2251,9 @@ func TestResetTimeoutPrecommitUponNewHeight(t *testing.T) {
 	startTestRound(cs1, height, round)
 	ensureNewRound(newRoundCh, height, round)
 
-	ensureNewProposal(proposalCh, height, round)
-	rs := cs1.GetRoundState()
-	theBlockHash := rs.ProposalBlock.Hash()
-	theBlockParts := rs.ProposalBlockParts.Header()
+	blockID := ensureNewProposal(proposalCh, height, round)
+	theBlockHash := blockID.Hash
+	theBlockParts := blockID.PartSetHeader
 
 	ensurePrevote(voteCh, height, round)
 	validatePrevote(t, cs1, round, vss[0], theBlockHash)
@@ -2285,7 +2279,7 @@ func TestResetTimeoutPrecommitUponNewHeight(t *testing.T) {
 	}
 	ensureNewProposal(proposalCh, height+1, 0)
 
-	rs = cs1.GetRoundState()
+	rs := cs1.GetRoundState()
 	assert.False(
 		t,
 		rs.TriggeredTimeoutPrecommit,

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -84,10 +84,9 @@ func TestStateProposerSelection0(t *testing.T) {
 	}
 
 	// Wait for complete proposal.
-	ensureNewProposal(proposalCh, height, round)
+	blockID := ensureNewProposal(proposalCh, height, round)
 
-	rs := cs1.GetRoundState()
-	signAddVotes(cs1, cmtproto.PrecommitType, rs.ProposalBlock.Hash(), rs.ProposalBlockParts.Header(), true, vss[1:]...)
+	signAddVotes(cs1, cmtproto.PrecommitType, blockID.Hash, blockID.PartSetHeader, true, vss[1:]...)
 
 	// Wait for new round so next validator is set.
 	ensureNewRound(newRoundCh, height+1, 0)
@@ -475,10 +474,9 @@ func TestStateLockNoPOL(t *testing.T) {
 
 	ensureNewRound(newRoundCh, height, round)
 
-	ensureNewProposal(proposalCh, height, round)
-	roundState := cs1.GetRoundState()
-	theBlockHash := roundState.ProposalBlock.Hash()
-	thePartSetHeader := roundState.ProposalBlockParts.Header()
+	blockID := ensureNewProposal(proposalCh, height, round)
+	theBlockHash := blockID.Hash
+	thePartSetHeader := blockID.PartSetHeader
 
 	ensurePrevote(voteCh, height, round) // prevote
 
@@ -684,10 +682,9 @@ func TestStateLockPOLRelock(t *testing.T) {
 	startTestRound(cs1, height, round)
 
 	ensureNewRound(newRoundCh, height, round)
-	ensureNewProposal(proposalCh, height, round)
-	rs := cs1.GetRoundState()
-	theBlockHash := rs.ProposalBlock.Hash()
-	theBlockParts := rs.ProposalBlockParts.Header()
+	blockID := ensureNewProposal(proposalCh, height, round)
+	theBlockHash := blockID.Hash
+	theBlockParts := blockID.PartSetHeader
 
 	ensurePrevote(voteCh, height, round) // prevote
 
@@ -784,10 +781,9 @@ func TestStateLockPOLUnlock(t *testing.T) {
 	startTestRound(cs1, height, round)
 	ensureNewRound(newRoundCh, height, round)
 
-	ensureNewProposal(proposalCh, height, round)
-	rs := cs1.GetRoundState()
-	theBlockHash := rs.ProposalBlock.Hash()
-	theBlockParts := rs.ProposalBlockParts.Header()
+	blockID := ensureNewProposal(proposalCh, height, round)
+	theBlockHash := blockID.Hash
+	theBlockParts := blockID.PartSetHeader
 
 	ensurePrevote(voteCh, height, round)
 	validatePrevote(t, cs1, round, vss[0], theBlockHash)
@@ -809,7 +805,7 @@ func TestStateLockPOLUnlock(t *testing.T) {
 
 	// timeout to new round
 	ensureNewTimeout(timeoutWaitCh, height, round, cs1.config.Precommit(round).Nanoseconds())
-	rs = cs1.GetRoundState()
+	rs := cs1.GetRoundState()
 	lockedBlockHash := rs.LockedBlock.Hash()
 
 	incrementRound(vs2, vs3, vs4)
@@ -876,10 +872,9 @@ func TestStateLockPOLUnlockOnUnknownBlock(t *testing.T) {
 	startTestRound(cs1, height, round)
 
 	ensureNewRound(newRoundCh, height, round)
-	ensureNewProposal(proposalCh, height, round)
-	rs := cs1.GetRoundState()
-	firstBlockHash := rs.ProposalBlock.Hash()
-	firstBlockParts := rs.ProposalBlockParts.Header()
+	blockID := ensureNewProposal(proposalCh, height, round)
+	firstBlockHash := blockID.Hash
+	firstBlockParts := blockID.PartSetHeader
 
 	ensurePrevote(voteCh, height, round) // prevote
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -37,6 +37,7 @@ import (
 func TestNodeStartStop(t *testing.T) {
 	config := test.ResetTestRoot("node_node_test")
 	defer os.RemoveAll(config.RootDir)
+	config.RPC.GRPCListenAddress = ""
 
 	// create & start node
 	n, err := DefaultNewNode(config, log.TestingLogger())
@@ -99,6 +100,7 @@ func TestSplitAndTrimEmpty(t *testing.T) {
 func TestNodeDelayedStart(t *testing.T) {
 	config := test.ResetTestRoot("node_delayed_start_test")
 	defer os.RemoveAll(config.RootDir)
+	config.RPC.GRPCListenAddress = ""
 	now := cmttime.Now()
 
 	// create & start node
@@ -137,6 +139,7 @@ func TestNodeSetAppVersion(t *testing.T) {
 func TestPprofServer(t *testing.T) {
 	config := test.ResetTestRoot("node_pprof_test")
 	defer os.RemoveAll(config.RootDir)
+	config.RPC.GRPCListenAddress = ""
 	config.RPC.PprofListenAddress = testFreeAddr(t)
 
 	// should not work yet
@@ -420,6 +423,7 @@ func TestMaxProposalBlockSize(t *testing.T) {
 func TestNodeNewNodeCustomReactors(t *testing.T) {
 	config := test.ResetTestRoot("node_new_node_custom_reactors_test")
 	defer os.RemoveAll(config.RootDir)
+	config.RPC.GRPCListenAddress = ""
 
 	cr := p2pmock.NewReactor()
 	cr.Channels = []*conn.ChannelDescriptor{


### PR DESCRIPTION
The same deadlock pattern existed across multiple consensus tests in
`state_test.go`, `replay_test.go`, and `node_test.go`:

- The consensus goroutine holds `cs.mtx` while publishing a vote event
  and blocks until the test drains it.
- The test calls `cs.GetRoundState()` (which acquires `cs.mtx`) between
  receiving the proposal event and draining the vote channel.
- Both sides wait on each other until `go test -timeout` aborts the run.

**Fix:** make `ensureNewProposal` return the `types.BlockID` from the
`EventDataCompleteProposal` it already reads. All call sites that only
needed `ProposalBlock.Hash()` and `ProposalBlockParts.Header()` now use
`blockID.Hash` and `blockID.PartSetHeader` directly. For sites that need
the full `ProposalBlock` (e.g. `Time`, `Txs`) but only use it after
channel drains, `GetRoundState()` is deferred to after those drains.

**Files fixed:**
- `consensus/common_test.go`: `ensureNewProposal` now returns `types.BlockID`
- `consensus/state_test.go`: 13 call sites fixed across 11 tests
- `consensus/replay_test.go`: 6 call sites fixed in `setupChainWithChangingValidators`
- `node/node_test.go`: 4 tests fixed to not bind the hardcoded GRPC port 36658,
  preventing address-in-use failures when tests run in parallel

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `CHANGELOG.md`
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments