### PR TITLE
fix(blocksync): reject implausibly high peer heights to prevent DoS (#5801)

### DIFF
--- a/blocksync/pool.go
+++ b/blocksync/pool.go
@@ -382,6 +382,20 @@ func (pool *BlockPool) SetPeerRange(peerID p2p.ID, base int64, height int64) {
 		return
 	}
 
+	// Reject implausibly high heights to prevent a malicious peer from inflating
+	// maxPeerHeight via a single StatusResponse and stalling blocksync (#5801).
+	// 1M blocks (~69 days at 6s/block) is generous for legitimate syncing nodes.
+	const maxHeightDrift = 1_000_000
+	if height > pool.height+maxHeightDrift {
+		pool.Logger.Error("Peer reported implausibly high height; banning",
+			"peer", peerID, "reportedHeight", height, "poolHeight", pool.height)
+		if _, exists := pool.peers[peerID]; exists {
+			pool.removePeer(peerID)
+		}
+		pool.banPeer(peerID)
+		return
+	}
+
 	peer := pool.peers[peerID]
 	if peer != nil {
 		if base < peer.base || height < peer.height {
@@ -443,11 +457,7 @@ func (pool *BlockPool) removePeer(peerID p2p.ID) {
 			}
 		}
 
-		// Find a new peer with the biggest height and update maxPeerHeight if the
-		// peer's height was the biggest.
-		if peer.height == pool.maxPeerHeight {
-			pool.updateMaxPeerHeight()
-		}
+		pool.updateMaxPeerHeight()
 	}
 }
 

--- a/blocksync/pool_test.go
+++ b/blocksync/pool_test.go
@@ -390,6 +390,88 @@ func TestBlockPoolMaliciousNode(t *testing.T) {
 	}
 }
 
+func TestSetPeerRange_RejectsImplausiblyHighHeight(t *testing.T) {
+	requestsCh := make(chan BlockRequest, 10)
+	errorsCh := make(chan peerError, 10)
+
+	pool := NewBlockPool(100, requestsCh, errorsCh)
+	pool.SetLogger(log.TestingLogger())
+	err := pool.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { pool.Stop() })
+
+	// Height just at the limit should be accepted.
+	pool.SetPeerRange("legit", 1, 100+1_000_000)
+	assert.EqualValues(t, 100+1_000_000, pool.MaxPeerHeight())
+	assert.False(t, pool.IsPeerBanned("legit"))
+
+	// Height one over the limit should be rejected and peer banned.
+	pool.SetPeerRange("malicious", 1, 100+1_000_001)
+	assert.True(t, pool.IsPeerBanned("malicious"))
+	// maxPeerHeight must not be inflated by the rejected peer.
+	assert.EqualValues(t, 100+1_000_000, pool.MaxPeerHeight())
+
+	// Extreme height (math.MaxInt64) should be rejected.
+	pool.SetPeerRange("extreme", 1, math.MaxInt64)
+	assert.True(t, pool.IsPeerBanned("extreme"))
+	assert.EqualValues(t, 100+1_000_000, pool.MaxPeerHeight())
+}
+
+func TestRemovePeer_AlwaysRecalculatesMaxPeerHeight(t *testing.T) {
+	requestsCh := make(chan BlockRequest, 10)
+	errorsCh := make(chan peerError, 10)
+
+	pool := NewBlockPool(1, requestsCh, errorsCh)
+	pool.SetLogger(log.TestingLogger())
+	err := pool.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { pool.Stop() })
+
+	pool.SetPeerRange("A", 1, 100)
+	pool.SetPeerRange("B", 1, 200)
+	pool.SetPeerRange("C", 1, 300)
+	assert.EqualValues(t, 300, pool.MaxPeerHeight())
+
+	// Remove the max-height peer: maxPeerHeight must drop.
+	pool.RemovePeer("C")
+	assert.EqualValues(t, 200, pool.MaxPeerHeight())
+
+	// Remove a non-max peer: maxPeerHeight must remain correct.
+	pool.RemovePeer("A")
+	assert.EqualValues(t, 200, pool.MaxPeerHeight())
+
+	// Remove last peer: maxPeerHeight must be 0.
+	pool.RemovePeer("B")
+	assert.EqualValues(t, 0, pool.MaxPeerHeight())
+}
+
+func TestHeightInflationDoS_SingleStatusResponse(t *testing.T) {
+	requestsCh := make(chan BlockRequest, 10)
+	errorsCh := make(chan peerError, 10)
+
+	pool := NewBlockPool(100, requestsCh, errorsCh)
+	pool.SetLogger(log.TestingLogger())
+	err := pool.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { pool.Stop() })
+
+	// Legitimate peer at pool height (node is synced).
+	pool.SetPeerRange("good", 1, 100)
+
+	// Malicious peer tries to inflate height — should be rejected.
+	pool.SetPeerRange("attacker", 1, 999_999_999_999)
+	assert.True(t, pool.IsPeerBanned("attacker"))
+	assert.EqualValues(t, 100, pool.MaxPeerHeight(), "maxPeerHeight must not be inflated by rejected peer")
+
+	// Removing the attacker must not affect maxPeerHeight.
+	pool.RemovePeer("attacker")
+	assert.EqualValues(t, 100, pool.MaxPeerHeight())
+
+	// Pool should consider itself caught up — not stuck chasing an unreachable height.
+	time.Sleep(peerConnWait + 1*time.Second)
+	assert.True(t, pool.IsCaughtUp(), "pool must not be stuck after malicious peer is rejected")
+}
+
 func TestBlockPoolMaliciousNodeMaxInt64(t *testing.T) {
 	// Setup:
 	// * each peer has blocks 1..N but the malicious peer reports 1..max(int64) (blocks N+1... do not exist)


### PR DESCRIPTION
## Summary

Mitigates an unpatched bypass of CVE-2025-24371 where a malicious peer can inflate `maxPeerHeight` via a single `StatusResponse` with an extreme height value (e.g. `math.MaxInt64`), permanently stalling blocksync on syncing nodes.

The existing v0.38.17 fix handles the case where a peer *subsequently reports a lower height*, but does not prevent the initial acceptance of an absurd value via a single message. A peer sending `base=1, height=MaxInt64` passes all current checks, inflates `maxPeerHeight`, and causes `IsCaughtUp()` to return `false` indefinitely — a permanent DoS.

## Changes to `blocksync/pool.go`

- **Reject implausibly high heights in `SetPeerRange`**: peers reporting `height > pool.height + 1,000,000` (~69 days at 6s/block) are immediately banned and removed. This prevents the inflated height from ever entering the system.
- **Always recalculate `maxPeerHeight` on peer removal**: changed from conditional (`if peer.height == pool.maxPeerHeight`) to unconditional `updateMaxPeerHeight()` call for defense-in-depth.

## Test coverage

Three new tests:

- `TestSetPeerRange_RejectsImplausiblyHighHeight` — boundary testing (at-limit accepted, over-limit rejected, MaxInt64 rejected)
- `TestRemovePeer_AlwaysRecalculatesMaxPeerHeight` — recalculation on removing max peer, non-max peer, and last peer
- `TestHeightInflationDoS_SingleStatusResponse` — full #5801 attack scenario: attacker rejected, `maxPeerHeight` not inflated, pool not stuck

All existing blocksync tests pass with zero regressions.

Closes #5801

Credit to @ehdus829 for reporting the original issue.