### PR TITLE
refactor(store): export BlockStore pruning errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@
 
 ### IMPROVEMENTS
 
+- `[store]` Export pruning errors returned by `BlockStore.PruneBlocks` so callers
+  can identify them with `errors.Is`.
+  ([\#1140](https://github.com/cometbft/cometbft/issues/1140))
 - `[blocksync]` replace `numPending int32` with `atomic.Int32` and document `BlockPool` field ownership
   ([\#5889](https://github.com/cometbft/cometbft/pull/5889))
 - `[execution]` cache validator set within a block cycle.

--- a/store/errors.go
+++ b/store/errors.go
@@ -1,0 +1,14 @@
+package store
+
+import "errors"
+
+var (
+	// ErrPruneHeightMustBePositive is returned when pruning to a non-positive height.
+	ErrPruneHeightMustBePositive = errors.New("height must be greater than 0")
+
+	// ErrPruneHeightBeyondLatest is returned when pruning beyond the latest stored height.
+	ErrPruneHeightBeyondLatest = errors.New("cannot prune beyond the latest height")
+
+	// ErrPruneHeightBelowBase is returned when pruning below the current base height.
+	ErrPruneHeightBelowBase = errors.New("cannot prune below base height")
+)

--- a/store/store.go
+++ b/store/store.go
@@ -358,18 +358,18 @@ func (bs *BlockStore) LoadSeenCommit(height int64) *types.Commit {
 // PruneBlocks removes block up to (but not including) a height. It returns number of blocks pruned and the evidence retain height - the height at which data needed to prove evidence must not be removed.
 func (bs *BlockStore) PruneBlocks(height int64, state sm.State) (uint64, int64, error) {
 	if height <= 0 {
-		return 0, -1, fmt.Errorf("height must be greater than 0")
+		return 0, -1, ErrPruneHeightMustBePositive
 	}
 	bs.mtx.RLock()
 	if height > bs.height {
 		bs.mtx.RUnlock()
-		return 0, -1, fmt.Errorf("cannot prune beyond the latest height %v", bs.height)
+		return 0, -1, fmt.Errorf("%w %v", ErrPruneHeightBeyondLatest, bs.height)
 	}
 	base := bs.base
 	bs.mtx.RUnlock()
 	if height < base {
-		return 0, -1, fmt.Errorf("cannot prune to height %v, it is lower than base height %v",
-			height, base)
+		return 0, -1, fmt.Errorf("%w: cannot prune to height %v, it is lower than base height %v",
+			ErrPruneHeightBelowBase, height, base)
 	}
 
 	pruned := uint64(0)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -592,10 +592,10 @@ func TestPruneBlocks(t *testing.T) {
 
 	// pruning an empty store should error, even when pruning to 0
 	_, _, err = bs.PruneBlocks(1, state)
-	require.Error(t, err)
+	require.ErrorIs(t, err, ErrPruneHeightBeyondLatest)
 
 	_, _, err = bs.PruneBlocks(0, state)
-	require.Error(t, err)
+	require.ErrorIs(t, err, ErrPruneHeightMustBePositive)
 
 	// make more than 1000 blocks, to test batch deletions
 	for h := int64(1); h <= 1500; h++ {
@@ -648,7 +648,7 @@ func TestPruneBlocks(t *testing.T) {
 
 	// Pruning below the current base should error
 	_, _, err = bs.PruneBlocks(1199, state)
-	require.Error(t, err)
+	require.ErrorIs(t, err, ErrPruneHeightBelowBase)
 
 	// Pruning to the current base should work
 	pruned, _, err = bs.PruneBlocks(1200, state)
@@ -673,7 +673,7 @@ func TestPruneBlocks(t *testing.T) {
 
 	// Pruning beyond the current height should error
 	_, _, err = bs.PruneBlocks(1501, state)
-	require.Error(t, err)
+	require.ErrorIs(t, err, ErrPruneHeightBeyondLatest)
 
 	// Pruning to the current height should work
 	pruned, _, err = bs.PruneBlocks(1500, state)


### PR DESCRIPTION
Partially addresses  #1140.

This exports the pruning errors returned by `BlockStore.PruneBlocks`, allowing callers to identify these cases programmatically with `errors.Is` instead of matching error strings.

The existing pruning behavior is unchanged; the returned errors now expose stable sentinel values for:
- non-positive prune heights
- prune heights beyond the latest stored height
- prune heights below the current base height
