### PR TITLE
fix(guard): refresh LRU recency and stop cleanup goroutine on Close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### BUG FIXES
 
+- `[guard]` refresh LRU recency on duplicate hits and stop the background
+  cleanup goroutine gracefully on `Close`
+  ([\#5937](https://github.com/cometbft/cometbft/pull/5937))
 - `[flowrate]` fix flaky `TestWriter` by comparing `Idle` with a duration
   tolerance instead of exact equality
   ([\#5929](https://github.com/cometbft/cometbft/pull/5929))

--- a/internal/guard/guard.go
+++ b/internal/guard/guard.go
@@ -17,6 +17,7 @@ type Guard[K comparable] struct {
 	ttlRemovals map[K]struct{}
 	doneCh      chan struct{}
 	doneOnce    sync.Once
+	wg          sync.WaitGroup
 }
 
 type entry struct {
@@ -53,30 +54,34 @@ func NewWithInterval[K comparable](capacity int, cleanInterval time.Duration) *G
 		ttlRemovals: ttlRemovals,
 	}
 
-	go func() {
+	g.wg.Go(func() {
 		ticker := time.NewTicker(cleanInterval)
 		defer ticker.Stop()
 
 		for {
 			select {
-			case <-ticker.C:
-				g.removeExpired()
 			case <-g.doneCh:
 				return
+			case <-ticker.C:
+				// doneCh wins ties: don't start a pass once closing
+				select {
+				case <-g.doneCh:
+					return
+				default:
+				}
+				g.removeExpired()
 			}
 		}
-	}()
+	})
 
 	return g
 }
 
-// Close closes the guard.
+// Close stops the background cleanup and waits for it to exit.
 func (g *Guard[K]) Close() {
 	g.doneOnce.Do(func() {
-		g.mu.Lock()
-		defer g.mu.Unlock()
-
 		close(g.doneCh)
+		g.wg.Wait()
 	})
 }
 

--- a/internal/guard/guard.go
+++ b/internal/guard/guard.go
@@ -80,14 +80,16 @@ func (g *Guard[K]) Close() {
 	})
 }
 
-// Guard guards the item against duplicates.
-// Doesn't have a TTL besides LRU eviction.
+// Guard guards the item against duplicates. A newly added key has no TTL
+// (only LRU eviction), but an existing key may carry a pending ForgetAfter
+// deadline; Guard must not clear it on a re-guard, or pending retries break.
 // Returns true if the key was added, false if it was already present.
 func (g *Guard[K]) Guard(key K) (added bool) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
-	if e, exists := g.lru.Peek(key); exists {
+	// Get, not Peek: a duplicate observation refreshes LRU recency.
+	if e, exists := g.lru.Get(key); exists {
 		if !e.expired() {
 			// exists and not expired -> guard!
 			return false

--- a/internal/guard/guard_test.go
+++ b/internal/guard/guard_test.go
@@ -80,6 +80,59 @@ func TestGuard(t *testing.T) {
 			require.True(t, g.Has("b"))
 			require.True(t, g.Has("c"))
 		})
+
+		t.Run("reAddAfterExpiry", func(t *testing.T) {
+			// ARRANGE
+			g := makeGuard(t, 10)
+			item := "item-1"
+			require.True(t, g.Guard(item))
+
+			// ACT
+			g.ForgetAfter(item, time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
+			readded := g.Guard(item)
+
+			// ASSERT
+			require.True(t, readded, "expired item should be guardable again")
+			require.True(t, g.Has(item))
+			require.False(t, g.Guard(item), "freshly re-added item should be guarded")
+		})
+
+		t.Run("evictionPurgesTTLRemovals", func(t *testing.T) {
+			// ARRANGE
+			g := makeGuard(t, 2)
+
+			// ACT
+			g.Guard("a")
+			g.ForgetAfter("a", time.Hour)
+			g.Guard("b")
+			g.Guard("c")
+
+			// ASSERT
+			require.False(t, g.Has("a"))
+
+			g.mu.Lock()
+			_, tracked := g.ttlRemovals["a"]
+			g.mu.Unlock()
+
+			require.False(t, tracked, "evicted key must be removed from ttlRemovals")
+		})
+
+		t.Run("reGuardRefreshesRecency", func(t *testing.T) {
+			// ARRANGE
+			g := makeGuard(t, 2)
+
+			// ACT: re-guard "a" so "b" becomes the oldest
+			g.Guard("a")
+			g.Guard("b")
+			g.Guard("a")
+			g.Guard("c")
+
+			// ASSERT
+			require.True(t, g.Has("a"), "re-guarded item must survive eviction")
+			require.False(t, g.Has("b"), "untouched oldest item is evicted")
+			require.True(t, g.Has("c"))
+		})
 	})
 
 	t.Run("Has", func(t *testing.T) {


### PR DESCRIPTION
## Overview

Tighten `internal/guard` behavior around LRU access and shutdown.

This PR keeps the app-mempool retry timeout semantics unchanged: duplicate
`Guard` hits do not clear or extend any pending `ForgetAfter` deadline.

Changes:

- Refresh LRU recency on duplicate `Guard` hits.
  `Guard` previously used `Peek`, so observing an already-guarded key did not
  update its LRU position. Since `Guard` is the public duplicate-observation
  path, it now uses `Get` for present keys. This only affects LRU ordering; it
  does not refresh or cancel `expiresAt`.

- Stop the cleanup goroutine deterministically on `Close`.
  `Close` now closes `doneCh` and waits for the background cleanup loop to exit.
  The previous mutex in `Close` did not provide that guarantee.

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `CHANGELOG.md`
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
