### PR TITLE
feat(consensus): add opt-in asynchronous block event publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 ### FEATURES
 
+- `[consensus]` add opt-in asynchronous block event publication via
+  `node.AsyncBlockEvents`; queued block-event tasks retain FIFO ordering, but
+  ordering relative to events from other publishers is not guaranteed
+  ([\#6040](https://github.com/cometbft/cometbft/pull/6040))
+
 ### STATE-BREAKING
 
 ### API-BREAKING

--- a/node/async_event_runner.go
+++ b/node/async_event_runner.go
@@ -4,7 +4,6 @@ import "sync"
 
 const defaultAsyncEventQueueSize = 128
 
-// asyncEventRunner executes tasks serially and drains accepted work on Stop.
 type asyncEventRunner struct {
 	tasks chan func()
 	done  chan struct{}

--- a/node/async_event_runner.go
+++ b/node/async_event_runner.go
@@ -1,0 +1,58 @@
+package node
+
+import "sync"
+
+const defaultAsyncEventQueueSize = 128
+
+// asyncEventRunner executes tasks serially and drains accepted work on Stop.
+type asyncEventRunner struct {
+	tasks chan func()
+	done  chan struct{}
+
+	startOnce sync.Once
+	stopOnce  sync.Once
+	mu        sync.RWMutex
+	stopped   bool
+}
+
+func newAsyncEventRunner(bufferSize int) *asyncEventRunner {
+	return &asyncEventRunner{
+		tasks: make(chan func(), bufferSize),
+		done:  make(chan struct{}),
+	}
+}
+
+func (r *asyncEventRunner) Start() {
+	r.startOnce.Do(func() {
+		go func() {
+			defer close(r.done)
+			for task := range r.tasks {
+				task()
+			}
+		}()
+	})
+}
+
+func (r *asyncEventRunner) Submit(task func()) {
+	r.Start()
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.stopped {
+		return
+	}
+	r.tasks <- task
+}
+
+func (r *asyncEventRunner) Stop() {
+	r.stopOnce.Do(func() {
+		r.Start()
+
+		r.mu.Lock()
+		r.stopped = true
+		close(r.tasks)
+		r.mu.Unlock()
+
+		<-r.done
+	})
+}

--- a/node/async_event_runner_test.go
+++ b/node/async_event_runner_test.go
@@ -1,0 +1,104 @@
+package node
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAsyncEventRunnerRunsTasksFIFO(t *testing.T) {
+	runner := newAsyncEventRunner(3)
+	defer runner.Stop()
+
+	done := make(chan int, 3)
+	for i := 0; i < 3; i++ {
+		i := i
+		runner.Submit(func() { done <- i })
+	}
+
+	for i := 0; i < 3; i++ {
+		select {
+		case got := <-done:
+			require.Equal(t, i, got)
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for task %d", i)
+		}
+	}
+}
+
+func TestAsyncEventRunnerStopDrainsAcceptedTasks(t *testing.T) {
+	runner := newAsyncEventRunner(2)
+
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	completed := make(chan int, 3)
+	runner.Submit(func() {
+		close(firstStarted)
+		<-releaseFirst
+		completed <- 0
+	})
+	<-firstStarted
+	runner.Submit(func() { completed <- 1 })
+	runner.Submit(func() { completed <- 2 })
+
+	stopDone := make(chan struct{})
+	go func() {
+		runner.Stop()
+		close(stopDone)
+	}()
+
+	select {
+	case <-stopDone:
+		t.Fatal("Stop returned while a task was still running")
+	case <-time.After(10 * time.Millisecond):
+	}
+	close(releaseFirst)
+
+	select {
+	case <-stopDone:
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not return after queued tasks completed")
+	}
+	for i := 0; i < 3; i++ {
+		require.Equal(t, i, <-completed)
+	}
+}
+
+func TestAsyncEventRunnerSubmitReturnsAfterStop(t *testing.T) {
+	runner := newAsyncEventRunner(0)
+	runner.Stop()
+
+	done := make(chan struct{})
+	go func() {
+		runner.Submit(func() {
+			t.Error("task submitted after Stop must not run")
+		})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Submit blocked after runner stopped")
+	}
+}
+
+func TestAsyncEventRunnerStartsOnFirstSubmit(t *testing.T) {
+	runner := newAsyncEventRunner(1)
+	defer runner.Stop()
+
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < defaultAsyncEventQueueSize+1; i++ {
+			runner.Submit(func() {})
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("submissions blocked because the runner did not start")
+	}
+}

--- a/node/async_event_runner_test.go
+++ b/node/async_event_runner_test.go
@@ -13,7 +13,6 @@ func TestAsyncEventRunnerRunsTasksFIFO(t *testing.T) {
 
 	done := make(chan int, 3)
 	for i := 0; i < 3; i++ {
-		i := i
 		runner.Submit(func() { done <- i })
 	}
 

--- a/node/node.go
+++ b/node/node.go
@@ -65,8 +65,10 @@ type Node struct {
 	eventBus          *types.EventBus // pub/sub for services
 	stateStore        sm.Store
 	blockStore        *store.BlockStore // store the blockchain to disk
-	bcReactor         p2p.Reactor       // for block-syncing
-	mempoolReactor    waitSyncReactor   // for gossipping transactions
+	blockExec         *sm.BlockExecutor
+	blockEventRunner  *asyncEventRunner
+	bcReactor         p2p.Reactor     // for block-syncing
+	mempoolReactor    waitSyncReactor // for gossipping transactions
 	mempool           mempl.Mempool
 	stateSync         bool                    // whether the node should state sync on startup
 	stateSyncReactor  *statesync.Reactor      // for hosting and restoring state sync snapshots
@@ -93,6 +95,20 @@ type waitSyncReactor interface {
 
 // Option sets a parameter for the node.
 type Option func(*Node)
+
+// AsyncBlockEvents opts the node into publishing block events outside the
+// ApplyBlock critical path. The node owns the runner and drains it before
+// stopping the indexer and event bus.
+func AsyncBlockEvents() Option {
+	return func(n *Node) {
+		if n.blockEventRunner != nil {
+			return
+		}
+		runner := newAsyncEventRunner(defaultAsyncEventQueueSize)
+		n.blockEventRunner = runner
+		n.blockExec.SetAsyncRunner(runner.Submit)
+	}
+}
 
 // CustomReactors allows you to add custom reactors (name -> p2p.Reactor) to
 // the node's Switch.
@@ -590,6 +606,7 @@ func NewNodeWithContext(
 
 		stateStore:       stateStore,
 		blockStore:       blockStore,
+		blockExec:        blockExec,
 		bcReactor:        bcReactor,
 		mempoolReactor:   mempoolReactor,
 		mempool:          mempool,
@@ -736,14 +753,9 @@ func (n *Node) OnStop() {
 
 	n.Logger.Info("Stopping Node")
 
-	// first stop the non-reactor services
-	if err := n.eventBus.Stop(); err != nil {
-		n.Logger.Error("Error closing eventBus", "err", err)
-	}
-	if n.indexerService != nil {
-		if err := n.indexerService.Stop(); err != nil {
-			n.Logger.Error("Error closing indexerService", "err", err)
-		}
+	if n.blockEventRunner == nil {
+		// Preserve the historical order: first stop the non-reactor event services.
+		n.stopEventServices()
 	}
 	// Close the priv validator before stopping the reactors: sw.Stop waits on
 	// the consensus receiveRoutine, which can be stuck retrying a gone remote
@@ -758,6 +770,12 @@ func (n *Node) OnStop() {
 	// now stop the reactors
 	if err := n.sw.Stop(); err != nil {
 		n.Logger.Error("Error closing switch", "err", err)
+	}
+	if n.blockEventRunner != nil {
+		// All event producers have stopped. Drain accepted work before stopping
+		// the event consumers.
+		n.blockEventRunner.Stop()
+		n.stopEventServices()
 	}
 
 	if mp, ok := n.transport.(*p2p.MultiplexTransport); ok {
@@ -809,6 +827,18 @@ func (n *Node) OnStop() {
 		n.Logger.Info("Closing evidencestore")
 		if err := n.EvidencePool().Close(); err != nil {
 			n.Logger.Error("problem closing evidencestore", "err", err)
+		}
+	}
+}
+
+// stopEventServices stops the EventBus and indexer in their historical order.
+func (n *Node) stopEventServices() {
+	if err := n.eventBus.Stop(); err != nil {
+		n.Logger.Error("Error closing eventBus", "err", err)
+	}
+	if n.indexerService != nil {
+		if err := n.indexerService.Stop(); err != nil {
+			n.Logger.Error("Error closing indexerService", "err", err)
 		}
 	}
 }

--- a/node/node.go
+++ b/node/node.go
@@ -831,7 +831,6 @@ func (n *Node) OnStop() {
 	}
 }
 
-// stopEventServices stops the EventBus and indexer in their historical order.
 func (n *Node) stopEventServices() {
 	if err := n.eventBus.Stop(); err != nil {
 		n.Logger.Error("Error closing eventBus", "err", err)

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -41,6 +41,7 @@ func TestNodeStartStop(t *testing.T) {
 	// create & start node
 	n, err := DefaultNewNode(config, log.TestingLogger())
 	require.NoError(t, err)
+	require.Nil(t, n.blockEventRunner)
 	err = n.Start()
 	require.NoError(t, err)
 
@@ -75,6 +76,33 @@ func TestNodeStartStop(t *testing.T) {
 		fmt.Println(err)
 		t.Fatal("timed out waiting for shutdown")
 	}
+}
+
+func TestNodeAsyncBlockEventsDrainBeforeEventBusStops(t *testing.T) {
+	config := newNodeTestConfig(t, "node_async_block_events_test")
+	defer os.RemoveAll(config.RootDir)
+
+	n, err := DefaultNewNodeWithOptions(config, log.TestingLogger(), AsyncBlockEvents())
+	require.NoError(t, err)
+	require.NotNil(t, n.blockEventRunner)
+	require.NoError(t, n.Start())
+
+	eventBusRunningDuringDrain := make(chan bool, 1)
+	n.blockEventRunner.Submit(func() {
+		<-n.sw.Quit()
+		eventBusRunningDuringDrain <- n.eventBus.IsRunning()
+	})
+
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- n.Stop() }()
+	select {
+	case err := <-stopDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for async event shutdown")
+	}
+	require.True(t, <-eventBusRunningDuringDrain)
+	require.False(t, n.eventBus.IsRunning())
 }
 
 func TestSplitAndTrimEmpty(t *testing.T) {

--- a/node/setup.go
+++ b/node/setup.go
@@ -62,6 +62,12 @@ type Provider func(*cfg.Config, log.Logger) (*Node, error)
 // PrivValidator, ClientCreator, GenesisDoc, and DBProvider.
 // It implements NodeProvider.
 func DefaultNewNode(config *cfg.Config, logger log.Logger) (*Node, error) {
+	return DefaultNewNodeWithOptions(config, logger)
+}
+
+// DefaultNewNodeWithOptions returns a default CometBFT node with the supplied
+// node options.
+func DefaultNewNodeWithOptions(config *cfg.Config, logger log.Logger, options ...Option) (*Node, error) {
 	nodeKey, err := p2p.LoadOrGenNodeKey(config.NodeKeyFile())
 	if err != nil {
 		return nil, fmt.Errorf("failed to load or gen node key %s: %w", config.NodeKeyFile(), err)
@@ -75,6 +81,7 @@ func DefaultNewNode(config *cfg.Config, logger log.Logger) (*Node, error) {
 		cfg.DefaultDBProvider,
 		DefaultMetricsProvider(config.Instrumentation),
 		logger,
+		options...,
 	)
 }
 

--- a/state/execution.go
+++ b/state/execution.go
@@ -55,7 +55,6 @@ type BlockExecutor struct {
 	// blockTimeTolerance is the maximum allowed difference between proposed block time and wall clock.
 	blockTimeTolerance time.Duration
 
-	// asyncRunner runs block event publication off the ApplyBlock critical path.
 	asyncRunner func(func())
 }
 

--- a/state/execution.go
+++ b/state/execution.go
@@ -54,6 +54,9 @@ type BlockExecutor struct {
 
 	// blockTimeTolerance is the maximum allowed difference between proposed block time and wall clock.
 	blockTimeTolerance time.Duration
+
+	// asyncRunner runs block event publication off the ApplyBlock critical path.
+	asyncRunner func(func())
 }
 
 type cachedValidators struct {
@@ -112,6 +115,14 @@ func (blockExec *BlockExecutor) Store() Store {
 // If not called, it defaults to types.NopEventBus.
 func (blockExec *BlockExecutor) SetEventBus(eventBus types.BlockEventPublisher) {
 	blockExec.eventBus = eventBus
+}
+
+// SetAsyncRunner opts into publishing block events off the ApplyBlock critical
+// path. The runner must execute accepted tasks in submission order, and its
+// owner must drain them before stopping the event bus. Passing nil restores
+// synchronous publication.
+func (blockExec *BlockExecutor) SetAsyncRunner(runner func(func())) {
+	blockExec.asyncRunner = runner
 }
 
 // CreateProposalBlock calls state.MakeBlock with evidence from the evpool
@@ -381,9 +392,19 @@ func (blockExec *BlockExecutor) applyBlock(state State, blockID types.BlockID, b
 		}
 	}
 
-	// Events are fired after everything else.
-	// NOTE: if we crash between Commit and Save, events wont be fired during replay
-	fireEvents(blockExec.logger, blockExec.eventBus, block, blockID, abciResponse, validatorUpdates)
+	eventBus := blockExec.eventBus
+	if _, ok := eventBus.(types.NopEventBus); !ok {
+		// Events are fired after everything else.
+		// NOTE: if we crash between Commit and Save, events wont be fired during replay
+		task := func() {
+			fireEvents(blockExec.logger, eventBus, block, blockID, abciResponse, validatorUpdates)
+		}
+		if blockExec.asyncRunner != nil {
+			blockExec.asyncRunner(task)
+		} else {
+			task()
+		}
+	}
 
 	return state, nil
 }

--- a/state/execution_bench_test.go
+++ b/state/execution_bench_test.go
@@ -27,8 +27,11 @@ func BenchmarkApplyBlockBlockEvents(b *testing.B) {
 
 	for _, tc := range testCases {
 		name := fmt.Sprintf("txs=%d/delay=%s", tc.txs, tc.delay)
-		b.Run(name, func(b *testing.B) {
-			benchmarkApplyBlockBlockEvents(b, tc.txs, tc.delay)
+		b.Run(name+"/sync", func(b *testing.B) {
+			benchmarkApplyBlockBlockEvents(b, tc.txs, tc.delay, false)
+		})
+		b.Run(name+"/async", func(b *testing.B) {
+			benchmarkApplyBlockBlockEvents(b, tc.txs, tc.delay, true)
 		})
 	}
 }
@@ -37,7 +40,7 @@ func BenchmarkApplyBlockBlockEvents(b *testing.B) {
 // an unbuffered consumer, as used by the indexer. Run with
 // a fixed iteration count so slow-consumer time does not make calibration
 // excessively long, for example: -benchtime=20x. Each iteration drains the
-// consumer outside the timer, so the benchmark measures ApplyBlock's
+// runner and consumer outside the timer, so the benchmark measures ApplyBlock's
 // critical path without treating an ever-growing event backlog as a speedup.
 func BenchmarkApplyBlockRealEventBus(b *testing.B) {
 	testCases := []struct {
@@ -57,18 +60,27 @@ func BenchmarkApplyBlockRealEventBus(b *testing.B) {
 
 	for _, tc := range testCases {
 		name := fmt.Sprintf("txs=%d/delay=%s/capacity=%d", tc.txs, tc.delay, tc.capacity)
-		b.Run(name, func(b *testing.B) {
-			benchmarkApplyBlockRealEventBus(b, tc.txs, tc.delay, tc.capacity)
+		b.Run(name+"/sync", func(b *testing.B) {
+			benchmarkApplyBlockRealEventBus(b, tc.txs, tc.delay, tc.capacity, false)
+		})
+		b.Run(name+"/async", func(b *testing.B) {
+			benchmarkApplyBlockRealEventBus(b, tc.txs, tc.delay, tc.capacity, true)
 		})
 	}
 }
 
-func benchmarkApplyBlockRealEventBus(b *testing.B, txs int, delay time.Duration, capacity int) {
+func benchmarkApplyBlockRealEventBus(b *testing.B, txs int, delay time.Duration, capacity int, async bool) {
 	state, stateDB, privVals := makeState(1, 1)
 	blockExec := newCachedBlockExec(b, stateDB)
 	events := newBenchmarkEventBus(b, capacity, delay)
 	b.Cleanup(events.Close)
 	blockExec.SetEventBus(events.bus)
+	var runner *benchmarkAsyncRunner
+	if async {
+		runner = newBenchmarkAsyncRunner()
+		b.Cleanup(runner.Stop)
+		blockExec.SetAsyncRunner(runner.Submit)
+	}
 
 	proposerAddr := state.NextValidators.Validators[0].Address
 	lastCommit := new(types.Commit)
@@ -92,6 +104,9 @@ func benchmarkApplyBlockRealEventBus(b *testing.B, txs int, delay time.Duration,
 		b.StopTimer()
 		require.NoError(b, err)
 
+		if runner != nil {
+			runner.Wait()
+		}
 		events.Wait()
 
 		extendedCommit, _, err := makeValidCommit(height, blockID, state.Validators, privVals)
@@ -147,7 +162,9 @@ func (e *benchmarkEventBus) consume(sub types.Subscription) {
 }
 
 func (e *benchmarkEventBus) ExpectBlock(txs int) {
-	e.pending.Add(txs + 1) // NewBlockEvents plus one event for each transaction.
+	// fireEvents also publishes NewBlock and NewBlockHeader, but this harness
+	// subscribes only to NewBlockEvents and Tx events.
+	e.pending.Add(1 + txs)
 }
 
 func (e *benchmarkEventBus) Wait() {
@@ -160,10 +177,16 @@ func (e *benchmarkEventBus) Close() {
 	e.consumers.Wait()
 }
 
-func benchmarkApplyBlockBlockEvents(b *testing.B, txs int, delay time.Duration) {
+func benchmarkApplyBlockBlockEvents(b *testing.B, txs int, delay time.Duration, async bool) {
 	state, stateDB, privVals := makeState(1, 1)
 	blockExec := newCachedBlockExec(b, stateDB)
 	blockExec.SetEventBus(delayedBlockEventPublisher{delay: delay})
+	var runner *benchmarkAsyncRunner
+	if async {
+		runner = newBenchmarkAsyncRunner()
+		b.Cleanup(runner.Stop)
+		blockExec.SetAsyncRunner(runner.Submit)
+	}
 
 	proposerAddr := state.NextValidators.Validators[0].Address
 	lastCommit := new(types.Commit)
@@ -184,6 +207,10 @@ func benchmarkApplyBlockBlockEvents(b *testing.B, txs int, delay time.Duration) 
 		state, err = blockExec.ApplyBlock(state, blockID, block)
 		b.StopTimer()
 		require.NoError(b, err)
+
+		if runner != nil {
+			runner.Wait()
+		}
 
 		extendedCommit, _, err := makeValidCommit(height, blockID, state.Validators, privVals)
 		require.NoError(b, err)
@@ -222,4 +249,55 @@ func (p delayedBlockEventPublisher) PublishEventNewEvidence(types.EventDataNewEv
 
 func (p delayedBlockEventPublisher) PublishEventTx(types.EventDataTx) error {
 	return p.publish()
+}
+
+type benchmarkAsyncRunner struct {
+	tasks chan func()
+	quit  chan struct{}
+	wg    sync.WaitGroup
+}
+
+func newBenchmarkAsyncRunner() *benchmarkAsyncRunner {
+	runner := &benchmarkAsyncRunner{
+		tasks: make(chan func(), 1),
+		quit:  make(chan struct{}),
+	}
+	go func() {
+		for {
+			select {
+			case <-runner.quit:
+				return
+			default:
+			}
+
+			select {
+			case task := <-runner.tasks:
+				select {
+				case <-runner.quit:
+					return
+				default:
+				}
+				task()
+			case <-runner.quit:
+				return
+			}
+		}
+	}()
+	return runner
+}
+
+func (r *benchmarkAsyncRunner) Submit(task func()) {
+	r.wg.Add(1)
+	r.tasks <- func() {
+		defer r.wg.Done()
+		task()
+	}
+}
+
+func (r *benchmarkAsyncRunner) Wait() {
+	r.wg.Wait()
+}
+
+func (r *benchmarkAsyncRunner) Stop() {
+	close(r.quit)
 }

--- a/state/execution_bench_test.go
+++ b/state/execution_bench_test.go
@@ -1,0 +1,225 @@
+package state_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/internal/test"
+	"github.com/cometbft/cometbft/types"
+)
+
+func BenchmarkApplyBlockBlockEvents(b *testing.B) {
+	testCases := []struct {
+		txs   int
+		delay time.Duration
+	}{
+		{txs: 0},
+		{txs: 100},
+		{txs: 1000},
+		{txs: 10, delay: 100 * time.Microsecond},
+		{txs: 100, delay: 100 * time.Microsecond},
+	}
+
+	for _, tc := range testCases {
+		name := fmt.Sprintf("txs=%d/delay=%s", tc.txs, tc.delay)
+		b.Run(name, func(b *testing.B) {
+			benchmarkApplyBlockBlockEvents(b, tc.txs, tc.delay)
+		})
+	}
+}
+
+// BenchmarkApplyBlockRealEventBus measures the existing EventBus buffer using
+// an unbuffered consumer, as used by the indexer. Run with
+// a fixed iteration count so slow-consumer time does not make calibration
+// excessively long, for example: -benchtime=20x. Each iteration drains the
+// consumer outside the timer, so the benchmark measures ApplyBlock's
+// critical path without treating an ever-growing event backlog as a speedup.
+func BenchmarkApplyBlockRealEventBus(b *testing.B) {
+	testCases := []struct {
+		txs      int
+		delay    time.Duration
+		capacity int
+	}{
+		{txs: 100, delay: 100 * time.Microsecond, capacity: 0},
+		{txs: 100, delay: 100 * time.Microsecond, capacity: 128},
+		// These capacities can hold every event emitted for one block. They
+		// isolate fireEvents processing cost from EventBus queue backpressure.
+		{txs: 100, delay: 100 * time.Microsecond, capacity: 1024},
+		{txs: 1000, capacity: 0},
+		{txs: 1000, capacity: 128},
+		{txs: 1000, capacity: 2048},
+	}
+
+	for _, tc := range testCases {
+		name := fmt.Sprintf("txs=%d/delay=%s/capacity=%d", tc.txs, tc.delay, tc.capacity)
+		b.Run(name, func(b *testing.B) {
+			benchmarkApplyBlockRealEventBus(b, tc.txs, tc.delay, tc.capacity)
+		})
+	}
+}
+
+func benchmarkApplyBlockRealEventBus(b *testing.B, txs int, delay time.Duration, capacity int) {
+	state, stateDB, privVals := makeState(1, 1)
+	blockExec := newCachedBlockExec(b, stateDB)
+	events := newBenchmarkEventBus(b, capacity, delay)
+	b.Cleanup(events.Close)
+	blockExec.SetEventBus(events.bus)
+
+	proposerAddr := state.NextValidators.Validators[0].Address
+	lastCommit := new(types.Commit)
+	b.ReportAllocs()
+	b.ReportMetric(float64(txs+3), "events/block")
+	b.ReportMetric(float64(capacity), "eventbus-capacity")
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		height := state.LastBlockHeight + 1
+		block, err := state.MakeBlock(height, test.MakeNTxs(height, int64(txs)), lastCommit, nil, proposerAddr)
+		require.NoError(b, err)
+		bps, err := block.MakePartSet(testPartSize)
+		require.NoError(b, err)
+		blockID := types.BlockID{Hash: block.Hash(), PartSetHeader: bps.Header()}
+		events.ExpectBlock(txs)
+
+		b.StartTimer()
+		state, err = blockExec.ApplyBlock(state, blockID, block)
+		b.StopTimer()
+		require.NoError(b, err)
+
+		events.Wait()
+
+		extendedCommit, _, err := makeValidCommit(height, blockID, state.Validators, privVals)
+		require.NoError(b, err)
+		lastCommit = extendedCommit.ToCommit()
+	}
+}
+
+type benchmarkEventBus struct {
+	bus *types.EventBus
+
+	delay     time.Duration
+	pending   sync.WaitGroup
+	consumers sync.WaitGroup
+}
+
+func newBenchmarkEventBus(b *testing.B, capacity int, delay time.Duration) *benchmarkEventBus {
+	b.Helper()
+	events := &benchmarkEventBus{
+		bus:   types.NewEventBusWithBufferCapacity(capacity),
+		delay: delay,
+	}
+	require.NoError(b, events.bus.Start())
+
+	blockSub, err := events.bus.SubscribeUnbuffered(
+		context.Background(), "benchmark-indexer", types.EventQueryNewBlockEvents)
+	require.NoError(b, err)
+	txSub, err := events.bus.SubscribeUnbuffered(
+		context.Background(), "benchmark-indexer", types.EventQueryTx)
+	require.NoError(b, err)
+
+	events.consume(blockSub)
+	events.consume(txSub)
+	return events
+}
+
+func (e *benchmarkEventBus) consume(sub types.Subscription) {
+	e.consumers.Add(1)
+	go func() {
+		defer e.consumers.Done()
+		for {
+			select {
+			case <-sub.Canceled():
+				return
+			case <-sub.Out():
+				if e.delay > 0 {
+					time.Sleep(e.delay)
+				}
+				e.pending.Done()
+			}
+		}
+	}()
+}
+
+func (e *benchmarkEventBus) ExpectBlock(txs int) {
+	e.pending.Add(txs + 1) // NewBlockEvents plus one event for each transaction.
+}
+
+func (e *benchmarkEventBus) Wait() {
+	e.pending.Wait()
+}
+
+func (e *benchmarkEventBus) Close() {
+	e.pending.Wait()
+	_ = e.bus.Stop()
+	e.consumers.Wait()
+}
+
+func benchmarkApplyBlockBlockEvents(b *testing.B, txs int, delay time.Duration) {
+	state, stateDB, privVals := makeState(1, 1)
+	blockExec := newCachedBlockExec(b, stateDB)
+	blockExec.SetEventBus(delayedBlockEventPublisher{delay: delay})
+
+	proposerAddr := state.NextValidators.Validators[0].Address
+	lastCommit := new(types.Commit)
+	b.ReportAllocs()
+	b.ReportMetric(float64(txs+3), "events/block")
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		height := state.LastBlockHeight + 1
+		block, err := state.MakeBlock(height, test.MakeNTxs(height, int64(txs)), lastCommit, nil, proposerAddr)
+		require.NoError(b, err)
+		bps, err := block.MakePartSet(testPartSize)
+		require.NoError(b, err)
+		blockID := types.BlockID{Hash: block.Hash(), PartSetHeader: bps.Header()}
+
+		b.StartTimer()
+		state, err = blockExec.ApplyBlock(state, blockID, block)
+		b.StopTimer()
+		require.NoError(b, err)
+
+		extendedCommit, _, err := makeValidCommit(height, blockID, state.Validators, privVals)
+		require.NoError(b, err)
+		lastCommit = extendedCommit.ToCommit()
+	}
+}
+
+type delayedBlockEventPublisher struct {
+	types.NopEventBus
+
+	delay time.Duration
+}
+
+func (p delayedBlockEventPublisher) publish() error {
+	if p.delay > 0 {
+		time.Sleep(p.delay)
+	}
+	return nil
+}
+
+func (p delayedBlockEventPublisher) PublishEventNewBlock(types.EventDataNewBlock) error {
+	return p.publish()
+}
+
+func (p delayedBlockEventPublisher) PublishEventNewBlockHeader(types.EventDataNewBlockHeader) error {
+	return p.publish()
+}
+
+func (p delayedBlockEventPublisher) PublishEventNewBlockEvents(types.EventDataNewBlockEvents) error {
+	return p.publish()
+}
+
+func (p delayedBlockEventPublisher) PublishEventNewEvidence(types.EventDataNewEvidence) error {
+	return p.publish()
+}
+
+func (p delayedBlockEventPublisher) PublishEventTx(types.EventDataTx) error {
+	return p.publish()
+}

--- a/state/execution_bench_test.go
+++ b/state/execution_bench_test.go
@@ -36,12 +36,9 @@ func BenchmarkApplyBlockBlockEvents(b *testing.B) {
 	}
 }
 
-// BenchmarkApplyBlockRealEventBus measures the existing EventBus buffer using
-// an unbuffered consumer, as used by the indexer. Run with
-// a fixed iteration count so slow-consumer time does not make calibration
-// excessively long, for example: -benchtime=20x. Each iteration drains the
-// runner and consumer outside the timer, so the benchmark measures ApplyBlock's
-// critical path without treating an ever-growing event backlog as a speedup.
+// BenchmarkApplyBlockRealEventBus uses unbuffered indexer-style consumers.
+// Each iteration drains pending work outside the timer so an accumulating
+// event backlog is not reported as an ApplyBlock speedup.
 func BenchmarkApplyBlockRealEventBus(b *testing.B) {
 	testCases := []struct {
 		txs      int

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -1118,7 +1118,7 @@ func TestCreateProposalAbsentVoteExtensions(t *testing.T) {
 	}
 }
 
-func newCachedBlockExec(t *testing.T, stateDB dbm.DB) *sm.BlockExecutor {
+func newCachedBlockExec(t testing.TB, stateDB dbm.DB) *sm.BlockExecutor {
 	t.Helper()
 	app := &testApp{}
 	cc := proxy.NewLocalClientCreator(app)

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cometbft/cometbft/crypto/tmhash"
 	"github.com/cometbft/cometbft/internal/test"
 	"github.com/cometbft/cometbft/libs/log"
+	cmtquery "github.com/cometbft/cometbft/libs/pubsub/query"
 	mpmocks "github.com/cometbft/cometbft/mempool/mocks"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	cmtversion "github.com/cometbft/cometbft/proto/tendermint/version"
@@ -1302,6 +1303,57 @@ func TestApplyBlockPublishesBlockEventsSynchronouslyByDefault(t *testing.T) {
 		require.NoError(t, err)
 	case <-time.After(time.Second):
 		t.Fatal("ApplyBlock did not return after event publication completed")
+	}
+}
+
+func TestApplyBlockAsyncBlockEventsMayLagLaterEventBusPublications(t *testing.T) {
+	state, stateDB, _ := makeState(1, 1)
+	exec := newCachedBlockExec(t, stateDB)
+
+	eventBus := types.NewEventBus()
+	require.NoError(t, eventBus.Start())
+	t.Cleanup(func() { require.NoError(t, eventBus.Stop()) })
+
+	sub, err := eventBus.Subscribe(t.Context(), "async-event-order", cmtquery.All, 16)
+	require.NoError(t, err)
+
+	exec.SetEventBus(eventBus)
+	queuedTasks := make(chan func(), 1)
+	exec.SetAsyncRunner(func(task func()) {
+		queuedTasks <- task
+	})
+
+	block, err := makeBlock(state, 1, new(types.Commit))
+	require.NoError(t, err)
+	bps, err := block.MakePartSet(testPartSize)
+	require.NoError(t, err)
+	blockID := types.BlockID{Hash: block.Hash(), PartSetHeader: bps.Header()}
+
+	_, err = exec.ApplyBlock(state, blockID, block)
+	require.NoError(t, err)
+
+	// ApplyBlock only enqueues block-event publication in asynchronous mode.
+	// A later synchronous publisher, such as consensus entering the next
+	// height, can therefore reach EventBus before the queued block events.
+	require.NoError(t, eventBus.PublishEventNewRoundStep(types.EventDataRoundState{}))
+	select {
+	case first := <-sub.Out():
+		require.IsType(t, types.EventDataRoundState{}, first.Data())
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the synchronous consensus event")
+	}
+
+	select {
+	case task := <-queuedTasks:
+		task()
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the queued block-event task")
+	}
+	select {
+	case second := <-sub.Out():
+		require.IsType(t, types.EventDataNewBlock{}, second.Data())
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the asynchronous block event")
 	}
 }
 

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -1218,6 +1218,106 @@ func TestValidateBlockCacheHeightAware(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestApplyBlockUsesAsyncRunnerForBlockEvents(t *testing.T) {
+	state, stateDB, _ := makeState(1, 1)
+	exec := newCachedBlockExec(t, stateDB)
+
+	eventBus := &blockingBlockEventPublisher{
+		newBlockStarted: make(chan struct{}, 1),
+		releaseNewBlock: make(chan struct{}),
+	}
+	exec.SetEventBus(eventBus)
+	exec.SetAsyncRunner(func(task func()) {
+		go task()
+	})
+
+	block, err := makeBlock(state, 1, new(types.Commit))
+	require.NoError(t, err)
+	bps, err := block.MakePartSet(testPartSize)
+	require.NoError(t, err)
+	blockID := types.BlockID{Hash: block.Hash(), PartSetHeader: bps.Header()}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := exec.ApplyBlock(state, blockID, block)
+		done <- err
+	}()
+
+	select {
+	case <-eventBus.newBlockStarted:
+	case <-time.After(time.Second):
+		t.Fatal("block event publication did not start")
+	}
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		close(eventBus.releaseNewBlock)
+		require.NoError(t, <-done)
+		t.Fatal("ApplyBlock waited for block event publication")
+	}
+
+	close(eventBus.releaseNewBlock)
+}
+
+func TestApplyBlockPublishesBlockEventsSynchronouslyByDefault(t *testing.T) {
+	state, stateDB, _ := makeState(1, 1)
+	exec := newCachedBlockExec(t, stateDB)
+
+	eventBus := &blockingBlockEventPublisher{
+		newBlockStarted: make(chan struct{}, 1),
+		releaseNewBlock: make(chan struct{}),
+	}
+	exec.SetEventBus(eventBus)
+
+	block, err := makeBlock(state, 1, new(types.Commit))
+	require.NoError(t, err)
+	bps, err := block.MakePartSet(testPartSize)
+	require.NoError(t, err)
+	blockID := types.BlockID{Hash: block.Hash(), PartSetHeader: bps.Header()}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := exec.ApplyBlock(state, blockID, block)
+		done <- err
+	}()
+
+	select {
+	case <-eventBus.newBlockStarted:
+	case <-time.After(time.Second):
+		t.Fatal("block event publication did not start")
+	}
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+		t.Fatal("ApplyBlock returned before synchronous event publication completed")
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	close(eventBus.releaseNewBlock)
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("ApplyBlock did not return after event publication completed")
+	}
+}
+
+type blockingBlockEventPublisher struct {
+	types.NopEventBus
+
+	newBlockStarted chan struct{}
+	releaseNewBlock chan struct{}
+}
+
+func (p *blockingBlockEventPublisher) PublishEventNewBlock(types.EventDataNewBlock) error {
+	p.newBlockStarted <- struct{}{}
+	<-p.releaseNewBlock
+	return nil
+}
+
 func stripSignatures(ec *types.ExtendedCommit) {
 	for i, commitSig := range ec.ExtendedSignatures {
 		commitSig.Extension = nil


### PR DESCRIPTION
## Summary

Block events are currently published synchronously at the end of `ApplyBlock`. For blocks containing many transactions, event construction and publication remain on the consensus critical path.

Increasing `event_bus_buffer_capacity` reduces subscriber backpressure, but does not remove this processing cost from `ApplyBlock`.

This issue was previously observed in https://github.com/crypto-org-chain/cometbft/pull/4#issue-2628451630, where profiling showed synchronous `fireEvents` delaying block execution. That observation motivates this work, while the benchmarks added by this PR provide reproducible evidence across controlled scenarios.

This PR adds opt-in asynchronous block event publication while preserving the existing synchronous behavior by default. Block-event tasks are processed in submission order through a bounded serial runner, and accepted work is drained before the EventBus and indexer are stopped.

### Event ordering

When asynchronous publication is enabled, block events may temporarily lag behind block execution and other synchronously published EventBus events.

FIFO ordering is preserved between queued block-event tasks. However, global ordering across different EventBus publishers is not guaranteed. For example, after the block events for height H are queued, consensus may publish `NewRoundStep` for height H+1 before clients receive `NewBlock` or transaction events for height H.

This does not affect consensus, block execution, or persisted state. Event consumers using asynchronous mode should rely on event heights and must not assume delivery order across different event types.

## Benchmarks

The benchmarks compare synchronous and asynchronous publication across several scenarios:

- Blocks with 0, 100, and 1,000 transactions, showing how publication cost scales with block size.
- A delayed event publisher, showing the impact of slow event processing on `ApplyBlock`.
- The real EventBus with unbuffered, indexer-style consumers.
- EventBus capacities of 0, 128, 1,024, and 2,048, covering both subscriber backpressure and sufficiently buffered publication.

The most relevant case uses 1,000 transactions and an EventBus capacity of 2,048. The buffer can hold all 1,003 events emitted for the block, so EventBus backpressure is not the bottleneck.

Representative results on Apple M4:

| Mode | `ApplyBlock` time |
| --- | ---: |
| Synchronous | 801–897 µs/op |
| Asynchronous | 214–241 µs/op |

This reduces the measured `ApplyBlock` critical-path time by approximately 3.5–4x, demonstrating that increasing the EventBus buffer alone does not eliminate the benefit of asynchronous publication.

This optimization moves event processing out of the consensus critical path. It does not reduce the total event-processing work, and event consumers may temporarily lag behind block execution.

## Testing

Unit and lifecycle tests cover:

- Synchronous publication remaining the default.
- FIFO asynchronous block-event processing.
- Block events potentially arriving after later synchronous EventBus publications.
- Draining accepted work during shutdown.
- Keeping the EventBus available until queued work completes.

```sh
go test ./consensus ./state ./node
```

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `CHANGELOG.md`
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments