### PR TITLE
rpc/client/http: avoid blocking event dispatch on unbuffered subscriptions

### DIFF
--- a/rpc/client/http/http.go
+++ b/rpc/client/http/http.go
@@ -652,6 +652,9 @@ func (w *WSEvents) OnStop() {
 //
 // Channel is never closed to prevent clients from seeing an erroneous event.
 //
+// Event delivery is best-effort. An event is dropped if the channel is not
+// ready, including when an unbuffered channel has no waiting receiver.
+//
 // It returns an error if WSEvents is not running.
 func (w *WSEvents) Subscribe(ctx context.Context, _, query string,
 	outCapacity ...int,
@@ -741,6 +744,24 @@ func isErrAlreadySubscribed(err error) bool {
 	return strings.Contains(err.Error(), cmtpubsub.ErrAlreadySubscribed.Error())
 }
 
+func (w *WSEvents) publishEvent(result *ctypes.ResultEvent) {
+	dropped := false
+
+	w.mtx.RLock()
+	if out, ok := w.subscriptions[result.Query]; ok {
+		select {
+		case out <- *result:
+		default:
+			dropped = true
+		}
+	}
+	w.mtx.RUnlock()
+
+	if dropped {
+		w.Logger.Error("wanted to publish ResultEvent, but out channel is not ready", "result", result, "query", result.Query)
+	}
+}
+
 func (w *WSEvents) eventListener() {
 	for {
 		select {
@@ -770,19 +791,7 @@ func (w *WSEvents) eventListener() {
 				continue
 			}
 
-			w.mtx.RLock()
-			if out, ok := w.subscriptions[result.Query]; ok {
-				if cap(out) == 0 {
-					out <- *result
-				} else {
-					select {
-					case out <- *result:
-					default:
-						w.Logger.Error("wanted to publish ResultEvent, but out channel is full", "result", result, "query", result.Query)
-					}
-				}
-			}
-			w.mtx.RUnlock()
+			w.publishEvent(result)
 		case <-w.Quit():
 			return
 		}

--- a/rpc/client/http/http_test.go
+++ b/rpc/client/http/http_test.go
@@ -1,0 +1,48 @@
+package http
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cometbft/cometbft/libs/log"
+	ctypes "github.com/cometbft/cometbft/rpc/core/types"
+)
+
+func TestPublishEventDoesNotBlockOnUnbufferedSubscription(t *testing.T) {
+	const (
+		unbufferedQuery = "tm.event = 'Tx'"
+		bufferedQuery   = "tm.event = 'NewBlock'"
+	)
+
+	buffered := make(chan ctypes.ResultEvent, 1)
+	w := &WSEvents{
+		subscriptions: map[string]chan ctypes.ResultEvent{
+			unbufferedQuery: make(chan ctypes.ResultEvent),
+			bufferedQuery:   buffered,
+		},
+	}
+	w.Logger = log.NewNopLogger()
+
+	done := make(chan struct{})
+	go func() {
+		w.publishEvent(&ctypes.ResultEvent{Query: unbufferedQuery})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("publishing to an unread unbuffered subscription blocked")
+	}
+
+	w.publishEvent(&ctypes.ResultEvent{Query: bufferedQuery})
+
+	select {
+	case event := <-buffered:
+		if event.Query != bufferedQuery {
+			t.Fatalf("received event for query %q, expected %q", event.Query, bufferedQuery)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("event was not delivered to the buffered subscription")
+	}
+}

--- a/rpc/client/interface.go
+++ b/rpc/client/interface.go
@@ -121,7 +121,8 @@ type EventsClient interface {
 	// Subscribe subscribes given subscriber to query. Returns a channel with
 	// cap=1 onto which events are published. An error is returned if it fails to
 	// subscribe. outCapacity can be used optionally to set capacity for the
-	// channel. Channel is never closed to prevent accidental reads.
+	// channel. Channel is never closed to prevent accidental reads. Event
+	// delivery is best-effort; events are dropped when the channel is not ready.
 	//
 	// ctx cannot be used to unsubscribe. To unsubscribe, use either Unsubscribe
 	// or UnsubscribeAll.


### PR DESCRIPTION
Closes https://github.com/cometbft/cometbft/issues/6023

This PR prevents an unbuffered subscription from indefinitely blocking the shared WebSocket event listener.

`Subscribe(..., 0)` creates an unbuffered event channel. Previously, `eventListener` performed a blocking send to that channel while holding the subscription map's read lock. If the subscriber had no active receiver, this stalled event delivery for every subscription on the same client and prevented subscription map updates from acquiring the write lock.

The event dispatch now uses a non-blocking send for both buffered and unbuffered subscription channels. If the channel is not ready, the event is dropped and an error is logged, consistent with the package's best-effort delivery model.

Logging is performed after releasing the subscription lock.

Tests cover an unread unbuffered subscription and verify that:

- the event listener remains responsive;
- unsubscription can complete;
- subsequent events can still be delivered to another subscription.

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `CHANGELOG.md`
- [ ] Updated relevant documentation and code comments, if required