### PR TITLE
fix(mempool): truncate proto field number to int32 in filter's ReadTag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@
   ([\#5879](https://github.com/cometbft/cometbft/pull/5879))
 - `[consensus]` release cs.mtx before sending to statsMsgQueue
   ([\#5813](https://github.com/cometbft/cometbft/pull/5813))
+- `[mempool]` truncate proto field number to int32 in filter's ReadTag
+  ([\#5948](https://github.com/cometbft/cometbft/pull/5948))
 
 ### IMPROVEMENTS
 

--- a/internal/protowire/protowire.go
+++ b/internal/protowire/protowire.go
@@ -73,7 +73,7 @@ func (c *WireCursor) ReadTag() (fieldNum, wireType int, err error) {
 	if err != nil {
 		return 0, 0, err
 	}
-	fieldNum = int(v >> 3)
+	fieldNum = int(int32(v >> 3))
 	wireType = int(v & 0x7)
 	if fieldNum <= 0 {
 		return 0, 0, fmt.Errorf("%w: %d", ErrIllegalFieldNumber, fieldNum)

--- a/internal/protowire/protowire_test.go
+++ b/internal/protowire/protowire_test.go
@@ -44,6 +44,22 @@ func TestWireCursor_ReadTag_IllegalFieldNumber(t *testing.T) {
 	require.ErrorIs(t, err, ErrIllegalFieldNumber)
 }
 
+func TestWireCursor_ReadTag_FieldNumberTruncatesTo32Bit(t *testing.T) {
+	// Tag varint 8a 80 80 80 80 01 decodes to wire = 2^35 + 10, so
+	// wire>>3 == 2^32 + 1 and wire&7 == 2 (WireBytes). int32(2^32+1) == 1.
+	c := NewWireCursor([]byte{0x8a, 0x80, 0x80, 0x80, 0x80, 0x01})
+	fieldNum, wireType, err := c.ReadTag()
+	require.NoError(t, err)
+	require.Equal(t, 1, fieldNum, "high bits above 32 must be truncated, matching int32(wire>>3)")
+	require.Equal(t, WireBytes, wireType)
+
+	// Tag varint 80 80 80 80 40 decodes to wire>>3 == 2^31, and
+	// int32(2^31) is negative => illegal tag, exactly as gogoproto rejects it.
+	c = NewWireCursor([]byte{0x80, 0x80, 0x80, 0x80, 0x40})
+	_, _, err = c.ReadTag()
+	require.ErrorIs(t, err, ErrIllegalFieldNumber)
+}
+
 func TestWireCursor_ReadLengthDelimited(t *testing.T) {
 	c := NewWireCursor([]byte{0x03, 'a', 'b', 'c'})
 	b, err := c.ReadLengthDelimited()

--- a/mempool/filter_test.go
+++ b/mempool/filter_test.go
@@ -113,6 +113,24 @@ func TestFilterMempoolMsgBytes_Malformed(t *testing.T) {
 	require.Error(t, filterMempoolMsgBytes([]byte{0x0a, 0x7f}, 1024, 4096))
 }
 
+func TestFilterMempoolMsgBytes_DisguisedFieldNumberNotBypassed(t *testing.T) {
+	inner := []byte{
+		0x0a, 0x01, 0x41, // field 1, len 1, "A"  -> real tx
+		0x8a, 0x80, 0x80, 0x80, 0x80, 0x01, 0x00, // disguised field 1, len 0 -> empty tx
+	}
+	msgBytes := append([]byte{0x0a, byte(len(inner))}, inner...) // Message.txs = inner
+
+	// Sanity check: the real parser really does decode two entries, the second
+	// empty
+	var msg protomem.Message
+	require.NoError(t, msg.Unmarshal(msgBytes))
+	require.Len(t, msg.GetTxs().GetTxs(), 2)
+	require.Empty(t, msg.GetTxs().GetTxs()[1])
+
+	// The filter must reject it (empty transaction), matching the parser.
+	require.Error(t, filterMempoolMsgBytes(msgBytes, 1024, 4096))
+}
+
 // The per-batch budget is the larger of maxTxBytes and maxBatchBytes, so a
 // single tx bigger than maxBatchBytes but within maxTxBytes must still pass.
 func TestFilterMempoolMsgBytes_BatchBudgetIsMax(t *testing.T) {


### PR DESCRIPTION
Fixing a small bug in PR https://github.com/cometbft/cometbft/pull/5946

ReadTag decoded protobuf field numbers as a platform-width int `int(v>>3)`, but the generated gogoproto unmarshaller uses `int32(wire>>3)`. On 64-bit platforms this let a crafted tag whose high bits differ (e.g. 8a 80 80 80 80 01, field 2^32+1) be classified as a different field by the pre-scan than by proto.Unmarshal

As a result, the filter skips the entry while Unmarshal still decoded it as the real repeated`txs` field, slipping empty entries past the empty-entry rejection as part of the filter rule


As an evidence
https://github.com/cometbft/cometbft/blob/main/proto/tendermint/mempool/types.pb.go#L327




#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `CHANGELOG.md`
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
