### PR TITLE
feat: Update DefaultBlockParams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,8 @@
   ([\#5866](https://github.com/cometbft/cometbft/pull/5866))
 - `[mempool]` Implement `MsgBytesFilter` in Reactor to prevent heap amplification attack
   ([\#5946](https://github.com/cometbft/cometbft/pull/5946))
+- `[types]` Update default max block bytes param to account for increased signature size of mldsa65.
+  ([\#NNNN](https://github.com/cometbft/cometbft/pull/NNNN))
 
 ### FEATURES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@
 - `[mempool]` Implement `MsgBytesFilter` in Reactor to prevent heap amplification attack
   ([\#5946](https://github.com/cometbft/cometbft/pull/5946))
 - `[types]` Update default max block bytes param to account for increased signature size of mldsa65.
-  ([\#NNNN](https://github.com/cometbft/cometbft/pull/NNNN))
+  ([\#5987](https://github.com/cometbft/cometbft/pull/5987))
 
 ### FEATURES
 

--- a/types/block.go
+++ b/types/block.go
@@ -280,7 +280,11 @@ func BlockFromProto(bp *cmtproto.Block) (*Block, error) {
 
 // MaxDataBytes returns the maximum size of block's data.
 //
-// XXX: Panics on negative result.
+// XXX: Panics on negative result. This halts chains whose Block.MaxBytes is
+// too small to fit the worst-case commit — reachable with large-signature key
+// types such as ml_dsa_65 (~3.4KB per validator) — and that is the expected
+// behavior: the misconfiguration must be fixed by raising Block.MaxBytes, not
+// papered over by producing blocks with no room for data.
 func MaxDataBytes(maxBytes, evidenceBytes int64, valsCount int) int64 {
 	maxDataBytes := maxBytes -
 		MaxOverheadForBlock -
@@ -302,7 +306,8 @@ func MaxDataBytes(maxBytes, evidenceBytes int64, valsCount int) int64 {
 // MaxDataBytesNoEvidence returns the maximum size of block's data when
 // evidence count is unknown (will be assumed to be 0).
 //
-// XXX: Panics on negative result.
+// XXX: Panics on negative result. Halts misconfigured chains; expected
+// behavior — see MaxDataBytes.
 func MaxDataBytesNoEvidence(maxBytes int64, valsCount int) int64 {
 	maxDataBytes := maxBytes -
 		MaxOverheadForBlock -

--- a/types/params.go
+++ b/types/params.go
@@ -57,6 +57,13 @@ type ConsensusParams struct {
 
 // BlockParams define limits on the block size and gas plus minimum time
 // between blocks.
+//
+// MaxBytes must cover the block's fixed overhead, header, evidence, and the
+// worst-case commit (MaxCommitBytes), which grows with validator count and
+// signature size. With large-signature key types such as ml_dsa_65 (3309-byte
+// signatures, ~3.4KB per validator), an undersized MaxBytes leaves no room for
+// data and block construction panics. Size it for the largest expected
+// validator set when enabling such key types.
 type BlockParams struct {
 	MaxBytes int64 `json:"max_bytes"`
 	MaxGas   int64 `json:"max_gas"`
@@ -71,6 +78,10 @@ type EvidenceParams struct {
 
 // ValidatorParams restrict the public key types validators can use.
 // NOTE: uses ABCI pubkey naming, not Amino names.
+//
+// Enabling large-signature key types (e.g. ml_dsa_65) inflates the
+// per-validator commit reserve; adjust Block.MaxBytes accordingly (see
+// BlockParams).
 type ValidatorParams struct {
 	PubKeyTypes []string `json:"pub_key_types"`
 }
@@ -116,10 +127,13 @@ func DefaultConsensusParams() *ConsensusParams {
 	}
 }
 
-// DefaultBlockParams returns a default BlockParams.
+// DefaultBlockParams returns a default BlockParams. MaxBytes budgets 21MiB
+// for data plus the worst-case commit for a maximum-size validator set
+// (MaxVotesCount validators at MaxSignatureSize), so the default stays valid
+// for any pub key type and validator count.
 func DefaultBlockParams() BlockParams {
 	return BlockParams{
-		MaxBytes: 22020096, // 21MB
+		MaxBytes: 22020096 + MaxCommitBytes(MaxVotesCount), // ~53MiB
 		MaxGas:   -1,
 	}
 }


### PR DESCRIPTION
---

Changes DefaultBlockParams to a higher MaxBytes value in order to account for the larger size of mldsa65 signatures.

Also adds comments to ensure users are aware that incorrect values can lead to chain halts and this is the expected behaviour.
