### PR TITLE
test(consensus): fix flaky TestByzantinePrevoteEquivocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### BUG FIXES
 
 - `[spec]` fix the inductive invariant `spec/light-client/accountability`
+- `[consensus]` fix flaky `TestByzantinePrevoteEquivocation`.
+  ([\#XXXX](https://github.com/cometbft/cometbft/pull/XXXX))
 
 ### IMPROVEMENTS
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - `[spec]` fix the inductive invariant `spec/light-client/accountability`
 - `[consensus]` fix flaky `TestByzantinePrevoteEquivocation`.
-  ([\#XXXX](https://github.com/cometbft/cometbft/pull/XXXX))
+  ([\#6041](https://github.com/cometbft/cometbft/pull/6041))
 
 ### IMPROVEMENTS
 

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -46,6 +46,19 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 	appFunc := newKVStore
 
 	genDoc, privVals := randGenesisDoc(nValidators, false, 30, nil)
+
+	// Give the byzantine validator enough power that the honest validators
+	// cannot reach +2/3 without it. Otherwise they can commit the height
+	// before the conflicting prevotes arrive, or push the byzantine node
+	// straight to precommit so it never prevotes, and no evidence is produced.
+	byzPubKey, err := privVals[byzantineNode].GetPubKey()
+	require.NoError(t, err)
+	for i := range genDoc.Validators {
+		if genDoc.Validators[i].PubKey.Equals(byzPubKey) {
+			genDoc.Validators[i].Power *= 2
+		}
+	}
+
 	css := make([]*State, nValidators)
 
 	for i := 0; i < nValidators; i++ {


### PR DESCRIPTION
## Summary

`TestByzantinePrevoteEquivocation` still times out sporadically on CI under `-race` after #5814 and #5839, with `Timed out waiting for validators to commit evidence`.

The root cause is that all four validators have equal power, so the three honest ones reach +2/3 without the byzantine node. Under load that opens two paths where no equivocation evidence is ever produced:

- The honest nodes precommit and their +2/3 precommits push the byzantine node straight from propose to precommit, so its overridden `doPrevote` never runs and the conflicting votes are never sent.
- The byzantine node does prevote, but its conflicting votes arrive after the honest nodes have already moved to height 3, and votes for a past height are dropped as a height mismatch.

This change doubles the byzantine validator's voting power so the honest validators cannot reach +2/3 at any height without its prevote. They now block in the prevote step until the byzantine node's first vote arrives, and the conflicting second vote is queued right behind it on the same peer connection, so every honest node observes the equivocation at height 2.

## Reproduction

The race is hard to hit locally, but it can be forced by adding `time.Sleep(500 * time.Millisecond)` at the top of the byzantine `doPrevote` override. With that delay the current test fails 2/2 with the same error as CI. With this fix and the same delay still in place it passes 3/3. The delay is not part of the change.

Without the delay, the fixed test passes 40/40 with `-race -cpu 1` and `go test ./consensus -race` is green.

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `CHANGELOG.md`
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments