### PR TITLE
fix(light): stop double-verifying every failing bisection step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
   an identical, wasted second time (not a correctness or security issue -
   `Verify` is pure over its inputs, so the duplicate call is provably a
   no-op)
-  ([\#PLACEHOLDER](https://github.com/cometbft/cometbft/pull/PLACEHOLDER))
+  ([\#6045](https://github.com/cometbft/cometbft/pull/6045))
 - `[spec]` fix the inductive invariant `spec/light-client/accountability`
 
 ### IMPROVEMENTS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ### BUG FIXES
 
+- `[light]` fix `verifySkipping`'s bisection loop appending every fetched
+  pivot block twice, causing each failing bisection step to be re-verified
+  an identical, wasted second time (not a correctness or security issue -
+  `Verify` is pure over its inputs, so the duplicate call is provably a
+  no-op)
+  ([\#PLACEHOLDER](https://github.com/cometbft/cometbft/pull/PLACEHOLDER))
 - `[spec]` fix the inductive invariant `spec/light-client/accountability`
 
 ### IMPROVEMENTS

--- a/light/client.go
+++ b/light/client.go
@@ -762,7 +762,6 @@ func (c *Client) verifySkipping(
 				default:
 					return nil, ErrVerificationFailed{From: verifiedBlock.Height, To: pivotHeight, Reason: providerErr}
 				}
-				blockCache = append(blockCache, interimBlock)
 			}
 			depth++
 

--- a/light/client_test.go
+++ b/light/client_test.go
@@ -407,6 +407,54 @@ func TestClientLargeBisectionVerification(t *testing.T) {
 	assert.Equal(t, h, h2)
 }
 
+// Regression test for the verifySkipping bisection loop appending each
+// fetched pivot block twice, causing every failing bisection step to be
+// re-verified an identical, wasted second time.
+//
+// Unlike TestClientLargeBisectionVerification, this uses a non-zero
+// valVariation so the validator set actually changes between blocks. That's
+// required to force VerifyNonAdjacent to fail and genuinely exercise
+// multiple bisection steps through ErrNewValSetCantBeTrusted - with
+// valVariation == 0 the validator set never changes, verification succeeds
+// immediately at depth 0, and the bisection loop never iterates.
+func TestClientLargeBisectionVerificationWithValSetChanges(t *testing.T) {
+	fullNode := mockp.New(genMockNode(chainID, 30, 20, 6, bTime))
+	trustedLightBlock, err := fullNode.LightBlock(ctx, 1)
+	require.NoError(t, err)
+
+	logger, steps := newVerifyStepLogger()
+	c, err := light.NewClient(
+		ctx,
+		chainID,
+		light.TrustOptions{
+			Period: 4 * time.Hour,
+			Height: trustedLightBlock.Height,
+			Hash:   trustedLightBlock.Hash(),
+		},
+		fullNode,
+		[]provider.Provider{fullNode},
+		dbs.New(dbm.NewMemDB(), chainID),
+		light.SkippingVerification(light.DefaultTrustLevel),
+		light.Logger(logger),
+	)
+	require.NoError(t, err)
+
+	target, err := fullNode.LightBlock(ctx, 30)
+	require.NoError(t, err)
+
+	h, err := c.Update(ctx, bTime.Add(200*time.Minute))
+	require.NoError(t, err)
+	assert.Equal(t, target.Height, h.Height)
+	assert.Equal(t, target.Hash(), h.Hash())
+
+	// The regression: a fetched pivot must never be verified twice in a row.
+	// This is the number-of-verification-rounds assertion, not just the
+	// end result, so a future change can't silently reintroduce the
+	// duplicate append without a test failing.
+	assert.Zero(t, countConsecutiveRepeats(*steps),
+		"a bisection pivot was verified more than once consecutively: %v", *steps)
+}
+
 func TestClientBisectionBetweenTrustedHeaders(t *testing.T) {
 	c, err := light.NewClient(
 		ctx,

--- a/light/client_test.go
+++ b/light/client_test.go
@@ -447,6 +447,10 @@ func TestClientLargeBisectionVerificationWithValSetChanges(t *testing.T) {
 	assert.Equal(t, target.Height, h.Height)
 	assert.Equal(t, target.Hash(), h.Hash())
 
+	// Guard against a future rename of the debug log message the collector
+	// keys on silently turning this into a vacuous assertion.
+	require.NotEmpty(t, *steps)
+
 	// The regression: a fetched pivot must never be verified twice in a row.
 	// This is the number-of-verification-rounds assertion, not just the
 	// end result, so a future change can't silently reintroduce the

--- a/light/helpers_test.go
+++ b/light/helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/crypto/ed25519"
 	"github.com/cometbft/cometbft/crypto/tmhash"
+	"github.com/cometbft/cometbft/libs/log"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	cmtversion "github.com/cometbft/cometbft/proto/tendermint/version"
 	"github.com/cometbft/cometbft/types"
@@ -254,4 +255,45 @@ func genMockNode(
 
 func hash(s string) []byte {
 	return tmhash.Sum([]byte(s))
+}
+
+// verifyStepLogger records the height of every non-adjacent bisection step
+// verifySkipping attempts, in order. It lets tests assert on the number and
+// shape of verification rounds, not just the final result.
+type verifyStepLogger struct {
+	steps *[]int64
+}
+
+func newVerifyStepLogger() (log.Logger, *[]int64) {
+	steps := &[]int64{}
+	return verifyStepLogger{steps: steps}, steps
+}
+
+func (l verifyStepLogger) Debug(msg string, keyvals ...any) {
+	if msg != "Verify non-adjacent newHeader against verifiedBlock" {
+		return
+	}
+	for i := 0; i < len(keyvals)-1; i += 2 {
+		if keyvals[i] == "newHeight" {
+			if h, ok := keyvals[i+1].(int64); ok {
+				*l.steps = append(*l.steps, h)
+			}
+		}
+	}
+}
+func (verifyStepLogger) Info(string, ...any)      {}
+func (verifyStepLogger) Warn(string, ...any)      {}
+func (verifyStepLogger) Error(string, ...any)     {}
+func (l verifyStepLogger) With(...any) log.Logger { return l }
+
+// countConsecutiveRepeats returns how many times a step's height is
+// identical to the immediately preceding step's height.
+func countConsecutiveRepeats(steps []int64) int {
+	repeats := 0
+	for i := 1; i < len(steps); i++ {
+		if steps[i] == steps[i-1] {
+			repeats++
+		}
+	}
+	return repeats
 }


### PR DESCRIPTION
## What it says on the box

`verifySkipping`'s bisection loop appended every fetched pivot block **twice**, so each failing bisection step got re-verified with an identical, wasted second call. Performance/efficiency bug, **not** a correctness or security issue — explained below.

## The bug

`light/client.go`, inside `verifySkipping`'s `ErrNewValSetCantBeTrusted` case:

```go
switch providerErr {
case nil:
    blockCache = append(blockCache, interimBlock)          // append #1
case provider.ErrLightBlockNotFound, provider.ErrNoResponse, provider.ErrHeightTooHigh:
    return nil, err
default:
    return nil, ErrVerificationFailed{From: verifiedBlock.Height, To: pivotHeight, Reason: providerErr}
}
blockCache = append(blockCache, interimBlock)               // append #2 — stray duplicate
```

Every other arm of the switch returns early, so the second append only ever runs alongside the first — it's pure duplication with no distinct purpose. Working through the loop's arithmetic: after both appends, `depth++` lands on the array index holding the *first* copy of `interimBlock`, not a fresh entry, so the very next iteration re-verifies the identical block against the identical trusted block with the identical `now` — guaranteed to hit the same code path again — before the loop's `depth == len(blockCache)-1` condition finally becomes true again and a genuinely new pivot gets fetched.

## Evidence

Built a capturing `log.Logger` recording every "Verify non-adjacent" step's height, driven through a real bisection with a non-zero `valVariation` (so the validator set genuinely changes and `VerifyNonAdjacent` actually fails and retries — more on why this matters below):

```
Before fix: 33 verification rounds, 8 consecutive repeats
  [30 17 17 10 10 6 6 3 30 17 17 10 10 6 30 17 17 10 30 17 17 13 30 17 30 24 24 20 30 24 30 27 30]
                ^^    ^^    ^^                ^^    ^^          ^^    ^^          ^^    ^^

After fix:  25 verification rounds, 0 repeats
  [30 17 10 6 3 30 17 10 6 30 17 10 30 17 13 30 17 30 24 20 30 24 30 27 30]
```

Same final verified block, height and hash, before and after. This is a real A/B measurement against the actual unfixed/fixed source, not a theoretical count.

## Why this is not a verification bypass

I checked this explicitly rather than assuming it from the shape of the fix. `Verify` is pure over its inputs:
- `blockCache[d]` is not mutated between the two (duplicate) visits — it's the same pointer.
- `verifiedBlock` is only reassigned on the `case nil:` success path, never on the duplicate no-op.
- `trustingPeriod`, `now`, `maxClockDrift`, and `trustLevel` are all fixed for the whole `verifySkipping` call — none of them change between the duplicate calls.

Given all of that, the duplicate call is provably a no-op returning the identical result to the first — it can't let anything through that the single call wouldn't have, and removing it can't skip anything the loop still needs. The A/B evidence above confirms this directly: same final block, fewer rounds, zero repeats.

## Why no existing test caught this

Two separate blind spots, both fixed here:

1. `TestClient_SkippingVerification`'s one case that reaches the failing-pivot arm succeeds at `depth == 1`, and the success branch immediately does `blockCache = blockCache[:depth]`, truncating the duplicate entry before it would ever be revisited.
2. `TestClientLargeBisectionVerification` — the repo's only large-scale bisection test — uses `genMockNode(chainID, 100, 3, 0, bTime)`, i.e. `valVariation = 0`. With a validator set that never changes, `VerifyNonAdjacent` succeeds immediately at `depth == 0` and the bisection loop **never iterates through a failing pivot at all**. This test structurally cannot exercise the buggy branch.

## The fix

Delete the stray duplicate append. One line.

## New test

`TestClientLargeBisectionVerificationWithValSetChanges` (`light/client_test.go`) uses a non-zero `valVariation` specifically to force genuine multi-step bisection through `ErrNewValSetCantBeTrusted`, and asserts on the **number of verification rounds** (zero consecutive repeats), not just the end result — so this can't silently regress again. Backed by a small `verifyStepLogger` helper in `light/helpers_test.go`.

Confirmed genuine red-before/green-after: stashed just the `client.go` fix and reran this exact new test — it fails on the unfixed source with the predicted duplicate pattern, passes after restoring the fix.

## Testing

```
$ go test ./light/... -v
ok  github.com/cometbft/cometbft/light          71.5s
ok  github.com/cometbft/cometbft/light/provider/http  20.1s
ok  github.com/cometbft/cometbft/light/store/db       1.0s
```

Full `light/` suite green, zero regressions. `gofmt -l` and `go vet ./light/...` clean.

## Codex adversarial review

Ran synchronously, verdict **SHIP**. It independently mutation-tested the new regression test — 20/20 passes against the fixed source, fails with the exact 8-repeat pattern when the duplicate append is restored — confirming the test is non-vacuous rather than just trusting the author's own claim. It also suggested one hardening (guard against a future rename of the debug log message the test's collector keys on silently making the assertion vacuous), which is included as a separate small commit.

## Scope note

Present identically on `main` and several release branches back to `v0.34.x` — this PR targets `main` only per standard convention; noting the multi-version presence here in case maintainers want to consider a backport.
