### PR TITLE
test(flowrate): fix flaky TestWriter by tolerating clock quantization in Idle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### BUG FIXES
 
+- `[flowrate]` fix flaky `TestWriter` by comparing `Idle` with a duration
+  tolerance instead of exact equality
+  ([\#5929](https://github.com/cometbft/cometbft/pull/5929))
 - `[rpc]` escape the request `Host` in the endpoints listing page so it cannot
   break out of the generated HTML
   ([\#5921](https://github.com/cometbft/cometbft/pull/5921))

--- a/libs/flowrate/io_test.go
+++ b/libs/flowrate/io_test.go
@@ -168,7 +168,7 @@ func statusesAreEqual(s1 *Status, s2 *Status) bool {
 	if s1.Active == s2.Active &&
 		s1.Start.Equal(s2.Start) &&
 		durationsAreEqual(s1.Duration, s2.Duration, maxDeviationForDuration) &&
-		s1.Idle == s2.Idle &&
+		durationsAreEqual(s1.Idle, s2.Idle, maxDeviationForDuration) &&
 		s1.Bytes == s2.Bytes &&
 		s1.Samples == s2.Samples &&
 		ratesAreEqual(s1.InstRate, s2.InstRate, maxDeviationForRate) &&
@@ -184,7 +184,11 @@ func statusesAreEqual(s1 *Status, s2 *Status) bool {
 }
 
 func durationsAreEqual(d1 time.Duration, d2 time.Duration, maxDeviation time.Duration) bool {
-	return d2-d1 <= maxDeviation
+	diff := d2 - d1
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff <= maxDeviation
 }
 
 func ratesAreEqual(r1 int64, r2 int64, maxDeviation int64) bool {


### PR DESCRIPTION
## Description
Fix CI failure at:  https://github.com/cometbft/cometbft/actions/runs/27431355897/job/81082257035?pr=5879
`statusesAreEqual` compared `Status.Idle` with exact equality (`==`) while every
other time-derived field (`Duration`, `TimeRem`, the rates) allowed a deviation.
`Idle` is the difference of two timestamps each rounded to the 20ms `clockRate`,
so scheduling jitter on loaded runners can push the two reads onto adjacent
ticks, producing a spurious 20ms idle and failing the strict `==`.

This compares `Idle` with the same `maxDeviationForDuration` tolerance, and makes
`durationsAreEqual` symmetric (absolute diff) so it bounds drift in both
directions.


---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `CHANGELOG.md`
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
