### PR TITLE
feat(mempool): allow subscribing to unconfirmed_txs via WebSocket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - `[mempool]` `[rpc]` allow subscribing via WebSocket to a new `MempoolTx`
   event, fired when a tx is admitted into the mempool (before it is included
   in a block), so clients no longer need to poll `/unconfirmed_txs`
-  ([\#1770](https://github.com/cometbft/cometbft/issues/1770))
+  ([\#6035](https://github.com/cometbft/cometbft/pull/6035)) (@gomesalexandre)
 
 ### STATE-BREAKING
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
 
 ### FEATURES
 
+- `[mempool]` `[rpc]` allow subscribing via WebSocket to a new `MempoolTx`
+  event, fired when a tx is admitted into the mempool (before it is included
+  in a block), so clients no longer need to poll `/unconfirmed_txs`
+  ([\#1770](https://github.com/cometbft/cometbft/issues/1770))
+
 ### STATE-BREAKING
 
 ### API-BREAKING

--- a/docs/core/subscription.md
+++ b/docs/core/subscription.md
@@ -59,6 +59,51 @@ results.
 
 Prior to version `v0.38.x`, floats were not supported as query parameters.
 
+## MempoolTx
+
+When a transaction is admitted into the mempool (i.e. it passes `CheckTx` for
+the first time), a `MempoolTx` event is published. This happens *before* the
+transaction is included in a block, if it ever is - it only reflects mempool
+admission, not consensus outcome. Compare this with the `Tx` event, which
+fires once a transaction has been committed in a block.
+
+This is useful for clients that would otherwise need to poll
+`/unconfirmed_txs` repeatedly to observe new transactions as they enter the
+mempool (e.g. MEV/backrunning tooling, network diagnostics).
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "subscribe",
+    "id": 0,
+    "params": {
+        "query": "tm.event='MempoolTx'"
+    }
+}
+```
+
+Response:
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 0,
+    "result": {
+        "query": "tm.event='MempoolTx'",
+        "data": {
+            "type": "tendermint/event/MempoolTx",
+            "value": {
+              "tx": "...",
+              "result": {
+                "code": 0,
+                "gas_wanted": "1"
+              }
+            }
+        }
+    }
+}
+```
+
 ## ValidatorSetUpdates
 
 When validator set changes, ValidatorSetUpdates event is published. The

--- a/docs/core/subscription.md
+++ b/docs/core/subscription.md
@@ -71,6 +71,10 @@ This is useful for clients that would otherwise need to poll
 `/unconfirmed_txs` repeatedly to observe new transactions as they enter the
 mempool (e.g. MEV/backrunning tooling, network diagnostics).
 
+Only fired when `mempool.type = "flood"` (the default). Nodes configured with
+`mempool.type = "app"` or `"nop"` do not emit this event yet - a subscription
+on such a node receives nothing, with no error.
+
 ```json
 {
     "jsonrpc": "2.0",

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -55,6 +55,11 @@ type CListMempool struct {
 
 	logger  log.Logger
 	metrics *Metrics
+
+	// eventBus publishes a MempoolTx event whenever a tx is admitted into
+	// the mempool. Defaults to a no-op so callers that don't care about
+	// mempool events (eg. most tests) don't need to wire one up.
+	eventBus types.MempoolTxEventPublisher
 }
 
 var _ Mempool = &CListMempool{}
@@ -77,6 +82,7 @@ func NewCListMempool(
 		recheck:      newRecheck(),
 		logger:       log.NewNopLogger(),
 		metrics:      NopMetrics(),
+		eventBus:     types.NopEventBus{},
 	}
 	mp.height.Store(height)
 
@@ -148,6 +154,13 @@ func WithPostCheck(f PostCheckFunc) CListMempoolOption {
 // WithMetrics sets the metrics.
 func WithMetrics(metrics *Metrics) CListMempoolOption {
 	return func(mem *CListMempool) { mem.metrics = metrics }
+}
+
+// WithEventBus sets the event bus used to publish a MempoolTx event
+// whenever a tx is admitted into the mempool. If not set, the mempool
+// publishes no such events.
+func WithEventBus(eventBus types.MempoolTxEventPublisher) CListMempoolOption {
+	return func(mem *CListMempool) { mem.eventBus = eventBus }
 }
 
 // Safe for concurrent use by multiple goroutines.
@@ -451,6 +464,12 @@ func (mem *CListMempool) resCbFirstTime(
 				"height", mem.height.Load(),
 				"total", mem.Size(),
 			)
+			if err := mem.eventBus.PublishEventMempoolTx(types.EventDataMempoolTx{
+				Tx:     tx,
+				Result: *r.CheckTx,
+			}); err != nil {
+				mem.logger.Error("failed publishing mempool tx event", "err", err)
+			}
 			mem.notifyTxsAvailable()
 		} else {
 			// ignore bad transaction

--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -231,6 +231,49 @@ func TestMempoolFilters(t *testing.T) {
 	}
 }
 
+// TestMempoolPublishesMempoolTxEventOnAdmission verifies that a subscriber
+// to the MempoolTx event receives a notification when a tx is admitted into
+// the mempool (i.e. passes CheckTx for the first time), mirroring how a
+// subscriber to the Tx event is notified when a tx is committed in a block.
+func TestMempoolPublishesMempoolTxEventOnAdmission(t *testing.T) {
+	app := kvstore.NewInMemoryApplication()
+	cc := proxy.NewLocalClientCreator(app)
+
+	conf := test.ResetTestRoot("mempool_test_event_bus")
+	defer os.RemoveAll(conf.RootDir)
+
+	client, err := cc.NewABCIClient()
+	require.NoError(t, err)
+	client.SetLogger(log.TestingLogger().With("module", "abci-client", "connection", "mempool"))
+	require.NoError(t, client.Start())
+	t.Cleanup(func() { require.NoError(t, client.Stop()) })
+
+	eventBus := types.NewEventBus()
+	eventBus.SetLogger(log.TestingLogger().With("module", "events"))
+	require.NoError(t, eventBus.Start())
+	t.Cleanup(func() { require.NoError(t, eventBus.Stop()) })
+
+	sub, err := eventBus.Subscribe(context.Background(), "test-client", types.EventQueryMempoolTx)
+	require.NoError(t, err)
+
+	appConnMem := proxy.NewAppConnMempool(client, proxy.NopMetrics())
+	mp := NewCListMempool(conf.Mempool, appConnMem, 0, WithEventBus(eventBus))
+	mp.SetLogger(log.TestingLogger())
+
+	tx := kvstore.NewRandomTx(20)
+	require.NoError(t, mp.CheckTx(tx, nil, TxInfo{SenderID: UnknownPeerID}))
+
+	select {
+	case msg := <-sub.Out():
+		data, ok := msg.Data().(types.EventDataMempoolTx)
+		require.True(t, ok, "unexpected event data type %T", msg.Data())
+		require.Equal(t, types.Tx(tx), data.Tx)
+		require.Equal(t, abci.CodeTypeOK, data.Result.Code)
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for MempoolTx event")
+	}
+}
+
 func TestMempoolUpdate(t *testing.T) {
 	app := kvstore.NewInMemoryApplication()
 	cc := proxy.NewLocalClientCreator(app)

--- a/node/node.go
+++ b/node/node.go
@@ -413,7 +413,7 @@ func NewNodeWithContext(
 	}
 
 	// create mempool with its reactor
-	mempool, mempoolReactor := createMempoolAndMempoolReactor(config, proxyApp, state, mempoolWaitForSync, memplMetrics, logger)
+	mempool, mempoolReactor := createMempoolAndMempoolReactor(config, proxyApp, state, mempoolWaitForSync, memplMetrics, eventBus, logger)
 
 	evidenceReactor, evidencePool, err := createEvidenceReactor(config, dbProvider, stateStore, blockStore, logger)
 	if err != nil {

--- a/node/setup.go
+++ b/node/setup.go
@@ -227,6 +227,7 @@ func createMempoolAndMempoolReactor(
 	state sm.State,
 	waitForSync bool,
 	memplMetrics *mempl.Metrics,
+	eventBus *types.EventBus,
 	logger log.Logger,
 ) (mempl.Mempool, waitSyncReactor) {
 	logger = logger.With("module", "mempool")
@@ -241,6 +242,7 @@ func createMempoolAndMempoolReactor(
 			mempl.WithMetrics(memplMetrics),
 			mempl.WithPreCheck(sm.TxPreCheck(state)),
 			mempl.WithPostCheck(sm.TxPostCheck(state)),
+			mempl.WithEventBus(eventBus),
 		)
 		mp.SetLogger(logger)
 		reactor := mempl.NewReactor(

--- a/types/event_bus.go
+++ b/types/event_bus.go
@@ -189,6 +189,24 @@ func (b *EventBus) PublishEventTx(data EventDataTx) error {
 	return b.pubsub.PublishWithEvents(ctx, data, events)
 }
 
+// PublishEventMempoolTx publishes a MempoolTx event with events from the
+// CheckTx response, fired when a tx is admitted into the mempool (i.e.
+// passes CheckTx for the first time), before it is included in a block.
+// Note it will add predefined keys (EventTypeKey, TxHashKey). Existing
+// events with the same keys will be overwritten.
+func (b *EventBus) PublishEventMempoolTx(data EventDataMempoolTx) error {
+	// no explicit deadline for publishing events
+	ctx := context.Background()
+
+	events := b.validateAndStringifyEvents(data.Result.Events)
+
+	// add predefined compositeKeys
+	events[EventTypeKey] = append(events[EventTypeKey], EventMempoolTx)
+	events[TxHashKey] = append(events[TxHashKey], fmt.Sprintf("%X", data.Tx.Hash()))
+
+	return b.pubsub.PublishWithEvents(ctx, data, events)
+}
+
 func (b *EventBus) PublishEventNewRoundStep(data EventDataRoundState) error {
 	return b.Publish(EventNewRoundStep, data)
 }
@@ -270,6 +288,10 @@ func (NopEventBus) PublishEventVote(EventDataVote) error {
 }
 
 func (NopEventBus) PublishEventTx(EventDataTx) error {
+	return nil
+}
+
+func (NopEventBus) PublishEventMempoolTx(EventDataMempoolTx) error {
 	return nil
 }
 

--- a/types/events.go
+++ b/types/events.go
@@ -23,6 +23,13 @@ const (
 	EventTx                  = "Tx"
 	EventValidatorSetUpdates = "ValidatorSetUpdates"
 
+	// Mempool events.
+	// EventMempoolTx is fired by the mempool when a transaction is admitted
+	// (i.e. passes CheckTx for the first time), before it is included in any
+	// block. Unlike EventTx, this carries no execution result: it only
+	// reflects mempool admission, not consensus outcome.
+	EventMempoolTx = "MempoolTx"
+
 	// Internal consensus events.
 	// These are used for testing the consensus state machine.
 	// They can also be used to build real-time consensus visualizers.
@@ -53,6 +60,7 @@ func init() {
 	cmtjson.RegisterType(EventDataNewBlockEvents{}, "tendermint/event/NewBlockEvents")
 	cmtjson.RegisterType(EventDataNewEvidence{}, "tendermint/event/NewEvidence")
 	cmtjson.RegisterType(EventDataTx{}, "tendermint/event/Tx")
+	cmtjson.RegisterType(EventDataMempoolTx{}, "tendermint/event/MempoolTx")
 	cmtjson.RegisterType(EventDataRoundState{}, "tendermint/event/RoundState")
 	cmtjson.RegisterType(EventDataNewRound{}, "tendermint/event/NewRound")
 	cmtjson.RegisterType(EventDataCompleteProposal{}, "tendermint/event/CompleteProposal")
@@ -88,6 +96,15 @@ type EventDataNewEvidence struct {
 // All txs fire EventDataTx
 type EventDataTx struct {
 	abci.TxResult
+}
+
+// EventDataMempoolTx is fired when a tx is admitted into the mempool, i.e.
+// it passes CheckTx for the first time. This happens before the tx is
+// included in a block (if it ever is), so Result here is the mempool's
+// CheckTx response, not a block execution result.
+type EventDataMempoolTx struct {
+	Tx     Tx                   `json:"tx"`
+	Result abci.ResponseCheckTx `json:"result"`
 }
 
 // NOTE: This goes into the replay WAL
@@ -152,6 +169,7 @@ var (
 	EventQueryNewBlock            = QueryForEvent(EventNewBlock)
 	EventQueryNewBlockHeader      = QueryForEvent(EventNewBlockHeader)
 	EventQueryNewBlockEvents      = QueryForEvent(EventNewBlockEvents)
+	EventQueryMempoolTx           = QueryForEvent(EventMempoolTx)
 	EventQueryNewEvidence         = QueryForEvent(EventNewEvidence)
 	EventQueryNewRound            = QueryForEvent(EventNewRound)
 	EventQueryNewRoundStep        = QueryForEvent(EventNewRoundStep)
@@ -186,4 +204,9 @@ type BlockEventPublisher interface {
 
 type TxEventPublisher interface {
 	PublishEventTx(EventDataTx) error
+}
+
+// MempoolTxEventPublisher publishes the mempool-admission event.
+type MempoolTxEventPublisher interface {
+	PublishEventMempoolTx(EventDataMempoolTx) error
 }

--- a/types/events.go
+++ b/types/events.go
@@ -26,8 +26,8 @@ const (
 	// Mempool events.
 	// EventMempoolTx is fired by the mempool when a transaction is admitted
 	// (i.e. passes CheckTx for the first time), before it is included in any
-	// block. Unlike EventTx, this carries no execution result: it only
-	// reflects mempool admission, not consensus outcome.
+	// block. It carries the CheckTx response, not a block execution result:
+	// unlike EventTx, this reflects mempool admission, not consensus outcome.
 	EventMempoolTx = "MempoolTx"
 
 	// Internal consensus events.


### PR DESCRIPTION
closes #1770

Adds a `MempoolTx` event, fired when a tx is admitted into the mempool (passes
`CheckTx` for the first time), mirroring how the existing `Tx` event is fired
on block commit. Clients can subscribe with `tm.event='MempoolTx'` instead of
polling `/unconfirmed_txs`.

## Use case

Answering the maintainer's question on the issue thread: MEV/backrunning
tooling and network diagnostics both want to observe txs the moment they enter
the mempool, not just once committed - polling `/unconfirmed_txs` on an
interval misses the timing precision either use case needs.

## Scope: `CListMempool` only

`AppMempool` (`mempool.type = "app"`) is a separate, newer implementation that
doesn't touch the `EventBus` at all today - wiring it there is left as a
follow-up rather than folded into this change. Documented explicitly in
`docs/core/subscription.md`: a node running `mempool.type = "app"` or `"nop"`
currently receives nothing on a `MempoolTx` subscription, with no error. Happy
to track that as a separate issue if useful.

## Things worth knowing before merging

**Publish is synchronous under `CheckTx`'s read lock.** `PublishEventMempoolTx`
follows the exact same pattern as the existing `PublishEventTx` (unbounded
context, error logged not propagated) - but the underlying pubsub `Server`
dispatches on an unbuffered channel by default
(`EventBusBufferCapacity` defaults to `0`), and `CheckTx` holds
`updateMtx.RLock()` for its entire body with the local ABCI client. So if the
pubsub loop is momentarily busy (e.g. draining a big block's `Tx` events into
an unbuffered subscriber like the indexer), a `MempoolTx` publish - which now
fires per admitted tx, not per block - queues behind it, and mempool-admission
latency inherits that delay. No deadlock: the indexer never takes mempool
locks, and it only subscribes to `Tx`/`NewBlockEvents` queries by default, so
it never receives `MempoolTx` itself. Operators who care can raise
`event_bus_buffer_capacity`. Flagging rather than restructuring the publish
path, since it matches the existing `Tx`-event pattern exactly.

**No zero-subscriber fast path.** Every admitted tx now pays a `Tx.Hash()`
computation, a couple of map allocations, and a pubsub dispatch, even with zero
`MempoolTx` subscribers - across every gossiped tx network-wide, not just
locally submitted ones. Small relative to the ABCI round-trip per `CheckTx`,
but nonzero. Happy to add an opt-in `mempool.publish_events` config flag as a
follow-up if that overhead matters to node operators.

**Queries without a `tm.event` clause now also match `MempoolTx`.** Since
`PublishEventMempoolTx` indexes the `CheckTx` response's app events and the tx
hash into the same composite-key space `Tx` events use, a subscription like
`transfer.recipient='X'` (no `tm.event` filter) will now also receive
mempool-admission events if the app emits that event in `CheckTx`, not just on
commit. Built-in flows are unaffected (`EventQueryTxFor` always includes
`tm.event='Tx'`, and cosmjs's tx-search/subscribe paths do the same), but a
hand-rolled subscriber without a `tm.event` clause changes behavior. Keeping
the shared key space since hash-based filtering is a real part of this
feature's value, but calling it out explicitly rather than leaving it for a
reviewer to discover.

## Testing

New test in `mempool/clist_mempool_test.go`: real `CListMempool` + real
`EventBus` + an in-memory kvstore app, subscribes via `EventQueryMempoolTx`,
asserts the subscriber receives `EventDataMempoolTx` with the right tx bytes
and `CheckTx` code.

`go build ./...` clean. `gofmt -l` clean on all changed files. `go vet
./mempool/... ./types/... ./node/... ./rpc/...` clean (one pre-existing,
unrelated finding on unmodified `main`, confirmed not touched by this diff).
`go test ./mempool/...`, `./types/...`, `./node/...`, `./rpc/core/...` all
pass, plus a targeted rerun of the existing `TestTxEventsSent` to confirm no
regression on the adjacent, pre-existing `Tx`-event subscription flow.
