### PR TITLE
fix(abci): add InsertTx/ReapTxs to socket transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - `[abci]` fix socket transport missing `InsertTx` and `ReapTxs` cases in
   `handleRequest` and `resMatchesReq`, causing `ErrUnexpectedResponse` and
   node self-kill when `mempool.type = "app"` with the default socket transport
-  ([\#NNNN](https://github.com/cometbft/cometbft/pull/NNNN))
+  ([\#5958](https://github.com/cometbft/cometbft/pull/5958))
 - `[flowrate]` fix flaky `TestWriter` by comparing `Idle` with a duration
   tolerance instead of exact equality
   ([\#5929](https://github.com/cometbft/cometbft/pull/5929))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### BUG FIXES
 
+- `[abci]` fix socket transport missing `InsertTx` and `ReapTxs` cases in
+  `handleRequest` and `resMatchesReq`, causing `ErrUnexpectedResponse` and
+  node self-kill when `mempool.type = "app"` with the default socket transport
+  ([\#NNNN](https://github.com/cometbft/cometbft/pull/NNNN))
 - `[flowrate]` fix flaky `TestWriter` by comparing `Idle` with a duration
   tolerance instead of exact equality
   ([\#5929](https://github.com/cometbft/cometbft/pull/5929))

--- a/abci/client/socket_client.go
+++ b/abci/client/socket_client.go
@@ -494,6 +494,10 @@ func resMatchesReq(req *types.Request, res *types.Response) (ok bool) {
 		_, ok = res.Value.(*types.Response_Info)
 	case *types.Request_CheckTx:
 		_, ok = res.Value.(*types.Response_CheckTx)
+	case *types.Request_InsertTx:
+		_, ok = res.Value.(*types.Response_InsertTx)
+	case *types.Request_ReapTxs:
+		_, ok = res.Value.(*types.Response_ReapTxs)
 	case *types.Request_Commit:
 		_, ok = res.Value.(*types.Response_Commit)
 	case *types.Request_Query:

--- a/abci/client/socket_client_test.go
+++ b/abci/client/socket_client_test.go
@@ -153,6 +153,19 @@ func setupClientServer(t *testing.T, app types.Application) (
 	return s, c
 }
 
+func TestInsertTxReapTxsSocket(t *testing.T) {
+	ctx := t.Context()
+	_, c := setupClientServer(t, types.BaseApplication{})
+
+	insertRes, err := c.InsertTx(ctx, &types.RequestInsertTx{Tx: []byte("test")})
+	require.NoError(t, err)
+	require.NotNil(t, insertRes)
+
+	reapRes, err := c.ReapTxs(ctx, &types.RequestReapTxs{})
+	require.NoError(t, err)
+	require.NotNil(t, reapRes)
+}
+
 type slowApp struct {
 	types.BaseApplication
 }

--- a/abci/server/socket_server.go
+++ b/abci/server/socket_server.go
@@ -246,6 +246,18 @@ func (s *SocketServer) handleRequest(ctx context.Context, req *types.Request) (*
 			return nil, err
 		}
 		return types.ToResponseCheckTx(res), nil
+	case *types.Request_InsertTx:
+		res, err := s.app.InsertTx(ctx, r.InsertTx)
+		if err != nil {
+			return nil, err
+		}
+		return types.ToResponseInsertTx(res), nil
+	case *types.Request_ReapTxs:
+		res, err := s.app.ReapTxs(ctx, r.ReapTxs)
+		if err != nil {
+			return nil, err
+		}
+		return types.ToResponseReapTxs(res), nil
 	case *types.Request_Commit:
 		res, err := s.app.Commit(ctx, r.Commit)
 		if err != nil {

--- a/abci/types/messages.go
+++ b/abci/types/messages.go
@@ -168,6 +168,18 @@ func ToResponseCheckTx(res *ResponseCheckTx) *Response {
 	}
 }
 
+func ToResponseInsertTx(res *ResponseInsertTx) *Response {
+	return &Response{
+		Value: &Response_InsertTx{res},
+	}
+}
+
+func ToResponseReapTxs(res *ResponseReapTxs) *Response {
+	return &Response{
+		Value: &Response_ReapTxs{res},
+	}
+}
+
 func ToResponseCommit(res *ResponseCommit) *Response {
 	return &Response{
 		Value: &Response_Commit{res},


### PR DESCRIPTION
### Problem

The socket server (`handleRequest`) and client (`resMatchesReq`) were missing cases for `Request_InsertTx` and `Request_ReapTxs`, which were added in the Krakatoa merge (#5615) but never wired into the socket type-switches.

With `mempool.type = "app"` and the default `abci = "socket"` transport (out-of-process app):
- Every `ReapTxs` response fails the `resMatchesReq` type-match check
- Returns `ErrUnexpectedResponse` → `stopForError` → `killTMOnClientError` → `cmtos.Kill()` (SIGTERM)
- `ReapTxs` fires every `ReapInterval` (~500ms), so the node self-kills within ~500ms of startup

The local and gRPC transports were correctly implemented; only socket was missed. `ToResponseInsertTx`/`ToResponseReapTxs` helpers were also missing from `messages.go` (the `ToRequest*` counterparts existed).

### Fix

- Add `Request_InsertTx` and `Request_ReapTxs` cases to `resMatchesReq` in `abci/client/socket_client.go`
- Add `Request_InsertTx` and `Request_ReapTxs` cases to `handleRequest` in `abci/server/socket_server.go`
- Add `ToResponseInsertTx` and `ToResponseReapTxs` helpers to `abci/types/messages.go`
- Add `TestInsertTxReapTxsSocket` round-trip test over a real socket server/client pair

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `CHANGELOG.md`
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments