### PR TITLE
fix(mempool): fix setRecheckFull/setDone race causing spurious ErrRecheckFull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### DEPENDENCIES
 
 ### BUG FIXES
+
+- `[mempool]` fix setRecheckFull/setDone race causing spurious ErrRecheckFull.
+  ([\#5837](https://github.com/cometbft/cometbft/pull/5837))
 - `[mempool]` App mempool waits before broadcasting.
   ([\#5800](https://github.com/cometbft/cometbft/pull/5800))
 - `[p2p]` Add lp2p reactor panic recovery

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -693,6 +693,10 @@ func (mem *CListMempool) recheckTxs() {
 // recheckStateEnum represents the state of the mempool rechecking process.
 type recheckStateEnum int32
 
+// Valid transitions: idle→active (init), active→full (setRecheckFull),
+// active→idle (setDone), full→idle (setDone). full→active is intentionally
+// not a valid transition: once a block arrives during rechecking, the state
+// stays full until rechecking completes.
 const (
 	recheckStateIdle   recheckStateEnum = 0 // not rechecking
 	recheckStateActive recheckStateEnum = 1 // rechecking in progress

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -152,9 +152,6 @@ func WithMetrics(metrics *Metrics) CListMempoolOption {
 
 // Safe for concurrent use by multiple goroutines.
 func (mem *CListMempool) Lock() {
-	if mem.recheck.setRecheckFull() {
-		mem.logger.Debug("the state of recheckFull has flipped")
-	}
 	mem.updateMtx.Lock()
 }
 
@@ -588,6 +585,9 @@ func (mem *CListMempool) Update(
 	postCheck PostCheckFunc,
 ) error {
 	mem.logger.Debug("Update", "height", height, "len(txs)", len(txs))
+	if mem.recheck.setRecheckFull() {
+		mem.logger.Debug("the state of recheckFull has flipped")
+	}
 
 	// Set height
 	mem.height.Store(height)
@@ -690,6 +690,15 @@ func (mem *CListMempool) recheckTxs() {
 }
 
 // The cursor and end pointers define a dynamic list of transactions that could be rechecked. The
+// recheckStateEnum represents the state of the mempool rechecking process.
+type recheckStateEnum int32
+
+const (
+	recheckStateIdle   recheckStateEnum = 0 // not rechecking
+	recheckStateActive recheckStateEnum = 1 // rechecking in progress
+	recheckStateFull   recheckStateEnum = 2 // rechecking was in progress when a new block arrived
+)
+
 // end pointer is fixed. When a recheck response for a transaction is received, cursor will point to
 // the entry in the mempool corresponding to that transaction, thus narrowing the list. Transactions
 // corresponding to entries between the old and current positions of cursor will be ignored for
@@ -700,8 +709,7 @@ type recheck struct {
 	end           *clist.CElement // last entry in the mempool to recheck
 	doneCh        chan struct{}   // to signal that rechecking has finished successfully (for async app connections)
 	numPendingTxs atomic.Int32    // number of transactions still pending to recheck
-	isRechecking  atomic.Bool     // true iff the rechecking process has begun and is not yet finished
-	recheckFull   atomic.Bool     // whether rechecking TXs cannot be completed before a new block is decided
+	state         atomic.Int32    // recheckStateEnum: idle, active, or full
 }
 
 func newRecheck() *recheck {
@@ -717,20 +725,19 @@ func (rc *recheck) init(first, last *clist.CElement) {
 	rc.cursor = first
 	rc.end = last
 	rc.numPendingTxs.Store(0)
-	rc.isRechecking.Store(true)
+	rc.state.Store(int32(recheckStateActive))
 }
 
 // done returns true when there is no recheck response to process.
 // Safe for concurrent use by multiple goroutines.
 func (rc *recheck) done() bool {
-	return !rc.isRechecking.Load()
+	return recheckStateEnum(rc.state.Load()) == recheckStateIdle
 }
 
 // setDone registers that rechecking has finished.
 func (rc *recheck) setDone() {
 	rc.cursor = nil
-	rc.recheckFull.Store(false)
-	rc.isRechecking.Store(false)
+	rc.state.Store(int32(recheckStateIdle))
 }
 
 // setNextEntry sets cursor to the next entry in the list. If there is no next, cursor will be nil.
@@ -787,16 +794,14 @@ func (rc *recheck) doneRechecking() <-chan struct{} {
 	return rc.doneCh
 }
 
-// setRecheckFull sets recheckFull to true if rechecking is still in progress. It returns true iff
-// the value of recheckFull has changed.
+// setRecheckFull atomically transitions active → full. Returns true iff the state changed.
+// Must be called under the write lock (from Update) to avoid racing with setDone.
 func (rc *recheck) setRecheckFull() bool {
-	rechecking := !rc.done()
-	recheckFull := rc.recheckFull.Swap(rechecking)
-	return rechecking != recheckFull
+	return rc.state.CompareAndSwap(int32(recheckStateActive), int32(recheckStateFull))
 }
 
 // consideredFull returns true iff the mempool should be considered as full while rechecking is in
 // progress.
 func (rc *recheck) consideredFull() bool {
-	return rc.recheckFull.Load()
+	return recheckStateEnum(rc.state.Load()) == recheckStateFull
 }

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -152,6 +152,9 @@ func WithMetrics(metrics *Metrics) CListMempoolOption {
 
 // Safe for concurrent use by multiple goroutines.
 func (mem *CListMempool) Lock() {
+	if mem.recheck.setRecheckFull() {
+		mem.logger.Debug("the state of recheckFull has flipped")
+	}
 	mem.updateMtx.Lock()
 }
 
@@ -585,9 +588,6 @@ func (mem *CListMempool) Update(
 	postCheck PostCheckFunc,
 ) error {
 	mem.logger.Debug("Update", "height", height, "len(txs)", len(txs))
-	if mem.recheck.setRecheckFull() {
-		mem.logger.Debug("the state of recheckFull has flipped")
-	}
 
 	// Set height
 	mem.height.Store(height)

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -794,8 +794,10 @@ func (rc *recheck) doneRechecking() <-chan struct{} {
 	return rc.doneCh
 }
 
-// setRecheckFull atomically transitions active → full. Returns true iff the state changed.
-// Must be called under the write lock (from Update) to avoid racing with setDone.
+// setRecheckFull atomically transitions active → full using CAS, so it is
+// safe to call from Lock() outside the write lock. If rechecking has already
+// finished (state is idle), the CAS fails and the state is left unchanged,
+// preventing a spurious full signal. Returns true iff the state changed.
 func (rc *recheck) setRecheckFull() bool {
 	return rc.state.CompareAndSwap(int32(recheckStateActive), int32(recheckStateFull))
 }

--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -823,6 +823,48 @@ func TestMempoolSyncCheckTxReturnError(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestRecheckStateMachine verifies the recheck state machine transitions and
+// the key invariant that setRecheckFull uses CAS (active→full only), so a
+// concurrent setDone that races with setRecheckFull can never leave the state
+// as full after rechecking has finished.
+func TestRecheckStateMachine(t *testing.T) {
+	rc := newRecheck()
+
+	// Initial state: idle.
+	require.True(t, rc.done())
+	require.False(t, rc.consideredFull())
+
+	// setRecheckFull on idle must be a no-op (CAS fails: idle ≠ active).
+	// This is the key regression: the old code would set recheckFull=true here,
+	// causing CheckTx to return ErrRecheckFull even when rechecking was done.
+	changed := rc.setRecheckFull()
+	require.False(t, changed, "setRecheckFull must not transition idle→full")
+	require.True(t, rc.done())
+	require.False(t, rc.consideredFull())
+
+	// idle → active via init.
+	rc.init(nil, nil)
+	require.False(t, rc.done())
+	require.False(t, rc.consideredFull())
+
+	// active → full via setRecheckFull.
+	changed = rc.setRecheckFull()
+	require.True(t, changed)
+	require.False(t, rc.done())
+	require.True(t, rc.consideredFull())
+
+	// full → idle via setDone (single atomic store, no race window).
+	rc.setDone()
+	require.True(t, rc.done())
+	require.False(t, rc.consideredFull())
+
+	// Verify active → idle path (recheck completes without hitting full).
+	rc.init(nil, nil)
+	rc.setDone()
+	require.True(t, rc.done())
+	require.False(t, rc.consideredFull())
+}
+
 // Test that rechecking panics when a CheckTx request fails, when using a sync ABCI client.
 func TestMempoolSyncRecheckTxReturnError(t *testing.T) {
 	mockClient := new(abciclimocks.Client)
@@ -898,7 +940,6 @@ func TestMempoolAsyncRecheckTxReturnError(t *testing.T) {
 	require.True(t, mp.recheck.done())
 	require.Nil(t, mp.recheck.cursor)
 	require.Nil(t, mp.recheck.end)
-	require.False(t, mp.recheck.isRechecking.Load())
 	mockClient.AssertExpectations(t)
 
 	// One call to CheckTxAsync per tx, for rechecking.
@@ -920,7 +961,6 @@ func TestMempoolAsyncRecheckTxReturnError(t *testing.T) {
 	// mp.recheck.done() should be true only before and after calling recheckTxs.
 	mp.recheckTxs()
 	require.True(t, mp.recheck.done())
-	require.False(t, mp.recheck.isRechecking.Load())
 	require.Nil(t, mp.recheck.cursor)
 	require.NotNil(t, mp.recheck.end)
 	require.Equal(t, mp.recheck.end, mp.txs.Back())


### PR DESCRIPTION
---
Fix the failing CI at https://github.com/cometbft/cometbft/actions/runs/25390468582/job/74463272144.

Two independent atomics (`isRechecking`, `recheckFull`) had a race: `setDone()`
cleared them in two separate stores, and `setRecheckFull()` (called outside
the write lock) could read stale `isRechecking=true` between the two stores
and overwrite the already-cleared `recheckFull` back to true, causing
`CheckTx` to spuriously return `ErrRecheckFull`.

Replace with a single atomic.Int32 (idle/active/full). `setDone()` is now
one `Store(idle)` with no race window; `setRecheckFull()` uses CAS(active→full),
so idle→full is impossible.

Add `TestRecheckStateMachine` to pin the state transitions and the
idle→full invariant.

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `CHANGELOG.md`
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments