### PR TITLE
feat: Backport mldsa verification

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,7 @@ linters:
             - github.com/cosmos
             - github.com/btcsuite/btcd/btcec/v2
             - github.com/BurntSushi/toml
+            - github.com/cloudflare/circl/sign/mldsa/mldsa65
             - github.com/go-git/go-git/v5
             - github.com/go-kit
             - github.com/go-logfmt/logfmt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## v0.38.26
+
+*August 12, 2026*
+
+### FEATURES
+
+- `[crypto]` Add ML-DSA-65 public key decoding and signature verification.
+
 ## v0.38.24
 
 *July 27, 2026*
@@ -242,6 +250,7 @@ encouraged to upgrade as soon as possible.
 *December 20 2024*
 
 This release:
+
 - fixes a bug that caused a node produce errors caused by the sending of next PEX requests too soon.
 As a consequence of this incorrect behavior a node would be marked as BAD.
 - Adds a proper description of `ExtendedVoteInfo` and `VoteInfo` in the spec.
@@ -698,7 +707,7 @@ gossip.
 This release includes the second part of ABCI++, called ABCI 2.0.
 ABCI 2.0 introduces ABCI methods `ExtendVote` and `VerifyVoteExtension`.
 These new methods allow the application to add data (opaque to CometBFT),
-called _vote extensions_ to precommit votes sent by validators.
+called *vote extensions* to precommit votes sent by validators.
 These vote extensions are made available to the proposer(s) of the next height.
 Additionally, ABCI 2.0 coalesces `BeginBlock`, `DeliverTx`, and `EndBlock`
 into one method, `FinalizeBlock`, whose `Request*` and `Response*`
@@ -782,7 +791,7 @@ for people who forked CometBFT and interact directly with the indexers kvstore.
 - `[light]` Fixed an edge case where a light client would panic when attempting
   to query a node that (1) has started from a non-zero height and (2) does
   not yet have any data. The light client will now, correctly, not panic
-  _and_ keep the node in its list of providers in the same way it would if
+  *and* keep the node in its list of providers in the same way it would if
   it queried a node starting from height zero that does not yet have data
   ([\#575](https://github.com/cometbft/cometbft/issues/575))
 - `[abci]` Restore the snake_case naming in JSON serialization of
@@ -947,7 +956,7 @@ See below for more details.
   [\#77](https://github.com/cometbft/cometbft/pull/77). @jmalicevic
   ([\#382](https://github.com/cometbft/cometbft/pull/382))
 - `[consensus]` ([\#386](https://github.com/cometbft/cometbft/pull/386)) Short-term fix for the case when `needProofBlock` cannot find previous block meta by defaulting to the creation of a new proof block. (@adizere)
-  - Special thanks to the [Vega.xyz](https://vega.xyz/) team, and in particular to Zohar (@ze97286), for reporting the problem and working with us to get to a fix.
+    - Special thanks to the [Vega.xyz](https://vega.xyz/) team, and in particular to Zohar (@ze97286), for reporting the problem and working with us to get to a fix.
 - `[docker]` enable cross platform build using docker buildx
   ([\#9073](https://github.com/tendermint/tendermint/pull/9073))
 - `[consensus]` fix round number of `enterPropose`
@@ -1036,7 +1045,7 @@ to this release!
 - `[consensus]` Short-term fix for the case when `needProofBlock` cannot find
   previous block meta by defaulting to the creation of a new proof block.
   ([\#386](https://github.com/cometbft/cometbft/pull/386): @adizere)
-  - Special thanks to the [Vega.xyz](https://vega.xyz/) team, and in particular
+    - Special thanks to the [Vega.xyz](https://vega.xyz/) team, and in particular
     to Zohar (@ze97286), for reporting the problem and working with us to get to
     a fix.
 - `[p2p]` Correctly use non-blocking `TrySendEnvelope` method when attempting to
@@ -1059,7 +1068,7 @@ to this release!
 ### FEATURES
 
 - `[rpc]` Add `match_event` query parameter to indicate to the RPC that it
-  should match events _within_ attributes, not only within a height
+  should match events *within* attributes, not only within a height
   ([tendermint/tendermint\#9759](https://github.com/tendermint/tendermint/pull/9759))
 
 ### IMPROVEMENTS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -250,7 +250,6 @@ encouraged to upgrade as soon as possible.
 *December 20 2024*
 
 This release:
-
 - fixes a bug that caused a node produce errors caused by the sending of next PEX requests too soon.
 As a consequence of this incorrect behavior a node would be marked as BAD.
 - Adds a proper description of `ExtendedVoteInfo` and `VoteInfo` in the spec.
@@ -707,7 +706,7 @@ gossip.
 This release includes the second part of ABCI++, called ABCI 2.0.
 ABCI 2.0 introduces ABCI methods `ExtendVote` and `VerifyVoteExtension`.
 These new methods allow the application to add data (opaque to CometBFT),
-called *vote extensions* to precommit votes sent by validators.
+called _vote extensions_ to precommit votes sent by validators.
 These vote extensions are made available to the proposer(s) of the next height.
 Additionally, ABCI 2.0 coalesces `BeginBlock`, `DeliverTx`, and `EndBlock`
 into one method, `FinalizeBlock`, whose `Request*` and `Response*`
@@ -791,7 +790,7 @@ for people who forked CometBFT and interact directly with the indexers kvstore.
 - `[light]` Fixed an edge case where a light client would panic when attempting
   to query a node that (1) has started from a non-zero height and (2) does
   not yet have any data. The light client will now, correctly, not panic
-  *and* keep the node in its list of providers in the same way it would if
+  _and_ keep the node in its list of providers in the same way it would if
   it queried a node starting from height zero that does not yet have data
   ([\#575](https://github.com/cometbft/cometbft/issues/575))
 - `[abci]` Restore the snake_case naming in JSON serialization of
@@ -956,7 +955,7 @@ See below for more details.
   [\#77](https://github.com/cometbft/cometbft/pull/77). @jmalicevic
   ([\#382](https://github.com/cometbft/cometbft/pull/382))
 - `[consensus]` ([\#386](https://github.com/cometbft/cometbft/pull/386)) Short-term fix for the case when `needProofBlock` cannot find previous block meta by defaulting to the creation of a new proof block. (@adizere)
-    - Special thanks to the [Vega.xyz](https://vega.xyz/) team, and in particular to Zohar (@ze97286), for reporting the problem and working with us to get to a fix.
+  - Special thanks to the [Vega.xyz](https://vega.xyz/) team, and in particular to Zohar (@ze97286), for reporting the problem and working with us to get to a fix.
 - `[docker]` enable cross platform build using docker buildx
   ([\#9073](https://github.com/tendermint/tendermint/pull/9073))
 - `[consensus]` fix round number of `enterPropose`
@@ -1045,7 +1044,7 @@ to this release!
 - `[consensus]` Short-term fix for the case when `needProofBlock` cannot find
   previous block meta by defaulting to the creation of a new proof block.
   ([\#386](https://github.com/cometbft/cometbft/pull/386): @adizere)
-    - Special thanks to the [Vega.xyz](https://vega.xyz/) team, and in particular
+  - Special thanks to the [Vega.xyz](https://vega.xyz/) team, and in particular
     to Zohar (@ze97286), for reporting the problem and working with us to get to
     a fix.
 - `[p2p]` Correctly use non-blocking `TrySendEnvelope` method when attempting to
@@ -1068,7 +1067,7 @@ to this release!
 ### FEATURES
 
 - `[rpc]` Add `match_event` query parameter to indicate to the RPC that it
-  should match events *within* attributes, not only within a height
+  should match events _within_ attributes, not only within a height
   ([tendermint/tendermint\#9759](https://github.com/tendermint/tendermint/pull/9759))
 
 ### IMPROVEMENTS

--- a/crypto/encoding/codec.go
+++ b/crypto/encoding/codec.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/crypto/ed25519"
+	"github.com/cometbft/cometbft/crypto/mldsa65"
 	"github.com/cometbft/cometbft/crypto/secp256k1"
 	"github.com/cometbft/cometbft/libs/json"
 	pc "github.com/cometbft/cometbft/proto/tendermint/crypto"
@@ -14,6 +15,7 @@ func init() {
 	json.RegisterType((*pc.PublicKey)(nil), "tendermint.crypto.PublicKey")
 	json.RegisterType((*pc.PublicKey_Ed25519)(nil), "tendermint.crypto.PublicKey_Ed25519")
 	json.RegisterType((*pc.PublicKey_Secp256K1)(nil), "tendermint.crypto.PublicKey_Secp256K1")
+	json.RegisterType((*pc.PublicKey_Mldsa65)(nil), "tendermint.crypto.PublicKey_Mldsa65")
 }
 
 // PubKeyToProto takes crypto.PubKey and transforms it to a protobuf Pubkey
@@ -30,6 +32,12 @@ func PubKeyToProto(k crypto.PubKey) (pc.PublicKey, error) {
 		kp = pc.PublicKey{
 			Sum: &pc.PublicKey_Secp256K1{
 				Secp256K1: k,
+			},
+		}
+	case mldsa65.PubKey:
+		kp = pc.PublicKey{
+			Sum: &pc.PublicKey_Mldsa65{
+				Mldsa65: k.Bytes(),
 			},
 		}
 	default:
@@ -57,6 +65,12 @@ func PubKeyFromProto(k pc.PublicKey) (crypto.PubKey, error) {
 		pk := make(secp256k1.PubKey, secp256k1.PubKeySize)
 		copy(pk, k.Secp256K1)
 		return pk, nil
+	case *pc.PublicKey_Mldsa65:
+		if len(k.Mldsa65) != mldsa65.PubKeySize {
+			return nil, fmt.Errorf("invalid size for PubKeyMlDsa65. Got %d, expected %d",
+				len(k.Mldsa65), mldsa65.PubKeySize)
+		}
+		return mldsa65.NewPubKeyFromBytes(k.Mldsa65)
 	default:
 		return nil, fmt.Errorf("fromproto: key type %v is not supported", k)
 	}

--- a/crypto/mldsa65/const.go
+++ b/crypto/mldsa65/const.go
@@ -1,0 +1,22 @@
+package mldsa65
+
+import "github.com/cloudflare/circl/sign/mldsa/mldsa65"
+
+const (
+	// PrivKeySize is the size, in bytes, of an ML-DSA-65 private key as
+	// serialized by circl (FIPS 204 packed form).
+	PrivKeySize = mldsa65.PrivateKeySize
+	// PubKeySize is the size, in bytes, of an ML-DSA-65 public key.
+	PubKeySize = mldsa65.PublicKeySize
+	// SignatureSize is the size, in bytes, of an ML-DSA-65 signature.
+	SignatureSize = mldsa65.SignatureSize
+	// SeedSize is the size, in bytes, of the seed used to derive a key pair.
+	SeedSize = mldsa65.SeedSize
+
+	// KeyType is the string identifier for the ML-DSA-65 algorithm.
+	KeyType = "ml_dsa_65"
+	// PrivKeyName is the amino route for the private key.
+	PrivKeyName = "cometbft/PrivKeyMlDsa65"
+	// PubKeyName is the amino route for the public key.
+	PubKeyName = "cometbft/PubKeyMlDsa65"
+)

--- a/crypto/mldsa65/key.go
+++ b/crypto/mldsa65/key.go
@@ -1,0 +1,243 @@
+// Package mldsa65 implements the NIST ML-DSA-65 post-quantum signature
+// scheme (FIPS 204) for use as a CometBFT validator key type.
+//
+// Keys and signatures are encoded as the packed byte form produced by
+// github.com/cloudflare/circl/sign/mldsa/mldsa65. Signing is deterministic
+// (randomized=false) and signs over an empty context string, matching the
+// "pure" mode of ML-DSA.
+package mldsa65
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/cloudflare/circl/sign/mldsa/mldsa65"
+
+	"github.com/cometbft/cometbft/crypto"
+	"github.com/cometbft/cometbft/crypto/tmhash"
+	cmtjson "github.com/cometbft/cometbft/libs/json"
+)
+
+var (
+	// ErrInvalidPrivKeySize is returned when private key bytes are the wrong length.
+	ErrInvalidPrivKeySize = fmt.Errorf("mldsa65: invalid private key size, expected %d bytes", PrivKeySize)
+	// ErrInvalidPubKeySize is returned when public key bytes are the wrong length.
+	ErrInvalidPubKeySize = fmt.Errorf("mldsa65: invalid public key size, expected %d bytes", PubKeySize)
+	// ErrDeserialization is returned when key bytes fail circl's UnmarshalBinary.
+	ErrDeserialization = errors.New("mldsa65: deserialization error")
+)
+
+func init() {
+	cmtjson.RegisterType(PubKey{}, PubKeyName)
+	cmtjson.RegisterType(PrivKey{}, PrivKeyName)
+}
+
+// ===============================================================================================
+// Private Key
+// ===============================================================================================
+
+var _ crypto.PrivKey = &PrivKey{}
+
+// PrivKey wraps a parsed ML-DSA-65 private key. The parsed form is retained so
+// Sign and PubKey avoid re-deserializing the 4032-byte packed key on every
+// call.
+type PrivKey struct {
+	sk *mldsa65.PrivateKey
+}
+
+// GenPrivKey generates a fresh ML-DSA-65 key using OS randomness.
+func GenPrivKey() (PrivKey, error) {
+	return genPrivKey(crypto.CReader())
+}
+
+func genPrivKey(r io.Reader) (PrivKey, error) {
+	_, sk, err := mldsa65.GenerateKey(r)
+	if err != nil {
+		return PrivKey{}, err
+	}
+	return PrivKey{sk: sk}, nil
+}
+
+// GenPrivKeyFromSeed deterministically derives a key from a 32-byte seed.
+func GenPrivKeyFromSeed(seed []byte) (PrivKey, error) {
+	if len(seed) != SeedSize {
+		return PrivKey{}, fmt.Errorf("mldsa65: seed must be %d bytes, got %d", SeedSize, len(seed))
+	}
+	var s [SeedSize]byte
+	copy(s[:], seed)
+	_, sk := mldsa65.NewKeyFromSeed(&s)
+	return PrivKey{sk: sk}, nil
+}
+
+// NewPrivKeyFromBytes validates and returns a PrivKey from the packed bytes.
+func NewPrivKeyFromBytes(bz []byte) (PrivKey, error) {
+	if len(bz) != PrivKeySize {
+		return PrivKey{}, ErrInvalidPrivKeySize
+	}
+	sk := new(mldsa65.PrivateKey)
+	if err := sk.UnmarshalBinary(bz); err != nil {
+		return PrivKey{}, ErrDeserialization
+	}
+	return PrivKey{sk: sk}, nil
+}
+
+// Bytes returns the packed private key bytes.
+func (privKey PrivKey) Bytes() []byte {
+	if privKey.sk == nil {
+		return nil
+	}
+	bz, err := privKey.sk.MarshalBinary()
+	if err != nil {
+		panic(fmt.Sprintf("mldsa65: marshal privkey: %v", err))
+	}
+	return bz
+}
+
+// PubKey returns the corresponding public key.
+func (privKey PrivKey) PubKey() crypto.PubKey {
+	pk, ok := privKey.sk.Public().(*mldsa65.PublicKey)
+	if !ok {
+		panic("mldsa65: unexpected public key type")
+	}
+	return PubKey{pk: pk}
+}
+
+// Equals returns true if the other key is also ML-DSA-65 and the bytes match.
+func (privKey PrivKey) Equals(other crypto.PrivKey) bool {
+	otherKey, ok := other.(PrivKey)
+	if !ok {
+		return false
+	}
+	return bytes.Equal(privKey.Bytes(), otherKey.Bytes())
+}
+
+// Type returns the algorithm identifier.
+func (PrivKey) Type() string {
+	return KeyType
+}
+
+// Sign produces a deterministic ML-DSA-65 signature with an empty context.
+func (privKey PrivKey) Sign(msg []byte) ([]byte, error) {
+	sig := make([]byte, SignatureSize)
+	if err := mldsa65.SignTo(privKey.sk, msg, nil, false, sig); err != nil {
+		return nil, err
+	}
+	return sig, nil
+}
+
+// MarshalJSON marshals the private key to JSON as its packed bytes.
+//
+// XXX: Not a pointer because our JSON encoder (libs/json) does not correctly
+// handle pointers.
+func (privKey PrivKey) MarshalJSON() ([]byte, error) {
+	return json.Marshal(privKey.Bytes())
+}
+
+// UnmarshalJSON unmarshals the private key from JSON.
+func (privKey *PrivKey) UnmarshalJSON(bz []byte) error {
+	var rawBytes []byte
+	if err := json.Unmarshal(bz, &rawBytes); err != nil {
+		return err
+	}
+	pk, err := NewPrivKeyFromBytes(rawBytes)
+	if err != nil {
+		return err
+	}
+	privKey.sk = pk.sk
+	return nil
+}
+
+// ===============================================================================================
+// Public Key
+// ===============================================================================================
+
+var _ crypto.PubKey = &PubKey{}
+
+// PubKey wraps a parsed ML-DSA-65 public key. The parsed form is retained so
+// VerifySignature avoids re-deserializing the 1952-byte packed key on every
+// call.
+type PubKey struct {
+	pk *mldsa65.PublicKey
+}
+
+// NewPubKeyFromBytes validates and returns a PubKey from the packed bytes.
+func NewPubKeyFromBytes(bz []byte) (PubKey, error) {
+	if len(bz) != PubKeySize {
+		return PubKey{}, ErrInvalidPubKeySize
+	}
+	pk := new(mldsa65.PublicKey)
+	if err := pk.UnmarshalBinary(bz); err != nil {
+		return PubKey{}, ErrDeserialization
+	}
+	return PubKey{pk: pk}, nil
+}
+
+// Address is SHA256(pubkey) truncated to 20 bytes, matching the convention used
+// by ed25519 and bls12381 validator keys.
+func (pubKey PubKey) Address() crypto.Address {
+	return crypto.Address(tmhash.SumTruncated(pubKey.Bytes()))
+}
+
+// VerifySignature verifies the signature against msg with an empty context.
+func (pubKey PubKey) VerifySignature(msg, sig []byte) bool {
+	if len(sig) != SignatureSize || pubKey.pk == nil {
+		return false
+	}
+	return mldsa65.Verify(pubKey.pk, msg, nil, sig)
+}
+
+// Bytes returns the packed public key bytes.
+func (pubKey PubKey) Bytes() []byte {
+	if pubKey.pk == nil {
+		return nil
+	}
+	bz, err := pubKey.pk.MarshalBinary()
+	if err != nil {
+		panic(fmt.Sprintf("mldsa65: marshal pubkey: %v", err))
+	}
+	return bz
+}
+
+// Type returns the algorithm identifier.
+func (PubKey) Type() string {
+	return KeyType
+}
+
+// Equals returns true if the other key is also ML-DSA-65 and the bytes match.
+func (pubKey PubKey) Equals(other crypto.PubKey) bool {
+	otherKey, ok := other.(PubKey)
+	if !ok {
+		return false
+	}
+	return bytes.Equal(pubKey.Bytes(), otherKey.Bytes())
+}
+
+// String returns a hex-formatted representation of the public key.
+func (pubKey PubKey) String() string {
+	return fmt.Sprintf("PubKeyMlDsa65{%X}", pubKey.Bytes())
+}
+
+// MarshalJSON marshals the public key to JSON as its packed bytes.
+//
+// XXX: Not a pointer because our JSON encoder (libs/json) does not correctly
+// handle pointers.
+func (pubKey PubKey) MarshalJSON() ([]byte, error) {
+	return json.Marshal(pubKey.Bytes())
+}
+
+// UnmarshalJSON unmarshals the public key from JSON.
+func (pubKey *PubKey) UnmarshalJSON(bz []byte) error {
+	var rawBytes []byte
+	if err := json.Unmarshal(bz, &rawBytes); err != nil {
+		return err
+	}
+	pk, err := NewPubKeyFromBytes(rawBytes)
+	if err != nil {
+		return err
+	}
+	pubKey.pk = pk.pk
+	return nil
+}

--- a/crypto/mldsa65/key_test.go
+++ b/crypto/mldsa65/key_test.go
@@ -1,0 +1,154 @@
+package mldsa65_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/crypto/mldsa65"
+)
+
+func TestSignAndVerify(t *testing.T) {
+	priv, err := mldsa65.GenPrivKey()
+	require.NoError(t, err)
+	require.Len(t, priv.Bytes(), mldsa65.PrivKeySize)
+
+	pub := priv.PubKey()
+	require.Equal(t, mldsa65.KeyType, pub.Type())
+	require.Len(t, pub.Bytes(), mldsa65.PubKeySize)
+
+	msg := []byte("the quick brown fox jumps over the lazy dog")
+	sig, err := priv.Sign(msg)
+	require.NoError(t, err)
+	require.Len(t, sig, mldsa65.SignatureSize)
+
+	require.True(t, pub.VerifySignature(msg, sig))
+
+	// Tamper with the message.
+	tampered := append([]byte(nil), msg...)
+	tampered[0] ^= 0xff
+	require.False(t, pub.VerifySignature(tampered, sig))
+
+	// Tamper with the signature.
+	badSig := append([]byte(nil), sig...)
+	badSig[0] ^= 0xff
+	require.False(t, pub.VerifySignature(msg, badSig))
+}
+
+func TestDeterministicFromSeed(t *testing.T) {
+	seed := make([]byte, mldsa65.SeedSize)
+	for i := range seed {
+		seed[i] = byte(i)
+	}
+
+	a, err := mldsa65.GenPrivKeyFromSeed(seed)
+	require.NoError(t, err)
+	b, err := mldsa65.GenPrivKeyFromSeed(seed)
+	require.NoError(t, err)
+	require.True(t, a.Equals(b))
+	require.True(t, a.PubKey().Equals(b.PubKey()))
+}
+
+func TestRoundTripBytes(t *testing.T) {
+	priv, err := mldsa65.GenPrivKey()
+	require.NoError(t, err)
+
+	got, err := mldsa65.NewPrivKeyFromBytes(priv.Bytes())
+	require.NoError(t, err)
+	require.True(t, priv.Equals(got))
+
+	pub := priv.PubKey().(mldsa65.PubKey)
+	gotPub, err := mldsa65.NewPubKeyFromBytes(pub.Bytes())
+	require.NoError(t, err)
+	require.True(t, pub.Equals(gotPub))
+
+	// Wrong sizes rejected.
+	_, err = mldsa65.NewPrivKeyFromBytes(priv.Bytes()[:10])
+	require.ErrorIs(t, err, mldsa65.ErrInvalidPrivKeySize)
+	_, err = mldsa65.NewPubKeyFromBytes(pub.Bytes()[:10])
+	require.ErrorIs(t, err, mldsa65.ErrInvalidPubKeySize)
+}
+
+func TestAddressIs20Bytes(t *testing.T) {
+	priv, err := mldsa65.GenPrivKey()
+	require.NoError(t, err)
+	addr := priv.PubKey().Address()
+	require.Len(t, addr, 20)
+}
+
+// TestVerifyManySignatures verifies many signatures under the same pubkey
+// and confirms that repeated verification on a single PubKey instance yields
+// correct results.
+func TestVerifyManySignatures(t *testing.T) {
+	priv, err := mldsa65.GenPrivKey()
+	require.NoError(t, err)
+	pub := priv.PubKey().(mldsa65.PubKey)
+
+	const iterations = 256
+	for i := 0; i < iterations; i++ {
+		msg := []byte(fmt.Sprintf("message %d", i))
+		sig, err := priv.Sign(msg)
+		require.NoError(t, err)
+		require.True(t, pub.VerifySignature(msg, sig), "iteration %d", i)
+
+		bad := append([]byte(nil), sig...)
+		bad[0] ^= 0xff
+		require.False(t, pub.VerifySignature(msg, bad), "tamper iteration %d", i)
+	}
+}
+
+// BenchmarkSign measures Sign on a single PrivKey. With the parsed key cached
+// in the struct, this should not include UnmarshalBinary cost.
+func BenchmarkSign(b *testing.B) {
+	priv, err := mldsa65.GenPrivKey()
+	if err != nil {
+		b.Fatal(err)
+	}
+	msg := []byte("benchmark message")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := priv.Sign(msg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkVerifySignature measures verification under a single pubkey.
+func BenchmarkVerifySignature(b *testing.B) {
+	priv, err := mldsa65.GenPrivKey()
+	if err != nil {
+		b.Fatal(err)
+	}
+	pub := priv.PubKey().(mldsa65.PubKey)
+	msg := []byte("benchmark message")
+	sig, err := priv.Sign(msg)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if !pub.VerifySignature(msg, sig) {
+			b.Fatal("verify failed")
+		}
+	}
+}
+
+// BenchmarkNewPubKeyFromBytes measures the cost of parsing a packed pubkey,
+// which is now the dominant cost when constructing PubKeys from wire bytes.
+func BenchmarkNewPubKeyFromBytes(b *testing.B) {
+	priv, err := mldsa65.GenPrivKey()
+	if err != nil {
+		b.Fatal(err)
+	}
+	bz := priv.PubKey().Bytes()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := mldsa65.NewPubKeyFromBytes(bz); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/adlio/schema v1.3.6
 	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
+	github.com/cloudflare/circl v1.6.3
 	github.com/cometbft/cometbft-db v0.14.1
 	github.com/cosmos/gogoproto v1.7.0
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0
@@ -56,7 +57,6 @@ require (
 	github.com/ProtonMail/go-crypto v1.1.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/cockroachdb/errors v1.11.3 // indirect
 	github.com/cockroachdb/fifo v0.0.0-20240606204812-0bbfbd93a7ce // indirect
 	github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
-github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
+github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
+github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v1.0.3-0.20230413201302-be42291fc80f h1:otljaYPt5hWxV3MUfO5dFPFiOXg9CyG5/kCfayTqsJ4=
 github.com/cockroachdb/datadriven v1.0.3-0.20230413201302-be42291fc80f/go.mod h1:a9RdTaap04u637JoCzcUoIcDmvwSUtcUFtT/C3kJlTU=

--- a/proto/tendermint/crypto/keys.pb.go
+++ b/proto/tendermint/crypto/keys.pb.go
@@ -30,6 +30,7 @@ type PublicKey struct {
 	//
 	//	*PublicKey_Ed25519
 	//	*PublicKey_Secp256K1
+	//	*PublicKey_Mldsa65
 	Sum isPublicKey_Sum `protobuf_oneof:"sum"`
 }
 
@@ -80,9 +81,13 @@ type PublicKey_Ed25519 struct {
 type PublicKey_Secp256K1 struct {
 	Secp256K1 []byte `protobuf:"bytes,2,opt,name=secp256k1,proto3,oneof" json:"secp256k1,omitempty"`
 }
+type PublicKey_Mldsa65 struct {
+	Mldsa65 []byte `protobuf:"bytes,4,opt,name=mldsa65,proto3,oneof" json:"mldsa65,omitempty"`
+}
 
 func (*PublicKey_Ed25519) isPublicKey_Sum()   {}
 func (*PublicKey_Secp256K1) isPublicKey_Sum() {}
+func (*PublicKey_Mldsa65) isPublicKey_Sum()   {}
 
 func (m *PublicKey) GetSum() isPublicKey_Sum {
 	if m != nil {
@@ -105,11 +110,19 @@ func (m *PublicKey) GetSecp256K1() []byte {
 	return nil
 }
 
+func (m *PublicKey) GetMldsa65() []byte {
+	if x, ok := m.GetSum().(*PublicKey_Mldsa65); ok {
+		return x.Mldsa65
+	}
+	return nil
+}
+
 // XXX_OneofWrappers is for the internal use of the proto package.
 func (*PublicKey) XXX_OneofWrappers() []interface{} {
 	return []interface{}{
 		(*PublicKey_Ed25519)(nil),
 		(*PublicKey_Secp256K1)(nil),
+		(*PublicKey_Mldsa65)(nil),
 	}
 }
 
@@ -120,20 +133,21 @@ func init() {
 func init() { proto.RegisterFile("tendermint/crypto/keys.proto", fileDescriptor_cb048658b234868c) }
 
 var fileDescriptor_cb048658b234868c = []byte{
-	// 204 bytes of a gzipped FileDescriptorProto
+	// 219 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x29, 0x49, 0xcd, 0x4b,
 	0x49, 0x2d, 0xca, 0xcd, 0xcc, 0x2b, 0xd1, 0x4f, 0x2e, 0xaa, 0x2c, 0x28, 0xc9, 0xd7, 0xcf, 0x4e,
 	0xad, 0x2c, 0xd6, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0x12, 0x44, 0xc8, 0xea, 0x41, 0x64, 0xa5,
-	0x44, 0xd2, 0xf3, 0xd3, 0xf3, 0xc1, 0xb2, 0xfa, 0x20, 0x16, 0x44, 0xa1, 0x52, 0x04, 0x17, 0x67,
+	0x44, 0xd2, 0xf3, 0xd3, 0xf3, 0xc1, 0xb2, 0xfa, 0x20, 0x16, 0x44, 0xa1, 0x52, 0x09, 0x17, 0x67,
 	0x40, 0x69, 0x52, 0x4e, 0x66, 0xb2, 0x77, 0x6a, 0xa5, 0x90, 0x14, 0x17, 0x7b, 0x6a, 0x8a, 0x91,
 	0xa9, 0xa9, 0xa1, 0xa5, 0x04, 0xa3, 0x02, 0xa3, 0x06, 0x8f, 0x07, 0x43, 0x10, 0x4c, 0x40, 0x48,
 	0x8e, 0x8b, 0xb3, 0x38, 0x35, 0xb9, 0xc0, 0xc8, 0xd4, 0x2c, 0xdb, 0x50, 0x82, 0x09, 0x2a, 0x8b,
-	0x10, 0xb2, 0xe2, 0x78, 0xb1, 0x40, 0x9e, 0xf1, 0xc5, 0x42, 0x79, 0x46, 0x27, 0x56, 0x2e, 0xe6,
-	0xe2, 0xd2, 0x5c, 0x27, 0xbf, 0x13, 0x8f, 0xe4, 0x18, 0x2f, 0x3c, 0x92, 0x63, 0x7c, 0xf0, 0x48,
-	0x8e, 0x71, 0xc2, 0x63, 0x39, 0x86, 0x0b, 0x8f, 0xe5, 0x18, 0x6e, 0x3c, 0x96, 0x63, 0x88, 0x32,
-	0x49, 0xcf, 0x2c, 0xc9, 0x28, 0x4d, 0xd2, 0x4b, 0xce, 0xcf, 0xd5, 0x4f, 0xce, 0xcf, 0x4d, 0x2d,
-	0x49, 0x4a, 0x2b, 0x41, 0x30, 0x20, 0x4e, 0xc4, 0xf0, 0x5d, 0x12, 0x1b, 0x58, 0xc2, 0x18, 0x10,
-	0x00, 0x00, 0xff, 0xff, 0xa3, 0xfb, 0xf7, 0x98, 0xf9, 0x00, 0x00, 0x00,
+	0x10, 0x02, 0xe9, 0xcd, 0xcd, 0x49, 0x29, 0x4e, 0x34, 0x33, 0x95, 0x60, 0x81, 0xe9, 0x85, 0x0a,
+	0x58, 0x71, 0xbc, 0x58, 0x20, 0xcf, 0xf8, 0x62, 0xa1, 0x3c, 0xa3, 0x13, 0x2b, 0x17, 0x73, 0x71,
+	0x69, 0xae, 0x93, 0xdf, 0x89, 0x47, 0x72, 0x8c, 0x17, 0x1e, 0xc9, 0x31, 0x3e, 0x78, 0x24, 0xc7,
+	0x38, 0xe1, 0xb1, 0x1c, 0xc3, 0x85, 0xc7, 0x72, 0x0c, 0x37, 0x1e, 0xcb, 0x31, 0x44, 0x99, 0xa4,
+	0x67, 0x96, 0x64, 0x94, 0x26, 0xe9, 0x25, 0xe7, 0xe7, 0xea, 0x27, 0xe7, 0xe7, 0xa6, 0x96, 0x24,
+	0xa5, 0x95, 0x20, 0x18, 0x10, 0xe7, 0x63, 0xf8, 0x3c, 0x89, 0x0d, 0x2c, 0x61, 0x0c, 0x08, 0x00,
+	0x00, 0xff, 0xff, 0xe5, 0xc1, 0xe7, 0xf4, 0x15, 0x01, 0x00, 0x00,
 }
 
 func (this *PublicKey) Compare(that interface{}) int {
@@ -174,6 +188,8 @@ func (this *PublicKey) Compare(that interface{}) int {
 			thisType = 0
 		case *PublicKey_Secp256K1:
 			thisType = 1
+		case *PublicKey_Mldsa65:
+			thisType = 2
 		default:
 			panic(fmt.Sprintf("compare: unexpected type %T in oneof", this.Sum))
 		}
@@ -183,6 +199,8 @@ func (this *PublicKey) Compare(that interface{}) int {
 			that1Type = 0
 		case *PublicKey_Secp256K1:
 			that1Type = 1
+		case *PublicKey_Mldsa65:
+			that1Type = 2
 		default:
 			panic(fmt.Sprintf("compare: unexpected type %T in oneof", that1.Sum))
 		}
@@ -254,6 +272,36 @@ func (this *PublicKey_Secp256K1) Compare(that interface{}) int {
 		return -1
 	}
 	if c := bytes.Compare(this.Secp256K1, that1.Secp256K1); c != 0 {
+		return c
+	}
+	return 0
+}
+func (this *PublicKey_Mldsa65) Compare(that interface{}) int {
+	if that == nil {
+		if this == nil {
+			return 0
+		}
+		return 1
+	}
+
+	that1, ok := that.(*PublicKey_Mldsa65)
+	if !ok {
+		that2, ok := that.(PublicKey_Mldsa65)
+		if ok {
+			that1 = &that2
+		} else {
+			return 1
+		}
+	}
+	if that1 == nil {
+		if this == nil {
+			return 0
+		}
+		return 1
+	} else if this == nil {
+		return -1
+	}
+	if c := bytes.Compare(this.Mldsa65, that1.Mldsa65); c != 0 {
 		return c
 	}
 	return 0
@@ -336,6 +384,30 @@ func (this *PublicKey_Secp256K1) Equal(that interface{}) bool {
 	}
 	return true
 }
+func (this *PublicKey_Mldsa65) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*PublicKey_Mldsa65)
+	if !ok {
+		that2, ok := that.(PublicKey_Mldsa65)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if !bytes.Equal(this.Mldsa65, that1.Mldsa65) {
+		return false
+	}
+	return true
+}
 func (m *PublicKey) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -400,6 +472,22 @@ func (m *PublicKey_Secp256K1) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+func (m *PublicKey_Mldsa65) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *PublicKey_Mldsa65) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.Mldsa65 != nil {
+		i -= len(m.Mldsa65)
+		copy(dAtA[i:], m.Mldsa65)
+		i = encodeVarintKeys(dAtA, i, uint64(len(m.Mldsa65)))
+		i--
+		dAtA[i] = 0x22
+	}
+	return len(dAtA) - i, nil
+}
 func encodeVarintKeys(dAtA []byte, offset int, v uint64) int {
 	offset -= sovKeys(v)
 	base := offset
@@ -443,6 +531,18 @@ func (m *PublicKey_Secp256K1) Size() (n int) {
 	_ = l
 	if m.Secp256K1 != nil {
 		l = len(m.Secp256K1)
+		n += 1 + l + sovKeys(uint64(l))
+	}
+	return n
+}
+func (m *PublicKey_Mldsa65) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Mldsa65 != nil {
+		l = len(m.Mldsa65)
 		n += 1 + l + sovKeys(uint64(l))
 	}
 	return n
@@ -548,6 +648,39 @@ func (m *PublicKey) Unmarshal(dAtA []byte) error {
 			v := make([]byte, postIndex-iNdEx)
 			copy(v, dAtA[iNdEx:postIndex])
 			m.Sum = &PublicKey_Secp256K1{v}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Mldsa65", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowKeys
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthKeys
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthKeys
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			v := make([]byte, postIndex-iNdEx)
+			copy(v, dAtA[iNdEx:postIndex])
+			m.Sum = &PublicKey_Mldsa65{v}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/proto/tendermint/crypto/keys.proto
+++ b/proto/tendermint/crypto/keys.proto
@@ -13,5 +13,6 @@ message PublicKey {
   oneof sum {
     bytes ed25519   = 1;
     bytes secp256k1 = 2;
+    bytes mldsa65   = 4;
   }
 }

--- a/state/tx_filter_test.go
+++ b/state/tx_filter_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestTxFilter(t *testing.T) {
 	genDoc := randomGenesisDoc()
-	genDoc.ConsensusParams.Block.MaxBytes = 3000
+	genDoc.ConsensusParams.Block.MaxBytes = 6247
 	genDoc.ConsensusParams.Evidence.MaxBytes = 1500
 
 	// Max size of Txs is much smaller than size of block,

--- a/types/block.go
+++ b/types/block.go
@@ -589,13 +589,18 @@ const (
 	BlockIDFlagNil
 )
 
-const (
-	// Max size of commit without any commitSigs -> 82 for BlockID, 8 for Height, 4 for Round.
-	MaxCommitOverheadBytes int64 = 94
-	// Commit sig size is made up of 64 bytes for the signature, 20 bytes for the address,
-	// 1 byte for the flag and 14 bytes for the timestamp
-	MaxCommitSigBytes int64 = 109
-)
+// MaxCommitOverheadBytes is the max size of commit without any commitSigs -> 82 for BlockID, 8 for Height, 4 for Round.
+const MaxCommitOverheadBytes int64 = 94
+
+// 4 bytes for field tags + 2 bytes for signature LEN (varint; 2 bytes covers
+// signatures up to 16383 bytes, which fits ML-DSA-65's 3309-byte sigs) +
+// 1 byte for validator address LEN + 1 byte for timestamp LEN + 3 misc.
+const maxCommitSigProtoEncOverhead = 4 + 2 + 1 + 1 + 3
+
+// MaxCommitSigBytes is the max commit sig size: MaxSignatureSize bytes for the
+// signature, 20 bytes for the address, 1 byte for the flag, 14 bytes for the
+// timestamp, plus proto framing overhead.
+var MaxCommitSigBytes = int64(MaxSignatureSize + 20 + 1 + 14 + maxCommitSigProtoEncOverhead)
 
 // CommitSig is a part of the Vote included in a Commit.
 type CommitSig struct {
@@ -606,9 +611,10 @@ type CommitSig struct {
 }
 
 func MaxCommitBytes(valCount int) int64 {
+	// 1 byte field tag + 1 byte LEN + 1 byte ???
+	const protoRepeatedFieldLenOverhead int64 = 3
 	// From the repeated commit sig field
-	var protoEncodingOverhead int64 = 2
-	return MaxCommitOverheadBytes + ((MaxCommitSigBytes + protoEncodingOverhead) * int64(valCount))
+	return MaxCommitOverheadBytes + ((MaxCommitSigBytes + protoRepeatedFieldLenOverhead) * int64(valCount))
 }
 
 // NewCommitSigAbsent returns new CommitSig with BlockIDFlagAbsent. Other

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -464,11 +464,11 @@ func TestBlockMaxDataBytes(t *testing.T) {
 	}{
 		0: {-10, 1, 0, true, 0},
 		1: {10, 1, 0, true, 0},
-		2: {841, 1, 0, true, 0},
-		3: {842, 1, 0, false, 0},
-		4: {843, 1, 0, false, 1},
-		5: {954, 2, 0, false, 1},
-		6: {1053, 2, 100, false, 0},
+		2: {4088, 1, 0, true, 0},
+		3: {4089, 1, 0, false, 0},
+		4: {4090, 1, 0, false, 1},
+		5: {7448, 2, 0, false, 1},
+		6: {7547, 2, 100, false, 0},
 	}
 
 	for i, tc := range testCases {
@@ -495,9 +495,9 @@ func TestBlockMaxDataBytesNoEvidence(t *testing.T) {
 	}{
 		0: {-10, 1, true, 0},
 		1: {10, 1, true, 0},
-		2: {841, 1, true, 0},
-		3: {842, 1, false, 0},
-		4: {843, 1, false, 1},
+		2: {4088, 1, true, 0},
+		3: {4089, 1, false, 0},
+		4: {4090, 1, false, 1},
 	}
 
 	for i, tc := range testCases {

--- a/types/params.go
+++ b/types/params.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/cometbft/cometbft/crypto/ed25519"
+	"github.com/cometbft/cometbft/crypto/mldsa65"
 	"github.com/cometbft/cometbft/crypto/secp256k1"
 	"github.com/cometbft/cometbft/crypto/tmhash"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
@@ -23,11 +24,13 @@ const (
 
 	ABCIPubKeyTypeEd25519   = ed25519.KeyType
 	ABCIPubKeyTypeSecp256k1 = secp256k1.KeyType
+	ABCIPubKeyTypeMlDsa65   = mldsa65.KeyType
 )
 
 var ABCIPubKeyTypesToNames = map[string]string{
 	ABCIPubKeyTypeEd25519:   ed25519.PubKeyName,
 	ABCIPubKeyTypeSecp256k1: secp256k1.PubKeyName,
+	ABCIPubKeyTypeMlDsa65:   mldsa65.PubKeyName,
 }
 
 // ConsensusParams contains consensus critical parameters that determine the

--- a/types/signable.go
+++ b/types/signable.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"github.com/cometbft/cometbft/crypto/ed25519"
+	"github.com/cometbft/cometbft/crypto/mldsa65"
 	cmtmath "github.com/cometbft/cometbft/libs/math"
 )
 
@@ -9,7 +10,7 @@ var (
 	// MaxSignatureSize is a maximum allowed signature size for the Proposal
 	// and Vote.
 	// XXX: secp256k1 does not have Size nor MaxSize defined.
-	MaxSignatureSize = cmtmath.MaxInt(ed25519.SignatureSize, 64)
+	MaxSignatureSize = cmtmath.MaxInt(ed25519.SignatureSize, mldsa65.SignatureSize)
 )
 
 // Signable is an interface for all signable things.


### PR DESCRIPTION
---

Backports mldsa65 signature verification for the purposes of verification of IBC connections with counterparty chains that are on v0.40 and begin to utilize mldsa signatures for validators. 

This does not enable v0.38 chains to use mldsa signatures themselves.