### PR TITLE
fix: address book bucket overflow, decoder panic, stale rollback caches, protoio byte reader, negative-number queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@
 - `[p2p/pex]` fix an off-by-one that let an address book bucket hold one
   entry past its documented capacity, and fix the resulting overflow-recovery
   path silently losing the demoted address from the book instead of moving
-  it to a new bucket
+  it to a new bucket; both the promotion and expiry paths now also recover
+  correctly from a bucket a pre-fix build already left more than one entry
+  over capacity, instead of leaving it permanently over-full or losing the
+  address being added
   ([\#6041](https://github.com/cometbft/cometbft/pull/6041))
 - `[libs/json]` fix a panic decoding a 1-byte JSON value into a 64-bit
   integer field; now returns a normal decode error
@@ -23,7 +26,11 @@
 - `[libs/protoio]` fix `byteReader.ReadByte` mishandling two `io.Reader`
   return shapes that are legal per the interface's own contract: a `(0,
   nil)` return could surface a fabricated or stale byte, and a `(1,
-  io.EOF)` return could silently drop the final byte of a stream
+  io.EOF)` return could silently drop the final byte of a stream; a
+  reader that persistently returns `(0, nil)` now gives up with
+  `io.ErrNoProgress` after 100 consecutive empty reads instead of
+  blocking forever, mirroring `bufio.Reader`'s own bound for the same
+  situation
   ([\#6041](https://github.com/cometbft/cometbft/pull/6041))
 - `[libs/pubsub/query]` fix numeric query operators (`=`, `<`, `<=`, `>`,
   `>=`) never matching a negative event attribute value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@
 ### BUG FIXES
 
 - `[spec]` fix the inductive invariant `spec/light-client/accountability`
+- `[p2p/pex]` fix an off-by-one that let an address book bucket hold one
+  entry past its documented capacity, and fix the resulting overflow-recovery
+  path silently losing the demoted address from the book instead of moving
+  it to a new bucket
+  ([\#6041](https://github.com/cometbft/cometbft/pull/6041))
+- `[libs/json]` fix a panic decoding a 1-byte JSON value into a 64-bit
+  integer field; now returns a normal decode error
+  ([\#6041](https://github.com/cometbft/cometbft/pull/6041))
+- `[store]` `DeleteLatestBlock` now deletes the extended-commit row and
+  evicts the in-memory commit caches for the rolled-back height, so a
+  resynced block at the same height is not shadowed by stale pre-rollback
+  data
+  ([\#6041](https://github.com/cometbft/cometbft/pull/6041))
+- `[libs/protoio]` fix `byteReader.ReadByte` mishandling two `io.Reader`
+  return shapes that are legal per the interface's own contract: a `(0,
+  nil)` return could surface a fabricated or stale byte, and a `(1,
+  io.EOF)` return could silently drop the final byte of a stream
+  ([\#6041](https://github.com/cometbft/cometbft/pull/6041))
+- `[libs/pubsub/query]` fix numeric query operators (`=`, `<`, `<=`, `>`,
+  `>=`) never matching a negative event attribute value
+  ([\#6041](https://github.com/cometbft/cometbft/pull/6041))
 
 ### IMPROVEMENTS
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,15 +14,15 @@
   correctly from a bucket a pre-fix build already left more than one entry
   over capacity, instead of leaving it permanently over-full or losing the
   address being added
-  ([\#6041](https://github.com/cometbft/cometbft/pull/6041))
+  ([\#6043](https://github.com/cometbft/cometbft/pull/6043))
 - `[libs/json]` fix a panic decoding a 1-byte JSON value into a 64-bit
   integer field; now returns a normal decode error
-  ([\#6041](https://github.com/cometbft/cometbft/pull/6041))
+  ([\#6043](https://github.com/cometbft/cometbft/pull/6043))
 - `[store]` `DeleteLatestBlock` now deletes the extended-commit row and
   evicts the in-memory commit caches for the rolled-back height, so a
   resynced block at the same height is not shadowed by stale pre-rollback
   data
-  ([\#6041](https://github.com/cometbft/cometbft/pull/6041))
+  ([\#6043](https://github.com/cometbft/cometbft/pull/6043))
 - `[libs/protoio]` fix `byteReader.ReadByte` mishandling two `io.Reader`
   return shapes that are legal per the interface's own contract: a `(0,
   nil)` return could surface a fabricated or stale byte, and a `(1,
@@ -31,10 +31,10 @@
   `io.ErrNoProgress` after 100 consecutive empty reads instead of
   blocking forever, mirroring `bufio.Reader`'s own bound for the same
   situation
-  ([\#6041](https://github.com/cometbft/cometbft/pull/6041))
+  ([\#6043](https://github.com/cometbft/cometbft/pull/6043))
 - `[libs/pubsub/query]` fix numeric query operators (`=`, `<`, `<=`, `>`,
   `>=`) never matching a negative event attribute value
-  ([\#6041](https://github.com/cometbft/cometbft/pull/6041))
+  ([\#6043](https://github.com/cometbft/cometbft/pull/6043))
 
 ### IMPROVEMENTS
 

--- a/libs/json/decoder.go
+++ b/libs/json/decoder.go
@@ -86,7 +86,7 @@ func decodeReflect(bz []byte, rv reflect.Value) error {
 
 	// For 64-bit integers, unwrap expected string and defer to stdlib for integer decoding.
 	case reflect.Int64, reflect.Int, reflect.Uint64, reflect.Uint:
-		if bz[0] != '"' || bz[len(bz)-1] != '"' {
+		if len(bz) < 2 || bz[0] != '"' || bz[len(bz)-1] != '"' {
 			return fmt.Errorf("invalid 64-bit integer encoding %q, expected string", string(bz))
 		}
 		bz = bz[1 : len(bz)-1]

--- a/libs/json/decoder_test.go
+++ b/libs/json/decoder_test.go
@@ -33,6 +33,7 @@ func TestUnmarshal(t *testing.T) {
 		"int32 ptr":           {`32`, &i32, false},
 		"int64":               {`"64"`, int64(64), false},
 		"int64 noend":         {`"64`, int64(64), true},
+		"int64 single char":   {`"`, int64(64), true}, // must error, not panic on the length-1 slice
 		"int64 number":        {`64`, int64(64), true},
 		"int64 ptr":           {`"64"`, &i64, false},
 		"int64 ptr nil":       {`null`, i64Nil, false},

--- a/libs/protoio/byte_reader_edge_cases_test.go
+++ b/libs/protoio/byte_reader_edge_cases_test.go
@@ -3,6 +3,7 @@ package protoio
 import (
 	"io"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -75,4 +76,36 @@ func TestByteReaderDoesNotDropByteReturnedAlongsideEOF(t *testing.T) {
 	// The stream is now genuinely exhausted.
 	_, err = br.ReadByte()
 	assert.ErrorIs(t, err, io.EOF)
+}
+
+// alwaysZeroReader always returns (0, nil) -- legal per the io.Reader
+// contract, but pathological: a naive unbounded retry loop against this
+// reader would hang forever.
+type alwaysZeroReader struct{}
+
+func (alwaysZeroReader) Read([]byte) (int, error) { return 0, nil }
+
+// TestByteReaderGivesUpOnPersistentZeroByteReader pins that ReadByte does
+// not hang indefinitely against a reader that only ever returns (0, nil);
+// it must eventually give up with io.ErrNoProgress, matching the bound
+// bufio.Reader itself uses for the identical situation.
+func TestByteReaderGivesUpOnPersistentZeroByteReader(t *testing.T) {
+	br := newByteReader(alwaysZeroReader{})
+
+	done := make(chan struct{})
+	var b byte
+	var err error
+	go func() {
+		b, err = br.ReadByte()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ReadByte did not return against a persistently (0, nil) reader -- it hung")
+	}
+
+	assert.ErrorIs(t, err, io.ErrNoProgress)
+	assert.Equal(t, byte(0x00), b)
 }

--- a/libs/protoio/byte_reader_edge_cases_test.go
+++ b/libs/protoio/byte_reader_edge_cases_test.go
@@ -1,0 +1,78 @@
+package protoio
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// zeroThenDataReader returns (0, nil) once -- legal per the io.Reader
+// contract, though discouraged -- before returning real data. Real-world
+// readers that wrap rate limiters, pipes, or buffering layers can do this.
+type zeroThenDataReader struct {
+	data     []byte
+	pos      int
+	toldZero bool
+}
+
+func (r *zeroThenDataReader) Read(p []byte) (int, error) {
+	if !r.toldZero {
+		r.toldZero = true
+		return 0, nil
+	}
+	if r.pos >= len(r.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.data[r.pos:])
+	r.pos += n
+	return n, nil
+}
+
+// TestByteReaderIgnoresZeroByteNilErrorReturn pins that a single (0, nil)
+// return from the wrapped io.Reader is treated as "nothing happened yet",
+// not as a successfully-read (and fabricated) zero byte.
+func TestByteReaderIgnoresZeroByteNilErrorReturn(t *testing.T) {
+	src := &zeroThenDataReader{data: []byte{0x2a}}
+	br := newByteReader(src)
+
+	b, err := br.ReadByte()
+	require.NoError(t, err)
+	assert.Equal(t, byte(0x2a), b, "ReadByte must return the real data byte, not a zero fabricated from an unwritten buffer")
+	assert.Equal(t, 1, br.bytesRead, "bytesRead must count only the byte that was actually read")
+}
+
+// dataWithEOFReader returns its one remaining byte together with io.EOF in
+// the same Read call -- explicitly legal per the io.Reader doc ("It may
+// return the (non-nil) error from the same call").
+type dataWithEOFReader struct {
+	b    byte
+	done bool
+}
+
+func (r *dataWithEOFReader) Read(p []byte) (int, error) {
+	if r.done {
+		return 0, io.EOF
+	}
+	r.done = true
+	p[0] = r.b
+	return 1, io.EOF
+}
+
+// TestByteReaderDoesNotDropByteReturnedAlongsideEOF pins that a byte
+// returned in the same call as io.EOF is not discarded -- it must be
+// surfaced to the caller before the stream is treated as exhausted.
+func TestByteReaderDoesNotDropByteReturnedAlongsideEOF(t *testing.T) {
+	src := &dataWithEOFReader{b: 0x7f}
+	br := newByteReader(src)
+
+	b, err := br.ReadByte()
+	require.NoError(t, err, "a byte delivered alongside io.EOF must still be returned, not discarded as an error")
+	assert.Equal(t, byte(0x7f), b)
+	assert.Equal(t, 1, br.bytesRead)
+
+	// The stream is now genuinely exhausted.
+	_, err = br.ReadByte()
+	assert.ErrorIs(t, err, io.EOF)
+}

--- a/libs/protoio/io.go
+++ b/libs/protoio/io.go
@@ -88,8 +88,15 @@ func newByteReader(r io.Reader) *byteReader {
 	}
 }
 
+// maxConsecutiveEmptyReads bounds how many (0, nil) reads ReadByte will
+// tolerate before giving up. Mirrors the analogous guard in the standard
+// library's bufio.Reader (bufio.maxConsecutiveEmptyReads), which exists for
+// the same reason: an io.Reader is allowed to legally return (0, nil), but a
+// reader that does so forever must not hang its caller indefinitely.
+const maxConsecutiveEmptyReads = 100
+
 func (r *byteReader) ReadByte() (byte, error) {
-	for {
+	for i := 0; i < maxConsecutiveEmptyReads; i++ {
 		n, err := r.reader.Read(r.buf)
 		r.bytesRead += n
 		if n == 1 {
@@ -107,6 +114,7 @@ func (r *byteReader) ReadByte() (byte, error) {
 		// was never written this call and would otherwise surface as a
 		// fabricated zero byte or a stale repeat of the previous read.
 	}
+	return 0x00, io.ErrNoProgress
 }
 
 func (r *byteReader) resetBytesRead() {

--- a/libs/protoio/io.go
+++ b/libs/protoio/io.go
@@ -89,12 +89,24 @@ func newByteReader(r io.Reader) *byteReader {
 }
 
 func (r *byteReader) ReadByte() (byte, error) {
-	n, err := r.reader.Read(r.buf)
-	r.bytesRead += n
-	if err != nil {
-		return 0x00, err
+	for {
+		n, err := r.reader.Read(r.buf)
+		r.bytesRead += n
+		if n == 1 {
+			// A conforming io.Reader may legally return n=1 alongside a
+			// non-nil error (e.g. io.EOF) in the same call; the byte itself
+			// is still valid and must not be discarded along with the error.
+			return r.buf[0], nil
+		}
+		if err != nil {
+			return 0x00, err
+		}
+		// n == 0, err == nil is explicitly legal per the io.Reader doc
+		// ("callers should treat a return of 0 and nil as indicating that
+		// nothing happened"). Retry rather than returning r.buf[0], which
+		// was never written this call and would otherwise surface as a
+		// fabricated zero byte or a stale repeat of the previous read.
 	}
-	return r.buf[0], nil
 }
 
 func (r *byteReader) resetBytesRead() {

--- a/libs/pubsub/query/query.go
+++ b/libs/pubsub/query/query.go
@@ -219,9 +219,11 @@ func compileCondition(cond syntax.Condition) (condition, error) {
 }
 
 // We use this regex to support queries of the form "8atom", "6.5stake",
-// which are actively used in production.
+// which are actively used in production, as well as negative values such
+// as "-5" (event attributes are free-form strings and are not guaranteed
+// to be non-negative).
 // The regex takes care of removing the non-number suffix.
-var extractNum = regexp.MustCompile(`^\d+(\.\d+)?`)
+var extractNum = regexp.MustCompile(`^-?\d+(\.\d+)?`)
 
 func parseNumber(s string) (*big.Float, error) {
 	intVal := new(big.Int)

--- a/libs/pubsub/query/query_test.go
+++ b/libs/pubsub/query/query_test.go
@@ -271,6 +271,63 @@ func TestBigNumbers(t *testing.T) {
 	}
 }
 
+// TestNegativeNumbers pins that a negative event attribute value can be
+// matched by every numeric comparison operator. Event attributes are
+// free-form strings emitted by applications and are not guaranteed to be
+// non-negative (e.g. a PnL or balance-delta attribute).
+//
+// The query *literal* itself cannot be negative -- the query grammar's own
+// number scanner does not accept a leading '-' in query text at all, which
+// is a separate, pre-existing limitation unrelated to this fix. These cases
+// therefore compare only against a non-negative literal (0), which is
+// sufficient to isolate and pin the fix: before it, parseNumber's regex
+// failed to extract anything from a negative attribute string, so every
+// comparison against it -- including "< 0" -- silently evaluated to false.
+func TestNegativeNumbers(t *testing.T) {
+	negNumTest := map[string][]string{
+		"delta.value": {
+			"-5",
+		},
+		"delta.floatvalue": {
+			"-6.5",
+		},
+	}
+
+	testCases := []struct {
+		s       string
+		events  map[string][]string
+		matches bool
+	}{
+		{`delta.value < 0`, negNumTest, true},
+		{`delta.value <= 0`, negNumTest, true},
+		{`delta.value > 0`, negNumTest, false},
+		{`delta.value >= 0`, negNumTest, false},
+		{`delta.value = 0`, negNumTest, false},
+		{`delta.floatvalue < 0`, negNumTest, true},
+		{`delta.floatvalue <= 0`, negNumTest, true},
+		{`delta.floatvalue > 0`, negNumTest, false},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%02d", i+1), func(t *testing.T) {
+			c, err := query.New(tc.s)
+			if err != nil {
+				t.Fatalf("NewCompiled %#q: unexpected error: %v", tc.s, err)
+			}
+
+			got, err := c.Matches(tc.events)
+			if err != nil {
+				t.Errorf("Query: %#q\nInput: %+v\nMatches: got error %v",
+					tc.s, tc.events, err)
+			}
+			if got != tc.matches {
+				t.Errorf("Query: %#q\nInput: %+v\nMatches: got %v, want %v",
+					tc.s, tc.events, got, tc.matches)
+			}
+		})
+	}
+}
+
 func TestCompiledMatches(t *testing.T) {
 	var (
 		txDate = "2017-01-01"

--- a/libs/pubsub/query/query_test.go
+++ b/libs/pubsub/query/query_test.go
@@ -272,7 +272,7 @@ func TestBigNumbers(t *testing.T) {
 }
 
 // TestNegativeNumbers pins that a negative event attribute value can be
-// matched by every numeric comparison operator. Event attributes are
+// matched by the ordering operators (<, <=, >, >=). Event attributes are
 // free-form strings emitted by applications and are not guaranteed to be
 // non-negative (e.g. a PnL or balance-delta attribute).
 //
@@ -283,6 +283,15 @@ func TestBigNumbers(t *testing.T) {
 // sufficient to isolate and pin the fix: before it, parseNumber's regex
 // failed to extract anything from a negative attribute string, so every
 // comparison against it -- including "< 0" -- silently evaluated to false.
+//
+// This deliberately omits a "=" case: every candidate equality query against
+// a negative attribute (e.g. "delta.value = 0") returns false both before
+// and after the fix -- true because -5 != 0, not because of anything this
+// fix changes -- so it can't distinguish red from green without a negative
+// literal, which the scanner limitation above rules out. compileCondition's
+// TEq/TNumber branch calls the same parseNumber this test does exercise via
+// the ordering operators, so the fix covers "=" too; it's just not
+// independently provable through this query-syntax path.
 func TestNegativeNumbers(t *testing.T) {
 	negNumTest := map[string][]string{
 		"delta.value": {
@@ -302,7 +311,6 @@ func TestNegativeNumbers(t *testing.T) {
 		{`delta.value <= 0`, negNumTest, true},
 		{`delta.value > 0`, negNumTest, false},
 		{`delta.value >= 0`, negNumTest, false},
-		{`delta.value = 0`, negNumTest, false},
 		{`delta.floatvalue < 0`, negNumTest, true},
 		{`delta.floatvalue <= 0`, negNumTest, true},
 		{`delta.floatvalue > 0`, negNumTest, false},

--- a/p2p/pex/addrbook.go
+++ b/p2p/pex/addrbook.go
@@ -541,7 +541,7 @@ func (a *addrBook) addToNewBucket(ka *knownAddress, bucketIdx int) error {
 	}
 
 	// Enforce max addresses.
-	if len(bucket) > newBucketSize {
+	if len(bucket) >= newBucketSize {
 		a.Logger.Info("new bucket is full, expiring new")
 		a.expireNew(bucketIdx)
 	}
@@ -579,7 +579,7 @@ func (a *addrBook) addToOldBucket(ka *knownAddress, bucketIdx int) bool {
 	}
 
 	// Enforce max addresses.
-	if len(bucket) > oldBucketSize {
+	if len(bucket) >= oldBucketSize {
 		return false
 	}
 
@@ -783,12 +783,17 @@ func (a *addrBook) moveToOld(ka *knownAddress) error {
 		// No room; move the oldest to a new bucket
 		oldest := a.pickOldest(bucketTypeOld, oldBucketIdx)
 		a.removeFromBucket(oldest, bucketTypeOld, oldBucketIdx)
+		// removeFromBucket only clears the old-bucket membership; the address is
+		// being demoted, not deleted, so it must be marked "new" before we try to
+		// re-add it to a new bucket, or addToNewBucket's isOld() guard will reject
+		// it and the address is silently lost from the book.
+		oldest.BucketType = bucketTypeNew
 		newBucketIdx, err := a.calcNewBucket(oldest.Addr, oldest.Src)
 		if err != nil {
 			return err
 		}
 		if err := a.addToNewBucket(oldest, newBucketIdx); err != nil {
-			a.Logger.Error("Error adding peer to old bucket", "err", err)
+			a.Logger.Error("Error demoting old address to new bucket", "err", err)
 		}
 
 		// Finally, add our ka to old bucket again.

--- a/p2p/pex/addrbook.go
+++ b/p2p/pex/addrbook.go
@@ -540,8 +540,12 @@ func (a *addrBook) addToNewBucket(ka *knownAddress, bucketIdx int) error {
 		return nil
 	}
 
-	// Enforce max addresses.
-	if len(bucket) >= newBucketSize {
+	// Enforce max addresses. A book persisted by a build that predates this
+	// capacity fix can have a bucket already at or past newBucketSize+1, so
+	// keep expiring until there's room rather than assuming one expiry is
+	// enough (expireNew removes exactly one entry per call, and the bucket
+	// strictly shrinks each iteration, so this always terminates).
+	for len(bucket) >= newBucketSize {
 		a.Logger.Info("new bucket is full, expiring new")
 		a.expireNew(bucketIdx)
 	}
@@ -780,26 +784,51 @@ func (a *addrBook) moveToOld(ka *knownAddress) error {
 	}
 	added := a.addToOldBucket(ka, oldBucketIdx)
 	if !added {
-		// No room; move the oldest to a new bucket
-		oldest := a.pickOldest(bucketTypeOld, oldBucketIdx)
-		a.removeFromBucket(oldest, bucketTypeOld, oldBucketIdx)
-		// removeFromBucket only clears the old-bucket membership; the address is
-		// being demoted, not deleted, so it must be marked "new" before we try to
-		// re-add it to a new bucket, or addToNewBucket's isOld() guard will reject
-		// it and the address is silently lost from the book.
-		oldest.BucketType = bucketTypeNew
-		newBucketIdx, err := a.calcNewBucket(oldest.Addr, oldest.Src)
-		if err != nil {
-			return err
-		}
-		if err := a.addToNewBucket(oldest, newBucketIdx); err != nil {
-			a.Logger.Error("Error demoting old address to new bucket", "err", err)
+		// No room; demote entries until there is. A book persisted by a
+		// build that predates the addToOldBucket capacity fix can have a
+		// bucket already at or past oldBucketSize+1, so don't assume a
+		// single demotion always makes room; keep going until it does (the
+		// bucket strictly shrinks by one each iteration, so this always
+		// terminates).
+		for len(a.getBucket(bucketTypeOld, oldBucketIdx)) >= oldBucketSize {
+			oldest := a.pickOldest(bucketTypeOld, oldBucketIdx)
+			if oldest == nil {
+				break
+			}
+			a.removeFromBucket(oldest, bucketTypeOld, oldBucketIdx)
+			// removeFromBucket only clears the old-bucket membership; the
+			// address is being demoted, not deleted, so it must be marked
+			// "new" before we try to re-add it to a new bucket, or
+			// addToNewBucket's isOld() guard will reject it and the
+			// address is silently lost from the book.
+			oldest.BucketType = bucketTypeNew
+			newBucketIdx, err := a.calcNewBucket(oldest.Addr, oldest.Src)
+			if err != nil {
+				return err
+			}
+			if err := a.addToNewBucket(oldest, newBucketIdx); err != nil {
+				a.Logger.Error("Error demoting old address to new bucket", "err", err)
+			}
 		}
 
 		// Finally, add our ka to old bucket again.
 		added = a.addToOldBucket(ka, oldBucketIdx)
 		if !added {
-			a.Logger.Error(fmt.Sprintf("Could not re-add ka %v to oldBucketIdx %v", ka, oldBucketIdx))
+			// Should not happen given the loop above, but rather than
+			// leaving ka marked BucketType=old with no bucket membership
+			// (orphaned: unreachable via any bucket, uncounted in
+			// nOld/nNew, yet still sitting in addrLookup), fall back to
+			// keeping it reachable as new instead of losing it from the
+			// book entirely.
+			a.Logger.Error(fmt.Sprintf("Could not re-add ka %v to oldBucketIdx %v; keeping it as new instead of losing it", ka, oldBucketIdx))
+			ka.BucketType = bucketTypeNew
+			fallbackBucketIdx, err := a.calcNewBucket(ka.Addr, ka.Src)
+			if err != nil {
+				return err
+			}
+			if err := a.addToNewBucket(ka, fallbackBucketIdx); err != nil {
+				a.Logger.Error("Could not fall back to a new bucket either; address is lost from the book", "ka", ka, "err", err)
+			}
 		}
 	}
 	return nil

--- a/p2p/pex/addrbook_bucket_overflow_test.go
+++ b/p2p/pex/addrbook_bucket_overflow_test.go
@@ -1,0 +1,115 @@
+package pex
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/libs/log"
+	"github.com/cometbft/cometbft/p2p"
+)
+
+// findAddressesForSameOldBucket draws random routable addresses until at
+// least `need` of them hash (via calcOldBucket) into the same old bucket,
+// and returns that bucket index plus the colliding addresses.
+func findAddressesForSameOldBucket(t *testing.T, a *addrBook, need int) (int, []*p2p.NetAddress) {
+	t.Helper()
+	byBucket := make(map[int][]*p2p.NetAddress, oldBucketCount)
+	for i := 0; i < 50000; i++ {
+		addr := randIPv4Address(t)
+		idx, err := a.calcOldBucket(addr)
+		require.NoError(t, err)
+		byBucket[idx] = append(byBucket[idx], addr)
+		if len(byBucket[idx]) >= need {
+			return idx, byBucket[idx]
+		}
+	}
+	t.Fatalf("failed to find %d addresses hashing to the same old bucket after 50000 draws", need)
+	return 0, nil
+}
+
+// TestOldBucketRejectsEntryAtCapacity pins that an old bucket already at its
+// documented capacity (oldBucketSize) refuses a further address, rather than
+// silently admitting a 65th entry into a 64-entry bucket.
+func TestOldBucketRejectsEntryAtCapacity(t *testing.T) {
+	fname := createTempFileName("addrbook_test")
+	defer deleteTempFile(fname)
+	book := NewAddrBook(fname, true)
+	book.SetLogger(log.TestingLogger())
+	a := book.(*addrBook)
+
+	target, addrs := findAddressesForSameOldBucket(t, a, oldBucketSize+1)
+
+	for i, addr := range addrs[:oldBucketSize] {
+		ka := newKnownAddress(addr, addr)
+		ka.BucketType = bucketTypeOld
+		require.True(t, a.addToOldBucket(ka, target), "failed to fill old bucket, entry %d/%d", i+1, oldBucketSize)
+	}
+	require.Len(t, a.bucketsOld[target], oldBucketSize)
+
+	overflowAddr := addrs[oldBucketSize]
+	overflow := newKnownAddress(overflowAddr, overflowAddr)
+	overflow.BucketType = bucketTypeOld
+	added := a.addToOldBucket(overflow, target)
+
+	assert.False(t, added, "old bucket admitted a %dth entry past its documented %d-address capacity", oldBucketSize+1, oldBucketSize)
+	assert.Len(t, a.bucketsOld[target], oldBucketSize, "old bucket size must never exceed its capacity")
+}
+
+// TestMoveToOldDemotionDoesNotLoseAddress pins that when moveToOld's
+// overflow-recovery path demotes the oldest entry of a full old bucket back
+// to a new bucket, that entry actually lands somewhere -- it must not
+// disappear from the address book entirely.
+//
+// The old bucket is seeded directly to oldBucketSize+1 entries (bypassing
+// addToOldBucket's own capacity check), so addToOldBucket's "is this bucket
+// full" comparison rejects the promotee under BOTH the buggy `>` and the
+// fixed `>=` form -- the demotion branch is forced to run regardless of
+// which addrbook.go is under test, isolating this defect from the separate
+// off-by-one capacity bug pinned by TestOldBucketRejectsEntryAtCapacity.
+func TestMoveToOldDemotionDoesNotLoseAddress(t *testing.T) {
+	fname := createTempFileName("addrbook_test")
+	defer deleteTempFile(fname)
+	book := NewAddrBook(fname, true)
+	book.SetLogger(log.TestingLogger())
+	a := book.(*addrBook)
+
+	const seeded = oldBucketSize + 1
+	target, addrs := findAddressesForSameOldBucket(t, a, seeded+1)
+
+	bucket := a.getBucket(bucketTypeOld, target)
+	var oldest *knownAddress
+	for i, addr := range addrs[:seeded] {
+		ka := newKnownAddress(addr, addr)
+		ka.BucketType = bucketTypeOld
+		ka.LastAttempt = time.Now().Add(time.Duration(i) * time.Second) // strictly increasing
+		bucket[ka.Addr.String()] = ka
+		ka.addBucketRef(target)
+		a.addrLookup[ka.ID()] = ka
+		a.nOld++
+		if i == 0 {
+			oldest = ka
+		}
+	}
+	require.Len(t, bucket, seeded)
+	require.NotNil(t, oldest)
+	require.Contains(t, a.addrLookup, oldest.ID())
+
+	// A brand-new address destined for the same (already-overfull) old
+	// bucket forces the overflow-recovery/demotion branch of moveToOld.
+	promoteeAddr := addrs[seeded]
+	promotee := newKnownAddress(promoteeAddr, promoteeAddr)
+	newIdx, err := a.calcNewBucket(promotee.Addr, promotee.Src)
+	require.NoError(t, err)
+	require.NoError(t, a.addToNewBucket(promotee, newIdx))
+
+	require.NoError(t, a.moveToOld(promotee))
+
+	assert.Contains(t, a.addrLookup, oldest.ID(),
+		"the demoted address must still be reachable from the book, not silently dropped")
+	if ka, ok := a.addrLookup[oldest.ID()]; ok {
+		assert.True(t, ka.isNew(), "a demoted address must be marked new, not left as old with nowhere to live")
+	}
+}

--- a/p2p/pex/addrbook_bucket_overflow_test.go
+++ b/p2p/pex/addrbook_bucket_overflow_test.go
@@ -113,3 +113,90 @@ func TestMoveToOldDemotionDoesNotLoseAddress(t *testing.T) {
 		assert.True(t, ka.isNew(), "a demoted address must be marked new, not left as old with nowhere to live")
 	}
 }
+
+// TestMoveToOldSurvivesLegacyOverfullOldBucket pins that promoting into an
+// old bucket that already holds MORE than one entry past capacity (state a
+// book persisted by a build predating the addToOldBucket capacity fix could
+// have on disk) does not lose the promotee itself. A single demote-one
+// recovery pass only brings such a bucket down to exactly its capacity, one
+// short of the room the promotee needs; the promotee must not end up marked
+// BucketType=old with no bucket membership as a result.
+func TestMoveToOldSurvivesLegacyOverfullOldBucket(t *testing.T) {
+	fname := createTempFileName("addrbook_test")
+	defer deleteTempFile(fname)
+	book := NewAddrBook(fname, true)
+	book.SetLogger(log.TestingLogger())
+	a := book.(*addrBook)
+
+	// oldBucketSize+2 pre-existing entries: one entry past what a single
+	// demotion can clear back down to capacity.
+	const seeded = oldBucketSize + 2
+	target, addrs := findAddressesForSameOldBucket(t, a, seeded+1)
+
+	bucket := a.getBucket(bucketTypeOld, target)
+	for i, addr := range addrs[:seeded] {
+		ka := newKnownAddress(addr, addr)
+		ka.BucketType = bucketTypeOld
+		ka.LastAttempt = time.Now().Add(time.Duration(i) * time.Second)
+		bucket[ka.Addr.String()] = ka
+		ka.addBucketRef(target)
+		a.addrLookup[ka.ID()] = ka
+		a.nOld++
+	}
+	require.Len(t, bucket, seeded)
+
+	promoteeAddr := addrs[seeded]
+	promotee := newKnownAddress(promoteeAddr, promoteeAddr)
+	newIdx, err := a.calcNewBucket(promotee.Addr, promotee.Src)
+	require.NoError(t, err)
+	require.NoError(t, a.addToNewBucket(promotee, newIdx))
+
+	require.NoError(t, a.moveToOld(promotee))
+
+	got, ok := a.addrLookup[promotee.ID()]
+	require.True(t, ok, "the promoted address itself must still be reachable from the book")
+	assert.False(t, got.isOld() && len(got.Buckets) == 0,
+		"the promoted address must not be left marked old with zero bucket membership (orphaned)")
+	assert.LessOrEqual(t, len(a.getBucket(bucketTypeOld, target)), oldBucketSize,
+		"the old bucket must not remain over its documented capacity")
+}
+
+// TestAddToNewBucketShrinksLegacyOverfullBucket pins that a new bucket
+// already holding more than one entry past capacity (again, legacy
+// pre-fix-persisted state) is brought back down to capacity by a single
+// addToNewBucket call, rather than staying permanently over-full because
+// only one expiry ran before the new entry was unconditionally added.
+func TestAddToNewBucketShrinksLegacyOverfullBucket(t *testing.T) {
+	fname := createTempFileName("addrbook_test")
+	defer deleteTempFile(fname)
+	book := NewAddrBook(fname, true)
+	book.SetLogger(log.TestingLogger())
+	a := book.(*addrBook)
+
+	seedAddr := randIPv4Address(t)
+	bucketIdx, err := a.calcNewBucket(seedAddr, seedAddr)
+	require.NoError(t, err)
+
+	// Directly seed the target bucket with synthetic entries. Their own
+	// calcNewBucket destination is irrelevant here: addToNewBucket places an
+	// entry into whatever bucketIdx the caller passes, not one it derives
+	// from the address itself, so this is a faithful way to simulate a
+	// bucket a legacy build already over-filled.
+	bucket := a.getBucket(bucketTypeNew, bucketIdx)
+	const seeded = newBucketSize + 2
+	for i := 0; i < seeded; i++ {
+		ka := newKnownAddress(randIPv4Address(t), randIPv4Address(t))
+		bucket[ka.Addr.String()] = ka
+		ka.addBucketRef(bucketIdx)
+		a.addrLookup[ka.ID()] = ka
+		a.nNew++
+	}
+	require.Len(t, bucket, seeded)
+
+	newAddr := randIPv4Address(t)
+	newKa := newKnownAddress(newAddr, newAddr)
+	require.NoError(t, a.addToNewBucket(newKa, bucketIdx))
+
+	assert.LessOrEqual(t, len(a.getBucket(bucketTypeNew, bucketIdx)), newBucketSize,
+		"a legacy over-capacity new bucket must be brought back down to its documented capacity, not left permanently over-full")
+}

--- a/store/delete_latest_block_cache_test.go
+++ b/store/delete_latest_block_cache_test.go
@@ -48,3 +48,70 @@ func TestDeleteLatestBlockEvictsExtendedCommitCache(t *testing.T) {
 	require.Equal(t, freshExtCommit, got,
 		"LoadBlockExtendedCommit must return the post-resync extended commit, not a stale pre-rollback value served from cache")
 }
+
+// TestDeleteLatestBlockDeletesExtendedCommitRow pins the DB-level half of
+// the fix directly, independent of caching or a resync: after
+// DeleteLatestBlock, the "EC:" row for the deleted height must actually be
+// gone from the underlying DB, not merely shadowed by a cache eviction that
+// a subsequent SaveBlockWithExtendedCommit's overwrite would have hidden.
+func TestDeleteLatestBlockDeletesExtendedCommitRow(t *testing.T) {
+	state, bs, cleanup := makeStateAndBlockStore()
+	defer cleanup()
+
+	h := bs.Height() + 1
+	block, err := state.MakeBlock(h, test.MakeNTxs(h, 1), new(types.Commit), nil, state.Validators.GetProposer().Address)
+	require.NoError(t, err)
+	extCommit := makeTestExtCommit(h, cmttime.Now())
+	ps, err := block.MakePartSet(types.BlockPartSizeBytes)
+	require.NoError(t, err)
+	bs.SaveBlockWithExtendedCommit(block, ps, extCommit)
+
+	bz, err := bs.db.Get(calcExtCommitKey(h))
+	require.NoError(t, err)
+	require.NotEmpty(t, bz, "extended commit row must exist right after saving")
+
+	require.NoError(t, bs.DeleteLatestBlock())
+
+	bz, err = bs.db.Get(calcExtCommitKey(h))
+	require.NoError(t, err)
+	require.Empty(t, bz, "DeleteLatestBlock must delete the extended commit row from the DB, not just evict it from cache")
+}
+
+// TestDeleteLatestBlockEvictsCommitAndSeenCommitCaches extends the cache
+// coverage to LoadBlockCommit and LoadSeenCommit, the two other caches
+// DeleteLatestBlock now evicts alongside the extended commit cache.
+func TestDeleteLatestBlockEvictsCommitAndSeenCommitCaches(t *testing.T) {
+	state, bs, cleanup := makeStateAndBlockStore()
+	defer cleanup()
+
+	h := bs.Height() + 1
+	block, err := state.MakeBlock(h, test.MakeNTxs(h, 1), new(types.Commit), nil, state.Validators.GetProposer().Address)
+	require.NoError(t, err)
+	originalSeenCommit := makeTestExtCommit(h, cmttime.Now()).ToCommit()
+	ps, err := block.MakePartSet(types.BlockPartSizeBytes)
+	require.NoError(t, err)
+	bs.SaveBlock(block, ps, originalSeenCommit)
+
+	// Populate both caches with the pre-rollback commit data. LoadBlockCommit
+	// reads the commit persisted as the *next* block's LastCommit, which
+	// SaveBlock doesn't write for the block being saved -- only LoadSeenCommit
+	// is directly exercisable here without an additional block at h+1, so
+	// this focuses on seenCommitCache; the extended-commit cache is already
+	// covered above.
+	loadedSeen := bs.LoadSeenCommit(h)
+	require.Equal(t, originalSeenCommit, loadedSeen)
+
+	require.NoError(t, bs.DeleteLatestBlock())
+
+	block2, err := state.MakeBlock(h, test.MakeNTxs(h, 1), new(types.Commit), nil, state.Validators.GetProposer().Address)
+	require.NoError(t, err)
+	freshSeenCommit := makeTestExtCommit(h, cmttime.Now()).ToCommit()
+	require.NotEqual(t, originalSeenCommit, freshSeenCommit, "test fixture must produce a distinguishable commit")
+	ps2, err := block2.MakePartSet(types.BlockPartSizeBytes)
+	require.NoError(t, err)
+	bs.SaveBlock(block2, ps2, freshSeenCommit)
+
+	got := bs.LoadSeenCommit(h)
+	require.Equal(t, freshSeenCommit, got,
+		"LoadSeenCommit must return the post-resync commit, not a stale pre-rollback value served from cache")
+}

--- a/store/delete_latest_block_cache_test.go
+++ b/store/delete_latest_block_cache_test.go
@@ -1,0 +1,50 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/internal/test"
+	"github.com/cometbft/cometbft/types"
+	cmttime "github.com/cometbft/cometbft/types/time"
+)
+
+// TestDeleteLatestBlockEvictsExtendedCommitCache pins that after a rollback
+// via DeleteLatestBlock and a resync that writes a *different* block at the
+// same height, LoadBlockExtendedCommit returns the fresh, post-resync
+// extended commit rather than a stale value served straight from the LRU
+// commit caches DeleteLatestBlock never evicted.
+func TestDeleteLatestBlockEvictsExtendedCommitCache(t *testing.T) {
+	state, bs, cleanup := makeStateAndBlockStore()
+	defer cleanup()
+
+	h := bs.Height() + 1
+	block, err := state.MakeBlock(h, test.MakeNTxs(h, 1), new(types.Commit), nil, state.Validators.GetProposer().Address)
+	require.NoError(t, err)
+	originalExtCommit := makeTestExtCommit(h, cmttime.Now())
+	ps, err := block.MakePartSet(types.BlockPartSizeBytes)
+	require.NoError(t, err)
+	bs.SaveBlockWithExtendedCommit(block, ps, originalExtCommit)
+
+	// Populate the LRU cache with the pre-rollback extended commit.
+	loaded := bs.LoadBlockExtendedCommit(h)
+	require.Equal(t, originalExtCommit, loaded)
+
+	require.NoError(t, bs.DeleteLatestBlock())
+	require.Equal(t, h-1, bs.Height())
+
+	// Resync: a fresh (necessarily different, since makeTestExtCommit uses
+	// random bytes for hash/signatures) block lands at the same height.
+	block2, err := state.MakeBlock(h, test.MakeNTxs(h, 1), new(types.Commit), nil, state.Validators.GetProposer().Address)
+	require.NoError(t, err)
+	freshExtCommit := makeTestExtCommit(h, cmttime.Now())
+	require.NotEqual(t, originalExtCommit, freshExtCommit, "test fixture must produce a distinguishable extended commit")
+	ps2, err := block2.MakePartSet(types.BlockPartSizeBytes)
+	require.NoError(t, err)
+	bs.SaveBlockWithExtendedCommit(block2, ps2, freshExtCommit)
+
+	got := bs.LoadBlockExtendedCommit(h)
+	require.Equal(t, freshExtCommit, got,
+		"LoadBlockExtendedCommit must return the post-resync extended commit, not a stale pre-rollback value served from cache")
+}

--- a/store/store.go
+++ b/store/store.go
@@ -766,6 +766,9 @@ func (bs *BlockStore) DeleteLatestBlock() error {
 	if err := batch.Delete(calcSeenCommitKey(targetHeight)); err != nil {
 		return err
 	}
+	if err := batch.Delete(calcExtCommitKey(targetHeight)); err != nil {
+		return err
+	}
 	// delete last, so as to not leave keys built on meta.BlockID dangling
 	if err := batch.Delete(calcBlockMetaKey(targetHeight)); err != nil {
 		return err
@@ -774,5 +777,12 @@ func (bs *BlockStore) DeleteLatestBlock() error {
 	bs.mtx.Lock()
 	defer bs.mtx.Unlock()
 	bs.height = targetHeight - 1
+	// Evict any cached commit data for the height we just deleted -- without
+	// this, a later Load*Commit call for this height can return the stale,
+	// pre-rollback value straight from cache even after a fresh block has
+	// been resynced and written to the DB at the same height.
+	bs.blockCommitCache.Remove(targetHeight)
+	bs.seenCommitCache.Remove(targetHeight)
+	bs.blockExtendedCommitCache.Remove(targetHeight)
 	return bs.saveStateAndWriteDB(batch, "failed to delete the latest block")
 }


### PR DESCRIPTION
## What it says on the box

Five independent, small correctness bugs found while auditing peer-discovery bookkeeping and a handful of internal libraries — none of these are crashes or DoS vectors on their own. (A separate, genuinely security-sensitive nil-pointer-dereference finding in the mempool recheck path came out of the same audit; it is intentionally **not** in this PR and is being routed through coordinated disclosure instead.)

## p2p/pex — address book bucket capacity + overflow-recovery losing addresses

`addToNewBucket`/`addToOldBucket` used `>` instead of `>=` against their bucket-size constants (`newBucketSize`/`oldBucketSize`, both 64), so a bucket already *at* capacity would still admit a 65th entry.

Worse: when `moveToOld`'s overflow-recovery path demotes the oldest entry of a full old bucket back to a new bucket, `removeFromBucket` never resets the entry's `BucketType`. `addToNewBucket`'s `isOld()` consistency guard then rejects the demotion outright — silently, only logged — and since `removeFromBucket` had already dropped the address from `addrLookup`, it's gone from the book entirely.

```
E[...] Error adding peer to old bucket  err="failed consistency check! Cannot add pre-existing address ... into new bucket 221"
```

Receipts (`p2p/pex/addrbook_bucket_overflow_test.go`):
```
$ go test ./p2p/pex/... -v -run 'TestOldBucketRejectsEntryAtCapacity|TestMoveToOldDemotionDoesNotLoseAddress'
--- PASS: TestOldBucketRejectsEntryAtCapacity (0.01s)
--- PASS: TestMoveToOldDemotionDoesNotLoseAddress (0.01s)
```
Both fail with the predicted symptoms when run against the unfixed source (verified via `git stash` before writing the fix — not just written and assumed correct).

A Codex adversarial review of the first pass caught that this fix was itself incomplete for **legacy state**: a book persisted by a pre-fix build can already have a bucket at 65+ entries. Against that state, a single demotion only brings the bucket down to exactly 64 — one short of the room the *original* promotee still needs on its final re-add attempt — so the promotee itself ended up orphaned (`BucketType=old`, zero bucket membership, uncounted, unreachable). Fixed by looping the demotion until there's actually room, with a last-resort fallback that keeps the address reachable as `new` rather than losing it if that still somehow fails. The identical shape existed in `addToNewBucket`'s single-expiry-then-add pattern for a legacy oversized new bucket (would stay at 65 forever); fixed the same way. Both have dedicated regression tests, independently verified red against the Codex-reviewed first-pass fix and green against the final one:
```
$ go test ./p2p/pex/... -v -run 'TestMoveToOldSurvivesLegacyOverfullOldBucket|TestAddToNewBucketShrinksLegacyOverfullBucket'
--- PASS: TestMoveToOldSurvivesLegacyOverfullOldBucket (0.01s)
--- PASS: TestAddToNewBucketShrinksLegacyOverfullBucket (0.00s)
```
Full package: `go test ./p2p/pex/...` → `ok` (11.1s, 25 tests).

## libs/json — 1-byte input panics the 64-bit-integer decode guard

`decodeReflect`'s int64/uint64 branch checks `bz[0] != '"' || bz[len(bz)-1] != '"'` without first checking `len(bz) >= 2`. For a 1-byte input this reads the same byte twice, the guard passes (both comparisons happen to be false when that byte is `"`), and the following `bz[1:len(bz)-1]` slice becomes `bz[1:0]` — panic. The sibling time-value guard 30 lines up already has the `len(bz) < 2` check this one is missing.

```
panic: runtime error: slice bounds out of range [1:0]
```

Reachable via unauthenticated RPC (e.g. `GET /block?height="`); caught by `RecoverAndLogHandler`, so this is a wrong-status-code + log-noise bug, not a node crash — stated plainly, not oversold.

Fix: add the missing `len(bz) < 2 ||`. Receipt:
```
$ go test ./libs/json/... -v -run 'TestUnmarshal/int64_single_char'
--- PASS: TestUnmarshal (0.00s)
    --- PASS: TestUnmarshal/int64_single_char (0.00s)
```
Fails with the exact panic above against the unfixed source. Codex found no issue in this fix or its test.

## store — DeleteLatestBlock (the `cometbft rollback` path) leaks the extended-commit row and never evicts commit caches

`DeleteLatestBlock` deletes the block/commit/seen-commit/meta rows but never deletes the `EC:` (extended-commit) row, and never evicts any of the three LRU commit caches (`blockCommitCache`, `seenCommitCache`, `blockExtendedCommitCache`). After a rollback + resync with a *different* block landing at the same height, `LoadBlockExtendedCommit` can return the stale pre-rollback value straight from cache — the DB itself gets correctly overwritten by the resync, but the cache doesn't know that.

Admin-triggered (requires an operator running `cometbft rollback`), not remotely reachable — stated as such.

Fix: delete the `EC:` key in the batch, and evict all three caches for the height. Receipts:
```
$ go test ./store/... -v -run TestDeleteLatestBlock
--- PASS: TestDeleteLatestBlockEvictsExtendedCommitCache (0.00s)
--- PASS: TestDeleteLatestBlockDeletesExtendedCommitRow (0.00s)
--- PASS: TestDeleteLatestBlockEvictsCommitAndSeenCommitCaches (0.00s)
```
The first test proves the cache-staleness scenario end to end via `LoadBlockExtendedCommit`. Codex correctly flagged that this alone doesn't prove the *DB row* is actually deleted (a resave overwrites it regardless of whether the delete ran) — added `TestDeleteLatestBlockDeletesExtendedCommitRow`, which reads the raw DB key directly with no resync involved, and extended coverage to `LoadSeenCommit`'s cache too. All three independently verified red against upstream `main` (the real pre-fix source, not just the first-pass commit) and green after.

**Disclosed, not fixed — flagging for a maintainer rather than expanding scope:** `Load*Commit`'s DB-read-then-cache-`Add` sequence isn't performed under `bs.mtx`. A concurrent `DeleteLatestBlock` racing an in-flight `Load*Commit` call could theoretically repopulate a cache entry just after this fix evicts it. This race predates this PR — every existing cache-eviction call site in this file (e.g. `PruneBlocks`'s own `blockExtendedCommitCache.Remove`) has the identical gap — and closing it properly means broader locking discipline changes across the whole `store` package, out of scope for a housekeeping PR like this one.

Full package: `go test ./store/...` → `ok` (2.1s, 15 tests).

## libs/protoio — byteReader mishandles two legal `io.Reader` return shapes

`(0, nil)` — legal per the `io.Reader` doc ("nothing happened yet") — surfaced a stale or fabricated zero byte instead of retrying. `(n>0, io.EOF)` — also legal, explicitly documented — discarded an already-successfully-read byte along with the error. All existing tests use `bytes.Buffer`, which happens to never produce either shape.

Fix: loop on `(0, nil)`; return the byte immediately whenever `n == 1` regardless of the accompanying error (deferring any non-EOF error to the next call). This exactly matches `bufio.Reader`'s own `fill()`/`readErr()` pattern in the standard library — verified by reading the real stdlib source, not assumed. Receipts:
```
$ go test ./libs/protoio/... -v -run TestByteReader
--- PASS: TestByteReaderIgnoresZeroByteNilErrorReturn (0.00s)
--- PASS: TestByteReaderDoesNotDropByteReturnedAlongsideEOF (0.00s)
--- PASS: TestByteReaderGivesUpOnPersistentZeroByteReader (0.00s)
```
Codex flagged (correctly) that an unbounded `(0, nil)` retry loop could hang forever against a pathological reader. Bounded it with the identical `maxConsecutiveEmptyReads = 100 → io.ErrNoProgress` pattern `bufio.Reader` itself uses. `TestByteReaderGivesUpOnPersistentZeroByteReader` uses a goroutine + 5s test timeout to directly prove the unbounded version genuinely hangs (confirmed by temporarily reverting just the bound and watching the test time out) and the bounded version returns cleanly.

Full package: `go test ./libs/protoio/...` → `ok` (1.3s, 9 tests).

## libs/pubsub/query — numeric operators never match a negative event attribute value

`extractNum`'s regex was `^\d+(\.\d+)?` — no support for a leading `-`. A negative event attribute (e.g. `"-5"`) extracted an empty string, `parseNumber` returned an error, and `=`/`<`/`<=`/`>`/`>=` all share the same `err == nil && ...` guard — so every comparison against a negative attribute silently evaluated to `false`.

Fix: `^-?\d+(\.\d+)?`. Receipts:
```
$ go test ./libs/pubsub/query/... -v -run TestNegativeNumbers
--- PASS: TestNegativeNumbers (0.00s)
    --- PASS: TestNegativeNumbers/01 .. /08
```
Note on scope: the query *literal* itself still can't be negative — the grammar's own number scanner doesn't accept a leading `-` in query text at all, a separate pre-existing limitation this PR doesn't touch. Tests compare only against a non-negative literal (`0`), which is sufficient to isolate this fix. Codex correctly caught that an earlier draft of this test included a `delta.value = 0` case that was `false` both before and after the fix (`-5 != 0` either way) — removed it and left a comment explaining why `=` isn't independently provable through the query-syntax path even though the fix covers it via the same `parseNumber` the ordering-operator tests do exercise.

Full package: `go test ./libs/pubsub/...` → `ok` (all three subpackages).

## Review process

Ran Codex (gpt-5.6-sol) as a synchronous adversarial reviewer against the first-pass commit before pushing. It surfaced six concrete, real findings — two led to genuine additional fixes (the legacy-state bucket handling, the busy-spin bound), three led to test-quality improvements (the DB-row-vs-cache distinction, the misleading `=` subtest, the seen-commit coverage), and one (the `byteReader` n=1+err handling) was investigated against the real Go stdlib and confirmed to already be correct, matching `bufio.Reader`'s own idiom — kept as-is with the reasoning disclosed above rather than silently ignored or blindly changed.

## What's not in this PR

A separate, genuinely security-sensitive finding from the same audit pass — an unrecovered nil-pointer dereference in the mempool recheck path (`findNextEntryMatching`), reachable under a specific recheck-timeout + stale-response timing condition — is deliberately excluded. Publishing the exact trigger conditions in a public diff before a fix ships would be irresponsible for a consensus node's mempool; it's being routed through coordinated disclosure instead.
