### PR TITLE
fix(lp2p): remove MaxStreamSize clamp in StreamReadSized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,9 +50,7 @@
   ([\#5868](https://github.com/cometbft/cometbft/pull/5868))
 - `[node]` close partial listeners on startRPC failure
   ([\#5869](https://github.com/cometbft/cometbft/pull/5869))
-- `[lp2p]` fix `StreamReadSized` clamping caller-supplied `maxSize` to the
-  4 MB `MaxStreamSize` constant, which silently rejected blocks >4 MB in
-  blocksync and statesync chunks when lp2p transport is enabled
+- `[lp2p]` remove `MaxStreamSize` clamp in `StreamReadSized`
   ([\#5954](https://github.com/cometbft/cometbft/pull/5954))
 - `[lp2p]` fallback to conn remote addr when resolving inbound peer
   ([\#5879](https://github.com/cometbft/cometbft/pull/5879))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@
   ([\#5868](https://github.com/cometbft/cometbft/pull/5868))
 - `[node]` close partial listeners on startRPC failure
   ([\#5869](https://github.com/cometbft/cometbft/pull/5869))
+- `[lp2p]` fix `StreamReadSized` clamping caller-supplied `maxSize` to the
+  4 MB `MaxStreamSize` constant, which silently rejected blocks >4 MB in
+  blocksync and statesync chunks when lp2p transport is enabled
+  ([\#5954](https://github.com/cometbft/cometbft/pull/5954))
 - `[lp2p]` fallback to conn remote addr when resolving inbound peer
   ([\#5879](https://github.com/cometbft/cometbft/pull/5879))
 - `[consensus]` release cs.mtx before sending to statsMsgQueue

--- a/lp2p/stream.go
+++ b/lp2p/stream.go
@@ -103,7 +103,11 @@ func StreamReadSized(s network.Stream, maxSize uint64) ([]byte, error) {
 		return nil, errors.Wrap(err, "failed to read payload size")
 	}
 
-	payloadLimit := min(maxSize, MaxStreamSize)
+	// Honor the caller's limit; MaxStreamSize is a fallback, not a hard cap.
+	payloadLimit := maxSize
+	if payloadLimit == 0 {
+		payloadLimit = MaxStreamSize
+	}
 
 	if payloadSize > payloadLimit {
 		return nil, errors.Errorf("payload is too large (got %d, max %d)", payloadSize, payloadLimit)

--- a/lp2p/stream_test.go
+++ b/lp2p/stream_test.go
@@ -168,6 +168,22 @@ func TestStream(t *testing.T) {
 			require.Nil(t, out)
 		})
 
+		t.Run("LargerThanMaxStreamSize", func(t *testing.T) {
+			// maxSize > MaxStreamSize must NOT be clamped — blocksync passes
+			// RecvMessageCapacity (~100MB) and must be able to receive large blocks.
+			payload := bytes.Repeat([]byte("x"), MaxStreamSize+1)
+			frame := append(uint64ToUvarint(uint64(len(payload))), payload...)
+
+			stream := &streamStub{
+				conn:   &connStub{closed: false},
+				readFn: bytes.NewReader(frame).Read,
+			}
+
+			out, err := StreamReadSized(stream, uint64(len(payload)))
+			require.NoError(t, err)
+			require.Equal(t, payload, out)
+		})
+
 		t.Run("InvalidHeader", func(t *testing.T) {
 			// ARRANGE
 			invalidHeader := []byte{0x80}


### PR DESCRIPTION
\`StreamReadSized\` enforces a per-read size limit passed in by the caller (the reactor's \`RecvMessageCapacity\`). The 4 MB \`MaxStreamSize\` constant is intended as a default fallback for callers that don't specify a limit.

## Problem

\`StreamReadSized\` applied \`payloadLimit := min(maxSize, MaxStreamSize)\`, clamping the caller-supplied limit down to 4 MB regardless of what the reactor configured. Blocksync sets \`RecvMessageCapacity = MaxBlockSizeBytes + 5 ≈ 100 MB\`; any block >4 MB was rejected with "payload is too large" and the stream was reset. The send side (\`StreamWrite\`) has no cap and serialises the full block, so a peer could send a 50 MB block that the receiver would always reject — a liveness failure for any lp2p node behind on a chain producing >4 MB blocks. Statesync's 16 MB chunks were similarly affected.

## Fix

Use \`maxSize\` directly. \`MaxStreamSize\` is now a fallback only when \`maxSize == 0\` (unset), not a hard global cap. Adds a regression test for \`maxSize > MaxStreamSize\`.

## Remaining issue

\`readExactly\` does \`make([]byte, payloadSize)\` immediately after reading the length-prefix header, so a malicious peer can force a receiver to allocate up to \`RecvMessageCapacity\` bytes before any payload data arrives. The old 4 MB clamp was inadvertently limiting this to 4 MB per stream.

The correct fix is to replace \`readExactly\` with \`io.ReadAll(io.LimitReader(...))\` so allocation grows only as data arrives. This is left as a follow-up to keep this PR minimal; the real guard in the meantime is the libp2p resource manager and \`RecvMessageCapacity\` being set to the consensus-enforced max block size.

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in \`CHANGELOG.md\`
- [ ] Updated relevant documentation (\`docs/\` or \`spec/\`) and code comments