### PR TITLE
fix(store): PruneBlocks intermediate checkpoint flushes the wrong base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ### BUG FIXES
 
+- `[store]` fix `PruneBlocks`' periodic checkpoint flush durably recording a
+  `Base` that points at the block just deleted in that same batch, instead of
+  one past it, corrupting `LoadBaseMeta`/`Size` and becoming permanent if
+  pruning later errors before its final flush
+  ([\#PENDING](https://github.com/cometbft/cometbft/pull/PENDING))
 - `[spec]` fix the inductive invariant `spec/light-client/accountability`
 
 ### IMPROVEMENTS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
   `Base` that points at the block just deleted in that same batch, instead of
   one past it, corrupting `LoadBaseMeta`/`Size` and becoming permanent if
   pruning later errors before its final flush
-  ([\#PENDING](https://github.com/cometbft/cometbft/pull/PENDING))
+  ([\#6042](https://github.com/cometbft/cometbft/pull/6042))
 - `[spec]` fix the inductive invariant `spec/light-client/accountability`
 
 ### IMPROVEMENTS

--- a/store/pruneblocks_intermediate_base_test.go
+++ b/store/pruneblocks_intermediate_base_test.go
@@ -1,7 +1,9 @@
 package store
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -24,6 +26,14 @@ import (
 type auditingDB struct {
 	dbm.DB
 	onWrite func(db dbm.DB)
+
+	// failOnBatchN, if > 0, makes the failOnBatchN'th batch write
+	// (WriteSync or Write, 1-indexed across the whole DB) return an error
+	// instead of committing, simulating PruneBlocks erroring out partway
+	// through, after some checkpoint flushes already landed but before the
+	// final flush.
+	failOnBatchN int
+	batchCount   int
 }
 
 func (a *auditingDB) NewBatch() dbm.Batch {
@@ -35,7 +45,18 @@ type auditingBatch struct {
 	audit *auditingDB
 }
 
+func (b *auditingBatch) shouldFail() bool {
+	if b.audit.failOnBatchN <= 0 {
+		return false
+	}
+	b.audit.batchCount++
+	return b.audit.batchCount == b.audit.failOnBatchN
+}
+
 func (b *auditingBatch) Write() error {
+	if b.shouldFail() {
+		return errors.New("injected write failure")
+	}
 	if err := b.Batch.Write(); err != nil {
 		return err
 	}
@@ -46,6 +67,9 @@ func (b *auditingBatch) Write() error {
 }
 
 func (b *auditingBatch) WriteSync() error {
+	if b.shouldFail() {
+		return errors.New("injected write failure")
+	}
 	if err := b.Batch.WriteSync(); err != nil {
 		return err
 	}
@@ -64,7 +88,7 @@ func (b *auditingBatch) WriteSync() error {
 // its final flush.
 func TestPruneBlocksIntermediateBaseNeverPointsAtDeletedBlock(t *testing.T) {
 	config := test.ResetTestRoot("blockchain_reactor_test")
-	t.Cleanup(func() { _ = config.RootDir })
+	t.Cleanup(func() { os.RemoveAll(config.RootDir) })
 
 	stateStore := sm.NewStore(dbm.NewMemDB(), sm.StoreOptions{
 		DiscardABCIResponses: false,
@@ -125,4 +149,62 @@ func TestPruneBlocksIntermediateBaseNeverPointsAtDeletedBlock(t *testing.T) {
 
 	// Sanity: final state is still correct either way.
 	assert.EqualValues(t, pruneTo, bs.Base())
+}
+
+// TestPruneBlocksCheckpointBaseSurvivesLaterError proves the "becomes
+// permanent" half of the same bug: if PruneBlocks errors after an
+// intermediate checkpoint flush has already landed but before the final
+// flush runs, whatever base the checkpoint persisted is what the store is
+// left with. On unfixed code that's a base pointing at a just-deleted block;
+// with the fix it's the correct next-surviving-block height.
+func TestPruneBlocksCheckpointBaseSurvivesLaterError(t *testing.T) {
+	config := test.ResetTestRoot("blockchain_reactor_test")
+	t.Cleanup(func() { os.RemoveAll(config.RootDir) })
+
+	stateStore := sm.NewStore(dbm.NewMemDB(), sm.StoreOptions{
+		DiscardABCIResponses: false,
+	})
+	state, err := stateStore.LoadFromDBOrGenesisFile(config.GenesisFile())
+	require.NoError(t, err)
+
+	underlying := dbm.NewMemDB()
+	adb := &auditingDB{DB: underlying}
+	bs := NewBlockStore(adb)
+
+	const total = int64(1500)
+	for h := int64(1); h <= total; h++ {
+		block, err := state.MakeBlock(h, test.MakeNTxs(h, 2), new(types.Commit), nil, state.Validators.GetProposer().Address)
+		require.NoError(t, err)
+		partSet, err := block.MakePartSet(types.BlockPartSizeBytes)
+		require.NoError(t, err)
+		seenCommit := makeTestExtCommit(h, cmttime.Now())
+		bs.SaveBlockWithExtendedCommit(block, partSet, seenCommit)
+	}
+
+	state.LastBlockTime = time.Date(2020, 1, 1, 1, 0, 0, 0, time.UTC)
+	state.LastBlockHeight = total
+	state.ConsensusParams.Evidence.MaxAgeNumBlocks = 400
+	state.ConsensusParams.Evidence.MaxAgeDuration = 1 * time.Second
+
+	// Reset the batch counter now, so it only counts writes made during the
+	// upcoming PruneBlocks call: batch #1 is the first (h=1000) checkpoint
+	// flush, batch #2 would be the final flush. Failing on #2 simulates an
+	// error landing after the first checkpoint durably persisted, before the
+	// prune as a whole completes.
+	adb.batchCount = 0
+	adb.failOnBatchN = 2
+
+	const pruneTo = int64(1200)
+	_, _, err = bs.PruneBlocks(pruneTo, state)
+	require.Error(t, err, "expected the injected failure on the final flush to surface")
+
+	// The first checkpoint's base is now permanent: PruneBlocks won't be
+	// retried by this test, and no later flush ever corrects it.
+	persistedBase := LoadBlockStoreState(underlying).Base
+	require.EqualValues(t, 1001, persistedBase, "expected the checkpoint's flush (fired while pruning height 1000) to have durably persisted base=1001, matching the final flush's own h+1-style semantics")
+
+	metaBytes, err := underlying.Get(calcBlockMetaKey(persistedBase))
+	require.NoError(t, err)
+	assert.NotEmpty(t, metaBytes,
+		"persisted Base=%d points at a block whose meta was already deleted -- this is the permanent corruption the fix prevents", persistedBase)
 }

--- a/store/pruneblocks_intermediate_base_test.go
+++ b/store/pruneblocks_intermediate_base_test.go
@@ -1,0 +1,128 @@
+package store
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	dbm "github.com/cometbft/cometbft-db"
+
+	"github.com/cometbft/cometbft/internal/test"
+	sm "github.com/cometbft/cometbft/state"
+	"github.com/cometbft/cometbft/types"
+	cmttime "github.com/cometbft/cometbft/types/time"
+)
+
+// auditingDB wraps a dbm.DB and, after every batch Write(), records the
+// durable BlockStoreState.Base and whether the block meta for that base
+// height is still present. This lets a test observe intermediate durable
+// state during a single PruneBlocks call, not just the state after it
+// returns.
+type auditingDB struct {
+	dbm.DB
+	onWrite func(db dbm.DB)
+}
+
+func (a *auditingDB) NewBatch() dbm.Batch {
+	return &auditingBatch{Batch: a.DB.NewBatch(), audit: a}
+}
+
+type auditingBatch struct {
+	dbm.Batch
+	audit *auditingDB
+}
+
+func (b *auditingBatch) Write() error {
+	if err := b.Batch.Write(); err != nil {
+		return err
+	}
+	if b.audit.onWrite != nil {
+		b.audit.onWrite(b.audit.DB)
+	}
+	return nil
+}
+
+func (b *auditingBatch) WriteSync() error {
+	if err := b.Batch.WriteSync(); err != nil {
+		return err
+	}
+	if b.audit.onWrite != nil {
+		b.audit.onWrite(b.audit.DB)
+	}
+	return nil
+}
+
+// TestPruneBlocksIntermediateBaseNeverPointsAtDeletedBlock is a regression
+// test for a bug where PruneBlocks' periodic checkpoint flush persisted
+// BlockStoreState.Base as the height JUST deleted in that iteration, instead
+// of one past it. On unfixed code this durably records a Base whose block
+// meta has already been deleted from the same batch, which corrupts
+// LoadBaseMeta/Size and can become permanent if PruneBlocks errors before
+// its final flush.
+func TestPruneBlocksIntermediateBaseNeverPointsAtDeletedBlock(t *testing.T) {
+	config := test.ResetTestRoot("blockchain_reactor_test")
+	t.Cleanup(func() { _ = config.RootDir })
+
+	stateStore := sm.NewStore(dbm.NewMemDB(), sm.StoreOptions{
+		DiscardABCIResponses: false,
+	})
+	state, err := stateStore.LoadFromDBOrGenesisFile(config.GenesisFile())
+	require.NoError(t, err)
+
+	underlying := dbm.NewMemDB()
+	var violations []string
+	adb := &auditingDB{DB: underlying}
+	adb.onWrite = func(db dbm.DB) {
+		bsState := LoadBlockStoreState(db)
+		base := bsState.Base
+		if base <= 0 {
+			return
+		}
+		metaBytes, err := db.Get(calcBlockMetaKey(base))
+		require.NoError(t, err)
+		if len(metaBytes) == 0 {
+			violations = append(violations, fmt.Sprintf(
+				"durable Base=%d but block meta for that height was already deleted", base))
+		}
+	}
+
+	bs := NewBlockStore(adb)
+
+	// Mirror TestPruneBlocks' proven setup: with this timestamp/evidence-age
+	// configuration, evidenceRetainHeight lands at 1100, so blocks below it
+	// (including the pruned%1000==0 checkpoint at h=1000) really do have
+	// their meta deleted, letting this test actually exercise the
+	// intermediate-flush bug rather than vacuously passing because nothing
+	// was deleted yet.
+	const total = int64(1500)
+	for h := int64(1); h <= total; h++ {
+		block, err := state.MakeBlock(h, test.MakeNTxs(h, 2), new(types.Commit), nil, state.Validators.GetProposer().Address)
+		require.NoError(t, err)
+		partSet, err := block.MakePartSet(types.BlockPartSizeBytes)
+		require.NoError(t, err)
+		seenCommit := makeTestExtCommit(h, cmttime.Now())
+		bs.SaveBlockWithExtendedCommit(block, partSet, seenCommit)
+	}
+
+	state.LastBlockTime = time.Date(2020, 1, 1, 1, 0, 0, 0, time.UTC)
+	state.LastBlockHeight = total
+	state.ConsensusParams.Evidence.MaxAgeNumBlocks = 400
+	state.ConsensusParams.Evidence.MaxAgeDuration = 1 * time.Second
+
+	const pruneTo = int64(1200)
+	pruned, evidenceRetainHeight, err := bs.PruneBlocks(pruneTo, state)
+	require.NoError(t, err)
+	require.EqualValues(t, pruneTo-1, pruned)
+	// Sanity: the checkpoint at h=1000 must fall below the evidence retain
+	// point, or its meta was never deleted and this test would pass
+	// vacuously.
+	require.Greater(t, evidenceRetainHeight, int64(1000))
+
+	require.Empty(t, violations, "intermediate checkpoint(s) recorded a durable Base pointing at an already-deleted block:\n%v", violations)
+
+	// Sanity: final state is still correct either way.
+	assert.EqualValues(t, pruneTo, bs.Base())
+}

--- a/store/store.go
+++ b/store/store.go
@@ -435,7 +435,12 @@ func (bs *BlockStore) PruneBlocks(height int64, state sm.State) (uint64, int64, 
 
 		// flush every 1000 blocks to avoid batches becoming too large
 		if pruned%1000 == 0 && pruned > 0 {
-			err := flush(batch, h)
+			// h has just been pruned in this iteration, so the new base is
+			// h+1, matching the final flush below (which passes height, the
+			// exclusive upper bound of what's been deleted). Passing h here
+			// would durably record a base pointing at a block whose meta was
+			// just deleted in this same batch.
+			err := flush(batch, h+1)
 			if err != nil {
 				return 0, -1, err
 			}


### PR DESCRIPTION
## What

`BlockStore.PruneBlocks`' periodic checkpoint flush (every 1000 blocks, to keep batches bounded) durably records `BlockStoreState.Base` as the height *just deleted* in that loop iteration, instead of one past it — the same off-by-one the final flush at the end of the same function already avoids correctly.

```go
// store/store.go, inside PruneBlocks
if pruned%1000 == 0 && pruned > 0 {
    err := flush(batch, h)       // BUG: h was just deleted in this iteration
    ...
}
...
err := flush(batch, height)      // correct: height is the exclusive upper bound of what's been deleted
```

The `flush` closure's own comment states the intent this defeats:

> "We can't trust batches to be atomic, so update base first to make sure no one tries to access missing blocks."

Every 1000-block checkpoint was doing the opposite: persisting a base whose own block meta had just been deleted in the same batch. `LoadBaseMeta()` returns nil for that height, `Size()` is off by one, and the node advertises a base it can't actually serve. If `PruneBlocks` errors out after a checkpoint flush but before the final flush runs (e.g. the batch failure the `flush` closure's comment is defending against), the wrong base becomes **permanent** — nothing ever corrects it.

## Fix

One-line change: `flush(batch, h)` → `flush(batch, h+1)`, matching the final flush's already-correct semantics.

## Testing

Two new regression tests in `store/pruneblocks_intermediate_base_test.go`, both verified against the real pre-fix source before I touched anything (temporarily reverted `store/store.go` to the parent commit with the new tests still in place):

- `TestPruneBlocksIntermediateBaseNeverPointsAtDeletedBlock` — wraps the DB to audit `BlockStoreState.Base` after *every* batch write during a real `PruneBlocks` call (not just the final state), and asserts no intermediate checkpoint ever records a base whose block meta doesn't exist. Fails on unfixed code with exactly the predicted violation (`durable Base=1000 but block meta for that height was already deleted`); passes fixed.
- `TestPruneBlocksCheckpointBaseSurvivesLaterError` — proves the "becomes permanent" claim directly: injects a failure on the *final* flush after the first checkpoint has already landed, and asserts the durably persisted base is the checkpoint's own value. Fails on unfixed code (`persisted base=1000`, pointing at an already-deleted block); passes fixed (`persisted base=1001`, a real surviving block).

Full `./store/...` suite: 16/16 passing, including the pre-existing `TestPruneBlocks`. `gofmt`/`go vet` clean.

## Review

Ran an adversarial pass on the diff before opening this. It caught a real, unrelated bug in my first test draft — a no-op `t.Cleanup` (assigned `config.RootDir` to `_` instead of removing it) — fixed. It also surfaced three findings I'm disclosing rather than folding into this PR, since each is a separate, larger design question:

1. **The `h+1` checkpoint base still assumes contiguity.** Under the store's normal contiguous-blocks invariant this is correct (which the existing `meta == nil { continue }` skip in the loop already accounts for as a defensive measure, not something this diff changes). But if a *prior* crash already left the store with an internal gap, a checkpoint's `h+1` could in principle point at a height that's also missing. This fix restores the intended invariant under normal operation; it doesn't add gap-detection to `flush`, which would be a separate, larger change.
2. **Per-block deletion order (`store.go`, inside the pruning loop body) deletes block meta before hash/commit/parts.** On a genuinely non-atomic partial batch write, a retry could see `meta == nil` and skip cleaning up the rest for that block. This is a pre-existing ordering question independent of the base-pointer bug this PR fixes.
3. **Pruning doesn't invalidate `blockCommitCache`/`seenCommitCache`** (only `blockExtendedCommitCache` is invalidated today), so a previously-loaded, now-pruned commit can still be served from cache.

Happy to open follow-ups for 2 and 3 if maintainers agree they're worth tracking separately.

## Changelog

Added an entry under `UNRELEASED > BUG FIXES`; backfilling the real PR number in a follow-up commit once this is open (per this repo's own convention of citing the PR number, not just the issue).
