### PR TITLE
docs(spec): align ConsensusParams with proto

### DIFF
--- a/spec/abci/abci++_app_requirements.md
+++ b/spec/abci/abci++_app_requirements.md
@@ -33,12 +33,10 @@ title: Requirements for the Application
         - [EvidenceParams.MaxAgeDuration](#evidenceparamsmaxageduration)
         - [EvidenceParams.MaxAgeNumBlocks](#evidenceparamsmaxagenumblocks)
         - [EvidenceParams.MaxBytes](#evidenceparamsmaxbytes)
-        - [FeatureParams.PbtsEnableHeight](#featureparamspbtsenableheight)
-        - [FeatureParams.VoteExtensionsEnableHeight](#featureparamsvoteextensionsenableheight)
+        - [ABCIParams.VoteExtensionsEnableHeight](#abciparamsvoteextensionsenableheight)
+        - [AuthorityParams.Authority](#authorityparamsauthority)
         - [ValidatorParams.PubKeyTypes](#validatorparamspubkeytypes)
         - [VersionParams.App](#versionparamsapp)
-        - [SynchronyParams.Precision](#synchronyparamsprecision)
-        - [SynchronyParams.MessageDelay](#synchronyparamsmessagedelay)
       - [Updating Consensus Parameters](#updating-consensus-parameters)
         - [`InitChain`](#initchain)
         - [`FinalizeBlock`, `PrepareProposal`/`ProcessProposal`](#finalizeblock-prepareproposalprocessproposal)
@@ -584,19 +582,17 @@ all full nodes have the same value at a given height.
 
 #### List of Parameters
 
-These are the current consensus parameters (as of v1.0.x):
+These are the current consensus parameters:
 
 1.  [BlockParams.MaxBytes](#blockparamsmaxbytes)
 2.  [BlockParams.MaxGas](#blockparamsmaxgas)
 3.  [EvidenceParams.MaxAgeDuration](#evidenceparamsmaxageduration)
 4.  [EvidenceParams.MaxAgeNumBlocks](#evidenceparamsmaxagenumblocks)
 5.  [EvidenceParams.MaxBytes](#evidenceparamsmaxbytes)
-6.  [FeatureParams.PbtsEnableHeight](#featureparamspbtsenableheight)
-7.  [FeatureParams.VoteExtensionsEnableHeight](#featureparamsvoteextensionsenableheight)
+6.  [ABCIParams.VoteExtensionsEnableHeight](#abciparamsvoteextensionsenableheight)
+7.  [AuthorityParams.Authority](#authorityparamsauthority)
 8.  [ValidatorParams.PubKeyTypes](#validatorparamspubkeytypes)
 9.  [VersionParams.App](#versionparamsapp)
-10. [SynchronyParams.Precision](#synchronyparamsprecision)
-11. [SynchronyParams.MessageDelay](#synchronyparamsmessagedelay)
 
 ##### BlockParams.MaxBytes
 
@@ -677,25 +673,7 @@ a block minus its overhead ( ~ `BlockParams.MaxBytes`).
 
 Must have `MaxBytes > 0`.
 
-##### FeatureParams.PbtsEnableHeight
-
-Height at which Proposer-Based Timestamps (PBTS) will be enabled.
-
-A value of 0 means that PBTS is disabled. A value > 0 denotes the
-height at which PBTS will be (or has been) enabled.
-
-From the specified height, and for all subsequent heights, the PBTS
-algorithm will be used to produce and validate block timestamps. Prior to
-this height, or when this height is set to 0, the legacy BFT Time
-algorithm is used to produce and validate timestamps.
-
-PBTS cannot be disabled once it is enabled.
-
-Cannot be set to heights lower or equal to the current blockchain height.
-
-Must have `PbtsEnableHeight > [Current height]`
-
-##### FeatureParams.VoteExtensionsEnableHeight
+##### ABCIParams.VoteExtensionsEnableHeight
 
 This parameter is either 0 or a positive height at which vote extensions
 become mandatory. If the value is zero (which is the default), vote
@@ -716,6 +694,12 @@ include the vote extensions from height `H`. For all heights after `H`
 Must always be set to a future height, 0, or the same height that was previously set.
 Once the chain's height reaches the value set, it cannot be changed to a different value.
 
+##### AuthorityParams.Authority
+
+This is an opaque string that the application can use to authorize consensus
+parameter changes outside governance.
+CometBFT only enforces a maximum length of 256 characters.
+
 ##### ValidatorParams.PubKeyTypes
 
 The parameter restricts the type of keys validators can use. The parameter uses ABCI pubkey naming, not Amino names.
@@ -723,24 +707,6 @@ The parameter restricts the type of keys validators can use. The parameter uses 
 ##### VersionParams.App
 
 This is the version of the ABCI application.
-
-##### SynchronyParams.Precision
-
-This sets a bound on how skewed a proposer's clock may be from any validator
-on the network while still producing valid proposals.
-
-This parameter is used by the
-[Proposer-Based Timestamps (PBTS)](../consensus/proposer-based-timestamp/README.md)
-algorithm.
-
-##### SynchronyParams.MessageDelay
-
-This sets a bound on how long a proposal message may take to reach all
-validators on a network and still be considered valid.
-
-This parameter is used by the
-[Proposer-Based Timestamps (PBTS)](../consensus/proposer-based-timestamp/README.md)
-algorithm.
 
 #### Updating Consensus Parameters
 

--- a/spec/abci/abci++_methods.md
+++ b/spec/abci/abci++_methods.md
@@ -796,7 +796,7 @@ Most of the data structures used in ABCI are shared [common data structures](../
     | validator | [ValidatorParams](../core/data_structures.md#validatorparams) | Parameters limiting the types of public keys validators can use.             | 3            | Yes           |
     | version   | [VersionsParams](../core/data_structures.md#versionparams)    | The ABCI application version.                                                | 4            | Yes           |
     | abci      | [ABCIParams](../core/data_structures.md#abciparams)           | ABCI-related parameters.                                                     | 5            | Yes           |
-    | synchrony | [SynchronyParams](../core/data_structures.md#synchronyparams) | Parameters determining the validity bounds of a proposal timestamp.          | 6            | Yes           |
+    | authority | [AuthorityParams](../core/data_structures.md#authorityparams) | Application-defined authority for consensus parameter changes.               | 6            | Yes           |
 
 ### ProofOps
 

--- a/spec/core/data_structures.md
+++ b/spec/core/data_structures.md
@@ -45,8 +45,7 @@ The CometBFT blockchain consists of a short list of data types:
     - [ValidatorParams](#validatorparams)
     - [VersionParams](#versionparams)
     - [ABCIParams](#abciparams)
-    - [FeatureParams](#featureparams)
-    - [SynchronyParams](#synchronyparams)
+    - [AuthorityParams](#authorityparams)
 
 
 ## Block
@@ -495,8 +494,8 @@ func SumTruncated(bz []byte) []byte {
 | evidence  | [EvidenceParams](#evidenceparams)   | Parameters determining the validity of evidences of Byzantine behavior. | 2            |
 | validator | [ValidatorParams](#validatorparams) | Parameters limiting the types of public keys validators can use.        | 3            |
 | version   | [VersionParams](#versionparams)     | The version of specific components of CometBFT.                         | 4            |
-| synchrony | [SynchronyParams](#synchronyparams) | Parameters determining the validity of block timestamps.                | 6            |
-| feature   | [FeatureParams](#featureparms)      | Parameters for configuring the height from which features are enabled.  | 7            |
+| abci      | [ABCIParams](#abciparams)           | ABCI-related parameters.                                                | 5            |
+| authority | [AuthorityParams](#authorityparams) | Application-defined authority for consensus parameter changes.          | 6            |
 
 ### BlockParams
 
@@ -553,34 +552,11 @@ The `app` parameter was named `app_version` in CometBFT 0.34.
 |-------------------------------|-------|---------------------------------------------------|:------------:|
 | vote_extensions_enable_height | int64 | The height where vote extensions will be enabled. | 1            |
 
-The `ABCIParams` type has been **deprecated** from CometBFT `v1.0`.
+### AuthorityParams
 
-### FeatureParams
-
-| Name                          | Type  | Description                                                       | Field Number |
-|-------------------------------|-------|-------------------------------------------------------------------|:------------:|
-| vote_extensions_enable_height | int64 | First height during which vote extensions will be enabled.        | 1            |
-| pbts_enable_height            | int64 | Height at which Proposer-Based Timestamps (PBTS) will be enabled. | 2            |
-
-From the configured height, and for all subsequent heights, the corresponding
-feature will be enabled.
-Cannot be set to heights lower or equal to the current blockchain height.
-A value of 0 (the default) indicates that the feature is disabled.
-
-### SynchronyParams
-
-| Name          | Type                                       | Description                                                                                                             | Field Number |
-|---------------|--------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|:------------:|
-| precision     | [google.protobuf.Duration][proto-duration] | Bound for how skewed a proposer's clock may be from any validator on the network while still producing valid proposals. | 1            |
-| message_delay | [google.protobuf.Duration][proto-duration] | Bound for how long a proposal message may take to reach all validators on a network and still be considered valid.      | 2            |
-
-These parameters are part of the Proposer-Based Timestamps (PBTS) algorithm.
-For more information on the relationship of the synchrony parameters to
-block timestamps validity, refer to the [PBTS specification][pbts].
-
-**Note:** Both `precision` and `message_delay` have upper bounds enforced in the implementation to prevent overflow errors during timestamp validation:
-- `precision` must not exceed `30s`
-- `message_delay` must not exceed `24h`
+| Name      | Type   | Description                                                                        | Field Number |
+|-----------|--------|------------------------------------------------------------------------------------|:------------:|
+| authority | string | Opaque application-defined authority for consensus parameter changes outside governance. | 1            |
 
 [pbts]: ../consensus/proposer-based-timestamp/README.md
 [bfttime]: ../consensus/bft-time.md


### PR DESCRIPTION
Align the `ConsensusParams` documentation with the current proto definition.

This updates the spec docs to:
- document the `abci` and `authority` fields in `ConsensusParams`
- describe `ABCIParams.VoteExtensionsEnableHeight`
- describe `AuthorityParams.Authority`
- remove stale `FeatureParams` and `SynchronyParams` entries from the current parameter list

Refs #1036




#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `CHANGELOG.md`
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
