### PR TITLE
fix(mempool): fire callback and release seen-guard on app.CheckTx error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,9 +42,9 @@
   ([\#5867](https://github.com/cometbft/cometbft/pull/5867))
 - `[blocksync]` fix removeTimedoutPeers deadlock found via Byzantine prevote gossip race
   ([\#5839](https://github.com/cometbft/cometbft/pull/5839))
-- `[mempool]` fix `AppMempool.CheckTx` not invoking callback or releasing
-  seen-guard on app error, causing `BroadcastTxSync`/`BroadcastTxCommit` to
-  hang until context expiry and blocking tx resubmission.
+- `[mempool]` fire callback and release seen-guard on `app.CheckTx` error,
+  preventing `BroadcastTxSync`/`BroadcastTxCommit` from hanging and allowing
+  tx resubmission.
   ([\#5952](https://github.com/cometbft/cometbft/pull/5952))
 - `[mempool]` fix setRecheckFull/setDone race causing spurious ErrRecheckFull.
   ([\#5837](https://github.com/cometbft/cometbft/pull/5837))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,9 +42,7 @@
   ([\#5867](https://github.com/cometbft/cometbft/pull/5867))
 - `[blocksync]` fix removeTimedoutPeers deadlock found via Byzantine prevote gossip race
   ([\#5839](https://github.com/cometbft/cometbft/pull/5839))
-- `[mempool]` fire callback and release seen-guard on `app.CheckTx` error,
-  preventing `BroadcastTxSync`/`BroadcastTxCommit` from hanging and allowing
-  tx resubmission.
+- `[mempool]` fire callback and release seen-guard on `app.CheckTx` error.
   ([\#5952](https://github.com/cometbft/cometbft/pull/5952))
 - `[mempool]` fix setRecheckFull/setDone race causing spurious ErrRecheckFull.
   ([\#5837](https://github.com/cometbft/cometbft/pull/5837))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@
   ([\#5867](https://github.com/cometbft/cometbft/pull/5867))
 - `[blocksync]` fix removeTimedoutPeers deadlock found via Byzantine prevote gossip race
   ([\#5839](https://github.com/cometbft/cometbft/pull/5839))
+- `[mempool]` fix `AppMempool.CheckTx` not invoking callback or releasing
+  seen-guard on app error, causing `BroadcastTxSync`/`BroadcastTxCommit` to
+  hang until context expiry and blocking tx resubmission.
+  ([\#5952](https://github.com/cometbft/cometbft/pull/5952))
 - `[mempool]` fix setRecheckFull/setDone race causing spurious ErrRecheckFull.
   ([\#5837](https://github.com/cometbft/cometbft/pull/5837))
 - `[abci]` fix deadlock when response callback re-enters the client.

--- a/mempool/app_mempool.go
+++ b/mempool/app_mempool.go
@@ -263,6 +263,11 @@ func (m *AppMempool) CheckTx(tx types.Tx, callback func(res *abci.ResponseCheckT
 		if err != nil {
 			// note that other ABCI methods panic if err is not nil
 			m.logger.Error("AppMempool.CheckTx: error inserting tx", "error", err, "tx", txHash(tx))
+			// Unblock RPC callers and release the seen-guard so the tx can be resubmitted.
+			m.forgetTx(tx, true)
+			if callback != nil {
+				callback(&abci.ResponseCheckTx{Code: abci.CodeTypeRetry, Log: err.Error()})
+			}
 			return
 		}
 

--- a/mempool/app_mempool_test.go
+++ b/mempool/app_mempool_test.go
@@ -207,6 +207,31 @@ func TestAppMempool(t *testing.T) {
 	})
 }
 
+func TestAppMempoolCheckTx_AppError(t *testing.T) {
+	appErr := fmt.Errorf("connection reset by peer")
+	tx := types.Tx("some-tx")
+
+	app := abcimock.NewClient(t)
+	app.On("CheckTx", mock.Anything, mock.Anything).
+		Return((*abci.ResponseCheckTx)(nil), appErr)
+
+	m := NewAppMempool(config.DefaultMempoolConfig(), app)
+
+	var result atomic.Pointer[abci.ResponseCheckTx]
+	err := m.CheckTx(tx, func(res *abci.ResponseCheckTx) { result.Store(res) }, TxInfo{})
+	require.NoError(t, err)
+
+	// callback must fire — RPC callers block on this
+	require.Eventually(t, func() bool { return result.Load() != nil }, time.Second, 10*time.Millisecond)
+
+	res := result.Load()
+	require.Equal(t, abci.CodeTypeRetry, res.Code)
+	require.Contains(t, res.Log, appErr.Error())
+
+	// seen-guard must clear so the tx can be resubmitted
+	require.Eventually(t, func() bool { return !m.guard.Has(tx.Key()) }, m.checkTxRetryDelay, 10*time.Millisecond)
+}
+
 func TestAppMempool_UsesConfigValues(t *testing.T) {
 	t.Run("ReapTxs receives MaxBytes and MaxGas from config", func(t *testing.T) {
 		cfg := config.TestMempoolConfig()


### PR DESCRIPTION
`AppMempool.CheckTx` dispatches the ABCI call in a goroutine and returns `nil` immediately. The goroutine is expected to invoke the caller-supplied callback on completion — this is how `BroadcastTxSync` and `BroadcastTxCommit` receive the result.

## Problem

On any transport or app error (`err != nil` from `app.CheckTx`), the goroutine logged and returned without:
1. Invoking the callback — `BroadcastTxSync`/`BroadcastTxCommit` block on `resCh` forever, returning only when the client context expires ("broadcast confirmation not received").
2. Calling `forgetTx` — the tx remains in the seen-guard (added by `guardTx` at entry), so identical resubmissions hit `ErrSeenTx` until LRU eviction or restart.

The `#5802`/`#5832` retry fix only covers the `res.Code != OK` path, not the `err != nil` early return.

## Fix

On `err != nil`, call `forgetTx(tx, true)` (retryable delay) and fire the callback with `CodeTypeRetry` so RPC callers return promptly and the tx can be resubmitted.

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `CHANGELOG.md`
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments