### PR TITLE
fix(rpc): escape request host in endpoints listing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### BUG FIXES
 
+- `[rpc]` escape the request `Host` in the endpoints listing page so it cannot
+  break out of the generated HTML
+  ([\#5921](https://github.com/cometbft/cometbft/pull/5921))
 - `[consensus]` Fix `double_sign_check_height = 1` performing no double-sign
   checks due to off-by-one error in loop condition (`i < N` should be
   `i <= N`). The value `1` now correctly checks the previous block as intended.

--- a/rpc/jsonrpc/server/http_json_handler.go
+++ b/rpc/jsonrpc/server/http_json_handler.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"html"
 	"io"
 	"net/http"
 	"reflect"
@@ -229,18 +230,21 @@ func writeListOfEndpoints(w http.ResponseWriter, r *http.Request, funcMap map[st
 	}
 	sort.Strings(noArgNames)
 	sort.Strings(argNames)
+	// The Host comes straight from the request, so escape it before it lands in
+	// the page to keep it from breaking out of the surrounding markup.
+	host := html.EscapeString(r.Host)
 	buf := new(bytes.Buffer)
 	buf.WriteString("<html><body>")
 	buf.WriteString("<br>Available endpoints:<br>")
 
 	for _, name := range noArgNames {
-		link := fmt.Sprintf("//%s/%s", r.Host, name)
+		link := fmt.Sprintf("//%s/%s", host, name)
 		fmt.Fprintf(buf, "<a href=\"%s\">%s</a></br>", link, link)
 	}
 
 	buf.WriteString("<br>Endpoints that require arguments:<br>")
 	for _, name := range argNames {
-		link := fmt.Sprintf("//%s/%s?", r.Host, name)
+		link := fmt.Sprintf("//%s/%s?", host, name)
 		funcData := funcMap[name]
 		for i, argName := range funcData.argNames {
 			link += argName + "=_"

--- a/rpc/jsonrpc/server/http_json_handler_test.go
+++ b/rpc/jsonrpc/server/http_json_handler_test.go
@@ -282,3 +282,23 @@ func TestRPCResponseCache(t *testing.T) {
 	res.Body.Close()
 	require.Nil(t, err, "reading from the body should not give back an error")
 }
+
+// The endpoints listing builds links from the request Host, so that value must
+// be escaped before it reaches the HTML page.
+func TestListOfEndpointsEscapesHost(t *testing.T) {
+	mux := testMux()
+
+	req, err := http.NewRequest("GET", "http://localhost/", strings.NewReader(""))
+	require.NoError(t, err)
+	req.Host = `localhost"><script>alert(1)</script>`
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	res := rec.Result()
+
+	body, err := io.ReadAll(res.Body)
+	res.Body.Close()
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(body), `"><script>`)
+	assert.Contains(t, string(body), `&lt;script&gt;`)
+}


### PR DESCRIPTION
**unescaped request host in the rpc endpoints page**

The endpoints listing served from the rpc root builds its links from the request Host, which comes straight off the wire, and writes it into the href attributes and link text with no escaping. A host carrying markup characters then sits in an HTML context verbatim, so anything able to influence that header (a fronting proxy, say) can drop attribute or tag content into the page. Escaping it with html.EscapeString before the links are built keeps it contained, and leaves ordinary host values untouched.

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `CHANGELOG.md`
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments