### PR TITLE
fix(p2p): replace fixed sleeps with deterministic peer-wait in switch tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   ([\#5888](https://github.com/cometbft/cometbft/pull/5888))
 - `[inspect]` fix flaky `TestInspectRun` and consolidate start/stop handshake
   ([\#5891](https://github.com/cometbft/cometbft/pull/5891))
+- `[p2p]` fix flaky switch tests by replacing fixed sleeps with deterministic peer-wait polling
+  ([\#5918](https://github.com/cometbft/cometbft/pull/5918))
 - `[p2p]` fix race and goroutine leak in `TestTransportMultiplexAcceptNonBlocking` test
   ([\#5878](https://github.com/cometbft/cometbft/pull/5878))
 - `[evidence]` fix flaky `TestReactorsGossipNoCommittedEvidence` test

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -546,7 +546,7 @@ func TestSwitchReconnectsToInboundPersistentPeer(t *testing.T) {
 
 	conn, err := rp.Dial(sw.NetAddress())
 	require.NoError(t, err)
-	time.Sleep(50 * time.Millisecond)
+	waitUntilSwitchHasAtLeastNPeers(sw, 1)
 	require.NotNil(t, sw.Peers().Get(rp.ID()))
 
 	conn.Close()
@@ -613,7 +613,7 @@ func TestSwitchDialPeersAsync(t *testing.T) {
 
 	err = sw.DialPeersAsync([]string{rp.Addr().String()})
 	require.NoError(t, err)
-	time.Sleep(dialRandomizerIntervalMilliseconds * time.Millisecond)
+	waitUntilSwitchHasAtLeastNPeers(sw, 1)
 	require.NotNil(t, sw.Peers().Get(rp.ID()))
 }
 
@@ -695,7 +695,7 @@ func TestSwitchAcceptRoutine(t *testing.T) {
 			}
 		}(c)
 	}
-	time.Sleep(100 * time.Millisecond)
+	waitUntilSwitchHasAtLeastNPeers(sw, cfg.MaxNumInboundPeers)
 	assert.Equal(t, cfg.MaxNumInboundPeers, sw.Peers().Size())
 
 	// 2. check we close new connections if we already have MaxNumInboundPeers peers
@@ -726,7 +726,7 @@ func TestSwitchAcceptRoutine(t *testing.T) {
 			}
 		}(c)
 	}
-	time.Sleep(10 * time.Millisecond)
+	waitUntilSwitchHasAtLeastNPeers(sw, cfg.MaxNumInboundPeers+unconditionalPeersNum)
 	assert.Equal(t, cfg.MaxNumInboundPeers+unconditionalPeersNum, sw.Peers().Size())
 
 	for _, peer := range peers {


### PR DESCRIPTION
## Summary

Fix CI failure at: https://github.com/cometbft/cometbft/actions/runs/26953832757/job/79525648357?pr=5879

Four tests in `p2p/switch_test.go` used `time.Sleep` as a fixed wait before asserting peer connection state, making them flaky on slow CI runners. Replace all four with `waitUntilSwitchHasAtLeastNPeers` which polls until the expected peer count is reached.

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `CHANGELOG.md`
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments