### PR TITLE
fix(node): defer eventBus.Stop to final step of OnStop lifecycle (#4054)

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -737,9 +737,6 @@ func (n *Node) OnStop() {
 	n.Logger.Info("Stopping Node")
 
 	// first stop the non-reactor services
-	if err := n.eventBus.Stop(); err != nil {
-		n.Logger.Error("Error closing eventBus", "err", err)
-	}
 	if n.indexerService != nil {
 		if err := n.indexerService.Stop(); err != nil {
 			n.Logger.Error("Error closing indexerService", "err", err)
@@ -810,6 +807,9 @@ func (n *Node) OnStop() {
 		if err := n.EvidencePool().Close(); err != nil {
 			n.Logger.Error("problem closing evidencestore", "err", err)
 		}
+	}
+	if err := n.eventBus.Stop(); err != nil {
+		n.Logger.Error("Error closing eventBus", "err", err)
 	}
 }
 


### PR DESCRIPTION
## Problem
During node teardown or fatal error shutdown, \ventBus\ was closed before background reactors and service listeners finished cleaning up, causing event subscribers to miss shutdown events and potential channel closed panics.

## Root Cause
\
.eventBus.Stop()\ was executed as the very first step of \Node.OnStop()\, before stopping reactors and RPC listeners.

## Fix
Moved \
.eventBus.Stop()\ to the final step of \Node.OnStop()\ after all reactors, services, and listeners have completed teardown.

## Verification
Ran \go test -v ./node -run TestNodeStartStop\ green.