### PR TITLE
fix: Update privval max remote signer size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,8 @@
   ([\#5866](https://github.com/cometbft/cometbft/pull/5866))
 - `[mempool]` Implement `MsgBytesFilter` in Reactor to prevent heap amplification attack
   ([\#5946](https://github.com/cometbft/cometbft/pull/5946))
+- `[privval]` Dynamically calculate privval maxRemoteSignerMsgSize.
+  ([\#5985](https://github.com/cometbft/cometbft/pull/5985))
 
 ### FEATURES
 

--- a/privval/signer_client_test.go
+++ b/privval/signer_client_test.go
@@ -197,6 +197,48 @@ func TestSignerVote(t *testing.T) {
 	}
 }
 
+// A precommit carrying a max-size vote extension (plus two signatures) far
+// exceeds the old 10 KiB remote signer message cap; it must round-trip.
+func TestSignerVoteMaxSizeExtension(t *testing.T) {
+	for _, tc := range getSignerTestCases(t) {
+		ts := time.Now()
+		hash := cmtrand.Bytes(tmhash.Size)
+		valAddr := cmtrand.Bytes(crypto.AddressSize)
+		ext := cmtrand.Bytes(types.MaxVoteExtensionSize)
+		newVote := func() *types.Vote {
+			return &types.Vote{
+				Type:             cmtproto.PrecommitType,
+				Height:           1,
+				Round:            2,
+				BlockID:          types.BlockID{Hash: hash, PartSetHeader: types.PartSetHeader{Hash: hash, Total: 2}},
+				Timestamp:        ts,
+				ValidatorAddress: valAddr,
+				ValidatorIndex:   1,
+				Extension:        ext,
+			}
+		}
+		want, have := newVote(), newVote()
+
+		t.Cleanup(func() {
+			if err := tc.signerServer.Stop(); err != nil {
+				t.Error(err)
+			}
+		})
+		t.Cleanup(func() {
+			if err := tc.signerClient.Close(); err != nil {
+				t.Error(err)
+			}
+		})
+
+		wantpb, havepb := want.ToProto(), have.ToProto()
+		require.NoError(t, tc.mockPV.SignVote(tc.chainID, wantpb))
+		require.NoError(t, tc.signerClient.SignVote(tc.chainID, havepb))
+
+		assert.Equal(t, wantpb.Signature, havepb.Signature)
+		assert.Equal(t, wantpb.ExtensionSignature, havepb.ExtensionSignature)
+	}
+}
+
 func TestSignerVoteResetDeadline(t *testing.T) {
 	for _, tc := range getSignerTestCases(t) {
 		ts := time.Now()

--- a/privval/signer_endpoint.go
+++ b/privval/signer_endpoint.go
@@ -9,11 +9,18 @@ import (
 	"github.com/cometbft/cometbft/libs/service"
 	cmtsync "github.com/cometbft/cometbft/libs/sync"
 	privvalproto "github.com/cometbft/cometbft/proto/tendermint/privval"
+	"github.com/cometbft/cometbft/types"
 )
 
 const (
 	defaultTimeoutReadWriteSeconds = 5
 )
+
+// maxRemoteSignerMsgSize bounds messages read from the remote signer
+// connection. The largest legitimate message is a precommit vote carrying a
+// max-size extension and two max-size signatures (e.g. ML-DSA-65); 1 KiB of
+// slack covers the remaining vote fields and proto framing.
+var maxRemoteSignerMsgSize = types.MaxVoteExtensionSize + 2*types.MaxSignatureSize + 1024
 
 type signerEndpoint struct {
 	service.BaseService
@@ -92,7 +99,6 @@ func (se *signerEndpoint) ReadMessage() (msg privvalproto.Message, err error) {
 	if err != nil {
 		return
 	}
-	const maxRemoteSignerMsgSize = 1024 * 10
 	protoReader := protoio.NewDelimitedReader(se.conn, maxRemoteSignerMsgSize)
 	_, err = protoReader.ReadMsg(&msg)
 	if _, ok := err.(timeoutError); ok {


### PR DESCRIPTION
---
Updates the privval's max message size to account for larger signature size of mldsa keys.

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `CHANGELOG.md`
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
