### PR TITLE
fix(node): use kernel-assigned ephemeral ports and fix OnStart cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
   ([\#5837](https://github.com/cometbft/cometbft/pull/5837))
 - `[abci]` fix deadlock when response callback re-enters the client.
   ([\#5850](https://github.com/cometbft/cometbft/pull/5850))
+- `[node]` fix(node): use kernel-assigned ephemeral ports and fix OnStart cleanup
+  ([\#5868](https://github.com/cometbft/cometbft/pull/5868))
 - `[node]` close partial listeners on startRPC failure
   ([\#5869](https://github.com/cometbft/cometbft/pull/5869))
 - `[consensus]` release cs.mtx before sending to statsMsgQueue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
   ([\#5837](https://github.com/cometbft/cometbft/pull/5837))
 - `[abci]` fix deadlock when response callback re-enters the client.
   ([\#5850](https://github.com/cometbft/cometbft/pull/5850))
-- `[node]` fix(node): use kernel-assigned ephemeral ports and fix OnStart cleanup
+- `[node]` use kernel-assigned ephemeral ports and fix `OnStart` cleanup
   ([\#5868](https://github.com/cometbft/cometbft/pull/5868))
 - `[node]` close partial listeners on startRPC failure
   ([\#5869](https://github.com/cometbft/cometbft/pull/5869))

--- a/node/node.go
+++ b/node/node.go
@@ -666,7 +666,11 @@ func (n *Node) OnStart() error {
 
 	// run pprof server if it is enabled
 	if n.config.RPC.IsPprofEnabled() {
-		pprofSrv, pprofLn = n.startPprofServer()
+		var err error
+		pprofSrv, pprofLn, err = n.startPprofServer()
+		if err != nil {
+			return err
+		}
 	}
 
 	// begin prometheus metrics gathering if it is enabled
@@ -993,11 +997,10 @@ func (n *Node) startPrometheusServer() *http.Server {
 }
 
 // starts a ppro
-func (n *Node) startPprofServer() (*http.Server, net.Listener) {
+func (n *Node) startPprofServer() (*http.Server, net.Listener, error) {
 	ln, err := net.Listen("tcp", n.config.RPC.PprofListenAddress)
 	if err != nil {
-		n.Logger.Error("pprof HTTP server failed to listen", "err", err)
-		return nil, nil
+		return nil, nil, fmt.Errorf("pprof HTTP server failed to listen: %w", err)
 	}
 	srv := &http.Server{
 		Handler:           nil,
@@ -1008,7 +1011,7 @@ func (n *Node) startPprofServer() (*http.Server, net.Listener) {
 			n.Logger.Error("pprof HTTP server Serve", "err", err)
 		}
 	}()
-	return srv, ln
+	return srv, ln, nil
 }
 
 // Switch returns the Node's Switch.

--- a/node/node.go
+++ b/node/node.go
@@ -81,6 +81,7 @@ type Node struct {
 	indexerService    *txindex.IndexerService
 	prometheusSrv     *http.Server
 	pprofSrv          *http.Server
+	pprofLn           net.Listener
 }
 
 type waitSyncReactor interface {
@@ -622,24 +623,65 @@ func (n *Node) OnStart() error {
 		time.Sleep(genTime.Sub(now))
 	}
 
+	var (
+		pprofSrv, prometheusSrv *http.Server
+		pprofLn                 net.Listener
+		rpcListeners            []net.Listener
+		mpListening             bool
+		swStarted               bool
+		ok                      bool
+	)
+	defer func() {
+		if ok {
+			return
+		}
+		if swStarted {
+			if err := n.sw.Stop(); err != nil {
+				n.Logger.Error("error stopping switch during OnStart cleanup", "err", err)
+			}
+		}
+		if mpListening {
+			if mp, isMP := n.transport.(*p2p.MultiplexTransport); isMP {
+				if err := mp.Close(); err != nil {
+					n.Logger.Error("error closing transport during OnStart cleanup", "err", err)
+				}
+			}
+		}
+		for _, l := range rpcListeners {
+			if err := l.Close(); err != nil {
+				n.Logger.Error("error closing rpc listener during OnStart cleanup", "err", err)
+			}
+		}
+		if prometheusSrv != nil {
+			if err := prometheusSrv.Shutdown(context.Background()); err != nil {
+				n.Logger.Error("error shutting down prometheus during OnStart cleanup", "err", err)
+			}
+		}
+		if pprofSrv != nil {
+			if err := pprofSrv.Shutdown(context.Background()); err != nil {
+				n.Logger.Error("error shutting down pprof during OnStart cleanup", "err", err)
+			}
+		}
+	}()
+
 	// run pprof server if it is enabled
 	if n.config.RPC.IsPprofEnabled() {
-		n.pprofSrv = n.startPprofServer()
+		pprofSrv, pprofLn = n.startPprofServer()
 	}
 
 	// begin prometheus metrics gathering if it is enabled
 	if n.config.Instrumentation.IsPrometheusEnabled() {
-		n.prometheusSrv = n.startPrometheusServer()
+		prometheusSrv = n.startPrometheusServer()
 	}
 
 	// Start the RPC server before the P2P server
 	// so we can eg. receive txs for the first block
 	if n.config.RPC.ListenAddress != "" {
-		listeners, err := n.startRPC()
+		var err error
+		rpcListeners, err = n.startRPC()
 		if err != nil {
 			return err
 		}
-		n.rpcListeners = listeners
 	}
 
 	// Start the transport.
@@ -648,23 +690,21 @@ func (n *Node) OnStart() error {
 		return err
 	}
 
-	if mp, ok := n.transport.(*p2p.MultiplexTransport); ok {
+	if mp, isMP := n.transport.(*p2p.MultiplexTransport); isMP {
 		if err := mp.Listen(*addr); err != nil {
 			return err
 		}
+		mpListening = true
 	}
 
 	// Start the switch (the P2P server).
-	err = n.sw.Start()
-	if err != nil {
+	if err := n.sw.Start(); err != nil {
 		return err
 	}
-
-	n.isListening = true
+	swStarted = true
 
 	// Always connect to persistent peers
-	err = n.sw.DialPeersAsync(splitAndTrimEmpty(n.config.P2P.PersistentPeers, ",", " "))
-	if err != nil {
+	if err := n.sw.DialPeersAsync(splitAndTrimEmpty(n.config.P2P.PersistentPeers, ",", " ")); err != nil {
 		return fmt.Errorf("could not dial peers from persistent_peers field: %w", err)
 	}
 
@@ -674,6 +714,13 @@ func (n *Node) OnStart() error {
 			return fmt.Errorf("failed to start state sync: %w", err)
 		}
 	}
+
+	// All steps succeeded — commit locals to node fields.
+	ok = true
+	n.pprofSrv, n.pprofLn = pprofSrv, pprofLn
+	n.prometheusSrv = prometheusSrv
+	n.rpcListeners = rpcListeners
+	n.isListening = true
 
 	return nil
 }
@@ -946,19 +993,22 @@ func (n *Node) startPrometheusServer() *http.Server {
 }
 
 // starts a ppro
-func (n *Node) startPprofServer() *http.Server {
+func (n *Node) startPprofServer() (*http.Server, net.Listener) {
+	ln, err := net.Listen("tcp", n.config.RPC.PprofListenAddress)
+	if err != nil {
+		n.Logger.Error("pprof HTTP server failed to listen", "err", err)
+		return nil, nil
+	}
 	srv := &http.Server{
-		Addr:              n.config.RPC.PprofListenAddress,
 		Handler:           nil,
 		ReadHeaderTimeout: readHeaderTimeout,
 	}
 	go func() {
-		if err := srv.ListenAndServe(); err != http.ErrServerClosed {
-			// Error starting or closing listener:
-			n.Logger.Error("pprof HTTP server ListenAndServe", "err", err)
+		if err := srv.Serve(ln); err != http.ErrServerClosed {
+			n.Logger.Error("pprof HTTP server Serve", "err", err)
 		}
 	}()
-	return srv
+	return srv, ln
 }
 
 // Switch returns the Node's Switch.

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -35,9 +35,8 @@ import (
 )
 
 func TestNodeStartStop(t *testing.T) {
-	config := test.ResetTestRoot("node_node_test")
+	config := newNodeTestConfig(t, "node_node_test")
 	defer os.RemoveAll(config.RootDir)
-	config.RPC.GRPCListenAddress = ""
 
 	// create & start node
 	n, err := DefaultNewNode(config, log.TestingLogger())
@@ -98,9 +97,8 @@ func TestSplitAndTrimEmpty(t *testing.T) {
 }
 
 func TestNodeDelayedStart(t *testing.T) {
-	config := test.ResetTestRoot("node_delayed_start_test")
+	config := newNodeTestConfig(t, "node_delayed_start_test")
 	defer os.RemoveAll(config.RootDir)
-	config.RPC.GRPCListenAddress = ""
 	now := cmttime.Now()
 
 	// create & start node
@@ -137,14 +135,9 @@ func TestNodeSetAppVersion(t *testing.T) {
 }
 
 func TestPprofServer(t *testing.T) {
-	config := test.ResetTestRoot("node_pprof_test")
+	config := newNodeTestConfig(t, "node_pprof_test")
 	defer os.RemoveAll(config.RootDir)
-	config.RPC.GRPCListenAddress = ""
-	config.RPC.PprofListenAddress = testFreeAddr(t)
-
-	// should not work yet
-	_, err := http.Get("http://" + config.RPC.PprofListenAddress) //nolint: bodyclose
-	assert.Error(t, err)
+	config.RPC.PprofListenAddress = "127.0.0.1:0"
 
 	n, err := DefaultNewNode(config, log.TestingLogger())
 	assert.NoError(t, err)
@@ -154,7 +147,8 @@ func TestPprofServer(t *testing.T) {
 	}()
 	assert.NotNil(t, n.pprofSrv)
 
-	resp, err := http.Get("http://" + config.RPC.PprofListenAddress + "/debug/pprof")
+	pprofAddr := n.pprofLn.Addr().String()
+	resp, err := http.Get("http://" + pprofAddr + "/debug/pprof")
 	assert.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, 200, resp.StatusCode)
@@ -273,6 +267,17 @@ func TestStartRPCCleansUpOnFailure(t *testing.T) {
 	probe, err := net.Listen("tcp", firstAddr)
 	require.NoError(t, err, "startRPC leaked first listener on %s", firstAddr)
 	probe.Close()
+}
+
+// newNodeTestConfig returns a test config with kernel-assigned ephemeral P2P
+// and RPC ports to avoid cross-test port conflicts.
+func newNodeTestConfig(t *testing.T, testName string) *cfg.Config {
+	t.Helper()
+	config := test.ResetTestRoot(testName)
+	config.P2P.ListenAddress = "tcp://127.0.0.1:0"
+	config.RPC.ListenAddress = "tcp://127.0.0.1:0"
+	config.RPC.GRPCListenAddress = ""
+	return config
 }
 
 // create a proposal block using real and full
@@ -450,9 +455,8 @@ func TestMaxProposalBlockSize(t *testing.T) {
 }
 
 func TestNodeNewNodeCustomReactors(t *testing.T) {
-	config := test.ResetTestRoot("node_new_node_custom_reactors_test")
+	config := newNodeTestConfig(t, "node_new_node_custom_reactors_test")
 	defer os.RemoveAll(config.RootDir)
-	config.RPC.GRPCListenAddress = ""
 
 	cr := p2pmock.NewReactor()
 	cr.Channels = []*conn.ChannelDescriptor{

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -145,7 +145,8 @@ func TestPprofServer(t *testing.T) {
 	defer func() {
 		require.NoError(t, n.Stop())
 	}()
-	assert.NotNil(t, n.pprofSrv)
+	require.NotNil(t, n.pprofSrv)
+	require.NotNil(t, n.pprofLn)
 
 	pprofAddr := n.pprofLn.Addr().String()
 	resp, err := http.Get("http://" + pprofAddr + "/debug/pprof")


### PR DESCRIPTION
## Summary
Fix ci failure at: https://github.com/cometbft/cometbft/actions/runs/25806158383/job/75809368250

Replace the `testFreeAddr/randPort` TOCTOU pattern (bind, record port,
close, re-bind) with OS-assigned port 0 for P2P, RPC, and pprof listen
addresses in node tests.

For pprof, refactor `startPprofServer` to call `net.Listen` explicitly
before starting the goroutine, returning the listener so the caller
holds it as a local and the actual bound address is readable after
`Start()` returns.

Fix `OnStart` to clean up any services it started if a later step fails,
using local temporaries committed to node fields only on success.

## Test plan

- [x] Run `go test ./node/... -run "TestNodeStartStop|TestNodeDelayedStart|TestPprofServer|TestNodeNewNodeCustomReactors" -count=1` — all four tests should pass.
