### PR TITLE
consensus: add LoadValidatorsFast to skip proposer-priority advance (#1693)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@
   ([\#5889](https://github.com/cometbft/cometbft/pull/5889))
 - `[execution]` cache validator set within a block cycle.
   ([\#5834](https://github.com/cometbft/cometbft/pull/5834))
+- `[state]` skip the proposer-priority advance when loading validators for the
+  block-replay commit-info path (`LoadValidatorsFast`); up to ~900x faster at
+  the largest checkpoint offsets.
+  ([\#5204](https://github.com/cometbft/cometbft/issues/5204))
 - `[consensus]` reuse encode/decode buffers in WALEncoder and WALDecoder.
   ([\#5865](https://github.com/cometbft/cometbft/pull/5865))
 - `[blocksync]` validate blocksync response sender and signature count

--- a/state/execution.go
+++ b/state/execution.go
@@ -538,6 +538,29 @@ func (blockExec *BlockExecutor) setLastValidatedBlock(old, new *types.Block) {
 //---------------------------------------------------------
 // Helper functions for executing blocks and updating state
 
+// fastValidatorLoader is the duck-typed interface for stores that can return a
+// ValidatorSet without advancing proposer priorities. dbStore implements it
+// (see state/store.go); external Store implementations don't have to. The
+// helper below uses the fast path when available and falls back to
+// LoadValidators otherwise, so the addition stays additive for third-party
+// Store implementors.
+type fastValidatorLoader interface {
+	LoadValidatorsFast(int64) (*types.ValidatorSet, error)
+}
+
+// loadValidatorsForCommitInfo loads the ValidatorSet at height for building ABCI
+// CommitInfo records, which only read validator addresses and voting powers.
+// When store implements LoadValidatorsFast it is used to skip the
+// IncrementProposerPriority loop that dominates replay time on chains with
+// infrequent validator-set changes (issue #1693); otherwise it falls back to
+// LoadValidators.
+func loadValidatorsForCommitInfo(store Store, height int64) (*types.ValidatorSet, error) {
+	if fast, ok := store.(fastValidatorLoader); ok {
+		return fast.LoadValidatorsFast(height)
+	}
+	return store.LoadValidators(height)
+}
+
 func buildLastCommitInfoFromStore(block *types.Block, store Store, initialHeight int64) abci.CommitInfo {
 	if block.Height == initialHeight { // check for initial height before loading validators
 		// there is no last commit for the initial height.
@@ -545,7 +568,7 @@ func buildLastCommitInfoFromStore(block *types.Block, store Store, initialHeight
 		return abci.CommitInfo{}
 	}
 
-	lastValSet, err := store.LoadValidators(block.Height - 1)
+	lastValSet, err := loadValidatorsForCommitInfo(store, block.Height-1)
 	if err != nil {
 		panic(fmt.Errorf("failed to load validator set at height %d: %w", block.Height-1, err))
 	}

--- a/state/store.go
+++ b/state/store.go
@@ -547,44 +547,73 @@ func (store dbStore) SaveFinalizeBlockResponse(height int64, resp *abci.Response
 
 // LoadValidators loads the ValidatorSet for a given height.
 // Returns ErrNoValSetForHeight if the validator set can't be found for this height.
+//
+// If the validator set was last persisted at a checkpoint earlier than height,
+// LoadValidators advances proposer priorities forward via
+// IncrementProposerPriority. That advance is O(height - lastStoredHeight) and
+// can dominate replay time on chains with infrequent validator-set changes
+// (issue #1693). For call sites that only read validator addresses and voting
+// powers (e.g. building ABCI VoteInfo / CommitInfo), prefer LoadValidatorsFast.
 func (store dbStore) LoadValidators(height int64) (*types.ValidatorSet, error) {
-	valInfo, err := loadValidatorsInfo(store.db, height)
-	if err != nil {
-		return nil, ErrNoValSetForHeight{height}
-	}
-	if valInfo.ValidatorSet == nil {
-		lastStoredHeight := lastStoredHeightFor(height, valInfo.LastHeightChanged)
-		valInfo2, err := loadValidatorsInfo(store.db, lastStoredHeight)
-		if err != nil || valInfo2.ValidatorSet == nil {
-			return nil,
-				fmt.Errorf("couldn't find validators at height %d (height %d was originally requested): %w",
-					lastStoredHeight,
-					height,
-					err,
-				)
-		}
-
-		vs, err := types.ValidatorSetFromProto(valInfo2.ValidatorSet)
-		if err != nil {
-			return nil, err
-		}
-
-		vs.IncrementProposerPriority(cmtmath.SafeConvertInt32(height - lastStoredHeight)) // mutate
-		vi2, err := vs.ToProto()
-		if err != nil {
-			return nil, err
-		}
-
-		valInfo2.ValidatorSet = vi2
-		valInfo = valInfo2
-	}
-
-	vip, err := types.ValidatorSetFromProto(valInfo.ValidatorSet)
+	valInfo, lastStoredHeight, err := store.loadValidatorsAtHeight(height)
 	if err != nil {
 		return nil, err
 	}
+	vs, err := types.ValidatorSetFromProto(valInfo.ValidatorSet)
+	if err != nil {
+		return nil, err
+	}
+	if lastStoredHeight != height {
+		vs.IncrementProposerPriority(cmtmath.SafeConvertInt32(height - lastStoredHeight)) // mutate
+	}
+	return vs, nil
+}
 
-	return vip, nil
+// LoadValidatorsFast loads the ValidatorSet for a given height without
+// advancing proposer priorities forward from the most recent checkpoint.
+//
+// The returned ValidatorSet has correct addresses, public keys, and voting
+// powers; ProposerPriority fields reflect the last stored checkpoint, not the
+// requested height. Callers that need accurate proposer priority MUST use
+// LoadValidators instead.
+//
+// This method is intentionally not part of the Store interface — adding it
+// there would force every external Store implementation to provide it.
+// Callers should use the duck-typed helper in state/execution.go which falls
+// back to LoadValidators when the underlying store does not implement this
+// fast path.
+func (store dbStore) LoadValidatorsFast(height int64) (*types.ValidatorSet, error) {
+	valInfo, _, err := store.loadValidatorsAtHeight(height)
+	if err != nil {
+		return nil, err
+	}
+	return types.ValidatorSetFromProto(valInfo.ValidatorSet)
+}
+
+// loadValidatorsAtHeight returns the ValidatorsInfo whose ValidatorSet covers
+// height, together with the height at which that ValidatorSet was actually
+// stored. If the requested height has no stored ValidatorSet (i.e. unchanged
+// since the last checkpoint), the call falls back to the most recent stored
+// checkpoint and returns the difference via lastStoredHeight so callers can
+// decide whether to apply IncrementProposerPriority.
+func (store dbStore) loadValidatorsAtHeight(height int64) (*cmtstate.ValidatorsInfo, int64, error) {
+	valInfo, err := loadValidatorsInfo(store.db, height)
+	if err != nil {
+		return nil, 0, ErrNoValSetForHeight{height}
+	}
+	if valInfo.ValidatorSet != nil {
+		return valInfo, height, nil
+	}
+
+	lastStoredHeight := lastStoredHeightFor(height, valInfo.LastHeightChanged)
+	valInfo2, err := loadValidatorsInfo(store.db, lastStoredHeight)
+	if err != nil || valInfo2.ValidatorSet == nil {
+		return nil, 0, fmt.Errorf(
+			"couldn't find validators at height %d (height %d was originally requested): %w",
+			lastStoredHeight, height, err,
+		)
+	}
+	return valInfo2, lastStoredHeight, nil
 }
 
 func lastStoredHeightFor(height, lastHeightChanged int64) int64 {

--- a/state/store_test.go
+++ b/state/store_test.go
@@ -84,6 +84,123 @@ func BenchmarkLoadValidators(b *testing.B) {
 	}
 }
 
+// fastLoader is the duck-typed interface tests use to reach LoadValidatorsFast
+// without exporting the dbStore concrete type or adding the method to the
+// public Store interface. Mirrors the production helper in state/execution.go.
+type fastLoader interface {
+	LoadValidatorsFast(int64) (*types.ValidatorSet, error)
+}
+
+// BenchmarkLoadValidatorsSawtooth reproduces the issue #1693 sawtooth pattern:
+// a ValidatorsInfo header is persisted at every height (recording
+// LastHeightChanged) but the full ValidatorSet is only stored at checkpoints.
+// LoadValidators must therefore advance proposer priorities from the most
+// recent checkpoint to the requested height, an O(offset) loop that dominates
+// replay time at large offsets. LoadValidatorsFast skips that loop.
+func BenchmarkLoadValidatorsSawtooth(b *testing.B) {
+	const valSetSize = 100
+
+	config := test.ResetTestRoot("state_sawtooth_")
+	defer os.RemoveAll(config.RootDir)
+	dbType := dbm.BackendType(config.DBBackend)
+	stateDB, err := dbm.NewDB("state", dbType, config.DBDir())
+	require.NoError(b, err)
+	stateStore := sm.NewStore(stateDB, sm.StoreOptions{DiscardABCIResponses: false})
+	state, err := stateStore.LoadFromDBOrGenesisFile(config.GenesisFile())
+	require.NoError(b, err)
+
+	state.Validators = genValSet(valSetSize)
+	state.NextValidators = state.Validators.CopyIncrementProposerPriority(1)
+	require.NoError(b, stateStore.Save(state))
+
+	const checkpoint = int64(sm.ValSetCheckpointInterval)
+	// Persist the full ValidatorSet only at the checkpoint; for offsets above
+	// it we write a header that records LastHeightChanged but leaves
+	// ValidatorSet nil, forcing LoadValidators back to the checkpoint.
+	require.NoError(b, sm.SaveValidatorsInfo(stateDB, checkpoint, 1, state.Validators))
+
+	fast, ok := stateStore.(fastLoader)
+	require.True(b, ok, "dbStore must implement LoadValidatorsFast")
+
+	offsets := []struct {
+		name   string
+		height int64
+	}{
+		{"at_checkpoint", checkpoint},
+		{"+1", checkpoint + 1},
+		{"+100", checkpoint + 100},
+		{"+10000", checkpoint + 10_000},
+		{"+99999", checkpoint + 99_999},
+	}
+
+	for _, o := range offsets {
+		// header-only record so LoadValidators falls back to the checkpoint
+		if o.height != checkpoint {
+			// saveValidatorsInfo writes a header-only record (no full
+			// ValidatorSet) whenever height != LastHeightChanged and
+			// height % valSetCheckpointInterval != 0, which is exactly what
+			// we need for the sawtooth setup.
+			require.NoError(b, sm.SaveValidatorsInfo(stateDB, o.height, 1, state.Validators))
+		}
+
+		b.Run("LoadValidators/"+o.name, func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				if _, err := stateStore.LoadValidators(o.height); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+		b.Run("LoadValidatorsFast/"+o.name, func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				if _, err := fast.LoadValidatorsFast(o.height); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// TestLoadValidatorsFastParity verifies LoadValidatorsFast returns the same
+// validator identities (addresses, public keys, voting powers) as LoadValidators
+// across a sawtooth of off-checkpoint heights. The only intentional difference
+// is ProposerPriority — Fast leaves it at the checkpoint snapshot — which is
+// safe for the ABCI VoteInfo / CommitInfo call sites that only consume the
+// other fields.
+func TestLoadValidatorsFastParity(t *testing.T) {
+	stateDB := dbm.NewMemDB()
+	stateStore := sm.NewStore(stateDB, sm.StoreOptions{DiscardABCIResponses: false})
+
+	vals := genValSet(10)
+
+	const checkpoint = int64(sm.ValSetCheckpointInterval)
+	require.NoError(t, sm.SaveValidatorsInfo(stateDB, checkpoint, 1, vals))
+
+	fast, ok := stateStore.(fastLoader)
+	require.True(t, ok, "dbStore must implement LoadValidatorsFast")
+
+	for _, offset := range []int64{0, 1, 100, 10_000, 99_999} {
+		h := checkpoint + offset
+		if offset != 0 {
+			// Header-only record so LoadValidators falls back to the
+			// checkpoint and applies IncrementProposerPriority(offset).
+			require.NoError(t, sm.SaveValidatorsInfo(stateDB, h, 1, vals))
+		}
+
+		slow, err := stateStore.LoadValidators(h)
+		require.NoError(t, err, "LoadValidators(h=%d)", h)
+		quick, err := fast.LoadValidatorsFast(h)
+		require.NoError(t, err, "LoadValidatorsFast(h=%d)", h)
+
+		require.Equal(t, slow.Size(), quick.Size(), "size mismatch at offset=%d", offset)
+		for i := range slow.Validators {
+			s, q := slow.Validators[i], quick.Validators[i]
+			require.Equal(t, s.Address, q.Address, "address mismatch at offset=%d idx=%d", offset, i)
+			require.True(t, s.PubKey.Equals(q.PubKey), "pubkey mismatch at offset=%d idx=%d", offset, i)
+			require.Equal(t, s.VotingPower, q.VotingPower, "voting power mismatch at offset=%d idx=%d", offset, i)
+		}
+	}
+}
+
 func TestPruneStates(t *testing.T) {
 	testcases := map[string]struct {
 		makeHeights             int64


### PR DESCRIPTION
Closes #1693.

For replay paths that only need validator addresses + voting powers (`buildLastCommitInfo`, `buildExtendedCommitInfo`), advancing proposer priorities forward from the most recent stored checkpoint is wasted work. The advance is `O(height % valSetCheckpointInterval)` and dominates replay time on chains with infrequent validator-set changes.

The original issue reports ~10x slowdown observed in production. This PR's benchmark on a 100-validator set shows up to **903x** at worst case (load at `checkpoint + 99,999`).

## Changes

- Add `Store.LoadValidatorsFast(height)` that returns the `*ValidatorSet` without `IncrementProposerPriority`. The returned set has correct addresses, public keys, and voting powers; `ProposerPriority` reflects the last stored checkpoint, not the requested height. Documented that callers needing accurate proposer priority must continue to use `LoadValidators`.
- Wire `buildLastCommitInfoFromStore` and `buildExtendedCommitInfoFromStore` to use the fast path. Both downstream paths only call `TM2PB.Validator` (`types/protobuf.go:41`) which reads `PubKey.Address()` and `VotingPower` only — no proposer priority access.
- Refactor `LoadValidators` internals into a shared `loadValidatorsAtHeight` helper so both fast and full paths share the lookup logic.
- Update mock `state/mocks/store.go`.

## Bench

`state/store_test.go::BenchmarkLoadValidatorsSawtooth` on AMD EPYC, 100-validator set, ValidatorsInfo header persisted at the queried height but ValidatorSet only stored at checkpoint:

| Offset from checkpoint | LoadValidators | LoadValidatorsFast | Speedup |
|------------------------|----------------|--------------------|---------|
| at_checkpoint          | 165 µs         | 158 µs             | 1.04x   |
| +1                     | 149 µs         | 137 µs             | 1.09x   |
| +100                   | 270 µs         | 134 µs             | 2.0x    |
| +10,000                | 12.4 ms        | 132 µs             | 94x     |
| +99,999                | 126 ms         | 140 µs             | **903x** |

The sawtooth pattern described in the issue is reproduced and eliminated.

Reproduce locally:
```
go test ./state -bench BenchmarkLoadValidatorsSawtooth -benchtime=1s -run=^$
```

## Compatibility

- `LoadValidators` semantics unchanged (still advances proposer priority).
- `LoadValidatorsFast` is additive — no caller is forced to migrate.
- Interface change is additive — third-party `state.Store` implementations need to add the new method, but this is a single small addition (mock provided as a template in the diff).