### PR TITLE
fix(p2p): report bound port when listening on port 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### BUG FIXES
 
+- `[p2p]` report the OS-assigned port when listening on port `0`, so
+  `NodeInfo.ListenAddr`, the `/status` RPC, and `Switch.NetAddress()` no longer
+  report port `0`
+  ([\#5928](https://github.com/cometbft/cometbft/pull/5928))
 - `[rpc]` escape the request `Host` in the endpoints listing page so it cannot
   break out of the generated HTML
   ([\#5921](https://github.com/cometbft/cometbft/pull/5921))

--- a/node/node.go
+++ b/node/node.go
@@ -699,6 +699,14 @@ func (n *Node) OnStart() error {
 			return err
 		}
 		mpListening = true
+
+		// Report the OS-assigned port when listening on ":0", unless an explicit
+		// ExternalAddress is set.
+		if n.config.P2P.ExternalAddress == "" {
+			if ni, ok := n.nodeInfo.(p2p.DefaultNodeInfo); ok {
+				n.nodeInfo = ni.WithListenPort(mp.NetAddress().Port)
+			}
+		}
 	}
 
 	// Start the switch (the P2P server).

--- a/p2p/node_info.go
+++ b/p2p/node_info.go
@@ -4,7 +4,10 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"net"
 	"reflect"
+	"strconv"
+	"strings"
 
 	cmtbytes "github.com/cometbft/cometbft/libs/bytes"
 	cmtstrings "github.com/cometbft/cometbft/libs/strings"
@@ -224,6 +227,25 @@ func (info DefaultNodeInfo) NetAddress() (*NetAddress, error) {
 
 func (info DefaultNodeInfo) HasChannel(chID byte) bool {
 	return bytes.Contains(info.Channels, []byte{chID})
+}
+
+// WithListenPort returns a copy of info with ListenAddr's port set to port when
+// the configured port is 0. Host and scheme are preserved; a non-zero or
+// unparseable ListenAddr is returned unchanged.
+func (info DefaultNodeInfo) WithListenPort(port uint16) DefaultNodeInfo {
+	scheme := ""
+	addr := info.ListenAddr
+	if i := strings.Index(addr, "://"); i >= 0 {
+		scheme, addr = addr[:i+len("://")], addr[i+len("://"):]
+	}
+
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil || portStr != "0" {
+		return info
+	}
+
+	info.ListenAddr = scheme + net.JoinHostPort(host, strconv.Itoa(int(port)))
+	return info
 }
 
 func (info DefaultNodeInfo) ToProto() *tmp2p.DefaultNodeInfo {

--- a/p2p/node_info_test.go
+++ b/p2p/node_info_test.go
@@ -123,3 +123,26 @@ func TestNodeInfoCompatible(t *testing.T) {
 		assert.Error(t, ni1.CompatibleWith(ni))
 	}
 }
+
+func TestNodeInfoWithListenPort(t *testing.T) {
+	const resolved = uint16(45678)
+
+	testCases := []struct {
+		name       string
+		listenAddr string
+		want       string
+	}{
+		{"replaces zero port", "127.0.0.1:0", "127.0.0.1:45678"},
+		{"keeps configured host", "0.0.0.0:0", "0.0.0.0:45678"},
+		{"preserves scheme", "tcp://127.0.0.1:0", "tcp://127.0.0.1:45678"},
+		{"leaves non-zero port", "127.0.0.1:26656", "127.0.0.1:26656"},
+		{"leaves unparseable addr", "not-an-address", "not-an-address"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ni := DefaultNodeInfo{ListenAddr: tc.listenAddr}
+			assert.Equal(t, tc.want, ni.WithListenPort(resolved).ListenAddr)
+		})
+	}
+}

--- a/p2p/transport.go
+++ b/p2p/transport.go
@@ -265,6 +265,10 @@ func (mt *MultiplexTransport) Listen(addr NetAddress) error {
 	}
 
 	mt.netAddr = addr
+	// Take the actual bound port (resolves port 0), but keep the configured IP.
+	if tcpAddr, ok := ln.Addr().(*net.TCPAddr); ok {
+		mt.netAddr.Port = uint16(tcpAddr.Port)
+	}
 	mt.listener = ln
 
 	go mt.acceptPeers()

--- a/p2p/transport.go
+++ b/p2p/transport.go
@@ -268,6 +268,10 @@ func (mt *MultiplexTransport) Listen(addr NetAddress) error {
 	// Take the actual bound port (resolves port 0), but keep the configured IP.
 	if tcpAddr, ok := ln.Addr().(*net.TCPAddr); ok {
 		mt.netAddr.Port = uint16(tcpAddr.Port)
+		// Advertise the resolved port to peers.
+		if ni, ok := mt.nodeInfo.(DefaultNodeInfo); ok {
+			mt.nodeInfo = ni.WithListenPort(mt.netAddr.Port)
+		}
 	}
 	mt.listener = ln
 

--- a/p2p/transport_test.go
+++ b/p2p/transport_test.go
@@ -649,6 +649,73 @@ func TestTransportAddChannel(t *testing.T) {
 	}
 }
 
+// Listening on port 0 must report the OS-assigned port, not 0.
+func TestTransportMultiplexListenResolvesEphemeralPort(t *testing.T) {
+	mt := newMultiplexTransport(
+		emptyNodeInfo(),
+		NodeKey{
+			PrivKey: ed25519.GenPrivKey(),
+		},
+	)
+	id := mt.nodeKey.ID()
+
+	addr, err := NewNetAddressString(IDAddressString(id, "127.0.0.1:0"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mt.Listen(*addr); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = mt.Close() })
+
+	na := mt.NetAddress()
+	if na.Port == 0 {
+		t.Errorf("expected NetAddress to report a resolved port, got 0")
+	}
+
+	wantPort := uint16(mt.listener.Addr().(*net.TCPAddr).Port)
+	if na.Port != wantPort {
+		t.Errorf("expected reported port %d, got %d", wantPort, na.Port)
+	}
+
+	if na.ID != id {
+		t.Errorf("expected ID %q, got %q", id, na.ID)
+	}
+	if !na.IP.Equal(net.ParseIP("127.0.0.1")) {
+		t.Errorf("expected IP 127.0.0.1, got %s", na.IP)
+	}
+}
+
+// Listening on a wildcard host must keep the configured IP, not ln.Addr()'s.
+func TestTransportMultiplexListenPreservesConfiguredHost(t *testing.T) {
+	mt := newMultiplexTransport(
+		emptyNodeInfo(),
+		NodeKey{
+			PrivKey: ed25519.GenPrivKey(),
+		},
+	)
+	id := mt.nodeKey.ID()
+
+	addr, err := NewNetAddressString(IDAddressString(id, "0.0.0.0:0"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mt.Listen(*addr); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = mt.Close() })
+
+	na := mt.NetAddress()
+	if !na.IP.Equal(net.ParseIP("0.0.0.0")) {
+		t.Errorf("expected configured IP 0.0.0.0 to be preserved, got %s", na.IP)
+	}
+	if na.Port == 0 {
+		t.Errorf("expected NetAddress to report a resolved port, got 0")
+	}
+}
+
 // create listener
 func testSetupMultiplexTransport(t *testing.T) *MultiplexTransport {
 	var (

--- a/p2p/transport_test.go
+++ b/p2p/transport_test.go
@@ -716,6 +716,33 @@ func TestTransportMultiplexListenPreservesConfiguredHost(t *testing.T) {
 	}
 }
 
+// Listening on port 0 must update the advertised NodeInfo.ListenAddr (sent to
+// peers in the handshake) with the resolved port.
+func TestTransportMultiplexListenUpdatesNodeInfoPort(t *testing.T) {
+	pv := ed25519.GenPrivKey()
+	id := PubKeyToID(pv.PubKey())
+	ni := testNodeInfo(id, "transport").(DefaultNodeInfo)
+	ni.ListenAddr = "127.0.0.1:0"
+
+	mt := newMultiplexTransport(ni, NodeKey{PrivKey: pv})
+
+	addr, err := NewNetAddressString(IDAddressString(id, "127.0.0.1:0"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mt.Listen(*addr); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = mt.Close() })
+
+	wantPort := uint16(mt.listener.Addr().(*net.TCPAddr).Port)
+	wantAddr := fmt.Sprintf("127.0.0.1:%d", wantPort)
+	if got := mt.nodeInfo.(DefaultNodeInfo).ListenAddr; got != wantAddr {
+		t.Errorf("expected advertised ListenAddr %q, got %q", wantAddr, got)
+	}
+}
+
 // create listener
 func testSetupMultiplexTransport(t *testing.T) *MultiplexTransport {
 	var (


### PR DESCRIPTION
## Description

`MultiplexTransport.Listen` stores the caller-supplied address verbatim, so
listening on port `0` leaves `NetAddress()` reporting `0` even though the OS has
bound a real ephemeral port. This takes the actual port from the listener while
keeping the configured IP, so a wildcard host (`0.0.0.0`/`[::]`) isn't reported
as a non-dialable address.

Found while resolving cosmos/cosmos-sdk#26478, which configures CometBFT with
`tcp://127.0.0.1:0` and reads back the actual address after startup.
