### PR TITLE
fix(mempool): Implement `MsgBytesFilter` in Reactor to prevent heap amplification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,8 +71,8 @@
   ([\#5860](https://github.com/cometbft/cometbft/pull/5860))
 - `[autofile]` skip fsync in `FlushAndSync` when no new data was written
   ([\#5866](https://github.com/cometbft/cometbft/pull/5866))
-- `[mempool]` Implement `MsgBytesFilter` in Reactor to prevent prevent heap amplification attack
-  ([\#5946](https://github.com/cometbft/cometbft/pull/5802))  
+- `[mempool]` Implement `MsgBytesFilter` in Reactor to prevent heap amplification attack
+  ([\#5946](https://github.com/cometbft/cometbft/pull/5946))
 
 ### FEATURES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@
   ([\#5860](https://github.com/cometbft/cometbft/pull/5860))
 - `[autofile]` skip fsync in `FlushAndSync` when no new data was written
   ([\#5866](https://github.com/cometbft/cometbft/pull/5866))
+- `[mempool]` Implement `MsgBytesFilter` in Reactor to prevent prevent heap amplification attack
+  ([\#5946](https://github.com/cometbft/cometbft/pull/5802))  
 
 ### FEATURES
 

--- a/internal/protowire/protowire.go
+++ b/internal/protowire/protowire.go
@@ -1,0 +1,127 @@
+// Package protowire provides a minimal, allocation-free reader for walking
+// raw protobuf wire bytes. Every read is bounds-checked and advances a cursor.
+package protowire
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Wire types (the low 3 bits of a field tag).
+const (
+	WireVarint  = 0
+	WireFixed64 = 1
+	WireBytes   = 2
+	WireFixed32 = 5
+)
+
+var (
+	// ErrVarintOverflow is returned when a varint does not terminate within
+	// the 10 bytes that can hold a 64-bit value.
+	ErrVarintOverflow = errors.New("protowire: varint overflow")
+	// ErrTruncatedVarint is returned when the buffer ends mid-varint.
+	ErrTruncatedVarint = errors.New("protowire: truncated varint")
+	// ErrOutOfBounds is returned when a length prefix or fixed-width field
+	// would run past the end of the buffer.
+	ErrOutOfBounds = errors.New("protowire: length out of bounds")
+	// ErrIllegalFieldNumber is returned when a tag decodes to a field number
+	// that is not a legal protobuf field number (>= 1).
+	ErrIllegalFieldNumber = errors.New("protowire: illegal field number")
+	// ErrUnsupportedWireType is returned when a tag carries a wire type the
+	// cursor does not know how to skip.
+	ErrUnsupportedWireType = errors.New("protowire: unsupported wire type")
+)
+
+// WireCursor walks a protobuf buffer left to right. Every read is bounds-checked
+// and advances the cursor; a read past the end returns an error rather than
+// panicking.
+type WireCursor struct {
+	buf []byte
+	pos int
+}
+
+// NewWireCursor returns a cursor positioned at the start of buf.
+func NewWireCursor(buf []byte) WireCursor {
+	return WireCursor{buf: buf}
+}
+
+// AtEnd reports whether the cursor has consumed the whole buffer.
+func (c *WireCursor) AtEnd() bool { return c.pos >= len(c.buf) }
+
+// ReadVarint decodes a base-128 varint at the cursor and advances past it.
+func (c *WireCursor) ReadVarint() (uint64, error) {
+	var v uint64
+	for shift := uint(0); ; shift += 7 {
+		if shift >= 64 {
+			return 0, ErrVarintOverflow
+		}
+		if c.pos >= len(c.buf) {
+			return 0, ErrTruncatedVarint
+		}
+		b := c.buf[c.pos]
+		c.pos++
+		v |= uint64(b&0x7f) << shift
+		if b < 0x80 {
+			return v, nil
+		}
+	}
+}
+
+// ReadTag decodes a field tag, splitting it into field number and wire type.
+func (c *WireCursor) ReadTag() (fieldNum, wireType int, err error) {
+	v, err := c.ReadVarint()
+	if err != nil {
+		return 0, 0, err
+	}
+	fieldNum = int(v >> 3)
+	wireType = int(v & 0x7)
+	if fieldNum <= 0 {
+		return 0, 0, fmt.Errorf("%w: %d", ErrIllegalFieldNumber, fieldNum)
+	}
+	return fieldNum, wireType, nil
+}
+
+// ReadLengthDelimited reads a length-prefixed run of bytes (wire type 2) and
+// returns it as a sub-slice of the underlying buffer, advancing past it.
+func (c *WireCursor) ReadLengthDelimited() ([]byte, error) {
+	length, err := c.ReadVarint()
+	if err != nil {
+		return nil, err
+	}
+	start := c.pos
+	end := start + int(length)
+	if end < start || end > len(c.buf) {
+		return nil, ErrOutOfBounds
+	}
+	c.pos = end
+	return c.buf[start:end], nil
+}
+
+// SkipField advances the cursor past the body of a field with the given wire
+// type, used to ignore fields the caller does not care about.
+func (c *WireCursor) SkipField(wireType int) error {
+	switch wireType {
+	case WireVarint:
+		_, err := c.ReadVarint()
+		return err
+	case WireFixed64:
+		return c.advance(8)
+	case WireBytes:
+		_, err := c.ReadLengthDelimited()
+		return err
+	case WireFixed32:
+		return c.advance(4)
+	default:
+		return fmt.Errorf("%w: %d", ErrUnsupportedWireType, wireType)
+	}
+}
+
+// advance moves the cursor forward by n bytes, bounds-checked.
+func (c *WireCursor) advance(n int) error {
+	end := c.pos + n
+	if end < c.pos || end > len(c.buf) {
+		return ErrOutOfBounds
+	}
+	c.pos = end
+	return nil
+}

--- a/internal/protowire/protowire.go
+++ b/internal/protowire/protowire.go
@@ -18,18 +18,18 @@ const (
 var (
 	// ErrVarintOverflow is returned when a varint does not terminate within
 	// the 10 bytes that can hold a 64-bit value.
-	ErrVarintOverflow = errors.New("protowire: varint overflow")
+	ErrVarintOverflow = errors.New("varint overflow")
 	// ErrTruncatedVarint is returned when the buffer ends mid-varint.
-	ErrTruncatedVarint = errors.New("protowire: truncated varint")
+	ErrTruncatedVarint = errors.New("truncated varint")
 	// ErrOutOfBounds is returned when a length prefix or fixed-width field
 	// would run past the end of the buffer.
-	ErrOutOfBounds = errors.New("protowire: length out of bounds")
+	ErrOutOfBounds = errors.New("length out of bounds")
 	// ErrIllegalFieldNumber is returned when a tag decodes to a field number
 	// that is not a legal protobuf field number (>= 1).
-	ErrIllegalFieldNumber = errors.New("protowire: illegal field number")
+	ErrIllegalFieldNumber = errors.New("illegal field number")
 	// ErrUnsupportedWireType is returned when a tag carries a wire type the
 	// cursor does not know how to skip.
-	ErrUnsupportedWireType = errors.New("protowire: unsupported wire type")
+	ErrUnsupportedWireType = errors.New("unsupported wire type")
 )
 
 // WireCursor walks a protobuf buffer left to right. Every read is bounds-checked

--- a/internal/protowire/protowire_test.go
+++ b/internal/protowire/protowire_test.go
@@ -1,0 +1,92 @@
+package protowire
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWireCursor_ReadVarint(t *testing.T) {
+	// 300 encodes as 0xac 0x02 in base-128 varint.
+	c := NewWireCursor([]byte{0xac, 0x02})
+	v, err := c.ReadVarint()
+	require.NoError(t, err)
+	require.Equal(t, uint64(300), v)
+	require.True(t, c.AtEnd())
+}
+
+func TestWireCursor_ReadVarint_Truncated(t *testing.T) {
+	c := NewWireCursor([]byte{0xff})
+	_, err := c.ReadVarint()
+	require.ErrorIs(t, err, ErrTruncatedVarint)
+}
+
+func TestWireCursor_ReadVarint_Overflow(t *testing.T) {
+	// 11 continuation bytes never terminate within 64 bits.
+	c := NewWireCursor([]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff})
+	_, err := c.ReadVarint()
+	require.ErrorIs(t, err, ErrVarintOverflow)
+}
+
+func TestWireCursor_ReadTag(t *testing.T) {
+	// Field 1, wire type 2 (length-delimited) => tag byte 0x0a.
+	c := NewWireCursor([]byte{0x0a})
+	fieldNum, wireType, err := c.ReadTag()
+	require.NoError(t, err)
+	require.Equal(t, 1, fieldNum)
+	require.Equal(t, WireBytes, wireType)
+}
+
+func TestWireCursor_ReadTag_IllegalFieldNumber(t *testing.T) {
+	// Tag 0x00 => field number 0, which is illegal.
+	c := NewWireCursor([]byte{0x00})
+	_, _, err := c.ReadTag()
+	require.ErrorIs(t, err, ErrIllegalFieldNumber)
+}
+
+func TestWireCursor_ReadLengthDelimited(t *testing.T) {
+	c := NewWireCursor([]byte{0x03, 'a', 'b', 'c'})
+	b, err := c.ReadLengthDelimited()
+	require.NoError(t, err)
+	require.Equal(t, []byte("abc"), b)
+	require.True(t, c.AtEnd())
+}
+
+func TestWireCursor_ReadLengthDelimited_OutOfBounds(t *testing.T) {
+	// Declares length 5 but only 1 byte follows.
+	c := NewWireCursor([]byte{0x05, 'a'})
+	_, err := c.ReadLengthDelimited()
+	require.ErrorIs(t, err, ErrOutOfBounds)
+}
+
+func TestWireCursor_SkipField(t *testing.T) {
+	testCases := []struct {
+		name     string
+		buf      []byte
+		wireType int
+	}{
+		{"varint", []byte{0xac, 0x02}, WireVarint},
+		{"fixed64", []byte{1, 2, 3, 4, 5, 6, 7, 8}, WireFixed64},
+		{"bytes", []byte{0x02, 'x', 'y'}, WireBytes},
+		{"fixed32", []byte{1, 2, 3, 4}, WireFixed32},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := NewWireCursor(tc.buf)
+			require.NoError(t, c.SkipField(tc.wireType))
+			require.True(t, c.AtEnd())
+		})
+	}
+}
+
+func TestWireCursor_SkipField_Unsupported(t *testing.T) {
+	c := NewWireCursor([]byte{0x00})
+	// Wire type 3 (start group) is not supported.
+	require.ErrorIs(t, c.SkipField(3), ErrUnsupportedWireType)
+}
+
+func TestWireCursor_SkipField_OutOfBounds(t *testing.T) {
+	// Fixed64 needs 8 bytes; only 2 are present.
+	c := NewWireCursor([]byte{1, 2})
+	require.ErrorIs(t, c.SkipField(WireFixed64), ErrOutOfBounds)
+}

--- a/mempool/app_reactor.go
+++ b/mempool/app_reactor.go
@@ -141,7 +141,7 @@ func (r *AppReactor) FilterMsgBytes(chID byte, _ p2p.Peer, msgBytes []byte) erro
 	if chID != MempoolChannel || len(msgBytes) == 0 {
 		return nil
 	}
-	return filterMempoolMsgBytes(msgBytes, r.config.MaxTxBytes, gossipBatchByteBudget(r.config))
+	return filterMempoolMsgBytes(msgBytes, r.config.MaxTxBytes, r.config.MaxBatchBytes)
 }
 
 func (r *AppReactor) Receive(e p2p.Envelope) {

--- a/mempool/app_reactor.go
+++ b/mempool/app_reactor.go
@@ -12,6 +12,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+var _ p2p.MsgBytesFilter = (*AppReactor)(nil)
+
 // AppReactor for interacting with AppMempool
 type AppReactor struct {
 	p2p.BaseReactor
@@ -132,6 +134,14 @@ func (r *AppReactor) EnableInOutTxs() {
 
 	r.Logger.Info("Enabled inbound and outbound transactions")
 	close(r.waitForSwitchingOnCh)
+}
+
+// FilterMsgBytes implements p2p.MsgBytesFilter.
+func (r *AppReactor) FilterMsgBytes(chID byte, _ p2p.Peer, msgBytes []byte) error {
+	if chID != MempoolChannel || len(msgBytes) == 0 {
+		return nil
+	}
+	return filterMempoolMsgBytes(msgBytes, r.config.MaxTxBytes, gossipBatchByteBudget(r.config))
 }
 
 func (r *AppReactor) Receive(e p2p.Envelope) {

--- a/mempool/filter.go
+++ b/mempool/filter.go
@@ -1,0 +1,238 @@
+package mempool
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/cometbft/cometbft/config"
+)
+
+// Protobuf wire types (the low 3 bits of a field tag).
+const (
+	wireVarint  = 0
+	wireFixed64 = 1
+	wireBytes   = 2
+	wireFixed32 = 5
+)
+
+// Field numbers we care about. Both happen to be 1: the Message oneof's only
+// member is Txs (field 1), and within Txs the repeated tx entries are field 1.
+const (
+	fieldMessageTxs = 1 // Message.sum: `Txs txs = 1`
+	fieldTxsEntry   = 1 // Txs: `repeated bytes txs = 1`
+)
+
+var (
+	errVarintOverflow   = errors.New("malformed mempool message: varint overflow")
+	errTruncatedVarint  = errors.New("malformed mempool message: truncated varint")
+	errOutOfBounds      = errors.New("malformed mempool message: length out of bounds")
+	errNoTransactions   = errors.New("mempool message contains no transactions")
+	errEmptyTransaction = errors.New("mempool batch contains an empty transaction")
+)
+
+// gossipBatchByteBudget is the max raw tx bytes a peer may pack into one gossip
+// message. A single tx can be MaxTxBytes even when MaxBatchBytes is smaller, so
+// the budget is the larger of the two. A non-positive result means unbounded.
+func gossipBatchByteBudget(cfg *config.MempoolConfig) int {
+	return max(cfg.MaxTxBytes, cfg.MaxBatchBytes)
+}
+
+// txLimits holds the size ceilings applied to a gossip batch. A non-positive
+// value disables that limit.
+type txLimits struct {
+	maxTxBytes    int // per-transaction ceiling
+	maxBatchBytes int // whole-message ceiling
+}
+
+// batchTally accumulates what has been seen so far while scanning a batch.
+type batchTally struct {
+	count      int // number of transaction entries
+	totalBytes int // sum of their sizes
+}
+
+// filterMempoolMsgBytes enforces the filtering rules above against
+// the raw wire bytes of a tendermint.mempool.Message.
+//
+// Filtering rules:
+//
+//  1. Well-formed: every varint, tag and length prefix must stay within the
+//     buffer. Truncated, overflowing or out-of-bounds encodings are rejected.
+//  2. No empty entries: every transaction must have at least one byte. An empty
+//     entry carries no payload yet still costs an allocation, so it is never
+//     legitimate — this is the core of the amplification attack.
+//  3. Per-tx bound: no single transaction may exceed maxTxBytes.
+//  4. Per-batch bound: the sum of all transaction sizes may not exceed
+//     maxBatchBytes.
+//  5. Non-empty message: the message must carry at least one transaction.
+func filterMempoolMsgBytes(msgBytes []byte, maxTxBytes, maxBatchBytes int) error {
+	limits := txLimits{maxTxBytes: maxTxBytes, maxBatchBytes: maxBatchBytes}
+	var tally batchTally
+
+	msg := wireCursor{buf: msgBytes}
+	for !msg.atEnd() {
+		fieldNum, wireType, err := msg.readTag()
+		if err != nil {
+			return err
+		}
+
+		// Anything that is not the Txs submessage is skipped, so unknown or
+		// future fields do not break the scan.
+		if fieldNum != fieldMessageTxs || wireType != wireBytes {
+			if err := msg.skipField(wireType); err != nil {
+				return err
+			}
+			continue
+		}
+
+		txsBytes, err := msg.readLengthDelimited()
+		if err != nil {
+			return err
+		}
+		if err := scanTxsSubmessage(txsBytes, limits, &tally); err != nil {
+			return err
+		}
+	}
+
+	if tally.count == 0 {
+		return errNoTransactions
+	}
+	return nil
+}
+
+// scanTxsSubmessage walks a Txs submessage (`repeated bytes txs = 1`),
+// validating each transaction entry against the limits and folding it into the
+// tally.
+func scanTxsSubmessage(txsBytes []byte, limits txLimits, tally *batchTally) error {
+	txs := wireCursor{buf: txsBytes}
+	for !txs.atEnd() {
+		fieldNum, wireType, err := txs.readTag()
+		if err != nil {
+			return err
+		}
+
+		if fieldNum != fieldTxsEntry || wireType != wireBytes {
+			if err := txs.skipField(wireType); err != nil {
+				return err
+			}
+			continue
+		}
+
+		tx, err := txs.readLengthDelimited()
+		if err != nil {
+			return err
+		}
+		if err := applyRules(tx, limits, tally); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// applyRules applies the per-entry rules (2-4) to a single transaction.
+func applyRules(tx []byte, limits txLimits, tally *batchTally) error {
+	// No empty transaction
+	if len(tx) == 0 {
+		return errEmptyTransaction
+	}
+	// Transaction cannot exceed maxTxBytes
+	if limits.maxTxBytes > 0 && len(tx) > limits.maxTxBytes {
+		return fmt.Errorf("transaction size %d exceeds max_tx_bytes %d", len(tx), limits.maxTxBytes)
+	}
+
+	tally.count++
+	tally.totalBytes += len(tx)
+
+	// The sum of all transaction sizes may not exceed maxBatchBytes
+	if limits.maxBatchBytes > 0 && tally.totalBytes > limits.maxBatchBytes {
+		return fmt.Errorf("mempool batch exceeds %d byte budget", limits.maxBatchBytes)
+	}
+	return nil
+}
+
+// wireCursor walks a protobuf buffer left to right. Every read is bounds-checked
+// and advances the cursor; a read past the end returns an error rather than
+// panicking, which is what enforces rule 1 (well-formedness).
+type wireCursor struct {
+	buf []byte
+	pos int
+}
+
+func (c *wireCursor) atEnd() bool { return c.pos >= len(c.buf) }
+
+// readVarint decodes a base-128 varint at the cursor and advances past it.
+func (c *wireCursor) readVarint() (uint64, error) {
+	var v uint64
+	for shift := uint(0); ; shift += 7 {
+		if shift >= 64 {
+			return 0, errVarintOverflow
+		}
+		if c.pos >= len(c.buf) {
+			return 0, errTruncatedVarint
+		}
+		b := c.buf[c.pos]
+		c.pos++
+		v |= uint64(b&0x7f) << shift
+		if b < 0x80 {
+			return v, nil
+		}
+	}
+}
+
+// readTag decodes a field tag, splitting it into field number and wire type.
+func (c *wireCursor) readTag() (fieldNum, wireType int, err error) {
+	v, err := c.readVarint()
+	if err != nil {
+		return 0, 0, err
+	}
+	fieldNum = int(v >> 3)
+	wireType = int(v & 0x7)
+	if fieldNum <= 0 {
+		return 0, 0, fmt.Errorf("malformed mempool message: illegal field number %d", fieldNum)
+	}
+	return fieldNum, wireType, nil
+}
+
+// readLengthDelimited reads a length-prefixed run of bytes (wire type 2) and
+// returns it as a sub-slice of the underlying buffer, advancing past it.
+func (c *wireCursor) readLengthDelimited() ([]byte, error) {
+	length, err := c.readVarint()
+	if err != nil {
+		return nil, err
+	}
+	start := c.pos
+	end := start + int(length)
+	if end < start || end > len(c.buf) {
+		return nil, errOutOfBounds
+	}
+	c.pos = end
+	return c.buf[start:end], nil
+}
+
+// skipField advances the cursor past the body of a field with the given wire
+// type, used to ignore fields the filter does not care about.
+func (c *wireCursor) skipField(wireType int) error {
+	switch wireType {
+	case wireVarint:
+		_, err := c.readVarint()
+		return err
+	case wireFixed64:
+		return c.advance(8)
+	case wireBytes:
+		_, err := c.readLengthDelimited()
+		return err
+	case wireFixed32:
+		return c.advance(4)
+	default:
+		return fmt.Errorf("malformed mempool message: unsupported wire type %d", wireType)
+	}
+}
+
+// advance moves the cursor forward by n bytes, bounds-checked.
+func (c *wireCursor) advance(n int) error {
+	end := c.pos + n
+	if end < c.pos || end > len(c.buf) {
+		return errOutOfBounds
+	}
+	c.pos = end
+	return nil
+}

--- a/mempool/filter.go
+++ b/mempool/filter.go
@@ -4,15 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/cometbft/cometbft/config"
-)
-
-// Protobuf wire types (the low 3 bits of a field tag).
-const (
-	wireVarint  = 0
-	wireFixed64 = 1
-	wireBytes   = 2
-	wireFixed32 = 5
+	"github.com/cometbft/cometbft/internal/protowire"
 )
 
 // Field numbers we care about. Both happen to be 1: the Message oneof's only
@@ -23,26 +15,9 @@ const (
 )
 
 var (
-	errVarintOverflow   = errors.New("malformed mempool message: varint overflow")
-	errTruncatedVarint  = errors.New("malformed mempool message: truncated varint")
-	errOutOfBounds      = errors.New("malformed mempool message: length out of bounds")
 	errNoTransactions   = errors.New("mempool message contains no transactions")
 	errEmptyTransaction = errors.New("mempool batch contains an empty transaction")
 )
-
-// gossipBatchByteBudget is the max raw tx bytes a peer may pack into one gossip
-// message. A single tx can be MaxTxBytes even when MaxBatchBytes is smaller, so
-// the budget is the larger of the two. A non-positive result means unbounded.
-func gossipBatchByteBudget(cfg *config.MempoolConfig) int {
-	return max(cfg.MaxTxBytes, cfg.MaxBatchBytes)
-}
-
-// txLimits holds the size ceilings applied to a gossip batch. A non-positive
-// value disables that limit.
-type txLimits struct {
-	maxTxBytes    int // per-transaction ceiling
-	maxBatchBytes int // whole-message ceiling
-}
 
 // batchTally accumulates what has been seen so far while scanning a batch.
 type batchTally struct {
@@ -53,6 +28,10 @@ type batchTally struct {
 // filterMempoolMsgBytes enforces the filtering rules above against
 // the raw wire bytes of a tendermint.mempool.Message.
 //
+// A single tx can be as large as maxTxBytes even when maxBatchBytes is smaller,
+// so the whole-message ceiling is the larger of the two. A non-positive value
+// for either limit disables that check.
+//
 // Filtering rules:
 //
 //  1. Well-formed: every varint, tag and length prefix must stay within the
@@ -62,33 +41,33 @@ type batchTally struct {
 //     legitimate — this is the core of the amplification attack.
 //  3. Per-tx bound: no single transaction may exceed maxTxBytes.
 //  4. Per-batch bound: the sum of all transaction sizes may not exceed
-//     maxBatchBytes.
+//     max(maxTxBytes, maxBatchBytes).
 //  5. Non-empty message: the message must carry at least one transaction.
 func filterMempoolMsgBytes(msgBytes []byte, maxTxBytes, maxBatchBytes int) error {
-	limits := txLimits{maxTxBytes: maxTxBytes, maxBatchBytes: maxBatchBytes}
+	batchBudget := max(maxTxBytes, maxBatchBytes)
 	var tally batchTally
 
-	msg := wireCursor{buf: msgBytes}
-	for !msg.atEnd() {
-		fieldNum, wireType, err := msg.readTag()
+	msg := protowire.NewWireCursor(msgBytes)
+	for !msg.AtEnd() {
+		fieldNum, wireType, err := msg.ReadTag()
 		if err != nil {
 			return err
 		}
 
 		// Anything that is not the Txs submessage is skipped, so unknown or
 		// future fields do not break the scan.
-		if fieldNum != fieldMessageTxs || wireType != wireBytes {
-			if err := msg.skipField(wireType); err != nil {
+		if fieldNum != fieldMessageTxs || wireType != protowire.WireBytes {
+			if err := msg.SkipField(wireType); err != nil {
 				return err
 			}
 			continue
 		}
 
-		txsBytes, err := msg.readLengthDelimited()
+		txsBytes, err := msg.ReadLengthDelimited()
 		if err != nil {
 			return err
 		}
-		if err := scanTxsSubmessage(txsBytes, limits, &tally); err != nil {
+		if err := scanTxsSubmessage(txsBytes, maxTxBytes, batchBudget, &tally); err != nil {
 			return err
 		}
 	}
@@ -102,26 +81,26 @@ func filterMempoolMsgBytes(msgBytes []byte, maxTxBytes, maxBatchBytes int) error
 // scanTxsSubmessage walks a Txs submessage (`repeated bytes txs = 1`),
 // validating each transaction entry against the limits and folding it into the
 // tally.
-func scanTxsSubmessage(txsBytes []byte, limits txLimits, tally *batchTally) error {
-	txs := wireCursor{buf: txsBytes}
-	for !txs.atEnd() {
-		fieldNum, wireType, err := txs.readTag()
+func scanTxsSubmessage(txsBytes []byte, maxTxBytes, batchBudget int, tally *batchTally) error {
+	txs := protowire.NewWireCursor(txsBytes)
+	for !txs.AtEnd() {
+		fieldNum, wireType, err := txs.ReadTag()
 		if err != nil {
 			return err
 		}
 
-		if fieldNum != fieldTxsEntry || wireType != wireBytes {
-			if err := txs.skipField(wireType); err != nil {
+		if fieldNum != fieldTxsEntry || wireType != protowire.WireBytes {
+			if err := txs.SkipField(wireType); err != nil {
 				return err
 			}
 			continue
 		}
 
-		tx, err := txs.readLengthDelimited()
+		tx, err := txs.ReadLengthDelimited()
 		if err != nil {
 			return err
 		}
-		if err := applyRules(tx, limits, tally); err != nil {
+		if err := applyRules(tx, maxTxBytes, batchBudget, tally); err != nil {
 			return err
 		}
 	}
@@ -129,110 +108,22 @@ func scanTxsSubmessage(txsBytes []byte, limits txLimits, tally *batchTally) erro
 }
 
 // applyRules applies the per-entry rules (2-4) to a single transaction.
-func applyRules(tx []byte, limits txLimits, tally *batchTally) error {
+func applyRules(tx []byte, maxTxBytes, batchBudget int, tally *batchTally) error {
 	// No empty transaction
 	if len(tx) == 0 {
 		return errEmptyTransaction
 	}
 	// Transaction cannot exceed maxTxBytes
-	if limits.maxTxBytes > 0 && len(tx) > limits.maxTxBytes {
-		return fmt.Errorf("transaction size %d exceeds max_tx_bytes %d", len(tx), limits.maxTxBytes)
+	if maxTxBytes > 0 && len(tx) > maxTxBytes {
+		return fmt.Errorf("transaction size %d exceeds max_tx_bytes %d", len(tx), maxTxBytes)
 	}
 
 	tally.count++
 	tally.totalBytes += len(tx)
 
-	// The sum of all transaction sizes may not exceed maxBatchBytes
-	if limits.maxBatchBytes > 0 && tally.totalBytes > limits.maxBatchBytes {
-		return fmt.Errorf("mempool batch exceeds %d byte budget", limits.maxBatchBytes)
+	// The sum of all transaction sizes may not exceed the batch budget.
+	if batchBudget > 0 && tally.totalBytes > batchBudget {
+		return fmt.Errorf("mempool batch exceeds %d byte budget", batchBudget)
 	}
-	return nil
-}
-
-// wireCursor walks a protobuf buffer left to right. Every read is bounds-checked
-// and advances the cursor; a read past the end returns an error rather than
-// panicking, which is what enforces rule 1 (well-formedness).
-type wireCursor struct {
-	buf []byte
-	pos int
-}
-
-func (c *wireCursor) atEnd() bool { return c.pos >= len(c.buf) }
-
-// readVarint decodes a base-128 varint at the cursor and advances past it.
-func (c *wireCursor) readVarint() (uint64, error) {
-	var v uint64
-	for shift := uint(0); ; shift += 7 {
-		if shift >= 64 {
-			return 0, errVarintOverflow
-		}
-		if c.pos >= len(c.buf) {
-			return 0, errTruncatedVarint
-		}
-		b := c.buf[c.pos]
-		c.pos++
-		v |= uint64(b&0x7f) << shift
-		if b < 0x80 {
-			return v, nil
-		}
-	}
-}
-
-// readTag decodes a field tag, splitting it into field number and wire type.
-func (c *wireCursor) readTag() (fieldNum, wireType int, err error) {
-	v, err := c.readVarint()
-	if err != nil {
-		return 0, 0, err
-	}
-	fieldNum = int(v >> 3)
-	wireType = int(v & 0x7)
-	if fieldNum <= 0 {
-		return 0, 0, fmt.Errorf("malformed mempool message: illegal field number %d", fieldNum)
-	}
-	return fieldNum, wireType, nil
-}
-
-// readLengthDelimited reads a length-prefixed run of bytes (wire type 2) and
-// returns it as a sub-slice of the underlying buffer, advancing past it.
-func (c *wireCursor) readLengthDelimited() ([]byte, error) {
-	length, err := c.readVarint()
-	if err != nil {
-		return nil, err
-	}
-	start := c.pos
-	end := start + int(length)
-	if end < start || end > len(c.buf) {
-		return nil, errOutOfBounds
-	}
-	c.pos = end
-	return c.buf[start:end], nil
-}
-
-// skipField advances the cursor past the body of a field with the given wire
-// type, used to ignore fields the filter does not care about.
-func (c *wireCursor) skipField(wireType int) error {
-	switch wireType {
-	case wireVarint:
-		_, err := c.readVarint()
-		return err
-	case wireFixed64:
-		return c.advance(8)
-	case wireBytes:
-		_, err := c.readLengthDelimited()
-		return err
-	case wireFixed32:
-		return c.advance(4)
-	default:
-		return fmt.Errorf("malformed mempool message: unsupported wire type %d", wireType)
-	}
-}
-
-// advance moves the cursor forward by n bytes, bounds-checked.
-func (c *wireCursor) advance(n int) error {
-	end := c.pos + n
-	if end < c.pos || end > len(c.buf) {
-		return errOutOfBounds
-	}
-	c.pos = end
 	return nil
 }

--- a/mempool/filter_test.go
+++ b/mempool/filter_test.go
@@ -113,21 +113,19 @@ func TestFilterMempoolMsgBytes_Malformed(t *testing.T) {
 	require.Error(t, filterMempoolMsgBytes([]byte{0x0a, 0x7f}, 1024, 4096))
 }
 
-func TestGossipBatchByteBudget(t *testing.T) {
-	testCases := []struct {
-		maxTxBytes    int
-		maxBatchBytes int
-		want          int
-	}{
-		{maxTxBytes: 1024, maxBatchBytes: 0, want: 1024},
-		{maxTxBytes: 1024, maxBatchBytes: 4096, want: 4096},
-		{maxTxBytes: 4096, maxBatchBytes: 1024, want: 4096}, // single large tx must still pass
-		{maxTxBytes: 0, maxBatchBytes: 0, want: 0},
-	}
-	for _, tc := range testCases {
-		cfg := &config.MempoolConfig{MaxTxBytes: tc.maxTxBytes, MaxBatchBytes: tc.maxBatchBytes}
-		assert.Equal(t, tc.want, gossipBatchByteBudget(cfg))
-	}
+// The per-batch budget is the larger of maxTxBytes and maxBatchBytes, so a
+// single tx bigger than maxBatchBytes but within maxTxBytes must still pass.
+func TestFilterMempoolMsgBytes_BatchBudgetIsMax(t *testing.T) {
+	const maxTxBytes = 4096
+	const maxBatchBytes = 1024
+
+	// One tx larger than maxBatchBytes but within maxTxBytes: allowed.
+	big := marshalTxsMsg(t, [][]byte{make([]byte, maxBatchBytes+1)})
+	require.NoError(t, filterMempoolMsgBytes(big, maxTxBytes, maxBatchBytes))
+
+	// A batch whose total exceeds the larger limit is still rejected.
+	over := marshalTxsMsg(t, [][]byte{make([]byte, maxTxBytes), make([]byte, 1)})
+	require.Error(t, filterMempoolMsgBytes(over, maxTxBytes, maxBatchBytes))
 }
 
 func TestReactorFilterMsgBytes_ChannelGuard(t *testing.T) {

--- a/mempool/filter_test.go
+++ b/mempool/filter_test.go
@@ -1,0 +1,145 @@
+package mempool
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/config"
+	protomem "github.com/cometbft/cometbft/proto/tendermint/mempool"
+)
+
+// marshalTxsMsg builds the wire bytes for a wrapped tendermint.mempool.Message
+// carrying the given raw transactions, exactly as it would appear on the wire.
+func marshalTxsMsg(t *testing.T, txs [][]byte) []byte {
+	t.Helper()
+	msg := &protomem.Message{Sum: &protomem.Message_Txs{Txs: &protomem.Txs{Txs: txs}}}
+	b, err := msg.Marshal()
+	require.NoError(t, err)
+	return b
+}
+
+func TestFilterMempoolMsgBytes(t *testing.T) {
+	const maxTxBytes = 1024
+	const maxBatchBytes = 4096
+
+	// A batch packed with empty entries: cheap on the wire, but len(txs) is huge.
+	emptyEntries := make([][]byte, 10000)
+	for i := range emptyEntries {
+		emptyEntries[i] = []byte{}
+	}
+
+	// A batch of one-byte entries whose declared sizes blow the byte budget.
+	overBudget := make([][]byte, maxBatchBytes+1)
+	for i := range overBudget {
+		overBudget[i] = []byte{0x01}
+	}
+
+	testCases := []struct {
+		name    string
+		txs     [][]byte
+		wantErr bool
+	}{
+		{
+			name:    "valid single tx",
+			txs:     [][]byte{[]byte("hello world")},
+			wantErr: false,
+		},
+		{
+			name:    "valid batch",
+			txs:     [][]byte{[]byte("tx-one"), []byte("tx-two"), []byte("tx-three")},
+			wantErr: false,
+		},
+		{
+			name:    "valid tx at max size",
+			txs:     [][]byte{make([]byte, maxTxBytes)},
+			wantErr: false,
+		},
+		{
+			name:    "empty txs list",
+			txs:     [][]byte{},
+			wantErr: true,
+		},
+		{
+			name:    "single empty entry",
+			txs:     [][]byte{{}},
+			wantErr: true,
+		},
+		{
+			name:    "empty-entry packing attack",
+			txs:     emptyEntries,
+			wantErr: true,
+		},
+		{
+			name:    "tx exceeds max_tx_bytes",
+			txs:     [][]byte{make([]byte, maxTxBytes+1)},
+			wantErr: true,
+		},
+		{
+			name:    "batch exceeds byte budget",
+			txs:     overBudget,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			msgBytes := marshalTxsMsg(t, tc.txs)
+			err := filterMempoolMsgBytes(msgBytes, maxTxBytes, maxBatchBytes)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestFilterMempoolMsgBytes_Unlimited(t *testing.T) {
+	// With maxTxBytes == 0 and maxBatchBytes == 0 the size checks are disabled,
+	// but empty entries are still rejected (they are never valid txs).
+	big := marshalTxsMsg(t, [][]byte{make([]byte, 1<<20)})
+	require.NoError(t, filterMempoolMsgBytes(big, 0, 0))
+
+	require.Error(t, filterMempoolMsgBytes(marshalTxsMsg(t, [][]byte{{}}), 0, 0))
+}
+
+func TestFilterMempoolMsgBytes_Malformed(t *testing.T) {
+	// Truncated varint for the outer Message field length.
+	require.Error(t, filterMempoolMsgBytes([]byte{0x0a, 0xff}, 1024, 4096))
+
+	// Length that runs past the end of the buffer.
+	require.Error(t, filterMempoolMsgBytes([]byte{0x0a, 0x7f}, 1024, 4096))
+}
+
+func TestGossipBatchByteBudget(t *testing.T) {
+	testCases := []struct {
+		maxTxBytes    int
+		maxBatchBytes int
+		want          int
+	}{
+		{maxTxBytes: 1024, maxBatchBytes: 0, want: 1024},
+		{maxTxBytes: 1024, maxBatchBytes: 4096, want: 4096},
+		{maxTxBytes: 4096, maxBatchBytes: 1024, want: 4096}, // single large tx must still pass
+		{maxTxBytes: 0, maxBatchBytes: 0, want: 0},
+	}
+	for _, tc := range testCases {
+		cfg := &config.MempoolConfig{MaxTxBytes: tc.maxTxBytes, MaxBatchBytes: tc.maxBatchBytes}
+		assert.Equal(t, tc.want, gossipBatchByteBudget(cfg))
+	}
+}
+
+func TestReactorFilterMsgBytes_ChannelGuard(t *testing.T) {
+	cfg := config.DefaultMempoolConfig()
+	r := &AppReactor{config: cfg}
+
+	bad := marshalTxsMsg(t, [][]byte{{}, {}, {}})
+
+	// Non-mempool channel: not our concern, must pass through untouched.
+	assert.NoError(t, r.FilterMsgBytes(byte(0x00), nil, bad))
+	// Empty payload: nothing to validate.
+	assert.NoError(t, r.FilterMsgBytes(MempoolChannel, nil, nil))
+	// Mempool channel with abusive payload: rejected.
+	assert.Error(t, r.FilterMsgBytes(MempoolChannel, nil, bad))
+}

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -16,6 +16,8 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
+var _ p2p.MsgBytesFilter = (*Reactor)(nil)
+
 // Reactor handles mempool tx broadcasting amongst peers.
 // It maintains a map from peer ID to counter, to prevent gossiping txs to the
 // peers you received it from.
@@ -144,6 +146,14 @@ func (memR *Reactor) AddPeer(peer p2p.Peer) {
 func (memR *Reactor) RemovePeer(peer p2p.Peer, _ any) {
 	memR.ids.Reclaim(peer)
 	// broadcast routine checks if peer is gone and returns
+}
+
+// FilterMsgBytes implements p2p.MsgBytesFilter.
+func (memR *Reactor) FilterMsgBytes(chID byte, _ p2p.Peer, msgBytes []byte) error {
+	if chID != MempoolChannel || len(msgBytes) == 0 {
+		return nil
+	}
+	return filterMempoolMsgBytes(msgBytes, memR.config.MaxTxBytes, gossipBatchByteBudget(memR.config))
 }
 
 // Receive implements Reactor.

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -153,7 +153,7 @@ func (memR *Reactor) FilterMsgBytes(chID byte, _ p2p.Peer, msgBytes []byte) erro
 	if chID != MempoolChannel || len(msgBytes) == 0 {
 		return nil
 	}
-	return filterMempoolMsgBytes(msgBytes, memR.config.MaxTxBytes, gossipBatchByteBudget(memR.config))
+	return filterMempoolMsgBytes(msgBytes, memR.config.MaxTxBytes, memR.config.MaxBatchBytes)
 }
 
 // Receive implements Reactor.


### PR DESCRIPTION
Implements the optional p2p.MsgBytesFilter interface (defined in p2p/base_reactor.go) for this reactor.

When provided, this filter runs against the raw message bytes before unmarshalling, allowing oversized or malformed messages to be rejected up front. This closes a heap-amplification vector where a small, count-packed wire payload could be unmarshalled into a disproportionately large in-memory structure, exhausting memory.

Motivation:

Previously the message bytes went straight to unmarshal with no pre-decode size/validity check. A crafted gossip message could exploit this to trigger excessive heap allocation. Rejecting bad messages before unmarshal eliminates the attack surface.


---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `CHANGELOG.md`
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
