### PR TITLE
fix: Floor max bytes calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,8 @@
   `[R||S||V]` signatures with canonical `V` in `{0,1}`.
 - `[state]` `MedianTime` skips `Nil` and `Absent` precommits, aligning with `VerifyCommit`'s commit tally.
   ([\#5901](https://github.com/cometbft/cometbft/pull/5901))
+- `[types]` `block.MaxDataBytes` and `block.MaxDataBytesNoEvidence` now floor instead of panicking on negative value.
+  ([\#5984](https://github.com/cometbft/cometbft/pull/5984))
 
 ### API-BREAKING
 

--- a/types/block.go
+++ b/types/block.go
@@ -278,10 +278,20 @@ func BlockFromProto(bp *cmtproto.Block) (*Block, error) {
 
 //-----------------------------------------------------------------------------
 
-// MaxDataBytes returns the maximum size of block's data.
+// MaxDataBytes returns the maximum size of block's data, floored at 0.
 //
-// XXX: Panics on negative result.
+// The worst-case commit reserve (MaxCommitBytes) can exceed a legal
+// Block.MaxBytes when validators use large signatures (e.g. ML-DSA-65's
+// 3309-byte sigs), since params validation cannot know the validator set
+// size. Flooring at 0 yields empty blocks instead of halting the chain.
+//
+// XXX: Panics if maxBytes is non-positive; callers must resolve the -1
+// (unlimited) sentinel to MaxBlockSizeBytes first.
 func MaxDataBytes(maxBytes, evidenceBytes int64, valsCount int) int64 {
+	if maxBytes <= 0 {
+		panic(fmt.Sprintf("MaxDataBytes: non-positive Block.MaxBytes=%d", maxBytes))
+	}
+
 	maxDataBytes := maxBytes -
 		MaxOverheadForBlock -
 		MaxHeaderBytes -
@@ -289,32 +299,29 @@ func MaxDataBytes(maxBytes, evidenceBytes int64, valsCount int) int64 {
 		evidenceBytes
 
 	if maxDataBytes < 0 {
-		panic(fmt.Sprintf(
-			"Negative MaxDataBytes. Block.MaxBytes=%d is too small to accommodate header&lastCommit&evidence=%d",
-			maxBytes,
-			-(maxDataBytes - maxBytes),
-		))
+		return 0
 	}
 
 	return maxDataBytes
 }
 
 // MaxDataBytesNoEvidence returns the maximum size of block's data when
-// evidence count is unknown (will be assumed to be 0).
+// evidence count is unknown (will be assumed to be 0), floored at 0.
 //
-// XXX: Panics on negative result.
+// XXX: Panics if maxBytes is non-positive; callers must resolve the -1
+// (unlimited) sentinel to MaxBlockSizeBytes first.
 func MaxDataBytesNoEvidence(maxBytes int64, valsCount int) int64 {
+	if maxBytes <= 0 {
+		panic(fmt.Sprintf("MaxDataBytesNoEvidence: non-positive Block.MaxBytes=%d", maxBytes))
+	}
+
 	maxDataBytes := maxBytes -
 		MaxOverheadForBlock -
 		MaxHeaderBytes -
 		MaxCommitBytes(valsCount)
 
 	if maxDataBytes < 0 {
-		panic(fmt.Sprintf(
-			"Negative MaxDataBytesNoEvidence. Block.MaxBytes=%d is too small to accommodate header&lastCommit&evidence=%d",
-			maxBytes,
-			-(maxDataBytes - maxBytes),
-		))
+		return 0
 	}
 
 	return maxDataBytes

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -461,11 +461,13 @@ func TestBlockMaxDataBytes(t *testing.T) {
 		result        int64
 	}{
 		0: {-10, 1, 0, true, 0},
-		1: {10, 1, 0, true, 0},
-		2: {4055, 1, 0, true, 0},
+		1: {10, 1, 0, false, 0},
+		2: {4055, 1, 0, false, 0},
 		3: {4089, 1, 0, false, 0},
 		4: {4090, 1, 0, false, 1},
 		5: {7447, 2, 0, false, 0},
+		// ML-DSA-sized commit reserve exceeds a legal 1MB MaxBytes: floor at 0.
+		6: {1048576, 400, 0, false, 0},
 	}
 
 	for i, tc := range testCases {
@@ -490,10 +492,12 @@ func TestBlockMaxDataBytesNoEvidence(t *testing.T) {
 		result    int64
 	}{
 		0: {-10, 1, true, 0},
-		1: {10, 1, true, 0},
-		2: {4055, 1, true, 0},
+		1: {10, 1, false, 0},
+		2: {4055, 1, false, 0},
 		3: {4089, 1, false, 0},
 		4: {4090, 1, false, 1},
+		// ML-DSA-sized commit reserve exceeds a legal 1MB MaxBytes: floor at 0.
+		5: {1048576, 400, false, 0},
 	}
 
 	for i, tc := range testCases {


### PR DESCRIPTION
---

Instead of panicking on negative value we now floor the calculation and return 0 instead. This is defensive coding against the increased possibility of larger block sizes due to mldsa signature size being significantly larger than ed25519 signatures.

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `CHANGELOG.md`
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
