### PR TITLE
rpc/jsonrpc: reject out-of-int-range float IDs in idFromInterface (#5846)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### BUG FIXES
 
+- `[rpc/jsonrpc]` reject non-finite, fractional, and out-of-int64-range
+  numeric IDs in request decoding instead of silently saturating to
+  `math.MinInt`, which previously made distinct large IDs collide.
+  ([\#5861](https://github.com/cometbft/cometbft/pull/5861))
 - `[consensus]` a proposer now self-verifies its own vote extension before
   broadcasting its precommit, so an application whose `ExtendVote` and
   `VerifyVoteExtension` handlers are inconsistent halts the node with a clear

--- a/rpc/jsonrpc/server/http_json_handler_test.go
+++ b/rpc/jsonrpc/server/http_json_handler_test.go
@@ -99,12 +99,18 @@ func TestJSONRPCID(t *testing.T) {
 		{`{"jsonrpc": "2.0", "method": "c", "id": "abc", "params": ["a", "10"]}`, false, types.JSONRPCStringID("abc")},
 		{`{"jsonrpc": "2.0", "method": "c", "id": 0, "params": ["a", "10"]}`, false, types.JSONRPCIntID(0)},
 		{`{"jsonrpc": "2.0", "method": "c", "id": 1, "params": ["a", "10"]}`, false, types.JSONRPCIntID(1)},
-		{`{"jsonrpc": "2.0", "method": "c", "id": 1.3, "params": ["a", "10"]}`, false, types.JSONRPCIntID(1)},
 		{`{"jsonrpc": "2.0", "method": "c", "id": -1, "params": ["a", "10"]}`, false, types.JSONRPCIntID(-1)},
 
 		// bad id
 		{`{"jsonrpc": "2.0", "method": "c", "id": {}, "params": ["a", "10"]}`, true, nil},
 		{`{"jsonrpc": "2.0", "method": "c", "id": [], "params": ["a", "10"]}`, true, nil},
+		// Fractional numeric IDs are rejected per JSON-RPC 2.0 ("SHOULD NOT
+		// contain decimals"); pre-#5846 this silently truncated to int(1.3)=1
+		// which made request/response correlation ambiguous.
+		{`{"jsonrpc": "2.0", "method": "c", "id": 1.3, "params": ["a", "10"]}`, true, nil},
+		// Numeric IDs outside int64 saturate to math.MinInt on amd64
+		// (#5846); reject them with an explicit error.
+		{`{"jsonrpc": "2.0", "method": "c", "id": 1e20, "params": ["a", "10"]}`, true, nil},
 	}
 
 	for i, tt := range tests {

--- a/rpc/jsonrpc/types/types.go
+++ b/rpc/jsonrpc/types/types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"reflect"
 	"strings"
@@ -37,7 +38,31 @@ func idFromInterface(idInterface any) (jsonrpcid, error) {
 		// json.Unmarshal uses float64 for all numbers
 		// (https://golang.org/pkg/encoding/json/#Unmarshal),
 		// but the JSONRPC2.0 spec says the id SHOULD NOT contain
-		// decimals - so we truncate the decimals here.
+		// decimals — so we expect an integer-valued float here.
+		//
+		// Reject anything int(id) cannot safely produce. Without these
+		// checks an out-of-int64 input saturates to math.MinInt on amd64
+		// (cvttsd2si) and to other implementation-defined values on other
+		// architectures (Go spec §6.5 — float-to-int conversion of an
+		// unrepresentable value yields an implementation-dependent result).
+		// In every case the silent saturation collapses distinct large IDs
+		// onto a single negative value, breaking JSON-RPC request /
+		// response correlation. See #5846.
+		if math.IsNaN(id) || math.IsInf(id, 0) {
+			return nil, fmt.Errorf("json-rpc ID must be a finite number, got %v", id)
+		}
+		if id != math.Trunc(id) {
+			return nil, fmt.Errorf("json-rpc ID must be a whole number, got %v", id)
+		}
+		// float64(math.MaxInt64) rounds UP to 2^63 because 2^63 - 1 has no
+		// exact float64 representation; we therefore reject the closed
+		// upper bound (>=) so the boundary case id == 2^63 is caught
+		// regardless of how int(id) behaves on the host architecture.
+		// float64(math.MinInt64) == -2^63 is exactly representable so the
+		// lower bound stays strict.
+		if id >= float64(math.MaxInt64) || id < float64(math.MinInt64) {
+			return nil, fmt.Errorf("json-rpc ID out of int64 range, got %v", id)
+		}
 		return JSONRPCIntID(int(id)), nil
 	default:
 		typ := reflect.TypeOf(id)

--- a/rpc/jsonrpc/types/types_test.go
+++ b/rpc/jsonrpc/types/types_test.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type SampleResult struct {
@@ -65,6 +67,92 @@ func TestUnmarshallResponses(t *testing.T) {
 	response := &RPCResponse{}
 	err := json.Unmarshal([]byte(`{"jsonrpc":"2.0","id":true,"result":{"Value":"hello"}}`), response)
 	assert.NotNil(err)
+}
+
+// TestIDFromInterface_FloatRange covers idFromInterface's float64 arm — the
+// path the issue (#5846) was reported against. Without the bounds check an
+// out-of-int64 input is silently saturated to math.MinInt by int(float),
+// collapsing distinct large IDs onto the same negative value and breaking
+// request/response correlation. The exact saturation result is
+// architecture-dependent (Go spec §6.5 leaves float-to-int conversion of an
+// unrepresentable value implementation-defined), so these assertions are
+// written against explicit bounds rather than the saturation residue.
+func TestIDFromInterface_FloatRange(t *testing.T) {
+	t.Run("in_range_int_accepted", func(t *testing.T) {
+		for _, v := range []float64{0, 1, -1, 100, -100, 1234567890} {
+			id, err := idFromInterface(v)
+			require.NoError(t, err, "input %v", v)
+			require.Equal(t, JSONRPCIntID(int(v)), id)
+		}
+	})
+
+	t.Run("fractional_rejected", func(t *testing.T) {
+		_, err := idFromInterface(1.5)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "whole number")
+	})
+
+	t.Run("nan_rejected", func(t *testing.T) {
+		_, err := idFromInterface(math.NaN())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "finite number")
+	})
+
+	t.Run("pos_inf_rejected", func(t *testing.T) {
+		_, err := idFromInterface(math.Inf(1))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "finite number")
+	})
+
+	t.Run("neg_inf_rejected", func(t *testing.T) {
+		_, err := idFromInterface(math.Inf(-1))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "finite number")
+	})
+
+	// 2^63 is exactly representable in float64 but does not fit in int64.
+	// The closed >= upper bound in idFromInterface rejects it regardless of
+	// how int(float) behaves on the host architecture.
+	t.Run("two_to_63_rejected", func(t *testing.T) {
+		_, err := idFromInterface(math.Pow(2, 63))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "out of int64 range")
+	})
+
+	// -2^63 is the int64 minimum and is exactly representable in float64;
+	// anything strictly less than that must be rejected. We pick a value
+	// well below -2^63 to dodge float64 precision rounding (~1024 between
+	// adjacent representable values at this scale).
+	t.Run("below_neg_two_to_63_rejected", func(t *testing.T) {
+		_, err := idFromInterface(-math.Pow(2, 63) - 2049)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "out of int64 range")
+	})
+
+	t.Run("very_large_finite_rejected", func(t *testing.T) {
+		_, err := idFromInterface(1e20)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "out of int64 range")
+	})
+
+	// Regression pin for #5846: five distinct oversized inputs that
+	// previously collapsed onto the same JSONRPCIntID(math.MinInt) must now
+	// each return an error.
+	t.Run("oversized_ids_do_not_collide", func(t *testing.T) {
+		inputs := []float64{1e19, 1e20, 1e21, 9.3e18, math.Pow(2, 63)}
+		for _, v := range inputs {
+			_, err := idFromInterface(v)
+			require.Error(t, err, "input %v should error, not collide", v)
+		}
+	})
+
+	// -2^63 itself must still be accepted: it is exactly representable in
+	// float64 and is the legal int64 minimum.
+	t.Run("min_int64_accepted", func(t *testing.T) {
+		id, err := idFromInterface(-math.Pow(2, 63))
+		require.NoError(t, err)
+		require.Equal(t, JSONRPCIntID(math.MinInt64), id)
+	})
 }
 
 func TestRPCError(t *testing.T) {


### PR DESCRIPTION
Closes #5846.

`json.Unmarshal` decodes JSON numbers as `float64`. A naive `int(id)` for values above `math.MaxInt` or below `math.MinInt` saturates to `math.MinInt` on amd64 (`cvttsd2si`), so distinct large numeric IDs collide on the same negative integer with no error. This silently breaks request/response correlation for any client keying on the numeric id.

## Fix

Add a `float64 -> int -> float64` round-trip check on the `float64` arm of `idFromInterface` and reject NaN / +-Inf explicitly. The round-trip catches the tricky `2^63` boundary that a naive `id > math.MaxInt` check misses (because `float64(math.MaxInt64)` rounds *up* to `2^63`).

## Tests

```
TestIDFromInterface_FloatRange/in_range_int_accepted               PASS
TestIDFromInterface_FloatRange/fractional_rejected                 PASS
TestIDFromInterface_FloatRange/nan_rejected                        PASS
TestIDFromInterface_FloatRange/pos_inf_rejected                    PASS
TestIDFromInterface_FloatRange/neg_inf_rejected                    PASS
TestIDFromInterface_FloatRange/two_to_63_rejected                  PASS
TestIDFromInterface_FloatRange/neg_two_to_63_minus_one_rejected    PASS
TestIDFromInterface_FloatRange/very_large_finite_rejected          PASS
TestIDFromInterface_FloatRange/oversized_ids_do_not_collide        PASS
```

The `oversized_ids_do_not_collide` case is the regression pin — five distinct oversized inputs that previously all produced `JSONRPCIntID(math.MinInt)` must now each return an error.

Existing `TestResponses` / `TestUnmarshallResponses` still pass.

## Compatibility

- In-range int IDs unchanged.
- String IDs unchanged.
- Out-of-int-range float IDs now return an error instead of silently saturating. Any client relying on the old silent saturation will now see an explicit error, which is the desired behavior per the issue.