### PR TITLE
consensus: validate vote extension WAL size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### BUG FIXES
 
+- `[consensus]` reject locally generated vote extensions before signing when
+  their complete Precommit message cannot fit in the consensus WAL
+  ([\#1253](https://github.com/cometbft/cometbft/issues/1253))
+
 ### IMPROVEMENTS
 
 ### FEATURES

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -2453,6 +2453,9 @@ func (cs *State) signVote(
 				return nil, err
 			}
 			vote.Extension = ext
+			if err := ensureVoteFitsWAL(vote); err != nil {
+				return nil, err
+			}
 
 			// Self-verify the extension before broadcasting. Every other validator
 			// runs VerifyVoteExtension on this precommit's extension and rejects
@@ -2485,6 +2488,17 @@ func (cs *State) signVote(
 	}
 
 	return vote, err
+}
+
+func ensureVoteFitsWAL(vote *types.Vote) error {
+	voteForSizing := *vote
+	voteForSizing.Signature = make([]byte, types.MaxSignatureSize)
+	voteForSizing.ExtensionSignature = make([]byte, types.MaxSignatureSize)
+	msg := msgInfo{Msg: &VoteMessage{Vote: &voteForSizing}}
+	if err := ensureWALMessageFits(msg); err != nil {
+		return fmt.Errorf("vote extension is too large to fit in the consensus WAL: %w", err)
+	}
+	return nil
 }
 
 func (cs *State) voteTime() time.Time {

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -1998,6 +1998,32 @@ func TestSelfVerifyVoteExtensionAccepts(t *testing.T) {
 	m.AssertExpectations(t)
 }
 
+func TestVoteExtensionMustFitWAL(t *testing.T) {
+	m := abcimocks.NewApplication(t)
+	m.On("PrepareProposal", mock.Anything, mock.Anything).Return(&abci.ResponsePrepareProposal{}, nil)
+	m.On("ProcessProposal", mock.Anything, mock.Anything).
+		Return(&abci.ResponseProcessProposal{Status: abci.ResponseProcessProposal_ACCEPT}, nil).Maybe()
+	m.On("ExtendVote", mock.Anything, mock.Anything).Return(&abci.ResponseExtendVote{
+		VoteExtension: make([]byte, types.MaxVoteExtensionSize),
+	}, nil).Once()
+
+	cs1, _ := randStateWithAppWithHeight(1, m, 1)
+
+	block, err := cs1.createProposalBlock(context.Background())
+	require.NoError(t, err)
+	parts, err := block.MakePartSet(types.BlockPartSizeBytes)
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		vote, err := cs1.signVote(cmtproto.PrecommitType, block.Hash(), parts.Header(), block)
+		require.Nil(t, vote)
+		require.ErrorContains(t, err, "vote extension is too large to fit in the consensus WAL")
+		require.ErrorContains(t, err, "msg is too big")
+	})
+	m.AssertNotCalled(t, "VerifyVoteExtension", mock.Anything, mock.Anything)
+	m.AssertExpectations(t)
+}
+
 // TestStateDoesntCrashOnInvalidVote tests that the state does not crash when
 // receiving an invalid vote. In particular, one with the incorrect
 // ValidatorIndex.

--- a/consensus/wal.go
+++ b/consensus/wal.go
@@ -29,6 +29,8 @@ const (
 	walDefaultFlushInterval = 2 * time.Second
 )
 
+var maxWALMessageTime = time.Date(9999, 12, 31, 23, 59, 59, 999999999, time.UTC)
+
 //--------------------------------------------------------
 // types and functions for savings consensus messages
 
@@ -297,23 +299,48 @@ func NewWALEncoder(wr io.Writer) *WALEncoder {
 	return &WALEncoder{wr: wr}
 }
 
+func timedWALMessageToProto(v *TimedWALMessage) (*cmtcons.TimedWALMessage, error) {
+	pbMsg, err := WALToProto(v.Msg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cmtcons.TimedWALMessage{
+		Time: v.Time,
+		Msg:  pbMsg,
+	}, nil
+}
+
+func validateWALMessageSize(pv *cmtcons.TimedWALMessage) (int, error) {
+	size := pv.Size()
+	if size > maxMsgSizeBytes {
+		return 0, fmt.Errorf("msg is too big: %d bytes, max: %d bytes", size, maxMsgSizeBytes)
+	}
+	return size, nil
+}
+
+// ensureWALMessageFits checks a message using the largest supported protobuf
+// timestamp so a message accepted here will fit when it is written later.
+func ensureWALMessageFits(msg WALMessage) error {
+	pv, err := timedWALMessageToProto(&TimedWALMessage{Time: maxWALMessageTime, Msg: msg})
+	if err != nil {
+		return err
+	}
+	_, err = validateWALMessageSize(pv)
+	return err
+}
+
 // Encode writes the custom encoding of v to the stream. It returns an error if
 // the encoded size of v is greater than 1MB. Any error encountered
 // during the write is also returned.
 func (enc *WALEncoder) Encode(v *TimedWALMessage) error {
-	pbMsg, err := WALToProto(v.Msg)
+	pv, err := timedWALMessageToProto(v)
 	if err != nil {
 		return err
 	}
-	pv := cmtcons.TimedWALMessage{
-		Time: v.Time,
-		Msg:  pbMsg,
-	}
-
-	size := pv.Size()
-	length := uint32(size)
-	if length > maxMsgSizeBytes {
-		return fmt.Errorf("msg is too big: %d bytes, max: %d bytes", length, maxMsgSizeBytes)
+	size, err := validateWALMessageSize(pv)
+	if err != nil {
+		return err
 	}
 
 	total := 8 + size
@@ -328,7 +355,7 @@ func (enc *WALEncoder) Encode(v *TimedWALMessage) error {
 	}
 
 	binary.BigEndian.PutUint32(enc.buf[0:4], crc32.Checksum(enc.buf[8:], crc32c))
-	binary.BigEndian.PutUint32(enc.buf[4:8], length)
+	binary.BigEndian.PutUint32(enc.buf[4:8], uint32(size))
 
 	_, err = enc.wr.Write(enc.buf)
 	return err

--- a/spec/abci/abci++_methods.md
+++ b/spec/abci/abci++_methods.md
@@ -526,6 +526,12 @@ When a node _p_ enters consensus round _r_, height _h_, in which _q_ is the prop
     * `ExtendVoteResponse.vote_extension` will only be attached to a non-`nil` Precommit message. If the consensus algorithm is to
       precommit `nil`, it will not call `ExtendVote`.
     * The Application logic that creates the extension can be non-deterministic.
+    * The Application should enforce a conservative maximum size for vote extensions in both
+      `ExtendVote` and `VerifyVoteExtension`. CometBFT must persist its complete local Precommit
+      message to the consensus WAL before broadcasting it, and the encoded WAL message is limited
+      to approximately 1 MiB. This limit includes the vote, signatures, and encoding overhead, not
+      only the vote extension. CometBFT will reject a locally generated extension before signing if
+      the complete Precommit cannot fit in the WAL.
 
 #### When does CometBFT call `ExtendVote`?
 


### PR DESCRIPTION
## Summary

Prevent application-generated vote extensions from producing a local Precommit that cannot be persisted to the consensus WAL.

This change:

* checks the fully wrapped WAL message before the private validator signs the vote
* sizes signatures conservatively using `types.MaxSignatureSize`
* sizes the WAL envelope using the largest supported protobuf timestamp
* reuses the same protobuf conversion and size validation as `WALEncoder`
* documents the application responsibility to enforce a conservative vote-extension limit
* adds regression coverage for a 1 MiB vote extension

Fixes #1253.

## Problem

The WAL limits an encoded message to approximately 1 MiB. An application can return a vote extension whose bytes fit within the nominal vote-extension limit while the complete Precommit does not fit after adding the vote fields, signatures, protobuf wrappers, and WAL timestamp.

Local votes are written with `WriteSync` before they are processed or broadcast. If the oversized message reaches that point, WAL encoding fails and consensus panics. Ignoring that error would be unsafe because a local signed vote must be durable before the node processes or broadcasts it. Increasing the WAL limit would not solve the underlying issue because application-generated vote extensions do not have a universal semantic size.

## Solution

After `ExtendVote` returns, `signVote` now builds a copy of the prospective vote for sizing. The copy uses maximum-size placeholders for both the vote signature and vote-extension signature. It is then wrapped as the same `msgInfo` and `TimedWALMessage` structure used by the WAL.

The WAL conversion and size validation have been factored into shared helpers. The preflight check uses the largest valid protobuf timestamp, so a message accepted before signing will still fit when written later. If the complete message exceeds the WAL limit, `signVote` returns a descriptive error before self-verification, private-validator signing, queueing, processing, or broadcast.

This preserves the existing durability invariant. It does not drop a signed vote, suppress a WAL error, remove vote extensions from replay, introduce a node-local consensus parameter, or impose an application-specific semantic limit.

## Application impact

Applications should continue to choose and enforce their own deterministic vote-extension policy in `ExtendVote` and `VerifyVoteExtension`. The specification now explains that the application limit must leave room for the remaining Precommit and WAL encoding overhead.

An oversized locally generated extension causes that validator to skip the vote and log the returned error instead of crashing later in the WAL write path. Other validators still apply the application-defined `VerifyVoteExtension` policy to received extensions.

## Validation

* Added `TestVoteExtensionMustFitWAL`, which returns a 1 MiB extension and verifies that `signVote` returns an error without panicking or calling `VerifyVoteExtension`.
* Existing accepted and rejected self-verification tests pass.
* Existing WAL oversized-message coverage passes through the refactored encoder.
* `go test ./consensus -count=1` passes.
* `make lint` passes with zero issues.
* `make test` passes for all locally runnable packages. The PostgreSQL indexer package cannot run because Docker is unavailable at `/var/run/docker.sock`.

## Checklist

- [x] Tests written and updated
- [x] Changelog entry added in `CHANGELOG.md`
- [x] Relevant ABCI specification updated
