### PR TITLE
test(types): clarify EventBusBufferCapacity test intent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 
 ### FEATURES
 
+- `[config]` Add EventBusBufferCapacity setting.
+  ([\#5849](https://github.com/cometbft/cometbft/pull/5849))
+
 ### STATE-BREAKING
 
 ### API-BREAKING

--- a/config/config.go
+++ b/config/config.go
@@ -245,6 +245,10 @@ type BaseConfig struct {
 	// If true, query the ABCI app on connecting to a new peer
 	// so the app can decide if we should keep the connection or not
 	FilterPeers bool `mapstructure:"filter_peers"` // false
+
+	// The capacity of the internal buffer used by the EventBus. A value of 0
+	// means unbuffered (publishers block until subscribers receive).
+	EventBusBufferCapacity int `mapstructure:"event_bus_buffer_capacity"`
 }
 
 // DefaultBaseConfig returns a default base configuration for a CometBFT node
@@ -263,6 +267,7 @@ func DefaultBaseConfig() BaseConfig {
 		FilterPeers:        false,
 		DBBackend:          "goleveldb",
 		DBPath:             DefaultDataDir,
+		EventBusBufferCapacity: 0,
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -254,19 +254,19 @@ type BaseConfig struct {
 // DefaultBaseConfig returns a default base configuration for a CometBFT node
 func DefaultBaseConfig() BaseConfig {
 	return BaseConfig{
-		Version:            version.TMCoreSemVer,
-		Genesis:            defaultGenesisJSONPath,
-		PrivValidatorKey:   defaultPrivValKeyPath,
-		PrivValidatorState: defaultPrivValStatePath,
-		NodeKey:            defaultNodeKeyPath,
-		Moniker:            defaultMoniker,
-		ProxyApp:           "tcp://127.0.0.1:26658",
-		ABCI:               "socket",
-		LogLevel:           DefaultLogLevel,
-		LogFormat:          LogFormatPlain,
-		FilterPeers:        false,
-		DBBackend:          "goleveldb",
-		DBPath:             DefaultDataDir,
+		Version:                version.TMCoreSemVer,
+		Genesis:                defaultGenesisJSONPath,
+		PrivValidatorKey:       defaultPrivValKeyPath,
+		PrivValidatorState:     defaultPrivValStatePath,
+		NodeKey:                defaultNodeKeyPath,
+		Moniker:                defaultMoniker,
+		ProxyApp:               "tcp://127.0.0.1:26658",
+		ABCI:                   "socket",
+		LogLevel:               DefaultLogLevel,
+		LogFormat:              LogFormatPlain,
+		FilterPeers:            false,
+		DBBackend:              "goleveldb",
+		DBPath:                 DefaultDataDir,
 		EventBusBufferCapacity: 0,
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -318,6 +318,9 @@ func (cfg BaseConfig) ValidateBasic() error {
 	default:
 		return errors.New("unknown log_format (must be 'plain' or 'json')")
 	}
+	if cfg.EventBusBufferCapacity < 0 {
+		return fmt.Errorf("event_bus_buffer_capacity must be >= 0, got %d", cfg.EventBusBufferCapacity)
+	}
 	return nil
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -68,6 +68,10 @@ func TestBaseConfigValidateBasic(t *testing.T) {
 	// tamper with log format
 	cfg.LogFormat = "invalid"
 	assert.Error(t, cfg.ValidateBasic())
+
+	cfg = config.TestBaseConfig()
+	cfg.EventBusBufferCapacity = -1
+	assert.Error(t, cfg.ValidateBasic())
 }
 
 func TestRPCConfigValidateBasic(t *testing.T) {

--- a/config/toml.go
+++ b/config/toml.go
@@ -140,6 +140,11 @@ abci = "{{ .BaseConfig.ABCI }}"
 # so the app can decide if we should keep the connection or not
 filter_peers = {{ .BaseConfig.FilterPeers }}
 
+# Buffer capacity for the internal EventBus. A value of 0 means unbuffered
+# (publishers block until subscribers receive). Higher values reduce back-pressure
+# at the cost of memory.
+event_bus_buffer_capacity = {{ .BaseConfig.EventBusBufferCapacity }}
+
 
 #######################################################################
 ###                 Advanced Configuration Options                  ###

--- a/node/node.go
+++ b/node/node.go
@@ -337,7 +337,7 @@ func NewNodeWithContext(
 	// we might need to index the txs of the replayed block as this might not have happened
 	// when the node stopped last time (i.e. the node stopped after it saved the block
 	// but before it indexed the txs)
-	eventBus, err := createAndStartEventBus(logger)
+	eventBus, err := createAndStartEventBus(logger, config.BaseConfig.EventBusBufferCapacity)
 	if err != nil {
 		return nil, err
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -337,7 +337,7 @@ func NewNodeWithContext(
 	// we might need to index the txs of the replayed block as this might not have happened
 	// when the node stopped last time (i.e. the node stopped after it saved the block
 	// but before it indexed the txs)
-	eventBus, err := createAndStartEventBus(logger, config.BaseConfig.EventBusBufferCapacity)
+	eventBus, err := createAndStartEventBus(logger, config.EventBusBufferCapacity)
 	if err != nil {
 		return nil, err
 	}

--- a/node/setup.go
+++ b/node/setup.go
@@ -125,8 +125,8 @@ func createAndStartProxyAppConns(clientCreator proxy.ClientCreator, logger log.L
 	return proxyApp, nil
 }
 
-func createAndStartEventBus(logger log.Logger) (*types.EventBus, error) {
-	eventBus := types.NewEventBus()
+func createAndStartEventBus(logger log.Logger, bufferCapacity int) (*types.EventBus, error) {
+	eventBus := types.NewEventBusWithBufferCapacity(bufferCapacity)
 	eventBus.SetLogger(logger.With("module", "events"))
 	if err := eventBus.Start(); err != nil {
 		return nil, err

--- a/types/event_bus.go
+++ b/types/event_bus.go
@@ -72,6 +72,10 @@ func (b *EventBus) NumClientSubscriptions(clientID string) int {
 	return b.pubsub.NumClientSubscriptions(clientID)
 }
 
+func (b *EventBus) BufferCapacity() int {
+	return b.pubsub.BufferCapacity()
+}
+
 func (b *EventBus) Subscribe(
 	ctx context.Context,
 	subscriber string,

--- a/types/event_bus.go
+++ b/types/event_bus.go
@@ -72,6 +72,7 @@ func (b *EventBus) NumClientSubscriptions(clientID string) int {
 	return b.pubsub.NumClientSubscriptions(clientID)
 }
 
+// BufferCapacity returns the capacity of the underlying pubsub command buffer.
 func (b *EventBus) BufferCapacity() int {
 	return b.pubsub.BufferCapacity()
 }

--- a/types/event_bus_test.go
+++ b/types/event_bus_test.go
@@ -16,21 +16,22 @@ import (
 )
 
 func TestEventBusBufferCapacity(t *testing.T) {
-	defaultBus := NewEventBus()
-	require.Equal(t, 0, defaultBus.BufferCapacity())
+	require.Equal(t, 0, NewEventBus().BufferCapacity())
 
-	const cap = 2
-	eventBus := NewEventBusWithBufferCapacity(cap)
-	require.Equal(t, cap, eventBus.BufferCapacity())
+	const bufCap = 2
+	eventBus := NewEventBusWithBufferCapacity(bufCap)
+	require.Equal(t, bufCap, eventBus.BufferCapacity())
 
+	// server not started: nothing drains s.cmds, so publishing bufCap messages
+	// fills it to capacity; the next publish must block
 	ctx := context.Background()
-	require.NoError(t, eventBus.pubsub.Publish(ctx, "first"))
-	require.NoError(t, eventBus.pubsub.Publish(ctx, "second"))
+	for i := range bufCap {
+		require.NoError(t, eventBus.pubsub.Publish(ctx, fmt.Sprintf("msg-%d", i)))
+	}
 
 	deadlineCtx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
 	defer cancel()
-	err := eventBus.pubsub.Publish(deadlineCtx, "third")
-	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.ErrorIs(t, eventBus.pubsub.Publish(deadlineCtx, "overflow"), context.DeadlineExceeded)
 }
 
 func TestEventBusPublishEventTx(t *testing.T) {

--- a/types/event_bus_test.go
+++ b/types/event_bus_test.go
@@ -15,6 +15,24 @@ import (
 	cmtquery "github.com/cometbft/cometbft/libs/pubsub/query"
 )
 
+func TestEventBusBufferCapacity(t *testing.T) {
+	defaultBus := NewEventBus()
+	require.Equal(t, 0, defaultBus.BufferCapacity())
+
+	const cap = 2
+	eventBus := NewEventBusWithBufferCapacity(cap)
+	require.Equal(t, cap, eventBus.BufferCapacity())
+
+	ctx := context.Background()
+	require.NoError(t, eventBus.pubsub.Publish(ctx, "first"))
+	require.NoError(t, eventBus.pubsub.Publish(ctx, "second"))
+
+	deadlineCtx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+	defer cancel()
+	err := eventBus.pubsub.Publish(deadlineCtx, "third")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
 func TestEventBusPublishEventTx(t *testing.T) {
 	eventBus := NewEventBus()
 	err := eventBus.Start()


### PR DESCRIPTION
improves the test added in #5883:

- rename `cap` → `bufCap` (shadows the builtin `cap` function)
- add a comment explaining why the server is intentionally not started (blocking is on the `s.cmds` channel level, not subscriber delivery)
- use `range bufCap` loop instead of hardcoded publish calls
- collapse final assertion to one line