### PR TITLE
chore: Bump max tx size default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,8 @@
   ([\#5985](https://github.com/cometbft/cometbft/pull/5985))
 - `[types]` Update default max block bytes param to account for increased signature size of mldsa65.
   ([\#5987](https://github.com/cometbft/cometbft/pull/5987))
+- `[config]` Update the default max_tx_bytes to account for increased signature size of mlsdsa65.
+  ([\#5989](https://github.com/cometbft/cometbft/pull/5989))
 
 ### FEATURES
 

--- a/config/config.go
+++ b/config/config.go
@@ -181,6 +181,8 @@ func (cfg *Config) CheckDeprecated() []string {
 
 // BaseConfig defines the base configuration for a CometBFT node
 type BaseConfig struct {
+
+	// The version of the CometBFT binary that created
 	// or last modified the config file
 	Version string `mapstructure:"version"`
 
@@ -487,7 +489,9 @@ func (cfg *RPCConfig) ValidateBasic() error {
 	}
 	if cfg.MaxSubscriptionClients < 0 {
 		return cmterrors.ErrNegativeField{Field: "max_subscription_clients"}
+
 	}
+	if cfg.MaxSubscriptionsPerClient < 0 {
 		return cmterrors.ErrNegativeField{Field: "max_subscriptions_per_client"}
 	}
 	if cfg.SubscriptionBufferSize < minSubscriptionBufferSize {

--- a/config/config.go
+++ b/config/config.go
@@ -181,8 +181,6 @@ func (cfg *Config) CheckDeprecated() []string {
 
 // BaseConfig defines the base configuration for a CometBFT node
 type BaseConfig struct {
-
-	// The version of the CometBFT binary that created
 	// or last modified the config file
 	Version string `mapstructure:"version"`
 
@@ -489,9 +487,7 @@ func (cfg *RPCConfig) ValidateBasic() error {
 	}
 	if cfg.MaxSubscriptionClients < 0 {
 		return cmterrors.ErrNegativeField{Field: "max_subscription_clients"}
-
 	}
-	if cfg.MaxSubscriptionsPerClient < 0 {
 		return cmterrors.ErrNegativeField{Field: "max_subscriptions_per_client"}
 	}
 	if cfg.SubscriptionBufferSize < minSubscriptionBufferSize {
@@ -1030,7 +1026,7 @@ func DefaultMempoolConfig() *MempoolConfig {
 		Size:        5000,
 		MaxTxsBytes: 1024 * 1024 * 1024, // 1GB
 		CacheSize:   10000,
-		MaxTxBytes:  4 * 1024 * 1024, // 4MB; fits post-quantum (ML-DSA) IBC client updates for large validator sets
+		MaxTxBytes:  4 * 1024 * 1024, // 4MB
 		ExperimentalMaxGossipConnectionsToNonPersistentPeers: 0,
 		ExperimentalMaxGossipConnectionsToPersistentPeers:    0,
 		// App mempool defaults

--- a/config/config.go
+++ b/config/config.go
@@ -1030,7 +1030,7 @@ func DefaultMempoolConfig() *MempoolConfig {
 		Size:        5000,
 		MaxTxsBytes: 1024 * 1024 * 1024, // 1GB
 		CacheSize:   10000,
-		MaxTxBytes:  1024 * 1024, // 1MB
+		MaxTxBytes:  4 * 1024 * 1024, // 4MB; fits post-quantum (ML-DSA) IBC client updates for large validator sets
 		ExperimentalMaxGossipConnectionsToNonPersistentPeers: 0,
 		ExperimentalMaxGossipConnectionsToPersistentPeers:    0,
 		// App mempool defaults

--- a/docs/core/configuration.md
+++ b/docs/core/configuration.md
@@ -350,7 +350,7 @@ keep-invalid-txs-in-cache = false
 
 # Maximum size of a single transaction.
 # NOTE: the max size of a tx transmitted over the network is {max_tx_bytes}.
-max_tx_bytes = 1048576
+max_tx_bytes = 4194304
 
 # Maximum size of a batch of transactions to send to a peer
 # Including space needed by encoding (one varint per transaction).

--- a/docs/references/config/config.toml.md
+++ b/docs/references/config/config.toml.md
@@ -1318,7 +1318,7 @@ The value `0` is undefined.
 ### mempool.max_tx_bytes
 Maximum size in bytes of a single transaction accepted into the mempool.
 ```toml
-max_tx_bytes = 1048576
+max_tx_bytes = 4194304
 ```
 
 | Value type          | integer |


### PR DESCRIPTION
---

Bumps max tx bytes to account for the potential of larger txs due to the need to incorporate validator signatures such as IBC txns or evidence.

In terms of picking a sane default, a chain w/ 100 validators all using mldsa65 signatures a `MsgSubmitMisbehaviour` which carries 2 full block headers would take ~1.5MB. 4MB here gives us plenty of overhead.