### PR TITLE
ci(kms): skip jobs when kms/ module does not exist yet

### DIFF
--- a/.github/workflows/kms.yml
+++ b/.github/workflows/kms.yml
@@ -37,15 +37,15 @@ jobs:
               - '.github/workflows/kms.yml'
 
       - run: echo "GO_VERSION=$(cat .github/workflows/go-version.env | grep GO_VERSION | cut -d '=' -f2)" >> $GITHUB_ENV
-        if: steps.filter.outputs.code == 'true'
+        if: steps.filter.outputs.code == 'true' && hashFiles('kms/go.mod') != ''
 
       - uses: actions/setup-go@v6
-        if: steps.filter.outputs.code == 'true'
+        if: steps.filter.outputs.code == 'true' && hashFiles('kms/go.mod') != ''
         with:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Build cometkms
-        if: steps.filter.outputs.code == 'true'
+        if: steps.filter.outputs.code == 'true' && hashFiles('kms/go.mod') != ''
         run: make kms-build
 
   test:
@@ -67,15 +67,15 @@ jobs:
               - '.github/workflows/kms.yml'
 
       - run: echo "GO_VERSION=$(cat .github/workflows/go-version.env | grep GO_VERSION | cut -d '=' -f2)" >> $GITHUB_ENV
-        if: steps.filter.outputs.code == 'true'
+        if: steps.filter.outputs.code == 'true' && hashFiles('kms/go.mod') != ''
 
       - uses: actions/setup-go@v6
-        if: steps.filter.outputs.code == 'true'
+        if: steps.filter.outputs.code == 'true' && hashFiles('kms/go.mod') != ''
         with:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Test cometkms (race detector)
-        if: steps.filter.outputs.code == 'true'
+        if: steps.filter.outputs.code == 'true' && hashFiles('kms/go.mod') != ''
         run: make kms-test-race
 
   lint:
@@ -98,13 +98,13 @@ jobs:
               - '.github/workflows/kms.yml'
 
       - run: echo "GO_VERSION=$(cat .github/workflows/go-version.env | grep GO_VERSION | cut -d '=' -f2)" >> $GITHUB_ENV
-        if: steps.filter.outputs.code == 'true'
+        if: steps.filter.outputs.code == 'true' && hashFiles('kms/go.mod') != ''
 
       - uses: actions/setup-go@v6
-        if: steps.filter.outputs.code == 'true'
+        if: steps.filter.outputs.code == 'true' && hashFiles('kms/go.mod') != ''
         with:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Lint cometkms
-        if: steps.filter.outputs.code == 'true'
+        if: steps.filter.outputs.code == 'true' && hashFiles('kms/go.mod') != ''
         run: make kms-lint


### PR DESCRIPTION
## Summary

- The `kms.yml` paths-filter includes `go.*` so that parent module changes trigger KMS jobs (the `kms` module depends on the parent via `replace => ../`).
- This also fires on dep bumps (e.g. dependabot `go.mod` updates) before the `kms/` directory has been committed, causing all three jobs to fail with `no go files to analyze`.
- Guard each job's run steps with `hashFiles('kms/go.mod') != ''` so they are silently skipped until the kms module lands.

Fixes the KMS workflow failures visible on #5915 and any other dep-bump PR until #5907/#5911/#5912 merge.

## Test plan

- [ ] Verify KMS workflow jobs show as skipped (not failed) on a PR that only touches `go.mod`/`go.sum`
- [ ] Verify KMS workflow jobs run normally once `kms/go.mod` exists (i.e. after one of the KMS feature PRs merges)